### PR TITLE
fix(timepicker): add aria-live to timepicker inputs

### DIFF
--- a/packages/react-magma-dom/src/components/TimePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/TimePicker/index.tsx
@@ -339,8 +339,8 @@ export const TimePicker = React.forwardRef<HTMLInputElement, TimePickerProps>(
           >
             <InputsContainer theme={theme}>
               <StyledNumInput
-                aria-label={i18n.timePicker.hoursAriaLabel}
                 aria-describedby={descriptionId}
+                aria-label={i18n.timePicker.hoursAriaLabel}
                 data-testid="hoursTimeInput"
                 id={hourId}
                 maxLength={2}


### PR DESCRIPTION
This is the fix suggested from Perkins for https://github.com/cengage/react-magma/issues/34

Not tested on Windows yet (NVDA and Jaws), only tested on Mac VoiceOver.