### PR TITLE
fix(date-picker): fix capitalizing a string that doesn't exist

### DIFF
--- a/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
@@ -66,7 +66,7 @@ export const CalendarHeader: React.FunctionComponent<CalendarHeaderProps> = (
   const currentMonth = format(focusedDate, 'MMMM yyyy', locale);
 
   const capitalizeCurrentMonth =
-    currentMonth.charAt(0).toUpperCase() + currentMonth.slice(1);
+  currentMonth && currentMonth.charAt(0).toUpperCase() + currentMonth.slice(1);
 
   return (
     <CalendarHeaderContainer theme={theme}>


### PR DESCRIPTION
for months

fix #222