### PR TITLE
fix StyledButton: move creation of wrappers outside of StyledButton render function

### DIFF
--- a/.changeset/red-falcons-cry.md
+++ b/.changeset/red-falcons-cry.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix StyledButton: move creation of wrappers outside of StyledButton render function

--- a/packages/react-magma-dom/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/react-magma-dom/src/components/IconButton/IconButton.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { IconButton, IconButtonProps } from '.';
-import { SettingsIcon, NotificationsIcon } from 'react-magma-icons';
+import { Global, css } from '@emotion/core';
+import { SettingsIcon, NotificationsIcon, ExpandMoreIcon } from 'react-magma-icons';
 import {
   ButtonColor,
   ButtonShape,
@@ -102,4 +103,36 @@ IconOnly.args = {
   isFullWidth: false,
   disabled: false,
   onClick: () => {},
+};
+
+const AnimatedIconTemplate: Story<IconButtonProps> = (props) => {
+  const [expanded, setExpanded] = React.useState(false);
+
+  return (
+    <>
+      <Global styles={css`
+        .animated-icon-button svg {
+          transition: transform 200ms;
+        }
+        
+        .animated-icon-button.expanded svg {
+          transform: rotate(180deg);
+        }
+      `} />
+      <IconButton
+        icon={<ExpandMoreIcon />}
+        aria-label="Button"
+        className={expanded ? 'animated-icon-button expanded' : 'animated-icon-button'}
+        onClick={() => setExpanded(state => !state)}
+        {...props}
+      />
+    </>
+  );
+};
+
+export const AnimatedIcon = AnimatedIconTemplate.bind({});
+AnimatedIcon.args = {
+  isInverse: false,
+  isFullWidth: false,
+  disabled: false,
 };

--- a/packages/react-magma-dom/src/components/StyledButton/index.tsx
+++ b/packages/react-magma-dom/src/components/StyledButton/index.tsx
@@ -124,6 +124,17 @@ export const BaseStyledButton = styled.button`
   ${buttonStyles}
 `;
 
+const SpinnerWrapper = styled.span`
+    position: absolute;
+    display: flex;
+  `;
+
+const ChildrenWrapper = styled.span<{ isLoading: boolean; testId?: string }>`
+    visibility: ${props => (props.isLoading ? 'hidden' : 'visible')};
+    display: inline-flex;
+    align-items: center;
+  `;
+
 export const StyledButton = React.forwardRef<
   HTMLButtonElement,
   StyledButtonProps
@@ -151,17 +162,6 @@ export const StyledButton = React.forwardRef<
       : size === ButtonSize.large
       ? theme.iconSizes.large
       : theme.iconSizes.medium;
-
-  const SpinnerWrapper = styled.span`
-    position: absolute;
-    display: flex;
-  `;
-
-  const ChildrenWrapper = styled.span<{ isLoading: boolean; testId?: string }>`
-    visibility: ${props => (props.isLoading ? 'hidden' : 'visible')};
-    display: inline-flex;
-    align-items: center;
-  `;
 
   return (
     <BaseStyledButton


### PR DESCRIPTION
Creating components inside render function will force React to re-mount all children without attempts at reconciliation, which is an absolute antipattern. This is an issue when you want to do some transitions or animations, as demonstrated on a newly added story for IconButton. Without the fix, `SpinnerWrapper` and `ChildrenWrapper` are new functions on every render, React is forced to assume these are different components and throws out their render trees, which aborts any ongoing events.

IconButton story is just an example to demonstrate the problem.