### PR TITLE
fix(Tabs): call onChange function when tab panel is changed by keyboard navigation

### DIFF
--- a/.changeset/early-melons-dress.md
+++ b/.changeset/early-melons-dress.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix(Tabs): call onChange function when tab panel is changed by keyboard navigation

--- a/packages/react-magma-dom/src/components/Tabs/Tabs.test.js
+++ b/packages/react-magma-dom/src/components/Tabs/Tabs.test.js
@@ -779,6 +779,24 @@ describe('Tabs', () => {
       expect(getByText('Tab 2 Info')).toBeVisible();
       expect(document.activeElement).toEqual(getByText('This is tab 2'));
     });
+
+    it('should call passed in onChange function when tab panel is changed by keyboard navigation', () => {
+      const onChange = jest.fn();
+      const { getByText } = render(
+        <Tabs onChange={onChange}>
+          <Tab>This is tab 1</Tab>
+          <Tab>This is tab 2</Tab>
+          <Tab>This is tab 3</Tab>
+        </Tabs>
+      );
+
+      fireEvent.keyDown(getByText('This is tab 1'), {
+        key: 'ArrowRight',
+      });
+
+      expect(onChange).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
   });
 });
 

--- a/packages/react-magma-dom/src/components/Tabs/Tabs.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/Tabs.tsx
@@ -379,6 +379,9 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
       }
 
       if (newActiveTabIndex !== null) {
+        onChange &&
+          typeof onChange === 'function' &&
+          onChange(newActiveTabIndex);
         setActiveTabIndex(newActiveTabIndex);
         (buttonRefArray.current[newActiveTabIndex]
           .current as HTMLButtonElement).focus();


### PR DESCRIPTION
Currently, `onChange` is not called when switching Tabs using keyboard and not clicking them. This can introduce bugs due to inconsistency.