### PR TITLE
fix(tag.stories.tsx): Preview updates when control props are toggled

### DIFF
--- a/.changeset/tame-jobs-march.md
+++ b/.changeset/tame-jobs-march.md
@@ -1,5 +1,5 @@
 ---
-"react-magma": patch
+"react-magma-dom": patch
 ---
 
 fix(tag.stories.tsx): Tag preview updates when control props are toggled

--- a/.changeset/tame-jobs-march.md
+++ b/.changeset/tame-jobs-march.md
@@ -1,0 +1,5 @@
+---
+"react-magma": patch
+---
+
+fix(tag.stories.tsx): Tag preview updates when control props are toggled

--- a/packages/react-magma-dom/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-magma-dom/src/components/Tag/Tag.stories.tsx
@@ -45,54 +45,61 @@ export default {
 export const Default = Template.bind({});
 Default.args = {};
 
-export const Disabled = () => {
+export const Disabled = args => {
   return (
     <>
-      <Tag disabled>Disabled</Tag>
+      <Tag {...args}>Disabled</Tag>
       <br />
       <br />
-      <Tag disabled color={TagColor.primary}>
+      <Tag {...args} color={TagColor.primary}>
         Disabled Primary
       </Tag>
       <br />
       <br />
-      <Tag disabled color={TagColor.highContrast}>
+      <Tag {...args} color={TagColor.highContrast}>
         Disabled High Contrast
       </Tag>
       <br />
       <br />
-      <Tag disabled color={TagColor.lowContrast}>
+      <Tag {...args} color={TagColor.lowContrast}>
         Disabled Low Contrast
       </Tag>
     </>
   );
 };
+Disabled.args = {
+  ...Default.args,
+  disabled: true,
+};
 
-export const DisabledInverse = () => {
+export const DisabledInverse = args => {
   return (
     <Card isInverse>
       <CardBody>
-        <Tag isInverse disabled>
-          Disabled Inverse
-        </Tag>
+        <Tag {...args}>Disabled Inverse</Tag>
         <br />
         <br />
-        <Tag isInverse disabled color={TagColor.primary}>
+        <Tag {...args} color={TagColor.primary}>
           Disabled Inverse Primary
         </Tag>
         <br />
         <br />
-        <Tag isInverse disabled color={TagColor.highContrast}>
+        <Tag {...args} color={TagColor.highContrast}>
           Disabled Inverse High Contrast
         </Tag>
         <br />
         <br />
-        <Tag isInverse disabled color={TagColor.lowContrast}>
+        <Tag {...args} color={TagColor.lowContrast}>
           Disabled Inverse Low Contrast
         </Tag>
       </CardBody>
     </Card>
   );
+};
+DisabledInverse.args = {
+  ...Default.args,
+  disabled: true,
+  isInverse: true,
 };
 
 export const WithIcon = TemplateIcon.bind({});


### PR DESCRIPTION
Fix https://github.com/cengage/react-magma/issues/565

Preview for Disabled and Disabled Inverse Tags now updates as the controls are changed.