### PR TITLE
fix(tag.tsx): Disabled tags have the correct cursor

### DIFF
--- a/.changeset/tall-toes-walk.md
+++ b/.changeset/tall-toes-walk.md
@@ -1,5 +1,5 @@
 ---
-"react-magma": patch
+"react-magma-dom": patch
 ---
 
 fix(tag.tsx): Disabled tags have the correct cursor

--- a/.changeset/tall-toes-walk.md
+++ b/.changeset/tall-toes-walk.md
@@ -1,0 +1,5 @@
+---
+"react-magma": patch
+---
+
+fix(tag.tsx): Disabled tags have the correct cursor

--- a/packages/react-magma-dom/src/components/Tag/Tag.tsx
+++ b/packages/react-magma-dom/src/components/Tag/Tag.tsx
@@ -312,7 +312,7 @@ const StyledButton = styled.button<{
   size: string;
 }>`
   ${TagStyling};
-  cursor: pointer;
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
 `;
 
 const StyledSpan = styled.span<{


### PR DESCRIPTION
Fix https://github.com/cengage/react-magma/issues/566 

Updating the cursor for tags that are disabled and have an icon/delete