### PR TITLE
feat(magmacolors.ts): Adding new rebrand colors

### DIFF
--- a/.changeset/rebrand-colors.md
+++ b/.changeset/rebrand-colors.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": major
+---
+
+feat(magmacolors.ts): Adding new rebrand colors

--- a/packages/dropzone/src/components/dropzone/Dropzone.test.js
+++ b/packages/dropzone/src/components/dropzone/Dropzone.test.js
@@ -140,7 +140,7 @@ describe('File Uploader', () => {
     fireDragEnter(dropzone, data);
     await flushPromises(rerender, ui);
 
-    expect(dropzone).toHaveStyle('border: 2px dashed #3a8200');
+    expect(dropzone).toHaveStyle('border: 2px dashed #178037');
   });
 
   it('border color changes for rejection', async () => {
@@ -155,7 +155,7 @@ describe('File Uploader', () => {
     fireDragEnter(dropzone, data);
     await flushPromises(rerender, ui);
 
-    expect(dropzone).toHaveStyle('border: 2px dashed #c61d23');
+    expect(dropzone).toHaveStyle('border: 2px dashed #D32821');
   });
 
   it('calls onSendFiles for a single file added via the input', async () => {

--- a/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -413,7 +413,7 @@ exports[`Alert Variants should render an alert with danger variant 1`] = `
 }
 
 .emotion-2 {
-  background-color: #C61D23;
+  background-color: #D32821;
   border-radius: 4px;
   color: #FFFFFF;
   display: -webkit-box;
@@ -512,7 +512,7 @@ exports[`Alert Variants should render an alert with danger variant 1`] = `
 }
 
 .emotion-2 {
-  background-color: #C61D23;
+  background-color: #D32821;
   border-radius: 4px;
   color: #FFFFFF;
   display: -webkit-box;
@@ -609,7 +609,7 @@ exports[`Alert Variants should render an alert with info variant 1`] = `
 }
 
 .emotion-2 {
-  background-color: #3F3F3F;
+  background-color: #707070;
   border-radius: 4px;
   color: #FFFFFF;
   display: -webkit-box;
@@ -708,7 +708,7 @@ exports[`Alert Variants should render an alert with info variant 1`] = `
 }
 
 .emotion-2 {
-  background-color: #3F3F3F;
+  background-color: #707070;
   border-radius: 4px;
   color: #FFFFFF;
   display: -webkit-box;
@@ -885,7 +885,7 @@ exports[`Alert Variants should render an alert with warning variant 1`] = `
 .emotion-2 {
   background-color: #FFC72C;
   border-radius: 4px;
-  color: #3F3F3F;
+  color: #707070;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -984,7 +984,7 @@ exports[`Alert Variants should render an alert with warning variant 1`] = `
 .emotion-2 {
   background-color: #FFC72C;
   border-radius: 4px;
-  color: #3F3F3F;
+  color: #707070;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1079,7 +1079,7 @@ exports[`Alert should render an alert with default variant 1`] = `
 }
 
 .emotion-2 {
-  background-color: #3F3F3F;
+  background-color: #707070;
   border-radius: 4px;
   color: #FFFFFF;
   display: -webkit-box;
@@ -1178,7 +1178,7 @@ exports[`Alert should render an alert with default variant 1`] = `
 }
 
 .emotion-2 {
-  background-color: #3F3F3F;
+  background-color: #707070;
   border-radius: 4px;
   color: #FFFFFF;
   display: -webkit-box;

--- a/packages/react-magma-dom/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/packages/react-magma-dom/src/components/Button/__snapshots__/Button.test.js.snap
@@ -18,9 +18,9 @@ exports[`Button Base Button Snapshot should render with large size 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -68,7 +68,7 @@ exports[`Button Base Button Snapshot should render with large size 1`] = `
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -92,7 +92,7 @@ exports[`Button Base Button Snapshot should render with large size 1`] = `
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -129,9 +129,9 @@ exports[`Button Base Button Snapshot should render with large size 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -179,7 +179,7 @@ exports[`Button Base Button Snapshot should render with large size 1`] = `
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -203,7 +203,7 @@ exports[`Button Base Button Snapshot should render with large size 1`] = `
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -256,9 +256,9 @@ exports[`Button Base Button Snapshot should render with small size 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -306,7 +306,7 @@ exports[`Button Base Button Snapshot should render with small size 1`] = `
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -330,7 +330,7 @@ exports[`Button Base Button Snapshot should render with small size 1`] = `
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -367,9 +367,9 @@ exports[`Button Base Button Snapshot should render with small size 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -417,7 +417,7 @@ exports[`Button Base Button Snapshot should render with small size 1`] = `
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -441,7 +441,7 @@ exports[`Button Base Button Snapshot should render with small size 1`] = `
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -498,7 +498,7 @@ exports[`Button Base Button Snapshot should render with updated color 1`] = `
   border: 2px solid;
   border-color: #BFBFBF;
   border-radius: 4px;
-  color: #3F3F3F;
+  color: #707070;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -545,11 +545,11 @@ exports[`Button Base Button Snapshot should render with updated color 1`] = `
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
   background: #e6e6e6;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-2:not(:disabled):after {
-  background: #3F3F3F;
+  background: #707070;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -569,7 +569,7 @@ exports[`Button Base Button Snapshot should render with updated color 1`] = `
 
 .emotion-2:not(:disabled):active {
   background: #ccc;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-2:not(:disabled):active:after {
@@ -609,7 +609,7 @@ exports[`Button Base Button Snapshot should render with updated color 1`] = `
   border: 2px solid;
   border-color: #BFBFBF;
   border-radius: 4px;
-  color: #3F3F3F;
+  color: #707070;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -656,11 +656,11 @@ exports[`Button Base Button Snapshot should render with updated color 1`] = `
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
   background: #e6e6e6;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-2:not(:disabled):after {
-  background: #3F3F3F;
+  background: #707070;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -680,7 +680,7 @@ exports[`Button Base Button Snapshot should render with updated color 1`] = `
 
 .emotion-2:not(:disabled):active {
   background: #ccc;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-2:not(:disabled):active:after {
@@ -733,9 +733,9 @@ exports[`Button Base Button Snapshot should render with updated shape 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 100%;
   color: #FFFFFF;
   cursor: pointer;
@@ -783,7 +783,7 @@ exports[`Button Base Button Snapshot should render with updated shape 1`] = `
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -807,7 +807,7 @@ exports[`Button Base Button Snapshot should render with updated shape 1`] = `
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -844,9 +844,9 @@ exports[`Button Base Button Snapshot should render with updated shape 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 100%;
   color: #FFFFFF;
   cursor: pointer;
@@ -894,7 +894,7 @@ exports[`Button Base Button Snapshot should render with updated shape 1`] = `
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -918,7 +918,7 @@ exports[`Button Base Button Snapshot should render with updated shape 1`] = `
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -972,9 +972,9 @@ exports[`Button Base Button Snapshot should render with updated textTransform 1`
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -1022,7 +1022,7 @@ exports[`Button Base Button Snapshot should render with updated textTransform 1`
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -1046,7 +1046,7 @@ exports[`Button Base Button Snapshot should render with updated textTransform 1`
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -1083,9 +1083,9 @@ exports[`Button Base Button Snapshot should render with updated textTransform 1`
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -1133,7 +1133,7 @@ exports[`Button Base Button Snapshot should render with updated textTransform 1`
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -1157,7 +1157,7 @@ exports[`Button Base Button Snapshot should render with updated textTransform 1`
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -1213,7 +1213,7 @@ exports[`Button Base Button Snapshot should render with updated variant 1`] = `
   background: rgba(0,0,0,0);
   border: 2px solid;
   border-radius: 4px;
-  color: #006298;
+  color: #3942B0;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1259,12 +1259,12 @@ exports[`Button Base Button Snapshot should render with updated variant 1`] = `
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #e5eff4;
-  color: #004165;
+  background: #ebecf7;
+  color: #2d3489;
 }
 
 .emotion-2:not(:disabled):after {
-  background: #006298;
+  background: #3942B0;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -1283,8 +1283,8 @@ exports[`Button Base Button Snapshot should render with updated variant 1`] = `
 }
 
 .emotion-2:not(:disabled):active {
-  background: #b2cfe0;
-  color: #002032;
+  background: #c3c6e7;
+  color: #202563;
 }
 
 .emotion-2:not(:disabled):active:after {
@@ -1323,7 +1323,7 @@ exports[`Button Base Button Snapshot should render with updated variant 1`] = `
   background: rgba(0,0,0,0);
   border: 2px solid;
   border-radius: 4px;
-  color: #006298;
+  color: #3942B0;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1369,12 +1369,12 @@ exports[`Button Base Button Snapshot should render with updated variant 1`] = `
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #e5eff4;
-  color: #004165;
+  background: #ebecf7;
+  color: #2d3489;
 }
 
 .emotion-2:not(:disabled):after {
-  background: #006298;
+  background: #3942B0;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -1393,8 +1393,8 @@ exports[`Button Base Button Snapshot should render with updated variant 1`] = `
 }
 
 .emotion-2:not(:disabled):active {
-  background: #b2cfe0;
-  color: #002032;
+  background: #c3c6e7;
+  color: #202563;
 }
 
 .emotion-2:not(:disabled):active:after {

--- a/packages/react-magma-dom/src/components/Heading/__snapshots__/Heading.test.js.snap
+++ b/packages/react-magma-dom/src/components/Heading/__snapshots__/Heading.test.js.snap
@@ -5,7 +5,7 @@ exports[`Heading Snapshot should render heading 1 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 28px;
   font-weight: 600;
   line-height: 40px;
@@ -30,7 +30,7 @@ exports[`Heading Snapshot should render heading 1 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 28px;
   font-weight: 600;
   line-height: 40px;
@@ -66,7 +66,7 @@ exports[`Heading Snapshot should render heading 2 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 24px;
   font-weight: 600;
   line-height: 32px;
@@ -91,7 +91,7 @@ exports[`Heading Snapshot should render heading 2 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 24px;
   font-weight: 600;
   line-height: 32px;
@@ -126,7 +126,7 @@ exports[`Heading Snapshot should render heading 3 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 20px;
   font-weight: 600;
   line-height: 32px;
@@ -151,7 +151,7 @@ exports[`Heading Snapshot should render heading 3 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 20px;
   font-weight: 600;
   line-height: 32px;
@@ -186,7 +186,7 @@ exports[`Heading Snapshot should render heading 4 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 18px;
   font-weight: 600;
   line-height: 24px;
@@ -211,7 +211,7 @@ exports[`Heading Snapshot should render heading 4 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 18px;
   font-weight: 600;
   line-height: 24px;
@@ -246,7 +246,7 @@ exports[`Heading Snapshot should render heading 5 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 18px;
   font-weight: 600;
   line-height: 24px;
@@ -271,7 +271,7 @@ exports[`Heading Snapshot should render heading 5 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 18px;
   font-weight: 600;
   line-height: 24px;
@@ -306,7 +306,7 @@ exports[`Heading Snapshot should render heading 6 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 12px;
   font-weight: 700;
   -webkit-letter-spacing: .32px;
@@ -340,7 +340,7 @@ exports[`Heading Snapshot should render heading 6 correctly 1`] = `
   border-bottom: 2px solid transparent;
   font-family: "Open Sans",Helvetica,sans-serif;
   padding: 0;
-  color: #3F3F3F;
+  color: #707070;
   font-size: 12px;
   font-weight: 700;
   -webkit-letter-spacing: .32px;

--- a/packages/react-magma-dom/src/components/IconButton/__snapshots__/IconButton.test.js.snap
+++ b/packages/react-magma-dom/src/components/IconButton/__snapshots__/IconButton.test.js.snap
@@ -18,9 +18,9 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 100%;
   color: #FFFFFF;
   cursor: pointer;
@@ -79,7 +79,7 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -103,7 +103,7 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -140,9 +140,9 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 100%;
   color: #FFFFFF;
   cursor: pointer;
@@ -201,7 +201,7 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -225,7 +225,7 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -293,9 +293,9 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 100%;
   color: #FFFFFF;
   cursor: pointer;
@@ -354,7 +354,7 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -378,7 +378,7 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -415,9 +415,9 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 100%;
   color: #FFFFFF;
   cursor: pointer;
@@ -476,7 +476,7 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -500,7 +500,7 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -572,7 +572,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
   border: 2px solid;
   border-color: #BFBFBF;
   border-radius: 100%;
-  color: #3F3F3F;
+  color: #707070;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -630,11 +630,11 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
   background: #e6e6e6;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-2:not(:disabled):after {
-  background: #3F3F3F;
+  background: #707070;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -654,7 +654,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
 
 .emotion-2:not(:disabled):active {
   background: #ccc;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-2:not(:disabled):active:after {
@@ -694,7 +694,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
   border: 2px solid;
   border-color: #BFBFBF;
   border-radius: 100%;
-  color: #3F3F3F;
+  color: #707070;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -752,11 +752,11 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
   background: #e6e6e6;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-2:not(:disabled):after {
-  background: #3F3F3F;
+  background: #707070;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -776,7 +776,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
 
 .emotion-2:not(:disabled):active {
   background: #ccc;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-2:not(:disabled):active:after {
@@ -843,9 +843,9 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -904,7 +904,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -928,7 +928,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -965,9 +965,9 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -1026,7 +1026,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -1050,7 +1050,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
 }
 
 .emotion-2:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -1121,7 +1121,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
   background: rgba(0,0,0,0);
   border: 2px solid;
   border-radius: 100%;
-  color: #006298;
+  color: #3942B0;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1178,12 +1178,12 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #e5eff4;
-  color: #004165;
+  background: #ebecf7;
+  color: #2d3489;
 }
 
 .emotion-2:not(:disabled):after {
-  background: #006298;
+  background: #3942B0;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -1202,8 +1202,8 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
 }
 
 .emotion-2:not(:disabled):active {
-  background: #b2cfe0;
-  color: #002032;
+  background: #c3c6e7;
+  color: #202563;
 }
 
 .emotion-2:not(:disabled):active:after {
@@ -1242,7 +1242,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
   background: rgba(0,0,0,0);
   border: 2px solid;
   border-radius: 100%;
-  color: #006298;
+  color: #3942B0;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1299,12 +1299,12 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
 
 .emotion-2:not(:disabled):hover,
 .emotion-2:not(:disabled):focus {
-  background: #e5eff4;
-  color: #004165;
+  background: #ebecf7;
+  color: #2d3489;
 }
 
 .emotion-2:not(:disabled):after {
-  background: #006298;
+  background: #3942B0;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -1323,8 +1323,8 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
 }
 
 .emotion-2:not(:disabled):active {
-  background: #b2cfe0;
-  color: #002032;
+  background: #c3c6e7;
+  color: #202563;
 }
 
 .emotion-2:not(:disabled):active:after {
@@ -1391,9 +1391,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -1441,7 +1441,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -1465,7 +1465,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -1506,9 +1506,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -1556,7 +1556,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -1580,7 +1580,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -1657,9 +1657,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -1707,7 +1707,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -1731,7 +1731,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -1772,9 +1772,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -1822,7 +1822,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -1846,7 +1846,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -1923,9 +1923,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -1973,7 +1973,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -1997,7 +1997,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -2038,9 +2038,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -2088,7 +2088,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -2112,7 +2112,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -2193,7 +2193,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
   border: 2px solid;
   border-color: #BFBFBF;
   border-radius: 4px;
-  color: #3F3F3F;
+  color: #707070;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -2240,11 +2240,11 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
   background: #e6e6e6;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-3:not(:disabled):after {
-  background: #3F3F3F;
+  background: #707070;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -2264,7 +2264,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
 
 .emotion-3:not(:disabled):active {
   background: #ccc;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-3:not(:disabled):active:after {
@@ -2308,7 +2308,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
   border: 2px solid;
   border-color: #BFBFBF;
   border-radius: 4px;
-  color: #3F3F3F;
+  color: #707070;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -2355,11 +2355,11 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
   background: #e6e6e6;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-3:not(:disabled):after {
-  background: #3F3F3F;
+  background: #707070;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -2379,7 +2379,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
 
 .emotion-3:not(:disabled):active {
   background: #ccc;
-  color: #3F3F3F;
+  color: #707070;
 }
 
 .emotion-3:not(:disabled):active:after {
@@ -2455,9 +2455,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -2505,7 +2505,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -2529,7 +2529,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -2570,9 +2570,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -2620,7 +2620,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -2644,7 +2644,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -2725,9 +2725,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -2775,7 +2775,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -2799,7 +2799,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -2840,9 +2840,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -2890,7 +2890,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -2914,7 +2914,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
 }
 
 .emotion-3:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -2994,7 +2994,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
   background: rgba(0,0,0,0);
   border: 2px solid;
   border-radius: 4px;
-  color: #006298;
+  color: #3942B0;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -3040,12 +3040,12 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #e5eff4;
-  color: #004165;
+  background: #ebecf7;
+  color: #2d3489;
 }
 
 .emotion-3:not(:disabled):after {
-  background: #006298;
+  background: #3942B0;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -3064,8 +3064,8 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
 }
 
 .emotion-3:not(:disabled):active {
-  background: #b2cfe0;
-  color: #002032;
+  background: #c3c6e7;
+  color: #202563;
 }
 
 .emotion-3:not(:disabled):active:after {
@@ -3108,7 +3108,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
   background: rgba(0,0,0,0);
   border: 2px solid;
   border-radius: 4px;
-  color: #006298;
+  color: #3942B0;
   cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -3154,12 +3154,12 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
 
 .emotion-3:not(:disabled):hover,
 .emotion-3:not(:disabled):focus {
-  background: #e5eff4;
-  color: #004165;
+  background: #ebecf7;
+  color: #2d3489;
 }
 
 .emotion-3:not(:disabled):after {
-  background: #006298;
+  background: #3942B0;
   border-radius: 50%;
   content: '';
   height: 28px;
@@ -3178,8 +3178,8 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
 }
 
 .emotion-3:not(:disabled):active {
-  background: #b2cfe0;
-  color: #002032;
+  background: #c3c6e7;
+  color: #202563;
 }
 
 .emotion-3:not(:disabled):active:after {

--- a/packages/react-magma-dom/src/components/SkipLink/SkipLink.test.js
+++ b/packages/react-magma-dom/src/components/SkipLink/SkipLink.test.js
@@ -21,7 +21,7 @@ describe('SkipLink', () => {
 
     expect(link).toBeInTheDocument();
     expect(link.innerHTML).toEqual('Skip Navigation');
-    expect(link).toHaveStyleRule('background', '#006298');
+    expect(link).toHaveStyleRule('background', '#3942B0');
     expect(link).toHaveStyleRule('color', '#FFFFFF');
     expect(link).toMatchSnapshot();
   });
@@ -83,7 +83,7 @@ describe('SkipLink', () => {
     const link = container.querySelector('a');
 
     expect(link).toHaveStyleRule('background', 'rgba(0,0,0,0)');
-    expect(link).toHaveStyleRule('color', '#3A8200');
+    expect(link).toHaveStyleRule('color', '#178037');
   });
 
   it('should render the skip link button the correct colors for an inverse button', () => {
@@ -91,7 +91,7 @@ describe('SkipLink', () => {
     const link = container.querySelector('a');
 
     expect(link).toHaveStyleRule('background', '#FFFFFF');
-    expect(link).toHaveStyleRule('color', '#006298');
+    expect(link).toHaveStyleRule('color', '#3942B0');
   });
 
   it('should render the skip link specified position top and left attributes', () => {

--- a/packages/react-magma-dom/src/components/SkipLink/__snapshots__/SkipLink.test.js.snap
+++ b/packages/react-magma-dom/src/components/SkipLink/__snapshots__/SkipLink.test.js.snap
@@ -6,9 +6,9 @@ exports[`SkipLink should render the skip link component 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -59,7 +59,7 @@ exports[`SkipLink should render the skip link component 1`] = `
 
 .emotion-0:not(:disabled):hover,
 .emotion-0:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -83,7 +83,7 @@ exports[`SkipLink should render the skip link component 1`] = `
 }
 
 .emotion-0:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 
@@ -114,9 +114,9 @@ exports[`SkipLink should render the skip link component 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #006298;
+  background: #3942B0;
   border: 0;
-  border-color: #006298;
+  border-color: #3942B0;
   border-radius: 4px;
   color: #FFFFFF;
   cursor: pointer;
@@ -167,7 +167,7 @@ exports[`SkipLink should render the skip link component 1`] = `
 
 .emotion-0:not(:disabled):hover,
 .emotion-0:not(:disabled):focus {
-  background: #004165;
+  background: #2d3489;
   color: #FFFFFF;
 }
 
@@ -191,7 +191,7 @@ exports[`SkipLink should render the skip link component 1`] = `
 }
 
 .emotion-0:not(:disabled):active {
-  background: #002032;
+  background: #202563;
   color: #FFFFFF;
 }
 

--- a/packages/react-magma-dom/src/components/StyledButton/StyledButton.test.js
+++ b/packages/react-magma-dom/src/components/StyledButton/StyledButton.test.js
@@ -77,10 +77,10 @@ describe('Styled Button', () => {
         const button = getByTestId('button-test');
 
         expect(button).toHaveStyleRule('background', magma.colors.primary);
-        expect(button).toHaveStyleRule('background', '#004165', {
+        expect(button).toHaveStyleRule('background', '#2d3489', {
           target: ':hover',
         });
-        expect(button).toHaveStyleRule('background', '#002032', {
+        expect(button).toHaveStyleRule('background', '#202563', {
           target: ':active',
         });
         expect(button).toHaveStyleRule('border-color', magma.colors.primary);
@@ -97,10 +97,10 @@ describe('Styled Button', () => {
         const button = getByTestId('button-test');
 
         expect(button).toHaveStyleRule('background', 'rgba(0,0,0,0)');
-        expect(button).toHaveStyleRule('background', '#e5eff4', {
+        expect(button).toHaveStyleRule('background', '#ebecf7', {
           target: ':hover',
         });
-        expect(button).toHaveStyleRule('background', '#b2cfe0', {
+        expect(button).toHaveStyleRule('background', '#c3c6e7', {
           target: ':active',
         });
         expect(button).toHaveStyleRule('color', magma.colors.primary);

--- a/packages/react-magma-dom/src/components/Toast/Toast.test.js
+++ b/packages/react-magma-dom/src/components/Toast/Toast.test.js
@@ -220,7 +220,7 @@ describe('Toast', () => {
 
     expect(getByTestId('test').firstChild.firstChild).toHaveStyleRule(
       'background-color',
-      '#3A8200'
+      '#178037'
     );
   });
 });

--- a/packages/react-magma-dom/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/packages/react-magma-dom/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Tooltip should render the tooltip component, positioned top by default 1`] = `
 .emotion-1 {
-  background: #3F3F3F;
+  background: #707070;
   border-radius: 4px;
   color: #FFFFFF;
   font-size: 12px;
@@ -64,11 +64,11 @@ exports[`Tooltip should render the tooltip component, positioned top by default 
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
-  background: #3F3F3F;
+  background: #707070;
 }
 
 .emotion-1 {
-  background: #3F3F3F;
+  background: #707070;
   border-radius: 4px;
   color: #FFFFFF;
   font-size: 12px;
@@ -130,7 +130,7 @@ exports[`Tooltip should render the tooltip component, positioned top by default 
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
-  background: #3F3F3F;
+  background: #707070;
 }
 
 <div

--- a/packages/react-magma-dom/src/theme/magma.ts
+++ b/packages/react-magma-dom/src/theme/magma.ts
@@ -2,6 +2,73 @@ import { ThemeTransitions, transitions } from './components/transition';
 
 export interface Colors {
   primary: string;
+  primary100: string;
+  primary200: string;
+  primary300: string;
+  primary400: string;
+  primary500: string;
+  primary600: string;
+  primary700: string;
+
+  secondary: string;
+  secondary500: string;
+  secondary600: string;
+  secondary700: string;
+  
+  tertiary: string;
+  tertiary500: string;
+  tertiary600: string;
+  tertiary700: string;
+
+  neutral: string;
+  neutral100: string;
+  neutral200: string;
+  neutral300: string;
+  neutral400: string;
+  neutral500: string;
+  neutral600: string;
+  neutral700: string;
+  neutral800: string;
+  neutral900: string;
+
+  info: string;
+  info100: string;
+  info200: string;
+  info300: string;
+  info400: string;
+  info500: string;
+  info600: string;
+  info700: string;
+
+  danger: string;
+  danger100: string;
+  danger200: string;
+  danger300: string;
+  danger400: string;
+  danger500: string;
+  danger600: string;
+  danger700: string;
+
+  warning: string;
+  warning100: string;
+  warning200: string;
+  warning300: string;
+  warning400: string;
+  warning500: string;
+  warning600: string;
+  warning700: string;
+
+  success: string;
+  success100: string;
+  success200: string;
+  success300: string;
+  success400: string;
+  success500: string;
+  success600: string;
+  success700: string;
+
+  // Legacy Colors - To be deleted after rebranding
+  // primary: string;
   primaryInverse: string;
   focus: string;
   focusInverse: string;
@@ -15,12 +82,12 @@ export interface Colors {
   pop04: string;
   pop05: string;
   pop06: string;
-  success: string;
+  // success: string;
   success02: string;
   successInverse: string;
-  danger: string;
+  // danger: string;
   dangerInverse: string;
-  neutral: string;
+  // neutral: string;
   neutral02: string;
   neutral03: string;
   neutral04: string;
@@ -314,8 +381,100 @@ const typeScale = {
   },
 };
 
+const primaryColors = {
+  primary100: '#E8E9F8',
+  primary200: '#BABDE9',
+  primary300: '#8B91DA',
+  primary400: '#5D65CB',
+  primary500: '#3942B0',
+  primary600: '#292F7C',
+  primary700: '#1A1E51',
+};
+
+const secondaryColors = {
+  secondary500: '#FEE449',
+  secondary600: '#FEDA0D',
+  secondary700: '#ECC901',
+};
+
+const tertiaryColors = {
+  tertiary500: '#CDDEFF',
+  tertiary600: '#A2C1FF',
+  tertiary700: '#79A5FF',
+};
+
+const neutralColors = {
+  neutral100: '#FFFFFF', // black
+  neutral200: '#F5F5F5',
+  neutral300: '#D4D4D4',
+  neutral400: '#8D8D8D',
+  neutral500: '#707070',
+  neutral600: '#5A5A5A',
+  neutral700: '#454545',
+  neutral800: '#2D2D2D',
+  neutral900: '#000000', // white
+};
+
+const infoColors = {
+  info100: '#E8F5FC',
+  info200: '#A6DEFF',
+  info300: '#2FB3FF',
+  info400: '#009AF3',
+  info500: '#0074B7',
+  info600: '#005F96',
+  info700: '#004A75',
+};
+
+const dangerColors = {
+  danger100: '#FCEBEA',
+  danger200: '#FAAEB0',
+  danger300: '#E8716D',
+  danger400: '#E24943',
+  danger500: '#D32821',
+  danger600: '#A91F1A',
+  danger700: '#7F1714',
+};
+
+const warningColors = {
+  warning100: '#FCEEE5',
+  warning200: '#F6CDB2',
+  warning300: '#E98B4C',
+  warning400: '#E06A1C',
+  warning500: '#AD5115',
+  warning600: '#8D4311',
+  warning700: '#6E340E',
+};
+
+const successColors = {
+  success100: '#E3FAEA',
+  success200: '#ACF0C1',
+  success300: '#3EDD6E',
+  success400: '#21B94E',
+  success500: '#178037',
+  success600: '#136A2D',
+  success700: '#0F5323',
+};
+
 const colors = {
-  primary: '#006298', // link color blue
+  primary: primaryColors.primary500,
+  secondary: secondaryColors.secondary500,
+  tertiary: tertiaryColors.tertiary500,
+  neutral: neutralColors.neutral500,
+  info: infoColors.info500,
+  danger: dangerColors.danger500,
+  warning: warningColors.warning500,
+  success: successColors.success500,
+  ...primaryColors,
+  ...secondaryColors,
+  ...tertiaryColors,
+  ...neutralColors,
+  ...infoColors,
+  ...dangerColors,
+  ...warningColors,
+  ...successColors,
+  
+  // Legacy Colors - To be deleted after rebranding
+  // primary: '#006298', // link color blue
   primaryInverse: '#70CDFF', // link color inverse blue
   focus: '#027EE1',
   focusInverse: 'rgba(255,255,255,0.7)',
@@ -329,12 +488,12 @@ const colors = {
   pop04: '#FFC72C',
   pop05: '#92278F',
   pop06: '#007A6D',
-  success: '#3A8200',
+  // success: '#3A8200',
   success02: '#48A200',
   successInverse: '#91CF60',
-  danger: '#C61D23',
+  // danger: '#C61D23',
   dangerInverse: '#F59295',
-  neutral: '#3F3F3F', // main dark grey text color
+  // neutral: '#3F3F3F', // main dark grey text color
   neutral02: '#575757',
   neutral03: '#707070',
   neutral04: '#8f8f8f', // lightest gray that meets 3:1 contrast ratio
@@ -357,6 +516,8 @@ const colors = {
   border: '#DFDFDF',
   borderInverse: 'rgba(255,255,255,0.25)',
 };
+
+console.log('>>>', colors);
 
 const spaceScale = {
   spacing01: '2px',

--- a/packages/react-magma-dom/src/theme/magma.ts
+++ b/packages/react-magma-dom/src/theme/magma.ts
@@ -517,8 +517,6 @@ const colors = {
   borderInverse: 'rgba(255,255,255,0.25)',
 };
 
-console.log('>>>', colors);
-
 const spaceScale = {
   spacing01: '2px',
   spacing02: '4px',

--- a/packages/react-magma-dom/src/theme/magmaColors.ts
+++ b/packages/react-magma-dom/src/theme/magmaColors.ts
@@ -1,6 +1,10 @@
 export enum MagmaColors {
   primary = 'primary',
   secondary = 'secondary',
-  success = 'success',
+  tertiary = 'tertiary',
+  neutral = 'neutral',
+  info = 'info',
   danger = 'danger',
+  warning = 'warning',
+  success = 'success',
 }


### PR DESCRIPTION
Adding the new rebrand colors per #648.

For now, I am leaving the legacy colors in the file until we transition all components to the new colors to avoid breaking anything. 

Colors can be accessed like: `theme.colors.primary` (which defaults to 500) or `theme.colors.primary600`