### PR TITLE
feat(progressbar): updating processBar colors

### DIFF
--- a/.changeset/rebrand-processBar.md
+++ b/.changeset/rebrand-processBar.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": major
+---
+
+feat(processBar): Updating processBar colors. `pop` and `pop02` have been removed.

--- a/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -38,7 +38,7 @@ export default {
     },
     percentage: {
       control: {
-        type: 'text',
+        type: 'number',
       },
     },
   },
@@ -47,6 +47,7 @@ export default {
 export const Default = Template.bind({});
 Default.args = {
   percentage: 25,
+  isInverse: false,
 };
 
 export const Inverse = Template.bind({});
@@ -57,7 +58,7 @@ Inverse.args = {
 
 Inverse.decorators = [
   Story => (
-    <Card background={magma.colors.neutral} isInverse>
+    <Card background={magma.colors.primary} isInverse>
       <CardBody>
         <Story />
       </CardBody>

--- a/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.test.js
+++ b/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.test.js
@@ -3,6 +3,7 @@ import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
 import { ProgressBar } from '.';
 import { render } from '@testing-library/react';
+import { transparentize } from 'polished';
 
 describe('ProgressBar', () => {
   it('should find element by testId', () => {
@@ -23,7 +24,7 @@ describe('ProgressBar', () => {
 
     expect(container.firstChild.firstChild).toHaveStyleRule(
       'background',
-      'rgba(0,0,0,0.25)'
+      transparentize(0.75, magma.colors.neutral900)
     );
   });
 
@@ -53,24 +54,6 @@ describe('ProgressBar', () => {
     );
   });
 
-  it('should render the progress bar component with pop color', () => {
-    const { container } = render(<ProgressBar percentage={50} color="pop" />);
-
-    expect(container.querySelector('[role="progressbar"]')).toHaveStyleRule(
-      'background',
-      magma.colors.pop
-    );
-  });
-
-  it('should render the progress bar component with pop02 color', () => {
-    const { container } = render(<ProgressBar percentage={50} color="pop02" />);
-
-    expect(container.querySelector('[role="progressbar"]')).toHaveStyleRule(
-      'background',
-      magma.colors.pop02
-    );
-  });
-
   it('should render the progress bar component with success color', () => {
     const { container } = render(
       <ProgressBar percentage={50} color="success" />
@@ -89,7 +72,7 @@ describe('ProgressBar', () => {
 
     expect(container.querySelector('[role="progressbar"]')).toHaveStyleRule(
       'background',
-      magma.colors.dangerInverse
+      magma.colors.danger200
     );
   });
 
@@ -100,7 +83,7 @@ describe('ProgressBar', () => {
 
     expect(container.querySelector('[role="progressbar"]')).toHaveStyleRule(
       'background',
-      magma.colors.successInverse
+      magma.colors.success200
     );
   });
 

--- a/packages/react-magma-dom/src/components/ProgressBar/index.tsx
+++ b/packages/react-magma-dom/src/components/ProgressBar/index.tsx
@@ -5,6 +5,7 @@ import { ThemeContext } from '../../theme/ThemeContext';
 import { convertStyleValueToString, useGenerateId } from '../../utils';
 import { useIsInverse } from '../../inverse';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { transparentize } from 'polished';
 
 export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -43,8 +44,6 @@ export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
 export enum ProgressBarColor {
   danger = 'danger',
   primary = 'primary', // default
-  pop = 'pop',
-  pop02 = 'pop02',
   success = 'success',
 }
 
@@ -52,20 +51,16 @@ function buildProgressBarBackground(props) {
   if (props.isInverse) {
     switch (props.color) {
       case 'danger':
-        return props.theme.colors.dangerInverse;
+        return props.theme.colors.danger200;
       case 'success':
-        return props.theme.colors.successInverse;
+        return props.theme.colors.success200;
       default:
-        return props.theme.colors.primaryInverse;
+        return props.theme.colors.tertiary;
     }
   }
   switch (props.color) {
     case 'danger':
       return props.theme.colors.danger;
-    case 'pop':
-      return props.theme.colors.pop;
-    case 'pop02':
-      return props.theme.colors.pop02;
     case 'success':
       return props.theme.colors.success;
     default:
@@ -80,17 +75,16 @@ const Container = styled.div<{ isLoadingIndicator?: boolean }>`
 
 const Track = styled.div<ProgressBarProps>`
   background: ${props =>
-    props.isInverse ? 'rgba(0,0,0,0.25)' : props.theme.colors.neutral08};
+    props.isInverse ? transparentize(0.75, props.theme.colors.neutral900) : props.theme.colors.neutral100};
   box-shadow: inset 0 0 0 1px
     ${props =>
       props.isInverse
-        ? `${props.theme.colors.neutral08}80`
-        : props.theme.colors.neutral04};
+        ? transparentize(0.5, props.theme.colors.neutral100)
+        : props.theme.colors.neutral};
   border-radius: 50em;
   overflow: hidden;
   display: flex;
   height: ${props => props.height};
-  /* padding: 1px; */
   width: 100%;
 `;
 

--- a/website/react-magma-docs/src/pages/api/progress-bar.mdx
+++ b/website/react-magma-docs/src/pages/api/progress-bar.mdx
@@ -71,7 +71,7 @@ export function Example() {
 ## Background Color
 
 The `color` prop can be used to set the background color of the progress bar. This prop takes the following values: `primary` and `danger`, and `success`.
-The default value is `primary` which renders as `#006298`, or `magma.colors.primary`.
+The default value is `primary` which renders as `#3942B0`, or `magma.colors.primary`.
 
 ```tsx
 import React from 'react';
@@ -115,7 +115,7 @@ export function Example() {
 ## Inverse
 
 `isInverse` is an optional boolean prop, that may be passed in when the component is to be displayed on a dark background. When the `isInverse` prop is used,
-the default background color of the progress bar is `#00A9E0` or `magma.colors.foundation03`.
+the default background color of the progress bar is `#CDDEFF` or `magma.colors.tertiary`.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
BREAKING CHANGE: Progress Bar `pop` and `pop02` colors have been removed.

re #478 & #479