### PR TITLE
docs(homepage): update focus on GitHub header icon

### DIFF
--- a/.changeset/homepage-focus-docs.md
+++ b/.changeset/homepage-focus-docs.md
@@ -1,0 +1,5 @@
+---
+"react-magma-docs": major
+---
+
+docs: update GitHub icon focus

--- a/website/react-magma-docs/src/components/Masthead/index.js
+++ b/website/react-magma-docs/src/components/Masthead/index.js
@@ -72,7 +72,7 @@ const LogoWrap = styled.span`
   }
 `;
 
-const RepoLink = styled(Link)`
+const RepoLink = styled.span`
   display: flex;
   align-items: center;
   position: relative;
@@ -91,8 +91,14 @@ const HeaderLogo = (
       React Magma
       {/* <Tag color={TagColor.primary} size={TagSize.small}>v3.0.0</Tag> */}
     </LogoLink>
-    <RepoLink to="https://github.com/cengage/react-magma">
-      <IconButton icon={<GithubIcon />} variant={ButtonVariant.link} />
+    <RepoLink>
+      <IconButton
+        icon={<GithubIcon />}
+        variant={ButtonVariant.link}
+        onClick={() =>
+          window.open('https://github.com/cengage/react-magma', '_blank')
+        }
+      />
     </RepoLink>
   </HeaderWrap>
 );


### PR DESCRIPTION
GitHub icon in the header of the homepage had 2 focus states:
![image](https://user-images.githubusercontent.com/91160746/171241230-252935b7-9c00-49a2-b19b-41bda39538ac.png)
![image](https://user-images.githubusercontent.com/91160746/171241441-5e3e6275-c1d7-4284-91a8-1df47f82c642.png)
