### PR TITLE
fix(toast): bring back dropshadow for toasts

### DIFF
--- a/.changeset/toast-dropshadow.md
+++ b/.changeset/toast-dropshadow.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": major
+---
+
+fix(toast): bring back dropshadow for toasts

--- a/.changeset/toast-inverse.md
+++ b/.changeset/toast-inverse.md
@@ -1,0 +1,5 @@
+---
+"react-magma-docs": major
+---
+
+toast: add toast `isInverse` example to docs

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -218,13 +218,10 @@ const StyledAlertInner = styled.div<AlertBaseProps>`
   ${props =>
     props.isToast &&
     css`
-      box-shadow: ${
-        props.isInverse
-          ? `0 2px 8px 0 ${transparentize(0.3, props.theme.colors.neutral900)}`
-          : `0 2px 8px 0 ${transparentize(0.6, props.theme.colors.neutral900)}`
-      }      
-      height: ${props.theme.spaceScale.spacing11};
-      padding-right:0;
+      box-shadow: ${props.isInverse
+        ? `0 2px 8px 0 ${transparentize(0.3, props.theme.colors.neutral900)}`
+        : `0 2px 8px 0 ${transparentize(0.6, props.theme.colors.neutral900)}`};
+      padding-right: 0;
     `}
 `;
 

--- a/packages/react-magma-dom/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-magma-dom/src/components/Toast/Toast.stories.tsx
@@ -1,13 +1,38 @@
 import React from 'react';
 import { Toast } from '.';
+import { magma } from '../../theme/magma';
+import { AlertVariant } from '../AlertBase';
 import { Button, ButtonSize } from '../Button';
 
 export default {
   component: Toast,
   title: 'Toast',
+  argTypes: {
+    isInverse: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    disableAutoDismiss: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    toastDuration: {
+      control: {
+        type: 'number',
+      },
+    },
+    variant: {
+      control: {
+        type: 'select',
+        options: AlertVariant,
+      },
+    },
+  },
 };
 
-export const Default = () => {
+export const Default = args => {
   const [showToast, setShowToast] = React.useState(false);
 
   function handleClick() {
@@ -19,18 +44,32 @@ export const Default = () => {
   }
 
   return (
-    <>
-      <Button size={ButtonSize.small} onClick={handleClick}>
+    <div
+      style={{ background: args.isInverse ? magma.colors.primary600 : 'none' }}
+    >
+      <Button
+        size={ButtonSize.small}
+        onClick={handleClick}
+        isInverse={args.isInverse}
+      >
         Show Default Toast
       </Button>
       {showToast ? (
-        <Toast onDismiss={handleDismiss}>Default Toast</Toast>
+        <Toast onDismiss={handleDismiss} {...args}>
+          Default Toast
+        </Toast>
       ) : null}
-    </>
+    </div>
   );
 };
+Default.args = {
+  variant: AlertVariant.info,
+  toastDuration: 5000,
+  disableAutoDismiss: false,
+  isInverse: false,
+};
 
-export const TwoLine = () => {
+export const TwoLine = args => {
   const [showToast, setShowToast] = React.useState(false);
 
   function handleClick() {
@@ -42,21 +81,30 @@ export const TwoLine = () => {
   }
 
   return (
-    <>
-      <Button size={ButtonSize.small} onClick={handleClick}>
+    <div
+      style={{ background: args.isInverse ? magma.colors.primary600 : 'none' }}
+    >
+      <Button
+        size={ButtonSize.small}
+        onClick={handleClick}
+        isInverse={args.isInverse}
+      >
         Show two line Toast
       </Button>
       {showToast ? (
-        <Toast onDismiss={handleDismiss}>
+        <Toast onDismiss={handleDismiss} {...args}>
           Toast with a breaking line of content which will appear exactly right
           now!
         </Toast>
       ) : null}
-    </>
+    </div>
   );
 };
+TwoLine.args = {
+  ...Default.args,
+};
 
-export const MultiLine = () => {
+export const MultiLine = args => {
   const [showToast, setShowToast] = React.useState(false);
 
   function handleClick() {
@@ -68,16 +116,25 @@ export const MultiLine = () => {
   }
 
   return (
-    <>
-      <Button size={ButtonSize.small} onClick={handleClick}>
+    <div
+      style={{ background: args.isInverse ? magma.colors.primary600 : 'none' }}
+    >
+      <Button
+        size={ButtonSize.small}
+        onClick={handleClick}
+        isInverse={args.isInverse}
+      >
         Show multiple line Toast
       </Button>
       {showToast ? (
-        <Toast onDismiss={handleDismiss}>
+        <Toast onDismiss={handleDismiss} {...args}>
           Toast with breaking lines of content which will appear right now! Also
           it's going to go all the way down here! I mean it! I really do!
         </Toast>
       ) : null}
-    </>
+    </div>
   );
+};
+MultiLine.args = {
+  ...Default.args,
 };

--- a/packages/react-magma-dom/src/components/Toast/index.tsx
+++ b/packages/react-magma-dom/src/components/Toast/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from '../../theme/styled';
-import { AlertBase, AlertBaseProps, transitionDuration } from '../AlertBase';
+import { AlertBase, AlertBaseProps, AlertVariant, transitionDuration } from '../AlertBase';
 import { getTrapElements } from '../../utils';
 import { useGenerateId } from '../../utils';
 import { ToastsContext } from './ToastsContainer';
@@ -22,6 +22,11 @@ export interface ToastProps extends AlertBaseProps {
    * @default false
    */
   disableAutoDismiss?: boolean;
+  /**
+   * The variant of the toast, indicating its function in the UI
+   * @default `AlertVariant.info`
+   */
+  variant?: AlertVariant;
   /**
    * Number of milliseconds the toast displays before it closes
    * @default 5000

--- a/website/react-magma-docs/src/pages/api/toast.mdx
+++ b/website/react-magma-docs/src/pages/api/toast.mdx
@@ -378,6 +378,125 @@ export function Example() {
 }
 ```
 
+## isInverse
+
+```tsx
+import React from 'react';
+import {
+  Announce,
+  Button,
+  ButtonColor,
+  ButtonGroup,
+  Card,
+  Toast,
+  ToastsContainer,
+  AlertVariant,
+} from 'react-magma-dom';
+
+export function Example() {
+  const [showToast, setShowToast] = React.useState(false);
+  const [showToast2, setShowToast2] = React.useState(false);
+  const [showToast3, setShowToast3] = React.useState(false);
+  const [showToast4, setShowToast4] = React.useState(false);
+
+  function handleClick() {
+    setShowToast(true);
+  }
+  function handleDismiss() {
+    setShowToast(false);
+  }
+
+  function handleClick2() {
+    setShowToast2(true);
+  }
+  function handleDismiss2() {
+    setShowToast2(false);
+  }
+
+  function handleClick3() {
+    setShowToast3(true);
+  }
+  function handleDismiss3() {
+    setShowToast3(false);
+  }
+
+  function handleClick4() {
+    setShowToast4(true);
+  }
+  function handleDismiss4() {
+    setShowToast4(false);
+  }
+
+  return (
+    <Card isInverse>
+      <ToastsContainer>
+        <Announce>
+          <ButtonGroup>
+            <Button onClick={handleClick} isInverse>
+              Show Success Inverse Toast
+            </Button>
+            {showToast && (
+              <Toast
+                id="toast1"
+                onDismiss={handleDismiss}
+                variant={AlertVariant.success}
+                isInverse
+              >
+                This is a success toast
+              </Toast>
+            )}
+
+            <Button onClick={handleClick2} isInverse>
+              Show Warning Inverse Toast
+            </Button>
+            {showToast2 && (
+              <Toast
+                id="toast2"
+                variant={AlertVariant.warning}
+                onDismiss={handleDismiss2}
+                isInverse
+              >
+                This is is a warning toast
+              </Toast>
+            )}
+            </ButtonGroup>
+            <br />
+            <ButtonGroup>
+            <Button onClick={handleClick3} isInverse>
+              Show Danger Toast Inverse
+            </Button>
+            {showToast3 && (
+              <Toast
+                id="toast3"
+                variant={AlertVariant.danger}
+                onDismiss={handleDismiss3}
+                isInverse
+              >
+                This is a danger toast
+              </Toast>
+            )}
+
+              <Button onClick={handleClick4} isInverse>
+                Show Info Toast Inverse
+              </Button>
+              {showToast4 && (
+                <Toast
+                  id="toast4"
+                  variant={AlertVariant.info}
+                  onDismiss={handleDismiss4}
+                  isInverse
+                >
+                  This is an info toast
+                </Toast>
+            )}
+          </ButtonGroup>
+        </Announce>
+      </ToastsContainer>
+    </Card>
+  );
+}
+```
+
 ## Testing
 
 Passing in the `testId` prop will pass the `testId` to the internal `Alert` element.


### PR DESCRIPTION
fix #753

- Fixing dropshadow
- Improving Storybook for toasts by adding controls (so we can easily see `isInverse`)
- Add `isInverse` to docs