### PR TITLE
fix(table): add `isInverse` support for TablePagination dropdowns

### DIFF
--- a/.changeset/table-pagination-inverse.md
+++ b/.changeset/table-pagination-inverse.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": major
+---
+
+feat(table): Add `isInverse` support for TablePagination dropdowns

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -84,8 +84,8 @@ export default {
     minWidth: {
       control: {
         type: 'number',
-      }
-    }
+      },
+    },
   },
 } as Meta;
 
@@ -262,7 +262,6 @@ export const ControlledPagination = args => {
   );
 
   return (
-
     <>
       <Table>
         <TableHead>
@@ -314,7 +313,6 @@ export const UncontrolledPagination = args => {
   return (
     <>
       <Table>
-
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -344,10 +342,14 @@ export const UncontrolledPagination = args => {
 
 export const PaginationInverse = args => {
   const [pageIndex, setPageIndex] = React.useState<number>(1);
-  const [rowsPerPage] = React.useState<number>(10);
+  const [rowsPerPage, setRowsPerPage] = React.useState<number>(10);
 
   function handlePageChange(_, page) {
     setPageIndex(page);
+  }
+
+  function handleRowsPerPageChange(newNumberOfRows) {
+    setRowsPerPage(newNumberOfRows);
   }
 
   const rowsToShow = rowsLong.slice(
@@ -380,6 +382,7 @@ export const PaginationInverse = args => {
         itemCount={rowsLong.length}
         isInverse
         onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
       />
     </Card>
   );

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -211,6 +211,7 @@ export const TablePagination = React.forwardRef<
         alignment={DropdownAlignment.end}
         dropDirection={dropdownDropDirection}
         activeIndex={activeIndex}
+        isInverse={isInverse}
       >
         <DropdownButton
           aria-label={i18n.table.pagination.rowsPerPageLabel}


### PR DESCRIPTION
fix #803

<img width="467" alt="image" src="https://user-images.githubusercontent.com/91160746/176285935-e85384f5-f36f-4204-9afb-8da7eb8015da.png">