### PR TITLE
docs: clean up docs for all components

### DIFF
--- a/.changeset/docs-cleanup.md
+++ b/.changeset/docs-cleanup.md
@@ -1,0 +1,5 @@
+---
+"react-magma-docs": major
+---
+
+docs: Clean up docs for all components. Ensure `isInverse` is documented.

--- a/packages/react-magma-dom/src/components/Alert/index.tsx
+++ b/packages/react-magma-dom/src/components/Alert/index.tsx
@@ -26,7 +26,7 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   testId?: string;
   /**
    * The variant of the alert, indicating its function in the UI
-   * @default `AlertVariant.info`
+   * @default AlertVariant.info
    */
   variant?: AlertVariant;
 }

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
@@ -39,6 +39,7 @@ export interface DrawerProps extends Omit<ModalProps, 'size'> {
    * Set the position of the drawer
    */
   position?: DrawerPosition;
+  isInverse?: boolean;
 }
 
 export const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -35,27 +35,27 @@ const Template: Story<DropdownProps> = args => (
 
 const HeaderIconTemplate: Story<DropdownProps> = args => (
   <div style={{ margin: '150px auto', textAlign: 'center' }}>
-      <Dropdown>
-        <DropdownButton size={ButtonSize.small} color={ButtonColor.marketing}>
-          Extra Props Example 1
-        </DropdownButton>
-        <DropdownContent>
+    <Dropdown {...args}>
+      <DropdownButton>Full Content Dropdown</DropdownButton>
+      <DropdownContent>
+        <DropdownMenuGroup header="Section title A">
           <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-        </DropdownContent>
-      </Dropdown>
-      <Dropdown>
-        <DropdownSplitButton
-        size={ButtonSize.large}
-        variant={ButtonVariant.solid}
-        color={ButtonColor.danger} aria-label={''}        >
-          Extra Props Split
-        </DropdownSplitButton>
-        <DropdownContent>
-          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-        </DropdownContent>
-      </Dropdown>
+          <DropdownMenuItem>Menu item 2</DropdownMenuItem>
+          <DropdownMenuItem disabled>Menu item disabled</DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownDivider />
+        <DropdownMenuGroup header="Section title B">
+          <DropdownMenuItem icon={<MenuIcon />}>Menu item 3</DropdownMenuItem>
+          <DropdownMenuItem icon={<SettingsIcon />}>
+            Menu item 4
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownDivider />
+        <DropdownMenuGroup>
+          <DropdownMenuItem>Log out</DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownContent>
+    </Dropdown>
   </div>
 );
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -35,27 +35,27 @@ const Template: Story<DropdownProps> = args => (
 
 const HeaderIconTemplate: Story<DropdownProps> = args => (
   <div style={{ margin: '150px auto', textAlign: 'center' }}>
-    <Dropdown {...args}>
-      <DropdownButton>Full Content Dropdown</DropdownButton>
-      <DropdownContent>
-        <DropdownMenuGroup header="Section title A">
+      <Dropdown>
+        <DropdownButton size={ButtonSize.small} color={ButtonColor.marketing}>
+          Extra Props Example 1
+        </DropdownButton>
+        <DropdownContent>
           <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-          <DropdownMenuItem>Menu item 2</DropdownMenuItem>
-          <DropdownMenuItem disabled>Menu item disabled</DropdownMenuItem>
-        </DropdownMenuGroup>
-        <DropdownDivider />
-        <DropdownMenuGroup header="Section title B">
-          <DropdownMenuItem icon={<MenuIcon />}>Menu item 3</DropdownMenuItem>
-          <DropdownMenuItem icon={<SettingsIcon />}>
-            Menu item 4
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-        <DropdownDivider />
-        <DropdownMenuGroup>
-          <DropdownMenuItem>Log out</DropdownMenuItem>
-        </DropdownMenuGroup>
-      </DropdownContent>
-    </Dropdown>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <Dropdown>
+        <DropdownSplitButton
+        size={ButtonSize.large}
+        variant={ButtonVariant.solid}
+        color={ButtonColor.danger} aria-label={''}        >
+          Extra Props Split
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
   </div>
 );
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -218,10 +218,10 @@ describe('Dropdown', () => {
     );
   });
 
-  it('should render a split dropdown with no margin on outline variants', () => {
+  it('should render a split dropdown with no margin on solid variants', () => {
     const { getByLabelText } = render(
       <Dropdown>
-        <DropdownSplitButton variant="outline">Toggle me</DropdownSplitButton>
+        <DropdownSplitButton variant="solid">Toggle me</DropdownSplitButton>
         <DropdownContent />
       </Dropdown>
     );

--- a/packages/react-magma-dom/src/components/LoadingIndicator/index.tsx
+++ b/packages/react-magma-dom/src/components/LoadingIndicator/index.tsx
@@ -41,6 +41,7 @@ export interface LoadingIndicatorProps
    * @default LoadingIndicatorType.spinner
    */
   type?: LoadingIndicatorType;
+  isInverse?: boolean;
 }
 
 export enum LoadingIndicatorType {

--- a/packages/schema-renderer/src/components/FormTemplate/index.tsx
+++ b/packages/schema-renderer/src/components/FormTemplate/index.tsx
@@ -5,6 +5,7 @@ import {
   ButtonVariant,
   ButtonType,
   Form,
+  ButtonGroup,
 } from 'react-magma-dom';
 
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
@@ -23,7 +24,7 @@ export const FormTemplate = ({
   const { submitting, pristine } = getState();
 
   const actions = (
-    <>
+    <ButtonGroup>
       <Button
         disabled={pristine}
         variant={ButtonVariant.link}
@@ -38,7 +39,7 @@ export const FormTemplate = ({
       >
         {submitLabel || 'Submit'}
       </Button>
-    </>
+    </ButtonGroup>
   );
 
   const actionsVisible = React.useMemo(() => {

--- a/website/react-magma-docs/src/pages/api/accordion.mdx
+++ b/website/react-magma-docs/src/pages/api/accordion.mdx
@@ -115,6 +115,7 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
+  ButtonGroup,
 } from 'react-magma-dom';
 
 export function Example() {
@@ -153,22 +154,24 @@ export function Example() {
 
   return (
     <>
-      <Button
-        disabled={disableExpandAll}
-        onClick={handleExpandAll}
-        size={ButtonSize.small}
-        variant={ButtonVariant.solid}
-      >
-        Expand All
-      </Button>
-      <Button
-        disabled={disableCollapseAll}
-        onClick={handleCollapseAll}
-        size={ButtonSize.small}
-        variant={ButtonVariant.solid}
-      >
-        Collapse All
-      </Button>
+      <ButtonGroup>
+        <Button
+          disabled={disableExpandAll}
+          onClick={handleExpandAll}
+          size={ButtonSize.small}
+          variant={ButtonVariant.solid}
+        >
+          Expand All
+        </Button>
+        <Button
+          disabled={disableCollapseAll}
+          onClick={handleCollapseAll}
+          size={ButtonSize.small}
+          variant={ButtonVariant.solid}
+        >
+          Collapse All
+        </Button>
+      </ButtonGroup>
 
       <Accordion index={expandedIndex} onExpandedChange={handleExpandedChange}>
         <AccordionItem>
@@ -252,7 +255,7 @@ export function Example() {
 }
 ```
 
-## InverseContext
+## Inverse
 
 The `isInverse` prop will render light text, to be used on a dark background. The children will
 inherit the `isInverse` prop unless specified otherwise.
@@ -264,23 +267,26 @@ import {
   AccordionItem,
   AccordionButton,
   AccordionPanel,
-  magma,
+  Card,
+  CardBody
 } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <div style={{background: magma.colors.primary600, padding: '12px'}}>
-      <Accordion isInverse>
-        <AccordionItem>
-          <AccordionButton>Section 1</AccordionButton>
-          <AccordionPanel>Content for section one lorem ipsum</AccordionPanel>
-        </AccordionItem>
-        <AccordionItem>
-          <AccordionButton>Section 2</AccordionButton>
-          <AccordionPanel>Content for section two lorem ipsum</AccordionPanel>
-        </AccordionItem>
-      </Accordion>
-    </div>
+    <Card isInverse>
+      <CardBody>
+        <Accordion isInverse>
+          <AccordionItem>
+            <AccordionButton>Section 1</AccordionButton>
+            <AccordionPanel>Content for section one lorem ipsum</AccordionPanel>
+          </AccordionItem>
+          <AccordionItem>
+            <AccordionButton>Section 2</AccordionButton>
+            <AccordionPanel>Content for section two lorem ipsum</AccordionPanel>
+          </AccordionItem>
+        </Accordion>
+      </CardBody>
+    </Card>
   );
 }
 ```
@@ -288,24 +294,6 @@ export function Example() {
 ## Accordion Props
 
 **Any other props supplied will be provided to the wrapping `div` element.**
-
-## AccordionItem Props
-
-**Any other props supplied will be provided to the wrapping `div` element.**
-
-<AccordionItemProps />
-
-## AccordionButton Props
-
-**Any other props supplied will be provided to the wrapping `button` element.**
-
-<AccordionButtonProps />
-
-## AccordionPanel Props
-
-**Any other props supplied will be provided to the wrapping `div` element.**
-
-<AccordionPanelProps />
 
 ### Controlled
 #### Single Controlled
@@ -324,3 +312,21 @@ export function Example() {
 #### Multiple Not Controlled
 
 <AccordionMultipleProps />
+
+## AccordionItem Props
+
+**Any other props supplied will be provided to the wrapping `div` element.**
+
+<AccordionItemProps />
+
+## AccordionButton Props
+
+**Any other props supplied will be provided to the wrapping `button` element.**
+
+<AccordionButtonProps />
+
+## AccordionPanel Props
+
+**Any other props supplied will be provided to the wrapping `div` element.**
+
+<AccordionPanelProps />

--- a/website/react-magma-docs/src/pages/api/alert.mdx
+++ b/website/react-magma-docs/src/pages/api/alert.mdx
@@ -96,30 +96,30 @@ export function Example() {
 }
 ```
 
-## Testing
+## Inverse
 
-Passing in the `testId` prop will add the `data-testid` attribute to the wrapper element for easier querying in tests.
+```tsx
+import React from 'react';
+import { Alert, AlertVariant, Container } from 'react-magma-dom';
 
-```html noCodeSandbox
-<div data-testid="test-id">
-  <span>
-    <svg
-      aria-hidden="true"
-      class="icon"
-      height="20"
-      width="20"
-      fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 27.3 27.3"
-    >
-      <path
-        d="M12.65,9.9V7.14h2.7V9.9ZM14,25A11,11,0,1,0,3,14,11,11,0,0,0,14,25ZM14,.35A13.65,13.65,0,1,1,.35,14,13.62,13.62,0,0,1,14,.35ZM12.65,20.86V12.65h2.7v8.21Z"
-        transform="translate(-0.35 -0.35)"
-      />
-    </svg>
-  </span>
-  <div>Default Alert</div>
-</div>
+export function Example() {
+  return (
+    <Container isInverse style={{padding: '12px 12px 0'}}>
+      <Alert variant={AlertVariant.info} isInverse>
+        Inverse Info Alert
+      </Alert>
+      <Alert variant={AlertVariant.success} isInverse>
+        Inverse Success Alert
+      </Alert>
+      <Alert variant={AlertVariant.warning} isInverse>
+        Inverse Warning Alert with <a href="#">linked text</a>
+      </Alert>
+      <Alert variant={AlertVariant.danger} isInverse>
+        Inverse Danger Alert
+      </Alert>
+    </Container>
+  );
+}
 ```
 
 ## Alert Props

--- a/website/react-magma-docs/src/pages/api/badge.mdx
+++ b/website/react-magma-docs/src/pages/api/badge.mdx
@@ -29,25 +29,28 @@ The `counter` is for displaying a numeric count, and can be used inside a button
 
 ```tsx
 import React from 'react';
-import { Badge, BadgeColor, BadgeVariant, Button } from 'react-magma-dom';
+import { Badge, BadgeColor, BadgeVariant, Button, ButtonGroup } from 'react-magma-dom';
 
 export function Example() {
   return (
     <>
       <Badge variant={BadgeVariant.label}>Label</Badge>
       <Badge variant={BadgeVariant.counter}>99+</Badge>
-      <Button>
-        Messages
-        <Badge variant={BadgeVariant.counter} color={BadgeColor.light}>
-          99+
-        </Badge>
-      </Button>
-      <Button color={BadgeColor.secondary}>
-        Messages
-        <Badge variant={BadgeVariant.counter} color={BadgeColor.primary}>
-          99+
-        </Badge>
-      </Button>
+      <br/><br/>
+      <ButtonGroup>
+        <Button>
+          Messages
+          <Badge variant={BadgeVariant.counter} color={BadgeColor.light}>
+            99+
+          </Badge>
+        </Button>
+        <Button color={BadgeColor.secondary}>
+          Messages
+          <Badge variant={BadgeVariant.counter} color={BadgeColor.primary}>
+            99+
+          </Badge>
+        </Button>
+      </ButtonGroup>
     </>
   );
 }
@@ -55,7 +58,7 @@ export function Example() {
 
 ## Colors
 
-Five colors of badges are available, `primary`, `secondary`, `success`, `danger`, and `light`. The default color is `secondary`.
+Five colors of badges are available, `primary` (default), `secondary`, `light`, `danger`, and `success`. 
 
 ```tsx
 import React from 'react';
@@ -103,6 +106,24 @@ export function Example() {
         Click me too
       </Badge>
     </>
+  );
+}
+```
+
+## Inverse
+```tsx
+import React from 'react';
+import { Badge, BadgeColor, Container } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Container isInverse style={{padding: '12px'}}>
+      <Badge color={BadgeColor.primary} isInverse>Primary</Badge>
+      <Badge color={BadgeColor.secondary} isInverse>Secondary</Badge>
+      <Badge color={BadgeColor.light} isInverse>Light</Badge>
+      <Badge color={BadgeColor.danger} isInverse>Danger</Badge>
+      <Badge color={BadgeColor.success} isInverse>Success</Badge>
+    </Container>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/banner.mdx
+++ b/website/react-magma-docs/src/pages/api/banner.mdx
@@ -113,6 +113,30 @@ export function Example() {
 }
 ```
 
+## Inverse
+```tsx
+import React from 'react';
+import { Banner, AlertVariant, Container } from 'react-magma-dom';
+
+export function Example() {
+  function handleActionButtonClick() {
+    alert('action button clicked!');
+  }
+  return (
+    <Container isInverse style={{padding: '12px'}}>
+      <Banner actionButtonText="Action"
+      actionButtonOnClick={handleActionButtonClick} isInverse>Default (info) banner</Banner>
+      <Banner variant={AlertVariant.success} actionButtonText="Action"
+      actionButtonOnClick={handleActionButtonClick} isInverse>Success banner</Banner>
+      <Banner variant={AlertVariant.warning} actionButtonText="Action"
+      actionButtonOnClick={handleActionButtonClick} isInverse>Warning banner</Banner>
+      <Banner variant={AlertVariant.danger} actionButtonText="Action"
+      actionButtonOnClick={handleActionButtonClick} isInverse>Danger banner</Banner>
+    </Container>
+  );
+}
+```
+
 ## Banner Props
 
 **This component uses `forwardRef`. The ref is applied to the outer `div` element.**

--- a/website/react-magma-docs/src/pages/api/blockquote.mdx
+++ b/website/react-magma-docs/src/pages/api/blockquote.mdx
@@ -164,19 +164,14 @@ export function Example() {
 }
 ```
 
-## Block Quote Item Props
-
-**Any other props supplied will be provided to the wrapping `div` element.**
-
-<BlockQuoteItemProps />
-
 ## Block Quote Props
 
 **Any other props supplied will be provided to the wrapping `div` element.**
 
 <BlockQuoteProps />
 
+## Block Quote Item Props
 
-# Block Quote Item Props
+**Any other props supplied will be provided to the wrapping `div` element.**
 
 <BlockQuoteItemProps />

--- a/website/react-magma-docs/src/pages/api/button-group.mdx
+++ b/website/react-magma-docs/src/pages/api/button-group.mdx
@@ -138,11 +138,11 @@ The `color`, `variant` and `size` props can be used on the ButtonGroup to set th
 
 ```typescript
 import React from 'react';
-import { ButtonGroup, Button, ButtonColor, ButtonVariant, ButtonSize, magma } from 'react-magma-dom';
+import { ButtonGroup, Button, ButtonColor, ButtonVariant, ButtonSize, Container } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <div style={{background: magma.colors.primary600}}>
+    <Container isInverse style={{padding: '12px'}}>
       <ButtonGroup color={ButtonColor.primary} variant={ButtonVariant.solid} size={ButtonSize.large} isInverse>
         <Button>1</Button>
         <Button color={ButtonColor.danger}>2</Button>
@@ -150,7 +150,7 @@ export function Example() {
         <Button>4</Button>
         <Button variant={ButtonVariant.link}>5</Button>
       </ButtonGroup>
-    </div>
+    </Container>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/button.mdx
+++ b/website/react-magma-docs/src/pages/api/button.mdx
@@ -354,7 +354,7 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the button element for easier querying in tests.
 
 ```html noCodeSandbox
-<Button data-testid="test-id">Default</Button>
+<Button testId="test-id">Default</Button>
 ```
 
 ## Button Props

--- a/website/react-magma-docs/src/pages/api/button.mdx
+++ b/website/react-magma-docs/src/pages/api/button.mdx
@@ -58,7 +58,7 @@ export function Example() {
 
 Variants for buttons include `solid` and `link`, with `solid` being the default value.
 
-The `marketing` buttons do not have a `link` variant, and will render as solid buttons.
+The `marketing` buttons can only use the `solid` variant.
 
 ```tsx
 import React from 'react';
@@ -204,7 +204,7 @@ import { Button, ButtonTextTransform, ButtonGroup } from 'react-magma-dom';
 export function Example() {
   return (
     <ButtonGroup>
-      <Button>All caps</Button>
+      <Button>All caps (default)</Button>
       <Button textTransform={ButtonTextTransform.none}>
         No Text Transform
       </Button>
@@ -246,12 +246,12 @@ import { Button, ButtonVariant, ButtonGroup } from 'react-magma-dom';
 export function Example() {
   return (
     <ButtonGroup>
-      <Button disabled>Disabled</Button>
+      <Button disabled>Disabled (default)</Button>
       <Button disabled variant={ButtonVariant.solid}>
-        Disabled
+        Disabled Solid
       </Button>
       <Button disabled variant={ButtonVariant.link}>
-        Disabled
+        Disabled Link
       </Button>
     </ButtonGroup>
   );

--- a/website/react-magma-docs/src/pages/api/checkboxes.mdx
+++ b/website/react-magma-docs/src/pages/api/checkboxes.mdx
@@ -450,35 +450,12 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the input element for easier querying in tests.
 
 ```html noCodeSandbox
-<div>
-  <input
-    id="checkbox0"
-    data-testid="test-id"
-    type="checkbox"
-    value=""
-    checked=""
+  <Checkbox
+    defaultChecked={true}
+    id="customId"
+    labelText="Checkbox"
+    testId="checkbox-id"
   />
-  <label for="checkbox0">
-    <span>
-      <span color="" class="css-1on1hey e1amet8c3"></span>
-      <svg
-        aria-hidden="true"
-        class="icon"
-        height="12"
-        width="12"
-        fill="currentColor"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 29.37 21.88"
-      >
-        <path
-          d="M26.71,3.06,11.89,17.88,4.4,10.4.87,13.93l11,11L30.24,6.59Z"
-          transform="translate(-0.87 -3.06)"
-        ></path>
-      </svg>
-    </span>
-    Checkbox Label
-  </label>
-</div>
 ```
 
 ## Checkbox Props

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -418,68 +418,6 @@ export function Example() {
 }
 ```
 
-## Inverse
-
-The isInverse prop is an optional boolean, that used when the component is to be displayed on a dark background.
-
-```tsx
-import React from 'react';
-import { Card, CardBody, Combobox } from 'react-magma-dom';
-
-export function Example() {
-  const [selectedItem, updateSelectedItem] = React.useState('');
-
-  function onSelectedItemChange(changes) {
-    updateSelectedItem(changes.selectedItem);
-  }
-
-  const [selectedItems, updateSelectedItems] = React.useState([]);
-
-  function handleSelectedItemsChange(changes) {
-    updateSelectedItems(changes.selectedItems);
-  }
-
-  function handleRemoveSelectedItem(removedItem) {
-    updateSelectedItems(selectedItems.filter(item => item !== removedItem));
-  }
-
-  return (
-    <Card isInverse>
-      <CardBody>
-        <Combobox
-          id="comboboxInverseId"
-          isInverse
-          labelText="Combobox"
-          defaultItems={[
-            { label: 'Red', value: 'red' },
-            { label: 'Blue', value: 'blue' },
-            { label: 'Green', value: 'green' },
-          ]}
-        />
-
-        <Combobox
-          errorMessage="Please correct this error"
-          isMulti
-          id="comboboxMultiInverseId"
-          isInverse
-          labelText="Multi combobox"
-          defaultItems={[
-            { label: 'Red', value: 'red' },
-            { label: 'Blue', value: 'blue' },
-            { label: 'Green', value: 'green' },
-          ]}
-          initialSelectedItems={[
-            { label: 'Red', value: 'red' },
-            { label: 'Blue', value: 'blue' },
-            { label: 'Green', value: 'green' },
-          ]}
-        />
-      </CardBody>
-    </Card>
-  );
-}
-```
-
 ## Accessibility
 
 The `getA11yStatusMessage` prop is a passed in function that allows for customization of the screen-reader accessible message whenever the following props
@@ -745,6 +683,8 @@ export function Example() {
 ```
 
 ## Inverse
+
+The isInverse prop is an optional boolean used when the component is to be displayed on a dark background.
 
 ```tsx
 import React from 'react';

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -1519,7 +1519,7 @@ export function Example() {
 
 ```typescript
 import React from 'react';
-import { Datagrid, Button, usePagination } from 'react-magma-dom';
+import { Datagrid, Button, usePagination, ButtonGroup, Spacer, SpacerAxis, magma } from 'react-magma-dom';
 
 export function Example() {
   const columns = [
@@ -1728,15 +1728,18 @@ export function Example() {
         }}
       >
         You are on page {page}
-        <Button
-          disabled={previousButton.disabled}
-          onClick={previousButton.onClick}
-        >
-          Previous Page
-        </Button>
-        <Button disabled={nextButton.disabled} onClick={nextButton.onClick}>
-          Next Page
-        </Button>
+        <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing05} />
+        <ButtonGroup>
+          <Button
+            disabled={previousButton.disabled}
+            onClick={previousButton.onClick}
+          >
+            Previous Page
+          </Button>
+          <Button disabled={nextButton.disabled} onClick={nextButton.onClick}>
+            Next Page
+          </Button>
+        </ButtonGroup>
       </div>
     );
   };
@@ -1949,7 +1952,7 @@ export function Example() {
 }
 ```
 
-## InverseContext
+## Inverse
 
 The `isInverse` prop will render a dark background and light text. The children will
 inherit the `isInverse` prop unless specified otherwise.

--- a/website/react-magma-docs/src/pages/api/date-pickers.mdx
+++ b/website/react-magma-docs/src/pages/api/date-pickers.mdx
@@ -114,12 +114,14 @@ export function Example() {
 
 ```tsx
 import React from 'react';
-import { DatePicker, Card, magma } from 'react-magma-dom';
+import { DatePicker, Card, CardBody, magma } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <Card background={magma.colors.primary}>
-      <DatePicker isInverse />
+    <Card isInverse>
+      <CardBody>
+        <DatePicker isInverse />
+      </CardBody>
     </Card>
   );
 }

--- a/website/react-magma-docs/src/pages/api/drawer.mdx
+++ b/website/react-magma-docs/src/pages/api/drawer.mdx
@@ -11,7 +11,7 @@ A container with a transition
 
 ## Basic Usage
 
-Drawer accepts a position (top, right, bottom, or left.)
+Drawer accepts a position (top, right, bottom, or left)
 
 ```typescript
 import React from 'react';
@@ -38,6 +38,39 @@ export function Example() {
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
     </>
+  );
+}
+```
+
+## Inverse
+```typescript
+import React from 'react';
+import { Button, Drawer, VisuallyHidden, Card, CardBody } from 'react-magma-dom';
+
+export function Example() {
+  const [showDrawer, setShowDrawer] = React.useState(false);
+
+  return (
+    <Card isInverse>
+      <CardBody>
+        <Drawer
+          header="Drawer Title"
+          onClose={() => setShowDrawer(false)}
+          isOpen={showDrawer}
+          position="right"
+          isInverse
+        >
+          <p>This is a Drawer, doing Drawer things.</p>
+          <p>
+            <Button isInverse>This is a button</Button>
+          </p>
+        </Drawer>
+        <Button onClick={() => setShowDrawer(true)} isInverse>
+          Show Drawer
+          <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
+        </Button>
+      </CardBody>
+    </Card>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -539,8 +539,9 @@ export function Example() {
       <Dropdown>
         <DropdownSplitButton
           size={ButtonSize.large}
-          variant="outline"
+          variant={ButtonVariant.solid}
           color={ButtonColor.danger}
+          aria-label={'Custom Button Example'}
         >
           Extra Props Split
         </DropdownSplitButton>
@@ -749,6 +750,35 @@ export function Example() {
         <DropdownMenuItem>Menu item number two</DropdownMenuItem>
       </DropdownContent>
     </Dropdown>
+  );
+}
+```
+
+## Inverse
+```tsx
+import React from 'react';
+import {
+  Dropdown,
+  DropdownButton,
+  DropdownContent,
+  DropdownMenuItem,
+  Card,
+  CardBody
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card isInverse>
+      <CardBody>
+        <Dropdown isInverse>
+          <DropdownButton>Basic Dropdown</DropdownButton>
+          <DropdownContent>
+            <DropdownMenuItem>Menu item one</DropdownMenuItem>
+            <DropdownMenuItem>Menu item two</DropdownMenuItem>
+          </DropdownContent>
+        </Dropdown>
+      </CardBody>
+    </Card>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/dropzone.mdx
+++ b/website/react-magma-docs/src/pages/api/dropzone.mdx
@@ -9,6 +9,12 @@ title: Dropzone
 
 Upload files
 
+<Alert variant="warning">
+  <strong>Important!</strong> Dropzone is imported from{' '}
+  <inlineCode>@react-magma/dropzone</inlineCode>{' '}
+  which must be installed as a peer dependency.
+</Alert>
+
 ## Basic Usage
 
 ```typescript
@@ -87,7 +93,7 @@ then switched to true when needed.
 ```typescript
 import React from 'react';
 import { Dropzone } from '@react-magma/dropzone';
-import { Button } from 'react-magma-dom';
+import { Button, Spacer } from 'react-magma-dom';
 
 export function Example() {
   const [file, setFile] = React.useState<string>();
@@ -131,6 +137,7 @@ export function Example() {
         onSendFile={onSendFile}
         sendFiles={sendFiles}
       />
+      <Spacer size={12} />
       <Button disabled={sendFiles} onClick={() => setSendFiles(true)}>
         Upload files
       </Button>

--- a/website/react-magma-docs/src/pages/api/form-field-wrapper.mdx
+++ b/website/react-magma-docs/src/pages/api/form-field-wrapper.mdx
@@ -20,7 +20,22 @@ export function Example() {
 }
 ```
 
-## InverseContext
+## Example
+
+```typescript
+import React from 'react';
+import { FormFieldContainer, Input } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <FormFieldContainer helperMessage={"Helper message"} labelText="FormFieldContainer Label">
+      <Input />
+    </FormFieldContainer>
+  );
+}
+```
+
+## Inverse
 
 The `isInverse` prop will render a dark background and light text. The children will
 inherit the `isInverse` prop unless specified otherwise.
@@ -38,32 +53,6 @@ export function Example() {
         </FormFieldContainer>
       </CardBody>
     </Card>
-  );
-}
-```
-
-## Internationalization
-
-If you're using strings in your component, they must be internationalized.
-
-Full example of <Link to="/api/internationalization">internationalization override options</Link>
-
-```tsx
-import React from 'react';
-import { FormFieldContainer, I18nContext, defaultI18n } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <I18nContext.Provider
-      value={{
-        ...defaultI18n,
-        example: 'example i18n',
-      }}
-    >
-      <FormFieldContainer fieldId="">
-        override default i18n value:{' '}
-      </FormFieldContainer>
-    </I18nContext.Provider>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/form.mdx
+++ b/website/react-magma-docs/src/pages/api/form.mdx
@@ -7,7 +7,7 @@ props:
 
 <DocsHeading type="api">Form</DocsHeading>
 
-The `Form` component is a relatively simple container. It is used to contain interactive controls and sublit information to a web server.
+The `Form` component is a relatively simple container. It is used to contain interactive controls and submit information to a web server.
 
 ## Basic Usage
 
@@ -16,10 +16,11 @@ import React from 'react';
 import {
   Button,
   ButtonType,
+  ButtonColor,
+  ButtonGroup,
   Form,
   Input,
   Spacer,
-  SpacerAxis,
 } from 'react-magma-dom';
 
 export function Example() {
@@ -30,14 +31,69 @@ export function Example() {
       description="Some Form Description"
       errorMessage="Some Form Error"
       actions={
-        <div>
-          <Spacer size="24" axis={SpacerAxis.vertical} />
+        <ButtonGroup>
+          <Button color={ButtonColor.secondary}>Cancel</Button>
           <Button type={ButtonType.submit}>Submit</Button>
-        </div>
+        </ButtonGroup>
       }
     >
-      <Input labelText="some input" />
+     <>
+        <Input labelText="Name" />
+        <Spacer size="12" />
+        <Input labelText="Email" />
+        <Spacer size="24" />
+      </>
     </Form>
+  );
+}
+```
+
+## Inverse
+
+```typescript
+import React from 'react';
+import {
+  Button,
+  ButtonType,
+  ButtonColor,
+  ButtonGroup,
+  Form,
+  Input,
+  Spacer,
+  Card,
+  CardBody,
+  TypographyVisualStyle,
+  TypographyContextVariant,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card isInverse>
+      <CardBody>
+        <Form
+          onSubmit={() => alert('form submitted')}
+          header="Form Heading"
+          description="Some Form Description"
+          errorMessage="Some Form Error"
+          headingVisualStyle={TypographyVisualStyle.headingLarge}
+          headingContextVariant={TypographyContextVariant.expressive}
+          isInverse
+          actions={
+            <ButtonGroup>
+              <Button color={ButtonColor.secondary}>Cancel</Button>
+              <Button type={ButtonType.submit}>Submit</Button>
+            </ButtonGroup>
+          }
+        >
+          <>
+            <Input labelText="Name" />
+            <Spacer size="12" />
+            <Input labelText="Email" />
+            <Spacer size="24" />
+          </>
+        </Form>
+      </CardBody>
+    </Card>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/formgroup.mdx
+++ b/website/react-magma-docs/src/pages/api/formgroup.mdx
@@ -126,6 +126,27 @@ export function Example() {
 }
 ```
 
+## Inverse
+
+```tsx
+import React from 'react';
+import { FormGroup, Checkbox, Toggle, Card, CardBody } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card isInverse>
+      <CardBody>
+        <FormGroup labelText="Choose one or more colors" isInverse>
+          <Checkbox labelText="Red" isInverse />
+          <Checkbox labelText="Blue" isInverse />
+          <Checkbox labelText="Purple" isInverse />
+        </FormGroup>
+      </CardBody>
+    </Card>
+  );
+}
+```
+
 ## Form Group Props
 
 **This component uses `forwardRef`. The ref is applied to the Form Group `div` element.**

--- a/website/react-magma-docs/src/pages/api/heading.mdx
+++ b/website/react-magma-docs/src/pages/api/heading.mdx
@@ -267,7 +267,7 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the heading element for easier querying in tests.
 
 ```html noCodeSandbox
-<Heading data-testid="test-id">Heading 1</Heading>
+<Heading testId="test-id">Heading 1</Heading>
 ```
 
 ## Heading Props

--- a/website/react-magma-docs/src/pages/api/heading.mdx
+++ b/website/react-magma-docs/src/pages/api/heading.mdx
@@ -267,7 +267,7 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the heading element for easier querying in tests.
 
 ```html noCodeSandbox
-<h1 data-testid="test-id">Heading 1</h1>
+<Heading data-testid="test-id">Heading 1</Heading>
 ```
 
 ## Heading Props

--- a/website/react-magma-docs/src/pages/api/hyperlink.mdx
+++ b/website/react-magma-docs/src/pages/api/hyperlink.mdx
@@ -46,7 +46,7 @@ Sometimes links can be styled as buttons in order to give them more weight on th
 
 ```tsx
 import React from 'react';
-import { ButtonColor, ButtonTextTransform, Hyperlink } from 'react-magma-dom';
+import { ButtonColor, ButtonTextTransform, Hyperlink, Spacer, SpacerAxis } from 'react-magma-dom';
 
 export function Example() {
   return (
@@ -59,14 +59,17 @@ export function Example() {
       >
         Google
       </Hyperlink>
+      <Spacer size="8" axis={SpacerAxis.horizontal} />
       <Hyperlink
         color={ButtonColor.secondary}
+        textTransform={ButtonTextTransform.none}
         styledAs="Button"
         target="_blank"
         to="https://www.google.com"
       >
         Google
       </Hyperlink>
+      <Spacer size="8" axis={SpacerAxis.horizontal} />
       <Hyperlink
         color={ButtonColor.danger}
         styledAs="Button"
@@ -75,6 +78,7 @@ export function Example() {
       >
         Google
       </Hyperlink>
+      <Spacer size="8" axis={SpacerAxis.horizontal} />
       <Hyperlink
         color={ButtonColor.marketing}
         styledAs="Button"

--- a/website/react-magma-docs/src/pages/api/icon-button.mdx
+++ b/website/react-magma-docs/src/pages/api/icon-button.mdx
@@ -395,7 +395,7 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the button element for easier querying in tests.
 
 ```html noCodeSandbox
-<IconButton data-testid="test-id" aria-label="Test">
+<IconButton testId="test-id" aria-label="Test">
   <svg
     aria-hidden="true"
     class="icon"

--- a/website/react-magma-docs/src/pages/api/icon-button.mdx
+++ b/website/react-magma-docs/src/pages/api/icon-button.mdx
@@ -303,6 +303,41 @@ export function Example() {
 }
 ```
 
+## Inverse
+```tsx
+import React from 'react';
+import { IconButton, ButtonVariant, ButtonColor, ButtonGroup } from 'react-magma-dom';
+import {
+  AlertIcon,
+  NotificationsIcon,
+  Card,
+  CardBody,
+} from 'react-magma-icons';
+
+export function Example() {
+  return (
+    <Card isInverse>
+      <CardBody>
+        <ButtonGroup>
+          <IconButton
+            aria-label="Alert"
+            variant={ButtonVariant.solid}
+            icon={<AlertIcon />}
+            isInverse
+          />
+          <IconButton
+            aria-label="Notifications"
+            variant={ButtonVariant.solid}
+            icon={<NotificationsIcon />}
+            isInverse
+          />
+        </ButtonGroup>
+      </CardBody>
+    </Card>
+  );
+}
+```
+
 ## Event Handling
 
 The `onClick` event will fire when the button is clicked, or when the enter or spacebar key is pressed.

--- a/website/react-magma-docs/src/pages/api/icon.mdx
+++ b/website/react-magma-docs/src/pages/api/icon.mdx
@@ -143,21 +143,7 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the svg element for easier querying in tests.
 
 ```html noCodeSandbox
-<svg
-  aria-hidden="true"
-  data-testid="test-id"
-  class="icon"
-  height="24"
-  width="24"
-  fill="currentColor"
-  xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 25.63 25.63"
->
-  <path
-    d="M15.26,10.15V7.56H12.74v2.59Zm0,10.29v-7.7H12.74v7.7ZM14,1.18A12.82,12.82,0,1,1,1.18,14,12.79,12.79,0,0,1,14,1.18Z"
-    transform="translate(-1.18 -1.18)"
-  ></path>
-</svg>
+<CheckIcon testId="check-icon-id" title="Check Icon" />
 ```
 
 ## Icon Props

--- a/website/react-magma-docs/src/pages/api/indeterminate.mdx
+++ b/website/react-magma-docs/src/pages/api/indeterminate.mdx
@@ -82,6 +82,31 @@ export function Example() {
 }
 ```
 
+## Inverse
+```tsx
+import React from 'react';
+import {
+  IndeterminateCheckbox,
+  IndeterminateCheckboxStatus,
+  Card,
+  CardBody,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card isInverse>
+      <CardBody>
+        <IndeterminateCheckbox
+          status={IndeterminateCheckboxStatus.indeterminate}
+          labelText="Colors"
+          isInverse
+        />
+      </CardBody>
+    </Card>
+  );
+}
+```
+
 ## Indeterminate Checkbox Props
 
 **Any other props supplied will be provided to the `Checkbox` Component, except for the `checked` prop.**

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -465,7 +465,7 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the input element for easier querying in tests.
 
 ```html noCodeSandbox
-  <Input labelText="Label" data-testid="test-id"/>
+  <Input labelText="Label" testId="test-id"/>
 ```
 
 ## Input Props

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -146,7 +146,7 @@ While React Magma provides the error styling, it is up to the consumer app to ha
 
 ```tsx
 import React from 'react';
-import { Input, Button } from 'react-magma-dom';
+import { Input, Button, ButtonGroup, Spacer } from 'react-magma-dom';
 export function Example() {
   const [hasError, setHasError] = React.useState(false);
   const [nameValue, setNameValue] = React.useState('');
@@ -174,10 +174,13 @@ export function Example() {
         required
         value={nameValue}
       />
-      <Button onClick={submit}>Submit</Button>
-      <Button onClick={reset} color="secondary">
-        Reset
-      </Button>
+      <Spacer size="12" />
+      <ButtonGroup>
+        <Button onClick={submit}>Submit</Button>
+        <Button onClick={reset} color="secondary">
+          Reset
+        </Button>
+      </ButtonGroup>
     </>
   );
 }
@@ -415,14 +418,14 @@ Using React's `forwardRef` feature you can gain access to the reference of the i
 
 ```tsx
 import React from 'react';
-import { Button, Input } from 'react-magma-dom';
+import { Button, Input, Spacer } from 'react-magma-dom';
 export function Example() {
   const inputRef = React.useRef();
 
   return (
     <div>
       <Input ref={inputRef} labelText="Input to be focused" />
-
+      <Spacer size="12" />
       <Button
         onClick={() => {
           inputRef.current.focus();
@@ -462,18 +465,7 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the input element for easier querying in tests.
 
 ```html noCodeSandbox
-<div>
-  <label for="input1">Label</label>
-  <div>
-    <input
-      id="input1"
-      data-testid="test-id"
-      placeholder="This is a placeholder"
-      type="text"
-      value="Default Value"
-    />
-  </div>
-</div>
+  <Input labelText="Label" data-testid="test-id"/>
 ```
 
 ## Input Props

--- a/website/react-magma-docs/src/pages/api/line-chart.mdx
+++ b/website/react-magma-docs/src/pages/api/line-chart.mdx
@@ -5,9 +5,13 @@ title: LineChart
 
 <DocsHeading type="api">LineChart</DocsHeading>
 
-## Basic Usage
+<Alert variant="warning">
+  <strong>Important!</strong> LineChart is imported from{' '}
+  <inlineCode>@react-magma/charts</inlineCode>{' '}
+  which must be installed as a peer dependency.
+</Alert>
 
-LineChart is imported from a separate `@react-magma/charts` package.
+## Basic Usage
 
 These charts use the [victory](https://formidable.com/open-source/victory/docs/victory-chart/) library components to build each piece of the chart. To override the `props` passed to any given `victory` component, pass them in through the `componentProps` prop with the component name as the object key.
 

--- a/website/react-magma-docs/src/pages/api/list.mdx
+++ b/website/react-magma-docs/src/pages/api/list.mdx
@@ -216,7 +216,7 @@ export function Example() {
 }
 ```
 
-## InverseContext
+## Inverse
 
 The `isInverse` prop will render a dark background and light text. The children will
 inherit the `isInverse` prop unless specified otherwise.

--- a/website/react-magma-docs/src/pages/api/loading-indicator.mdx
+++ b/website/react-magma-docs/src/pages/api/loading-indicator.mdx
@@ -141,6 +141,22 @@ export function Example() {
 }
 ```
 
+## Inverse
+
+```tsx
+import React from 'react';
+import { LoadingIndicator, Card, CardBody } from 'react-magma-dom';
+export function Example() {
+  return (
+    <Card isInverse>
+      <CardBody>
+        <LoadingIndicator isInverse />
+      </CardBody>
+    </Card>
+  );
+}
+```
+
 ## Loading Indicator Props
 
 **All of the [global HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes) can be provided as props will be applied to the internal element. The internal element will be either a `div` when using the `ProgressBar` or a `span` when using the `Spinner`. Additionally, depending on which component is used internally, you can provide any props that the <Link to="/api/spinner#spinner_props">Spinner</Link> or the <Link to="/api/progress-bar#progress_bar_props">ProgressBar</Link> accepts. This is controlled by the passed in `type` prop.**

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -233,7 +233,7 @@ export function Example() {
 ## isInverse
 ```tsx
 import React from 'react';
-import { Button, Hyperlink, Modal, VisuallyHidden } from 'react-magma-dom';
+import { Button, Hyperlink, Modal, VisuallyHidden, Card, CardBody } from 'react-magma-dom';
 export function Example() {
   const [showModal, setShowModal] = React.useState(false);
 
@@ -257,12 +257,14 @@ export function Example() {
           modal
         </p>
       </Modal>
-      <div style={{background: magma.colors.primary600, padding: '12px'}}>
-        <Button onClick={() => setShowModal(true)} isInverse>
-          Show Modal
-          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
-        </Button>
-      </div>
+      <Card isInverse>
+        <CardBody>
+          <Button onClick={() => setShowModal(true)} isInverse>
+            Show Modal
+            <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+          </Button>
+        </CardBody>
+      </Card>
     </>
   );
 }

--- a/website/react-magma-docs/src/pages/api/radio.mdx
+++ b/website/react-magma-docs/src/pages/api/radio.mdx
@@ -508,21 +508,10 @@ export function Example() {
 Passing in the `testId` prop will add the `data-testid` attribute to the wrapper element for `RadioGroup` and the input element for `Radio` for easier querying in tests.
 
 ```html noCodeSandbox
-<div aria-labelledby="basicGroup" data-testid="group-test=id" role="radiogroup">
-  <label id="basicGroup">Basic usage</label>
-  <div>
-    <input
-      id="radio1"
-      data-testid="radio-test-id"
-      name="basic"
-      type="radio"
-      value="1"
-    />
-    <label for="radio1">
-      <span> <span color=""></span> </span> Option one label
-    </label>
-  </div>
-</div>
+<RadioGroup labelText="Labelled by label" name="labelledByProp" testId="radiogroup-id">
+  <Radio value="1" labelText="Label" testId="radio-1" />
+  <Radio value="2" labelText="Label" testId="radio-2" />
+</RadioGroup>
 ```
 
 ## Radio Group Props

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -101,7 +101,7 @@ export function Example() {
 
 ## Table With Border
 
-The `hasOuterBorder ` prop is a boolean which gives the table an outer border. By default the border is off.
+The `hasOuterBorder` prop is a boolean which gives the table an outer border. By default the border is off.
 
 ```tsx
 import React from 'react';

--- a/website/react-magma-docs/src/pages/api/tabs.mdx
+++ b/website/react-magma-docs/src/pages/api/tabs.mdx
@@ -880,21 +880,25 @@ export function Example() {
 
 ```tsx
 import React from 'react';
-import { TabsContainer, Tabs, Tab, magma } from 'react-magma-dom';
+import { TabsContainer, Tabs, Tab, Card, CardBody, magma } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <TabsContainer>
-      <Tabs
-        aria-label="Sample Inverse Colors On Dark Background Tabs"
-        isInverse
-        backgroundColor={magma.colors.neutral800}
-      >
-        <Tab>First item</Tab>
-        <Tab>Second item</Tab>
-        <Tab>Third item</Tab>
-      </Tabs>
-    </TabsContainer>
+    <Card style={{background: magma.colors.neutral800}}>
+      <CardBody>
+        <TabsContainer>
+          <Tabs
+            aria-label="Sample Inverse Colors On Dark Background Tabs"
+            isInverse
+            backgroundColor={magma.colors.neutral800}
+          >
+            <Tab>First item</Tab>
+            <Tab>Second item</Tab>
+            <Tab>Third item</Tab>
+          </Tabs>
+        </TabsContainer>
+      </CardBody>
+    </Card>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/tag.mdx
+++ b/website/react-magma-docs/src/pages/api/tag.mdx
@@ -27,6 +27,27 @@ export function Example() {
 }
 ```
 
+## Colors
+
+```tsx
+import React from 'react';
+import { Spacer, SpacerAxis, Tag, magma } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <Tag>Default</Tag>
+      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
+      <Tag color="primary">Primary</Tag>
+      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
+      <Tag color="lowContrast">Low Contrast</Tag>
+      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
+      <Tag color="highContrast">High Contrast</Tag>
+    </>
+  );
+}
+```
+
 ## Tag With Icon
 
 ```typescript
@@ -163,27 +184,6 @@ export function Example() {
           Show Tags Again
         </Button>
       )}
-    </>
-  );
-}
-```
-
-## Colors
-
-```tsx
-import React from 'react';
-import { Spacer, SpacerAxis, Tag, magma } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <>
-      <Tag>Default</Tag>
-      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
-      <Tag color="primary">Primary</Tag>
-      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
-      <Tag color="lowContrast">Low Contrast</Tag>
-      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
-      <Tag color="highContrast">High Contrast</Tag>
     </>
   );
 }

--- a/website/react-magma-docs/src/pages/api/theme.mdx
+++ b/website/react-magma-docs/src/pages/api/theme.mdx
@@ -27,6 +27,7 @@ import {
   ThemeContext,
   magma,
   ButtonGroup,
+  Spacer,
 } from 'react-magma-dom';
 
 const magmaDark = Object.assign({}, magma, {
@@ -93,6 +94,7 @@ export function Example() {
           },
         ]}
       />
+      <Spacer size="24" />
       <ThemeContext.Provider value={theme}>
         <DemoComponent />
       </ThemeContext.Provider>

--- a/website/react-magma-docs/src/pages/api/toast.mdx
+++ b/website/react-magma-docs/src/pages/api/toast.mdx
@@ -590,25 +590,7 @@ export function Example() {
 Passing in the `testId` prop will pass the `testId` to the internal `Alert` element.
 
 ```html noCodeSandbox
-<div data-testid="test-id">
-  <span>
-    <svg
-      aria-hidden="true"
-      class="icon"
-      height="20"
-      width="20"
-      fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 27.3 27.3"
-    >
-      <path
-        d="M12.65,9.9V7.14h2.7V9.9ZM14,25A11,11,0,1,0,3,14,11,11,0,0,0,14,25ZM14,.35A13.65,13.65,0,1,1,.35,14,13.62,13.62,0,0,1,14,.35ZM12.65,20.86V12.65h2.7v8.21Z"
-        transform="translate(-0.35 -0.35)"
-      ></path>
-    </svg>
-  </span>
-  <div>Quick Toast</div>
-</div>
+ <Toast testId="toast-id" onDismiss={() => {}}>This is a toast</Toast>
 ```
 
 ## ToastsContainer Props

--- a/website/react-magma-docs/src/pages/api/toast.mdx
+++ b/website/react-magma-docs/src/pages/api/toast.mdx
@@ -48,32 +48,116 @@ Variants for toasts include `info`, `success`, `warning`, and `danger`, with `in
 
 **It is strongly recommended that `warning` and `danger` toasts do not auto-dismiss**, so that users have time to process the information in them.
 
-### Info
-
 ```tsx
 import React from 'react';
-import { Button, Toast, AlertVariant } from 'react-magma-dom';
+import {
+  Announce,
+  Button,
+  ButtonColor,
+  ButtonGroup,
+  Card,
+  Toast,
+  ToastsContainer,
+  AlertVariant,
+  Spacer,
+} from 'react-magma-dom';
 
 export function Example() {
   const [showToast, setShowToast] = React.useState(false);
+  const [showToast2, setShowToast2] = React.useState(false);
+  const [showToast3, setShowToast3] = React.useState(false);
+  const [showToast4, setShowToast4] = React.useState(false);
 
   function handleClick() {
     setShowToast(true);
   }
-
   function handleDismiss() {
     setShowToast(false);
   }
 
+  function handleClick2() {
+    setShowToast2(true);
+  }
+  function handleDismiss2() {
+    setShowToast2(false);
+  }
+
+  function handleClick3() {
+    setShowToast3(true);
+  }
+  function handleDismiss3() {
+    setShowToast3(false);
+  }
+
+  function handleClick4() {
+    setShowToast4(true);
+  }
+  function handleDismiss4() {
+    setShowToast4(false);
+  }
+
   return (
-    <>
-      <Button onClick={handleClick}>Show Success Toast</Button>
-      {showToast ? (
-        <Toast onDismiss={handleDismiss} variant={AlertVariant.success}>
-          Success Toast
-        </Toast>
-      ) : null}
-    </>
+      <ToastsContainer>
+        <Announce>
+          <ButtonGroup>
+            <Button onClick={handleClick}>
+              Show Success Toast
+            </Button>
+            {showToast && (
+              <Toast
+                id="toast1"
+                onDismiss={handleDismiss}
+                variant={AlertVariant.success}
+              >
+                This is a success toast
+              </Toast>
+            )}
+
+            <Button onClick={handleClick2}>
+              Show Warning Toast
+            </Button>
+            {showToast2 && (
+              <Toast
+                id="toast2"
+                variant={AlertVariant.warning}
+                onDismiss={handleDismiss2}
+                disableAutoDismiss
+              >
+                This is is a warning toast
+              </Toast>
+            )}
+            </ButtonGroup>
+            <br />
+            <ButtonGroup>
+            <Button onClick={handleClick3}>
+              Show Danger Toast
+            </Button>
+            {showToast3 && (
+              <Toast
+                id="toast3"
+                variant={AlertVariant.danger}
+                onDismiss={handleDismiss3}
+                disableAutoDismiss
+              >
+                This is a danger toast
+              </Toast>
+            )}
+
+              <Button onClick={handleClick4}>
+                Show Info Toast
+              </Button>
+              {showToast4 && (
+                <Toast
+                  id="toast4"
+                  variant={AlertVariant.info}
+                  onDismiss={handleDismiss4}
+                >
+                  This is an info toast
+                </Toast>
+            )}
+          </ButtonGroup>
+        </Announce>
+      </ToastsContainer>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/toggle.mdx
+++ b/website/react-magma-docs/src/pages/api/toggle.mdx
@@ -156,35 +156,30 @@ export function Example() {
 }
 ```
 
+## Inverse
+
+```tsx
+import React from 'react';
+import { Toggle, Card, CardBody } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card isInverse>
+      <CardBody>
+        <Toggle isInverse labelText="Inverse toggle" />
+        <Toggle isInverse disabled checked labelText="Inverse disabled" />
+      </CardBody>
+    </Card>
+  );
+}
+```
+
 ## Testing
 
 Passing in the `testId` prop will add the `data-testid` attribute to the input element for easier querying in tests.
 
 ```html noCodeSandbox
-<div>
-  <input id="Toggle0" data-testid="test-id" name="" type="checkbox" value="" />
-  <label for="Toggle0">
-    <span>Toggle Label</span>
-    <span>
-      <span>
-        <svg
-          aria-hidden="true"
-          class="icon"
-          height="11"
-          width="11"
-          fill="currentColor"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 29.37 21.88"
-        >
-          <path
-            d="M26.71,3.06,11.89,17.88,4.4,10.4.87,13.93l11,11L30.24,6.59Z"
-            transform="translate(-0.87 -3.06)"
-          ></path>
-        </svg>
-      </span>
-    </span>
-  </label>
-</div>
+<Toggle labelText="Toggle label" testId="toggle-testid" />
 ```
 
 ## Toggle Props

--- a/website/react-magma-docs/src/pages/api/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/api/tooltip.mdx
@@ -213,17 +213,18 @@ The values of some style properties are set in the Magma theme.
 
 ```js noCodeSandbox
     tooltip: {
-        arrowSize: '6px',
-        backgroundColor: magma.colors.neutral,
-        fontWeight: 600,
-        maxWidth: '300px',
-        textColor: magma.colors.neutral100,
-        typeScale: magma.typeScale.size01,
-        zIndex: 999,
-        inverse: { backgroundColor:
-        magma.colors.neutral100,
-        textColor: magma.colors.neutral,
-      }
+      arrowSize: '4px',
+      arrowSizeDoubled: '8px',
+      backgroundColor: colors.neutral700,
+      fontWeight: 500,
+      maxWidth: '300px',
+      textColor: colors.neutral100,
+      typeScale: typeScale.size01,
+      zIndex: 999,
+      inverse: {
+        backgroundColor: colors.neutral100,
+        textColor: colors.neutral700,
+      },
     }
 ```
 
@@ -248,7 +249,7 @@ export function Example() {
     tooltip: Object.assign({}, magma.tooltip, {
       arrowSize: '10px',
       arrowSizeDoubled: '20px',
-      backgroundColor: magma.colors.primary,
+      backgroundColor: magma.colors.danger,
       fontWeight: 'normal',
       typeScale: magma.typeScale.size03,
     }),

--- a/website/react-magma-docs/src/pages/design/button.mdx
+++ b/website/react-magma-docs/src/pages/design/button.mdx
@@ -42,7 +42,7 @@ Text buttons are typically used for less important actions.
 
 Outlined buttons are used for more emphasis than text buttons due to the stroke.
 
-<Button color="secondary" variant="outline">
+<Button color="secondary" variant="solid">
   Outlined Button
 </Button>
 


### PR DESCRIPTION
Went through all the docs and did a clean up. Some highlights:

- Ensured all components documented the `isInverse` prop examples
- Confirmed all documented `props` had examples
- Removed references to `outline` buttons (which no longer exist)
- Wrapped certain examples with `ButtonGroup`
