### PR TITLE
fix(nativeselect): add background color to the options for `isInverse`

### DIFF
--- a/.changeset/native-select-windows.md
+++ b/.changeset/native-select-windows.md
@@ -1,5 +1,5 @@
 ---
-"react-magma-dom": patch
+"react-magma-dom": major
 ---
 
 fix(nativeSelect): Add background color to the options for `isInverse`. In Windows, the Native Select dropdown has a white background which makes the options invisible. 

--- a/.changeset/native-select-windows.md
+++ b/.changeset/native-select-windows.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix(nativeSelect): Add background color to the options for `isInverse`. In Windows, the Native Select dropdown has a white background which makes the options invisible. 

--- a/packages/react-magma-dom/src/components/Banner/Banner.stories.tsx
+++ b/packages/react-magma-dom/src/components/Banner/Banner.stories.tsx
@@ -24,7 +24,7 @@ const Template: Story<BannerProps> = args => (
       </Hyperlink>
     </Banner>
     <Banner {...args} variant={AlertVariant.warning}>
-      Default (waning) banner with&nbsp;
+      Default (warning) banner with&nbsp;
       <Hyperlink to="#" isInverse={args.isInverse}>
         hyperlink
       </Hyperlink>
@@ -61,7 +61,7 @@ const Template: Story<BannerProps> = args => (
       variant={AlertVariant.warning}
       {...args}
     >
-      Dismissible (waning) banner
+      Dismissible (warning) banner
     </Banner>
     <Banner
       isDismissible

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -11,6 +11,7 @@ import { SelectTriggerButton } from '../Select/SelectTriggerButton';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { useIsInverse } from '../../inverse';
 import { useGenerateId } from '../../utils';
+import { ThemeInterface } from '../../theme/magma';
 
 /**
  * @children required
@@ -24,9 +25,16 @@ export interface NativeSelectProps
   testId?: string;
   optionLabel?: string;
 }
-const StyledNativeSelect = styled.select`
+const StyledNativeSelect = styled.select<{
+  theme: ThemeInterface;
+  isInverse?: boolean;
+}>`
   ${inputBaseStyles};
   background: inherit;
+  > option {
+    background: ${props =>
+      props.isInverse ? props.theme.colors.neutral600 : 'none'};
+  }
 `;
 
 export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(


### PR DESCRIPTION
fix #831 

**Tested with BrowserStack:**

Windows > Chrome:
![nativeSelect_windows](https://user-images.githubusercontent.com/91160746/179790031-32dc54b2-9b6d-4d06-9be9-925b0f9c8637.gif)

Windows > Firefox:
![image](https://user-images.githubusercontent.com/91160746/179795022-12350767-ee6f-4dea-9f04-12872b15c34e.png)

Windows > Opera:
![image](https://user-images.githubusercontent.com/91160746/179796707-0be30d1d-3f7a-4812-bb84-c44f9558d1be.png)
