### PR TITLE
fix(datepicker): update spacing around buttons

### DIFF
--- a/.changeset/datepicker-button-spacing.md
+++ b/.changeset/datepicker-button-spacing.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": major
+---
+
+feat(datepicker): Update spacing around buttons

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
@@ -101,6 +101,7 @@ export const CalendarHeader = React.forwardRef<
           type={ButtonType.button}
           variant={ButtonVariant.link}
           onClick={onPrevMonthClick}
+          style={{ margin: '6px' }}
         />
       </CalendarIconButton>
       <CalendarIconButton next>
@@ -114,6 +115,7 @@ export const CalendarHeader = React.forwardRef<
           type={ButtonType.button}
           variant={ButtonVariant.link}
           onClick={onNextMonthClick}
+          style={{ margin: '6px' }}
         />
       </CalendarIconButton>
     </CalendarHeaderContainer>

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -61,6 +61,7 @@ const Th = styled.th<{ isInverse?: boolean }>`
 `;
 
 const HelperButton = styled.span<{ theme?: any }>`
+  margin: ${props => props.theme.spaceScale.spacing02};
   top: ${props => props.theme.spaceScale.spacing01};
   position: absolute;
   left: ${props => props.theme.spaceScale.spacing01};
@@ -72,6 +73,7 @@ const CloseButton = styled.span<{ theme?: any }>`
   right: ${props => props.theme.spaceScale.spacing01};
   top: ${props => props.theme.spaceScale.spacing01};
   z-index: 1;
+  margin: ${props => props.theme.spaceScale.spacing02};
 `;
 
 export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
@@ -112,7 +112,7 @@ export const HelperInformation: React.FunctionComponent<
           icon={<CloseIcon />}
           isInverse={isInverse}
           size={ButtonSize.medium}
-          style={{ left: '16px' }}
+          style={{ left: '16px', margin: '4px' }}
           type={ButtonType.button}
           onClick={props.onClose}
           variant={ButtonVariant.link}


### PR DESCRIPTION
While we were going over bugs, I noticed that the buttons in DatePicker were missing margin (since we removed that from Buttons):
![image](https://user-images.githubusercontent.com/91160746/179809084-36dd2e99-47c1-4c42-9813-9e7b6666f35e.png)
![image](https://user-images.githubusercontent.com/91160746/179809194-e6104073-2814-4f24-b354-0a64d796032f.png)

This is to add that spacing back:
![image](https://user-images.githubusercontent.com/91160746/179809228-2509a91e-423a-4f7f-b7a5-6129425e65c8.png)
![image](https://user-images.githubusercontent.com/91160746/179809256-c70fc52a-324c-411f-adcf-af9fe25a6c20.png)

