### PR TITLE
feat(datagrid): Add `isSortableBySelected` prop to DataGrid, allowing tables to be sorted by the selected items.

### DIFF
--- a/.changeset/datagrid_sortable.md
+++ b/.changeset/datagrid_sortable.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+feat(datagrid): Add `isSortableBySelected` prop to DataGrid, allowing tables to be sorted by the selected items.

--- a/.changeset/datagrid_sortable.md
+++ b/.changeset/datagrid_sortable.md
@@ -1,5 +1,5 @@
 ---
-'react-magma-dom': patch
+'react-magma-dom': minor
 ---
 
 feat(datagrid): Add `isSortableBySelected` prop to DataGrid, allowing tables to be sorted by the selected items.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,14 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@react-magma/charts": "0.0.4",
+    "@react-magma/dropzone": "0.1.5",
+    "react-magma-dom": "2.5.14",
+    "@react-magma/schema-renderer": "0.0.12",
+    "@cengage-patterns/header": "2.0.12",
+    "react-magma-docs": "2.2.16",
+    "react-magma-landing": "1.0.10"
+  },
+  "changesets": []
+}

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Datagrid } from '.';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { DatagridProps } from './Datagrid';
-import { TablePaginationProps, TableRowColor } from '../Table';
+import {
+  TablePaginationProps,
+  TableRowColor,
+  TableSortDirection,
+} from '../Table';
 import { usePagination } from '../Pagination/usePagination';
 import { Button } from '../Button';
 
@@ -188,22 +192,23 @@ const Template: Story<Omit<DatagridProps, 'selectedRows'>> = args => (
   <Datagrid {...args}>Sample Text</Datagrid>
 );
 
-const ControlledTemplate: Story<Omit<DatagridProps, 'defaultSelectedRows'>> =
-  args => {
-    const [selectedRows, updatedSelectedRows] = React.useState<
-      (string | number)[]
-    >([1]);
+const ControlledTemplate: Story<
+  Omit<DatagridProps, 'defaultSelectedRows'>
+> = args => {
+  const [selectedRows, updatedSelectedRows] = React.useState<
+    (string | number)[]
+  >([1]);
 
-    return (
-      <Datagrid
-        {...args}
-        selectedRows={selectedRows}
-        onSelectedRowsChange={updatedSelectedRows}
-      >
-        Sample Text
-      </Datagrid>
-    );
-  };
+  return (
+    <Datagrid
+      {...args}
+      selectedRows={selectedRows}
+      onSelectedRowsChange={updatedSelectedRows}
+    >
+      Sample Text
+    </Datagrid>
+  );
+};
 
 const ControlledPaginatedTemplate: Story<DatagridProps> = ({
   paginationProps,
@@ -290,6 +295,7 @@ const defaultArgs = {
   hasVerticalBorders: false,
   hasZebraStripes: false,
   isSelectable: false,
+  isSortableBySelected: false,
   paginationProps: {},
 };
 
@@ -303,7 +309,110 @@ ColoredRows.args = {
 };
 
 export const Selectable = Template.bind({});
-Selectable.args = { ...defaultArgs, isSelectable: true };
+Selectable.args = {
+  ...defaultArgs,
+  isSelectable: true,
+};
+
+export const SelectableAndSortable: Story<DatagridProps> = ({
+  paginationProps,
+  ...args
+}) => {
+  const requestSort = key => {
+    let direction = TableSortDirection.ascending;
+    if (
+      sortConfig &&
+      sortConfig.key === key &&
+      sortConfig.direction === TableSortDirection.ascending
+    ) {
+      direction = TableSortDirection.descending;
+    }
+    const message = `Table is sorted by ${key}, ${direction}`;
+    setSortConfig({ key, direction, message });
+  };
+
+  const productColumns = [
+    { field: 'name', header: 'Name' },
+    { field: 'price', header: 'Price' },
+    { field: 'stock', header: 'Stock' },
+  ];
+  const products = [
+    { id: 1, name: 'Cheese', price: 5, stock: 20 },
+    { id: 2, name: 'Milk', price: 5, stock: 32 },
+    { id: 3, name: 'Yogurt', price: 3, stock: 12 },
+    { id: 4, name: 'Heavy Cream', price: 10, stock: 9 },
+    { id: 5, name: 'Butter', price: 2, stock: 99 },
+    { id: 6, name: 'Sour Cream ', price: 4, stock: 86 },
+  ];
+
+  const [sortConfig, setSortConfig] = React.useState({
+    key: '',
+    direction: TableSortDirection.none,
+    message: '',
+  });
+
+  const [selectedItems, setSelectedItems] = React.useState([]);
+
+  const sortedItems = React.useMemo(() => {
+    let sortableItems = [...products];
+
+    if (sortConfig !== null) {
+      sortableItems.sort((a, b) => {
+        if (a[sortConfig.key] < b[sortConfig.key]) {
+          return sortConfig.direction === TableSortDirection.ascending ? -1 : 1;
+        }
+        if (a[sortConfig.key] > b[sortConfig.key]) {
+          return sortConfig.direction === TableSortDirection.ascending ? 1 : -1;
+        }
+        return 0;
+      });
+    }
+    // console.log('sortableItems', sortableItems);
+    return sortableItems;
+  }, [products, sortConfig]);
+
+  function handleSelectedItems(
+    id: string | number,
+    ev: React.ChangeEvent<HTMLInputElement>
+  ) {
+    if (ev.target.checked) {
+      if (!selectedItems.includes(id)) {
+        setSelectedItems([...selectedItems, id]);
+      }
+    } else if (!ev.target.checked) {
+      setSelectedItems(selectedItems.filter(i => i !== id));
+    }
+  }
+
+  function handleHeaderSelect(ev: React.ChangeEvent<HTMLInputElement>) {
+    if (ev.target.checked) {
+      const checkedIds = [];
+      products.filter(prod => checkedIds.push(prod.id));
+      setSelectedItems(checkedIds);
+    } else {
+      setSelectedItems([]);
+    }
+  }
+
+  return (
+    <Datagrid
+      {...args}
+      rows={sortedItems}
+      columns={productColumns}
+      onSortBySelected={() => {
+        requestSort('selectable');
+      }}
+      onRowSelect={handleSelectedItems}
+      onHeaderSelect={handleHeaderSelect}
+      sortDirection={sortConfig.direction}
+    />
+  );
+};
+
+SelectableAndSortable.args = {
+  isSelectable: true,
+  isSortableBySelected: true,
+};
 
 export const ControlledSelectable = ControlledTemplate.bind({});
 ControlledSelectable.args = {
@@ -352,40 +461,41 @@ WithoutPagination.args = {
   hasPagination: false,
 };
 
-const CustomPaginationComponent: React.FunctionComponent<TablePaginationProps> =
-  props => {
-    const { itemCount, rowsPerPage, onPageChange } = props;
-    const { page, pageButtons } = usePagination({
-      count: itemCount / rowsPerPage,
-      numberOfAdjacentPages: 0,
-      numberOfEdgePages: 0,
-      onPageChange,
-    });
+const CustomPaginationComponent: React.FunctionComponent<
+  TablePaginationProps
+> = props => {
+  const { itemCount, rowsPerPage, onPageChange } = props;
+  const { page, pageButtons } = usePagination({
+    count: itemCount / rowsPerPage,
+    numberOfAdjacentPages: 0,
+    numberOfEdgePages: 0,
+    onPageChange,
+  });
 
-    const previousButton = pageButtons[0];
-    const nextButton = pageButtons[pageButtons.length - 1];
+  const previousButton = pageButtons[0];
+  const nextButton = pageButtons[pageButtons.length - 1];
 
-    return (
-      <div
-        style={{
-          alignItems: 'center',
-          display: 'flex',
-          justifyContent: 'flex-end',
-        }}
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        display: 'flex',
+        justifyContent: 'flex-end',
+      }}
+    >
+      You are on page {page}
+      <Button
+        disabled={previousButton.disabled}
+        onClick={previousButton.onClick}
       >
-        You are on page {page}
-        <Button
-          disabled={previousButton.disabled}
-          onClick={previousButton.onClick}
-        >
-          Previous Page
-        </Button>
-        <Button disabled={nextButton.disabled} onClick={nextButton.onClick}>
-          Next Page
-        </Button>
-      </div>
-    );
-  };
+        Previous Page
+      </Button>
+      <Button disabled={nextButton.disabled} onClick={nextButton.onClick}>
+        Next Page
+      </Button>
+    </div>
+  );
+};
 
 export const PaginationWithCustomComponent = Template.bind({});
 PaginationWithCustomComponent.args = {

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Datagrid } from '.';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { DatagridProps } from './Datagrid';
@@ -323,7 +323,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
     direction: TableSortDirection.none,
     message: '',
   });
-  
+
   const requestSort = (key: string) => {
     let direction = TableSortDirection.ascending;
     if (
@@ -388,7 +388,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
     }
   }, [sortConfig]);
 
-  function handleSelectedItems(
+  function handleRowSelect(
     id: string | number,
     ev: React.ChangeEvent<HTMLInputElement>
   ) {
@@ -419,7 +419,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
       onSortBySelected={() => {
         requestSort('name');
       }}
-      onRowSelect={handleSelectedItems}
+      onRowSelect={handleRowSelect}
       onHeaderSelect={handleHeaderSelect}
       sortDirection={sortConfig.direction}
     />

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -318,6 +318,12 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
   paginationProps,
   ...args
 }) => {
+  const [sortConfig, setSortConfig] = React.useState({
+    key: '',
+    direction: TableSortDirection.none,
+    message: '',
+  });
+  
   const requestSort = (key: string) => {
     let direction = TableSortDirection.ascending;
     if (
@@ -344,12 +350,6 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
     { id: 5, name: 'Butter', price: 2, stock: 99 },
     { id: 6, name: 'Sour Cream ', price: 4, stock: 86 },
   ];
-
-  const [sortConfig, setSortConfig] = React.useState({
-    key: '',
-    direction: TableSortDirection.none,
-    message: '',
-  });
 
   const [selectedItems, setSelectedItems] = React.useState([]);
 
@@ -402,7 +402,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
   }
 
   function handleHeaderSelect(ev: React.ChangeEvent<HTMLInputElement>) {
-    if (ev.target.checked) {
+    if (ev.target.checked && selectedItems.length === 0) {
       const checkedIds = [];
       products.filter(prod => checkedIds.push(prod.id));
       setSelectedItems(checkedIds);

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -318,7 +318,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
   paginationProps,
   ...args
 }) => {
-  const requestSort = key => {
+  const requestSort = (key: string) => {
     let direction = TableSortDirection.ascending;
     if (
       sortConfig &&
@@ -354,22 +354,39 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
   const [selectedItems, setSelectedItems] = React.useState([]);
 
   const sortedItems = React.useMemo(() => {
-    let sortableItems = [...products];
+    const selectedItemsToSort = products.filter(product =>
+      selectedItems.includes(product.id)
+    );
+    const nonSelectedItems = products.filter(
+      product => !selectedItems.includes(product.id)
+    );
 
+    let sortOrder = 0;
     if (sortConfig !== null) {
-      sortableItems.sort((a, b) => {
+      if (selectedItemsToSort.length < 2) {
+        sortOrder =
+          sortConfig.direction === TableSortDirection.ascending ? -1 : 1;
+      }
+      selectedItemsToSort.sort((a, b) => {
         if (a[sortConfig.key] < b[sortConfig.key]) {
-          return sortConfig.direction === TableSortDirection.ascending ? -1 : 1;
+          sortOrder =
+            sortConfig.direction === TableSortDirection.ascending ? -1 : 1;
         }
         if (a[sortConfig.key] > b[sortConfig.key]) {
-          return sortConfig.direction === TableSortDirection.ascending ? 1 : -1;
+          sortOrder =
+            sortConfig.direction === TableSortDirection.ascending ? 1 : -1;
         }
-        return 0;
+        return sortOrder;
       });
     }
-    // console.log('sortableItems', sortableItems);
-    return sortableItems;
-  }, [products, sortConfig]);
+    if (selectedItemsToSort.length === 0) {
+      return products;
+    } else if (sortOrder === 1) {
+      return selectedItemsToSort.concat(nonSelectedItems);
+    } else {
+      return nonSelectedItems.concat(selectedItemsToSort);
+    }
+  }, [sortConfig]);
 
   function handleSelectedItems(
     id: string | number,
@@ -400,7 +417,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
       rows={sortedItems}
       columns={productColumns}
       onSortBySelected={() => {
-        requestSort('selectable');
+        requestSort('name');
       }}
       onRowSelect={handleSelectedItems}
       onHeaderSelect={handleHeaderSelect}

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -583,6 +583,88 @@ describe('Datagrid', () => {
     });
   });
 
+  describe('selectable AND sortable', () => {
+    it('should allow for selectable rows', () => {
+      const { container } = render(
+        <Datagrid
+          columns={columns}
+          rows={rows}
+          isSelectable
+          isSortableBySelected
+        />
+      );
+
+      const selectableRowCheckbox = container
+        .querySelector('tbody')
+        .firstChild.querySelector('input');
+
+      expect(selectableRowCheckbox).toBeInTheDocument();
+    });
+
+    it('should call passed in onHeaderSelect function when header checkbox is clicked', () => {
+      const onHeaderSelect = jest.fn();
+      const { container } = render(
+        <Datagrid
+          columns={columns}
+          rows={rows}
+          isSelectable
+          isSortableBySelected
+          onHeaderSelect={onHeaderSelect}
+        />
+      );
+
+      const headerCheckbox = container
+        .querySelector('thead')
+        .firstChild.querySelector('input');
+
+      headerCheckbox.click();
+
+      expect(onHeaderSelect).toHaveBeenCalled();
+    });
+
+    it('should call passed in onRowSelect function with the row id when a row checkbox is clicked', () => {
+      const onRowSelect = jest.fn();
+      const { container } = render(
+        <Datagrid
+          columns={columns}
+          rows={rows}
+          isSelectable
+          isSortableBySelected
+          onRowSelect={onRowSelect}
+        />
+      );
+
+      const selectableRowCheckbox = container
+        .querySelector('tbody')
+        .firstChild.querySelector('input');
+
+      selectableRowCheckbox.click();
+
+      expect(onRowSelect).toHaveBeenCalledWith(rows[0].id, expect.any(Object));
+    });
+
+    it('should call handleRowSort when the sort button is clicked', () => {
+      const onSortBySelected = jest.fn();
+      const onSelectedRowsChange = jest.fn();
+      const { getByTestId } = render(
+        <Datagrid
+          columns={columns}
+          rows={[rows[0]]}
+          isSelectable
+          isSortableBySelected
+          selectedRows={[rows[0].id]}
+          onSelectedRowsChange={onSelectedRowsChange}
+          onSortBySelected={onSortBySelected}
+        />
+      );
+
+      const sortButton = getByTestId('-sort-button');
+      sortButton.click();
+
+      expect(onSortBySelected).toHaveBeenCalled();
+    });
+  });
+
   describe('pagination', () => {
     it('should render pagination controls', () => {
       const pagination = {

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -14,6 +14,7 @@ import {
   TableHeaderCellProps,
   TableRowColor,
   TablePaginationProps,
+  TableSortDirection,
 } from '../Table';
 import { defaultComponents } from './components';
 
@@ -110,6 +111,12 @@ export interface BaseDatagridProps extends TableProps {
    * Pagination data used to create the pagination footer. Created using the usePagination hook.
    */
   paginationProps?: Partial<TablePaginationProps>;
+  onSortBySelected?: () => void;
+  /**
+   * Direction by which the column is sorted
+   * @default TableSortDirection.none
+   */
+  sortDirection?: TableSortDirection;
 }
 
 export interface ControlledSelectedRowsProps {
@@ -147,6 +154,8 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       rows,
       selectedRows: selectedRowsProp,
       hasPagination = true,
+      onSortBySelected,
+      sortDirection,
       ...other
     } = props;
     const [rowsToShow, setRowsToShow] = React.useState<DatagridRow[]>([]);
@@ -228,6 +237,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
     }
 
     function handleHeaderSelect(event: React.ChangeEvent<HTMLInputElement>) {
+      // console.log('handleHeaderSelect clicked');
       if (
         headerRowStatus === IndeterminateCheckboxStatus.indeterminate ||
         headerRowStatus === IndeterminateCheckboxStatus.checked
@@ -252,6 +262,13 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       }
     }
 
+    function handleRowSort() {
+      onSortBySelected &&
+        typeof onSortBySelected === 'function' &&
+        onSortBySelected();
+      // console.log('handleRowSort');
+    }
+
     return (
       <>
         <Table {...other} ref={ref}>
@@ -259,6 +276,8 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
             <TableRow
               headerRowStatus={headerRowStatus}
               onHeaderRowSelect={handleHeaderSelect}
+              onSort={handleRowSort}
+              sortDirection={sortDirection}
             >
               {columns.map(({ field, header, ...other }) => (
                 <TableHeaderCell

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -111,6 +111,9 @@ export interface BaseDatagridProps extends TableProps {
    * Pagination data used to create the pagination footer. Created using the usePagination hook.
    */
   paginationProps?: Partial<TablePaginationProps>;
+  /**
+   * Function called when the sort button is clicked for selectable tables
+   */
   onSortBySelected?: () => void;
   /**
    * Direction by which the column is sorted

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -186,6 +186,10 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       setRowsToShow(hasPagination ? getPageItems(currentPage) : rows);
     }, [currentPage, rowsPerPage]);
 
+    React.useEffect(() => {
+      setRowsToShow(rows);
+    }, [rows]);
+
     const { Pagination } = defaultComponents({
       ...customComponents,
     });
@@ -237,7 +241,6 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
     }
 
     function handleHeaderSelect(event: React.ChangeEvent<HTMLInputElement>) {
-      // console.log('handleHeaderSelect clicked');
       if (
         headerRowStatus === IndeterminateCheckboxStatus.indeterminate ||
         headerRowStatus === IndeterminateCheckboxStatus.checked
@@ -266,7 +269,6 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       onSortBySelected &&
         typeof onSortBySelected === 'function' &&
         onSortBySelected();
-      // console.log('handleRowSort');
     }
 
     return (

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -475,7 +475,7 @@ export const RowColorsInverse = () => {
   );
 };
 
-export const Sortable = () => {
+export const Sortable = args => {
   const products = [
     { id: 1, name: 'Cheese', price: 5, stock: 20 },
     { id: 2, name: 'Milk', price: 5, stock: 32 },

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -26,9 +26,12 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
   hasZebraStripes?: boolean;
   isInverse?: boolean;
   /**
-   * @internal
+   * @internal - used within DataGrid
    */
   isSelectable?: boolean;
+  /**
+   * @internal - used within DataGrid
+   */
   isSortableBySelected?: boolean;
   /**
    * Minimum width for the table in pixels

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -29,6 +29,7 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    * @internal
    */
   isSelectable?: boolean;
+  isSortableBySelected?: boolean;
   /**
    * Minimum width for the table in pixels
    * @default 600
@@ -75,6 +76,7 @@ interface TableContextInterface {
   isSelectable?: boolean;
   rowCount?: number;
   selectedItems?: Array<number>;
+  isSortableBySelected?: boolean;
 }
 
 export const TableContext = React.createContext<TableContextInterface>({
@@ -84,6 +86,7 @@ export const TableContext = React.createContext<TableContextInterface>({
   hasVerticalBorders: false,
   isInverse: false,
   isSelectable: false,
+  isSortableBySelected: false,
   rowCount: 0,
   selectedItems: [],
 });
@@ -119,6 +122,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       rowCount,
       selectedItems,
       testId,
+      isSortableBySelected,
       ...other
     } = props;
 
@@ -135,6 +139,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           hasVerticalBorders,
           isInverse: isInverse,
           isSelectable,
+          isSortableBySelected,
         }}
       >
         <TableContainer>

--- a/packages/react-magma-dom/src/components/Table/TableRow.test.js
+++ b/packages/react-magma-dom/src/components/Table/TableRow.test.js
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Table, TableBody, TableCell, TableRow, TableRowColor } from '.';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TableRowColor,
+  TableSortDirection,
+  TableHeaderCell,
+} from '.';
 import { render } from '@testing-library/react';
 import { magma } from '../../theme/magma';
 
@@ -106,6 +115,90 @@ describe('Table Row', () => {
         'color',
         magma.colors.neutral08
       );
+    });
+  });
+
+  describe('sortable', () => {
+    it('should call onSort function when icon is clicked', () => {
+      const testId = 'sortable-test-id';
+      const onSortSpy = jest.fn();
+      const { getByTestId } = render(
+        <Table isSelectable isSortableBySelected>
+          <TableHead>
+            <TableRow
+              testId={testId}
+              sortDirection={TableSortDirection.none}
+              onSort={onSortSpy}
+            >
+              <TableHeaderCell>heading 1</TableHeaderCell>
+              <TableHeaderCell>heading 2</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+        </Table>
+      );
+
+      const sortButton = getByTestId('sortable-test-id-sort-button');
+      sortButton.click();
+      expect(onSortSpy).toHaveBeenCalled();
+    });
+
+    describe('should display the correct sort direction icon', () => {
+      it('should show ascending', () => {
+        const sortTestId = 'sort-ascending';
+        const onSortFunc = jest.fn();
+        const { getByTestId } = render(
+          <Table isSelectable isSortableBySelected>
+            <TableHead>
+              <TableRow
+                sortDirection={TableSortDirection.ascending}
+                onSort={onSortFunc}
+              >
+                <TableHeaderCell>heading 1</TableHeaderCell>
+                <TableHeaderCell>heading 2</TableHeaderCell>
+              </TableRow>
+            </TableHead>
+          </Table>
+        );
+        expect(getByTestId(sortTestId)).toBeInTheDocument();
+      });
+
+      it('should show descending', () => {
+        const sortTestId = 'sort-descending';
+        const onSortFunc = jest.fn();
+        const { getByTestId } = render(
+          <Table isSelectable isSortableBySelected>
+            <TableHead>
+              <TableRow
+                sortDirection={TableSortDirection.descending}
+                onSort={onSortFunc}
+              >
+                <TableHeaderCell>heading 1</TableHeaderCell>
+                <TableHeaderCell>heading 2</TableHeaderCell>
+              </TableRow>
+            </TableHead>
+          </Table>
+        );
+        expect(getByTestId(sortTestId)).toBeInTheDocument();
+      });
+
+      it('should show double arrow', () => {
+        const sortTestId = 'sort-none';
+        const onSortFunc = jest.fn();
+        const { getByTestId } = render(
+          <Table isSelectable isSortableBySelected>
+            <TableHead>
+              <TableRow
+                sortDirection={TableSortDirection.none}
+                onSort={onSortFunc}
+              >
+                <TableHeaderCell>heading 1</TableHeaderCell>
+                <TableHeaderCell>heading 2</TableHeaderCell>
+              </TableRow>
+            </TableHead>
+          </Table>
+        );
+        expect(getByTestId(sortTestId)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -217,9 +217,25 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
 
     const SortIcon =
       sortDirection === TableSortDirection.ascending ? (
-        <SouthIcon size={theme.iconSizes.small} />
+        <SouthIcon
+          color={
+            tableContext.isInverse
+              ? theme.colors.neutral06
+              : theme.colors.neutral04
+          }
+          size={theme.iconSizes.small}
+          testId="sort-ascending"
+        />
       ) : sortDirection === TableSortDirection.descending ? (
-        <NorthIcon size={theme.iconSizes.small} />
+        <NorthIcon
+          color={
+            tableContext.isInverse
+              ? theme.colors.neutral06
+              : theme.colors.neutral04
+          }
+          size={theme.iconSizes.small}
+          testId="sort-descending"
+        />
       ) : (
         <SortDoubleArrowIcon
           color={
@@ -228,6 +244,7 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
               : theme.colors.neutral04
           }
           size={theme.iconSizes.small}
+          testId="sort-none"
         />
       );
 
@@ -264,6 +281,7 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
                   theme={theme}
                   onMouseEnter={handleMouseEnter}
                   onMouseLeave={handleMouseLeave}
+                  data-testid={`${testId || ''}-sort-button`}
                 >
                   <SortIconWrapper theme={theme}>{SortIcon}</SortIconWrapper>
                 </SortButton>

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -213,7 +213,6 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
 
     function handleSort() {
       onSort && typeof onSort === 'function' && onSort();
-      console.log('sort button clicked');
     }
 
     const SortIcon =
@@ -243,29 +242,32 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
         theme={theme}
       >
         {tableContext.isSelectable && isHeaderRow && (
-          <TableHeaderCell width={theme.spaceScale.spacing05} style={{background: isHovering ? theme.colors.neutral06 : ''}}>
-            <span style={{display: 'flex', flexDirection: 'row'}}>
-            <IndeterminateCheckbox
-              status={headerRowStatus}
-              isInverse={getIsCheckboxInverse()}
-              labelStyle={{ padding: 0 }}
-              labelText="Select all rows"
-              isTextVisuallyHidden
-              onChange={onHeaderRowSelect}
-            />
-            {tableContext.isSortableBySelected && (
-              <SortButton
-                density={tableContext.density}
-                isInverse={tableContext.isInverse}
-                onClick={handleSort}
-                textAlign={TableCellAlign.left}
-                theme={theme}
-                onMouseEnter={handleMouseEnter}
-                onMouseLeave={handleMouseLeave}
-              >
-                <SortIconWrapper theme={theme}>{SortIcon}</SortIconWrapper>
-              </SortButton>
-            )}
+          <TableHeaderCell
+            width={theme.spaceScale.spacing05}
+            style={{ background: isHovering ? theme.colors.neutral06 : '' }}
+          >
+            <span style={{ display: 'flex', flexDirection: 'row' }}>
+              <IndeterminateCheckbox
+                status={headerRowStatus}
+                isInverse={getIsCheckboxInverse()}
+                labelStyle={{ padding: 0 }}
+                labelText="Select all rows"
+                isTextVisuallyHidden
+                onChange={onHeaderRowSelect}
+              />
+              {tableContext.isSortableBySelected && (
+                <SortButton
+                  density={tableContext.density}
+                  isInverse={tableContext.isInverse}
+                  onClick={handleSort}
+                  textAlign={TableCellAlign.left}
+                  theme={theme}
+                  onMouseEnter={handleMouseEnter}
+                  onMouseLeave={handleMouseLeave}
+                >
+                  <SortIconWrapper theme={theme}>{SortIcon}</SortIconWrapper>
+                </SortButton>
+              )}
             </span>
           </TableHeaderCell>
         )}

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -1,13 +1,22 @@
 import * as React from 'react';
 import styled from '../../theme/styled';
 import { css } from '@emotion/core';
-import { TableContext, TableRowColor, TableCell, TableHeaderCell } from './';
+import {
+  TableContext,
+  TableRowColor,
+  TableCell,
+  TableHeaderCell,
+  TableCellAlign,
+  TableDensity,
+  TableSortDirection,
+} from './';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { Checkbox } from '../Checkbox';
 import {
   IndeterminateCheckbox,
   IndeterminateCheckboxStatus,
 } from '../IndeterminateCheckbox';
+import { NorthIcon, SortDoubleArrowIcon, SouthIcon } from 'react-magma-icons';
 
 /**
  * @children required
@@ -21,6 +30,15 @@ export interface TableRowProps
   headerRowStatus?: IndeterminateCheckboxStatus;
   isSelected?: boolean;
   isSelectableDisabled?: boolean;
+  /**
+   * Direction by which the column is sorted
+   * @default TableSortDirection.none
+   */
+  sortDirection?: TableSortDirection;
+  /**
+   * Event that fires when clicking the table header cell sort button
+   */
+  onSort?: () => void;
   onHeaderRowSelect?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onTableRowSelect?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   rowIndex?: number;
@@ -104,6 +122,47 @@ const StyledTableRow = styled.tr<{
     `};
 `;
 
+const SortButton = styled.button<{
+  density?: TableDensity;
+  isInverse?: boolean;
+  textAlign?: TableCellAlign;
+}>`
+  align-items: flex-end;
+  background: none;
+  border: 0;
+  color: inherit;
+  margin: 0;
+  text-align: left;
+  width: 100%;
+  flex: 1 1 auto;
+
+  &:focus {
+    outline: 2px dotted
+      ${props =>
+        props.isInverse
+          ? props.theme.colors.focusInverse
+          : props.theme.colors.focus};
+    outline-offset: -2px;
+  }
+
+  &:hover,
+  &:focus {
+    cursor: pointer;
+
+    svg {
+      fill: ${props =>
+        props.isInverse
+          ? props.theme.colors.neutral08
+          : props.theme.colors.neutral};
+    }
+  }
+`;
+
+const SortIconWrapper = styled.span`
+  position: relative;
+  top: ${props => props.theme.spaceScale.spacing01};
+`;
+
 export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
   (props, ref) => {
     const {
@@ -111,9 +170,11 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
       headerRowStatus,
       isSelected,
       isSelectableDisabled,
+      sortDirection,
       onHeaderRowSelect,
       onTableRowSelect,
       rowIndex,
+      onSort,
       testId,
       ...other
     } = props;
@@ -140,6 +201,37 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
       return tableContext.isInverse;
     }
 
+    const [isHovering, setIsHovering] = React.useState(false);
+
+    const handleMouseEnter = () => {
+      if (tableContext.isSortableBySelected) setIsHovering(true);
+    };
+
+    const handleMouseLeave = () => {
+      if (tableContext.isSortableBySelected) setIsHovering(false);
+    };
+
+    function handleSort() {
+      onSort && typeof onSort === 'function' && onSort();
+      console.log('sort button clicked');
+    }
+
+    const SortIcon =
+      sortDirection === TableSortDirection.ascending ? (
+        <SouthIcon size={theme.iconSizes.small} />
+      ) : sortDirection === TableSortDirection.descending ? (
+        <NorthIcon size={theme.iconSizes.small} />
+      ) : (
+        <SortDoubleArrowIcon
+          color={
+            tableContext.isInverse
+              ? theme.colors.neutral06
+              : theme.colors.neutral04
+          }
+          size={theme.iconSizes.small}
+        />
+      );
+
     return (
       <StyledTableRow
         {...other}
@@ -151,7 +243,8 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
         theme={theme}
       >
         {tableContext.isSelectable && isHeaderRow && (
-          <TableHeaderCell width={theme.spaceScale.spacing05}>
+          <TableHeaderCell width={theme.spaceScale.spacing05} style={{background: isHovering ? theme.colors.neutral06 : ''}}>
+            <span style={{display: 'flex', flexDirection: 'row'}}>
             <IndeterminateCheckbox
               status={headerRowStatus}
               isInverse={getIsCheckboxInverse()}
@@ -160,6 +253,20 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
               isTextVisuallyHidden
               onChange={onHeaderRowSelect}
             />
+            {tableContext.isSortableBySelected && (
+              <SortButton
+                density={tableContext.density}
+                isInverse={tableContext.isInverse}
+                onClick={handleSort}
+                textAlign={TableCellAlign.left}
+                theme={theme}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+              >
+                <SortIconWrapper theme={theme}>{SortIcon}</SortIconWrapper>
+              </SortButton>
+            )}
+            </span>
           </TableHeaderCell>
         )}
         {tableContext.isSelectable && !isHeaderRow && (

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -665,6 +665,126 @@ export function Example() {
 }
 ```
 
+## Selectable and Sortable
+
+```typescript
+import React from 'react';
+import { Datagrid, TableSortDirection } from 'react-magma-dom';
+
+export function Example() {
+
+  const [sortConfig, setSortConfig] = React.useState({
+    key: '',
+    direction: TableSortDirection.none,
+    message: '',
+  });
+
+  const requestSort = (key: string) => {
+    let direction = TableSortDirection.ascending;
+    if (
+      sortConfig &&
+      sortConfig.key === key &&
+      sortConfig.direction === TableSortDirection.ascending
+    ) {
+      direction = TableSortDirection.descending;
+    }
+    const message = `Table is sorted by ${key}, ${direction}`;
+    setSortConfig({ key, direction, message });
+  };
+
+  const productColumns = [
+    { field: 'name', header: 'Name' },
+    { field: 'price', header: 'Price' },
+    { field: 'stock', header: 'Stock' },
+  ];
+  const products = [
+    { id: 1, name: 'Cheese', price: 5, stock: 20 },
+    { id: 2, name: 'Milk', price: 5, stock: 32 },
+    { id: 3, name: 'Yogurt', price: 3, stock: 12 },
+    { id: 4, name: 'Heavy Cream', price: 10, stock: 9 },
+    { id: 5, name: 'Butter', price: 2, stock: 99 },
+    { id: 6, name: 'Sour Cream ', price: 4, stock: 86 },
+  ];
+
+  const [selectedItems, setSelectedItems] = React.useState([]);
+
+  const sortedItems = React.useMemo(() => {
+    const selectedItemsToSort = products.filter(product =>
+      selectedItems.includes(product.id)
+    );
+    const nonSelectedItems = products.filter(
+      product => !selectedItems.includes(product.id)
+    );
+
+    let sortOrder = 0;
+    if (sortConfig !== null) {
+      if (selectedItemsToSort.length < 2) {
+        sortOrder =
+          sortConfig.direction === TableSortDirection.ascending ? -1 : 1;
+      }
+      selectedItemsToSort.sort((a, b) => {
+        if (a[sortConfig.key] < b[sortConfig.key]) {
+          sortOrder =
+            sortConfig.direction === TableSortDirection.ascending ? -1 : 1;
+        }
+        if (a[sortConfig.key] > b[sortConfig.key]) {
+          sortOrder =
+            sortConfig.direction === TableSortDirection.ascending ? 1 : -1;
+        }
+        return sortOrder;
+      });
+    }
+    if (selectedItemsToSort.length === 0) {
+      return products;
+    } else if (sortOrder === 1) {
+      return selectedItemsToSort.concat(nonSelectedItems);
+    } else {
+      return nonSelectedItems.concat(selectedItemsToSort);
+    }
+  }, [sortConfig]);
+
+  function handleSelectedItems(
+    id: string | number,
+    ev: React.ChangeEvent<HTMLInputElement>
+  ) {
+    if (ev.target.checked) {
+      if (!selectedItems.includes(id)) {
+        setSelectedItems([...selectedItems, id]);
+      }
+    } else if (!ev.target.checked) {
+      setSelectedItems(selectedItems.filter(i => i !== id));
+    }
+  }
+
+  function handleHeaderSelect(ev: React.ChangeEvent<HTMLInputElement>) {
+    if (ev.target.checked && selectedItems.length === 0) {
+      const checkedIds = [];
+      products.filter(prod => checkedIds.push(prod.id));
+      setSelectedItems(checkedIds);
+    } else {
+      setSelectedItems([]);
+    }
+  }
+
+  return (
+    <Datagrid
+      isSelectable
+      isSortableBySelected
+      rows={sortedItems}
+      columns={productColumns}
+      onSortBySelected={() => {
+        requestSort('name');
+      }}
+      onRowSelect={handleSelectedItems}
+      onHeaderSelect={handleHeaderSelect}
+      sortDirection={sortConfig.direction}
+    />
+  );
+}
+
+```
+
+
 ## Controlled Selectable Column
 
 ```typescript


### PR DESCRIPTION
re #828

![isSortableBySelected](https://user-images.githubusercontent.com/91160746/180848966-e05e9082-f734-43bb-a955-7fbec5e24e0f.gif)
 