### PR TITLE
fix(pagination): fix Pagination a11y issue regarding `<ul>` only having `<li>` as children

### DIFF
--- a/.changeset/pagination-a11y.md
+++ b/.changeset/pagination-a11y.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(pagination): Fix Pagination a11y issue regarding `<ul>` only having `<li>` as children.

--- a/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
@@ -125,7 +125,7 @@ const NavButton = styled(IconButton)`
   width: ${BuildButtonSize};
 `;
 
-const StyledEllipsis = styled.div`
+const StyledEllipsis = styled.li`
   align-items: center;
   display: flex;
   font-size: ${pageButtonTypeSize};
@@ -181,6 +181,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
               if (type === 'start-ellipsis' || type === 'end-ellipsis') {
                 return (
                   <StyledEllipsis
+                    aria-current={Boolean(ariaCurrent)}
                     key={index}
                     isInverse={isInverse}
                     size={size}


### PR DESCRIPTION
fix #508 #509 #510 #511 #512 #513

---

**Before:**
![image](https://user-images.githubusercontent.com/91160746/182888483-9b11c783-2635-4f55-a708-4929c60e3f64.png)


**After:**
![image](https://user-images.githubusercontent.com/91160746/182888257-f05d3286-9b0b-4553-aad9-5f70441873d6.png)
