### PR TITLE
fix(datagrid): add aria-label to sort by selectable button

### DIFF
--- a/.changeset/datagrid-a11y.md
+++ b/.changeset/datagrid-a11y.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(datagrid): Add aria-label to sort by selectable button

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -13,6 +13,8 @@ import { Button } from '../Button';
 import { ButtonGroup } from '../ButtonGroup';
 import { magma } from '../../theme/magma';
 import { Spacer, SpacerAxis } from '../Spacer';
+import { Announce } from '../Announce';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 const rowsForPagination = [
   {
@@ -483,17 +485,22 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
   }
 
   return (
-    <Datagrid
-      {...args}
-      rows={sortedItems}
-      columns={productColumns}
-      onSortBySelected={() => {
-        requestSort('name');
-      }}
-      onRowSelect={handleRowSelect}
-      onHeaderSelect={handleHeaderSelect}
-      sortDirection={selectedDirection}
-    />
+    <>
+      <Datagrid
+        {...args}
+        rows={sortedItems}
+        columns={productColumns}
+        onSortBySelected={() => {
+          requestSort('name');
+        }}
+        onRowSelect={handleRowSelect}
+        onHeaderSelect={handleHeaderSelect}
+        sortDirection={selectedDirection}
+        />
+        <Announce>
+          <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
+      </Announce>
+    </>
   );
 };
 

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -308,6 +308,7 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
                   onMouseEnter={handleMouseEnter}
                   onMouseLeave={handleMouseLeave}
                   data-testid={`${testId || ''}-sort-button`}
+                  aria-label="Sort rows"
                 >
                   <SortIconWrapper theme={theme}>{SortIcon}</SortIconWrapper>
                 </SortButton>

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -667,7 +667,7 @@ export function Example() {
 
 ```typescript
 import React from 'react';
-import { Datagrid, TableSortDirection } from 'react-magma-dom';
+import { Datagrid, TableSortDirection, Announce, VisuallyHidden } from 'react-magma-dom';
 
 export function Example() {
 
@@ -829,18 +829,23 @@ const [sortConfig, setSortConfig] = React.useState({
   }
 
   return (
-    <Datagrid
-      isSelectable
-      isSortableBySelected
-      rows={sortedItems}
-      columns={productColumns}
-      onSortBySelected={() => {
-        requestSort('name');
-      }}
-      onRowSelect={handleSelectedItems}
-      onHeaderSelect={handleHeaderSelect}
-      sortDirection={selectedDirection}
-    />
+    <>
+      <Datagrid
+        isSelectable
+        isSortableBySelected
+        rows={sortedItems}
+        columns={productColumns}
+        onSortBySelected={() => {
+          requestSort('name');
+        }}
+        onRowSelect={handleSelectedItems}
+        onHeaderSelect={handleHeaderSelect}
+        sortDirection={selectedDirection}
+      />
+      <Announce>
+        <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
+      </Announce>
+    </>
   );
 }
 


### PR DESCRIPTION
fix #873

In addition, add better accessibility to sort by selectable examples in storybook and docs.