### PR TITLE
fix(globalstyles): fix default `a:hover` color to match Hyperlink

### DIFF
--- a/.changeset/anchor-color-landing.md
+++ b/.changeset/anchor-color-landing.md
@@ -1,0 +1,5 @@
+---
+'react-magma-landing': patch
+---
+
+Update anchor stylings.

--- a/.changeset/anchor-color.md
+++ b/.changeset/anchor-color.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(GlobalStyles): Fix default `a:hover` color to match Hyperlink

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -58,6 +58,11 @@ export const Default = () => {
           </Hyperlink>
         </CardBody>
       </Card>
+      <Card>
+        <CardBody>
+          <a href="https://www.google.com">This is a link that doesn't use Hyperlink</a>
+        </CardBody>
+      </Card>
     </>
   );
 };

--- a/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
+++ b/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
@@ -47,13 +47,18 @@ function getStyles(theme, isInverse: boolean) {
     }
 
     a {
-      color: ${isInverse ? theme.colors.neutral200 : theme.colors.primary};
+      color: ${isInverse ? theme.colors.tertiary : theme.colors.primary};
       cursor: pointer;
       text-decoration: underline;
 
       &:hover,
       &:focus {
-        color: ${isInverse ? theme.colors.focusInverse : theme.colors.focus};
+        color: ${isInverse ? theme.colors.primary100 : theme.colors.primary400};
+      }
+      &:focus {
+        outline: 2px solid
+          ${isInverse ? theme.colors.focusInverse : theme.colors.focus};
+        outline-offset: 2px;
       }
     }
 

--- a/website/react-magma-landing/static/styles.css
+++ b/website/react-magma-landing/static/styles.css
@@ -8,7 +8,7 @@
 
 *:focus {
   outline: 2px solid #0074B7;
-  outline-offset: 3px;
+  outline-offset: 2px;
 }
 
 html {
@@ -39,7 +39,7 @@ a {
 
 a:hover,
 a:focus {
-  color: #79A5FF;
+  color: #5D65CB;
 }
 
 h1,


### PR DESCRIPTION
Issue: #900

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix our Global style for anchors in react-magma-dom and our landing page.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/91160746/189206887-668b7cd1-0570-49ed-9d8d-e8785e20af41.png)

## Checklist 
- [x] changeset has been added
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
- Look at storybook under the Hyperlink story
- Confirm in the docs site that links on the pages have the correct styling
