### PR TITLE
fix(buttongroup): add `flex-wrap: wrap` to ButtonGroup

### DIFF
--- a/.changeset/buttongroup.md
+++ b/.changeset/buttongroup.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(ButtonGroup): Add `flex-wrap: wrap` to ButtonGroup

--- a/.changeset/smallScreens-docs.md
+++ b/.changeset/smallScreens-docs.md
@@ -1,0 +1,5 @@
+---
+"react-magma-docs": patch
+---
+
+Update API pages that scroll horizontally on small screens.

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -124,6 +124,10 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .emotion-12 > button:first-child,
@@ -323,6 +327,10 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .emotion-12 > button:first-child,
@@ -573,6 +581,9 @@ exports[`ButtonGroup Vertical No Space Does NOT remove the border radius around 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: start;
   -webkit-box-align: start;
   -ms-flex-align: start;
@@ -730,6 +741,9 @@ exports[`ButtonGroup Vertical No Space Does NOT remove the border radius around 
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: start;
   -webkit-box-align: start;
   -ms-flex-align: start;
@@ -938,6 +952,10 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .emotion-22 > button:first-child,
@@ -1269,6 +1287,10 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .emotion-22 > button:first-child,
@@ -1737,6 +1759,9 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -2076,6 +2101,9 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -2552,6 +2580,10 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .emotion-22 > button:first-child,
@@ -2929,6 +2961,10 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .emotion-22 > button:first-child,

--- a/packages/react-magma-dom/src/components/ButtonGroup/index.tsx
+++ b/packages/react-magma-dom/src/components/ButtonGroup/index.tsx
@@ -143,11 +143,18 @@ const StyledButtonGroup = styled.div<{
   justify-content: ${props => buildButtonAlignment(props)};
   flex-direction: ${props =>
     props.orientation === ButtonGroupOrientation.vertical ? 'column' : 'row'};
+  flex-wrap: wrap;
 
   ${props =>
     props.orientation === ButtonGroupOrientation.vertical &&
     css`
       align-items: ${buildButtonAlignment(props)};
+    `}
+
+  ${props =>
+    props.orientation === ButtonGroupOrientation.horizontal &&
+    css`
+      row-gap: ${props.theme.spaceScale.spacing03};
     `}
 
   > button, > div {

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -97,13 +97,10 @@ import React from 'react';
 import { Combobox } from 'react-magma-dom';
 
 export function Example() {
-  const [
-    highlightedIndexChangeCount,
-    updateHighlightedIndexChangeCount,
-  ] = React.useState<number>(0);
-  const [isOpenChangeCount, updateIsOpenChangeCount] = React.useState<number>(
-    0
-  );
+  const [highlightedIndexChangeCount, updateHighlightedIndexChangeCount] =
+    React.useState<number>(0);
+  const [isOpenChangeCount, updateIsOpenChangeCount] =
+    React.useState<number>(0);
   const [selectedItem, updateSelectedItem] = React.useState(undefined);
 
   function onHighlightedIndexChange(changes) {
@@ -858,9 +855,8 @@ import React from 'react';
 import { Combobox } from 'react-magma-dom';
 
 export function Example() {
-  const [controlledSelectedItem, updateControlledSelectedItem] = React.useState(
-    ''
-  );
+  const [controlledSelectedItem, updateControlledSelectedItem] =
+    React.useState('');
   const [controlledItems, updateControlledItems] = React.useState([
     { id: 0, name: 'red', representation: 'Red', hex: '#FF0000' },
     { id: 1, name: 'blue', representation: 'Blue', hex: '#0000FF' },
@@ -1226,7 +1222,7 @@ The `type` property in the `changes` object that is returned from the `onStateCh
 corresponds to a `stateChangeTypes` property. The list of all the possible types for a `combobox` or a
 `multi-combobox` are listed below.
 
-<Alert variant="info">
+<Alert variant="info" style={{ maxWidth: '100%', overflow: 'scroll' }}>
   In the development environment these types equate to strings
   <br />
   (eg:{' '}
@@ -1244,41 +1240,137 @@ corresponds to a `stateChangeTypes` property. The list of all the possible types
 
 ### Combobox
 
-- `ComboboxStateChangeTypes.InputKeyDownArrowDown`
-- `ComboboxStateChangeTypes.InputKeyDownArrowUp`
-- `ComboboxStateChangeTypes.InputKeyDownEscape`
-- `ComboboxStateChangeTypes.InputKeyDownHome`
-- `ComboboxStateChangeTypes.InputKeyDownEnd`
-- `ComboboxStateChangeTypes.InputKeyDownEnter`
-- `ComboboxStateChangeTypes.InputChange`
-- `ComboboxStateChangeTypes.InputBlur`
-- `ComboboxStateChangeTypes.MenuMouseLeave`
-- `ComboboxStateChangeTypes.ItemMouseMove`
-- `ComboboxStateChangeTypes.ItemClick`
-- `ComboboxStateChangeTypes.ToggleButtonClick`
-- `ComboboxStateChangeTypes.FunctionToggleMenu`
-- `ComboboxStateChangeTypes.FunctionOpenMenu`
-- `ComboboxStateChangeTypes.FunctionCloseMenu`
-- `ComboboxStateChangeTypes.FunctionSetHighlightedIndex`
-- `ComboboxStateChangeTypes.FunctionSelectItem`
-- `ComboboxStateChangeTypes.FunctionSetInputValue`
-- `ComboboxStateChangeTypes.FunctionReset`
+<div style={{ overflowX: 'scroll' }}>
+  <ul>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.InputKeyDownArrowDown</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.InputKeyDownArrowUp</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.InputKeyDownEscape</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.InputKeyDownHome</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.InputKeyDownEnd</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.InputKeyDownEnter</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.InputChange</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.InputBlur</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.MenuMouseLeave</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.ItemMouseMove</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.ItemClick</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.ToggleButtonClick</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.FunctionToggleMenu</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.FunctionOpenMenu</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.FunctionCloseMenu</inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        ComboboxStateChangeTypes.FunctionSetHighlightedIndex
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.FunctionSelectItem</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.FunctionSetInputValue</inlineCode>
+    </li>
+    <li>
+      <inlineCode>ComboboxStateChangeTypes.FunctionReset</inlineCode>
+    </li>
+  </ul>
+</div>
 
 ### MultiCombobox
 
-- `MultipleSelectionStateChangeTypes.SelectedItemClick`
-- `MultipleSelectionStateChangeTypes.SelectedItemKeyDownDelete`
-- `MultipleSelectionStateChangeTypes.SelectedItemKeyDownBackspace`
-- `MultipleSelectionStateChangeTypes.SelectedItemKeyDownNavigationNext`
-- `MultipleSelectionStateChangeTypes.SelectedItemKeyDownNavigationPrevious`
-- `MultipleSelectionStateChangeTypes.DropdownKeyDownNavigationPrevious`
-- `MultipleSelectionStateChangeTypes.DropdownKeyDownBackspace`
-- `MultipleSelectionStateChangeTypes.DropdownClick`
-- `MultipleSelectionStateChangeTypes.FunctionAddSelectedItem`
-- `MultipleSelectionStateChangeTypes.FunctionRemoveSelectedItem`
-- `MultipleSelectionStateChangeTypes.FunctionSetSelectedItems`
-- `MultipleSelectionStateChangeTypes.FunctionSetActiveIndex`
-- `MultipleSelectionStateChangeTypes.FunctionReset`
+<div style={{ overflowX: 'scroll' }}>
+  <ul>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemClick
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemKeyDownDelete
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemKeyDownBackspace
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemKeyDownNavigationNext
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemKeyDownNavigationPrevious
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.DropdownKeyDownNavigationPrevious
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.DropdownKeyDownBackspace
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>MultipleSelectionStateChangeTypes.DropdownClick</inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.FunctionAddSelectedItem
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.FunctionRemoveSelectedItem
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.FunctionSetSelectedItems
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.FunctionSetActiveIndex
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>MultipleSelectionStateChangeTypes.FunctionReset</inlineCode>
+    </li>
+  </ul>
+</div>
 
 ## Combobox Props
 

--- a/website/react-magma-docs/src/pages/api/flex.mdx
+++ b/website/react-magma-docs/src/pages/api/flex.mdx
@@ -125,17 +125,17 @@ export function Example() {
   return (
     <Flex behavior={FlexBehavior.container} spacing={4}>
       <Flex behavior={FlexBehavior.item} xs={4}>
-        <Card width={200}>
+        <Card>
           <CardBody>Content</CardBody>
         </Card>
       </Flex>
       <Flex behavior={FlexBehavior.item} xs={4}>
-        <Card width={200}>
+        <Card>
           <CardBody>Content</CardBody>
         </Card>
       </Flex>
       <Flex behavior={FlexBehavior.item} xs={4}>
-        <Card width={200}>
+        <Card>
           <CardBody>Content</CardBody>
         </Card>
       </Flex>

--- a/website/react-magma-docs/src/pages/api/icon-button.mdx
+++ b/website/react-magma-docs/src/pages/api/icon-button.mdx
@@ -24,7 +24,12 @@ If no children are included, then they render in the icon-only style.
 
 ```tsx
 import React from 'react';
-import { IconButton, ButtonVariant, ButtonColor, ButtonGroup } from 'react-magma-dom';
+import {
+  IconButton,
+  ButtonVariant,
+  ButtonColor,
+  ButtonGroup,
+} from 'react-magma-dom';
 import {
   AlertIcon,
   CheckIcon,
@@ -157,9 +162,7 @@ import { NotificationsIcon } from 'react-magma-icons';
 export function Example() {
   const icon = <NotificationsIcon size={10} />;
 
-  return (
-    <IconButton icon={icon}>Notification with Custom Icon Size</IconButton>
-  );
+  return <IconButton icon={icon}>With Custom Icon Size</IconButton>;
 }
 ```
 
@@ -170,7 +173,12 @@ The `iconPosition` property takes the values `left` and `right`.
 
 ```tsx
 import React from 'react';
-import { ButtonColor, ButtonIconPosition, IconButton, ButtonGroup } from 'react-magma-dom';
+import {
+  ButtonColor,
+  ButtonIconPosition,
+  IconButton,
+  ButtonGroup,
+} from 'react-magma-dom';
 import { NotificationsIcon, InfoIcon } from 'react-magma-icons';
 
 export function Example() {
@@ -195,7 +203,12 @@ Sizes for `IconButtons` include `small`, `medium`, and `large`, with `medium` be
 
 ```tsx
 import React from 'react';
-import { ButtonIconPosition, ButtonSize, IconButton, ButtonGroup } from 'react-magma-dom';
+import {
+  ButtonIconPosition,
+  ButtonSize,
+  IconButton,
+  ButtonGroup,
+} from 'react-magma-dom';
 import { NotificationsIcon } from 'react-magma-icons';
 
 export function Example() {
@@ -212,7 +225,7 @@ export function Example() {
           size={ButtonSize.large}
         />
       </ButtonGroup>
-      <br/>
+      <br />
       <ButtonGroup>
         <IconButton
           icon={<NotificationsIcon />}
@@ -283,7 +296,7 @@ export function Example() {
   return (
     <>
       <IconButton icon={<NotificationsIcon />} isFullWidth>
-        Full-Width Notifications Button
+        Full-Width Notifications Btn
       </IconButton>
       <br />
       <IconButton
@@ -291,7 +304,7 @@ export function Example() {
         isFullWidth
         iconPosition={ButtonIconPosition.right}
       >
-        Full-Width Notifications Button
+        Full-Width Notifications Btn
       </IconButton>
       <br />
       <IconButton
@@ -304,9 +317,15 @@ export function Example() {
 ```
 
 ## Inverse
+
 ```tsx
 import React from 'react';
-import { IconButton, ButtonVariant, ButtonColor, ButtonGroup } from 'react-magma-dom';
+import {
+  IconButton,
+  ButtonVariant,
+  ButtonColor,
+  ButtonGroup,
+} from 'react-magma-dom';
 import {
   AlertIcon,
   NotificationsIcon,

--- a/website/react-magma-docs/src/pages/api/select.mdx
+++ b/website/react-magma-docs/src/pages/api/select.mdx
@@ -125,10 +125,8 @@ import React from 'react';
 import { Select } from 'react-magma-dom';
 
 export function Example() {
-  const [
-    highlightedIndexChangeCount,
-    updateHighlightedIndexChangeCount,
-  ] = React.useState(0);
+  const [highlightedIndexChangeCount, updateHighlightedIndexChangeCount] =
+    React.useState(0);
   const [isOpenChangeCount, updateIsOpenChangeCount] = React.useState(0);
   const [selectedItem, updateSelectedItem] = React.useState(undefined);
 
@@ -582,9 +580,8 @@ import React from 'react';
 import { Select } from 'react-magma-dom';
 
 export function Example() {
-  const [currentSelectEvent, updateCurrentSelectEvent] = React.useState(
-    undefined
-  );
+  const [currentSelectEvent, updateCurrentSelectEvent] =
+    React.useState(undefined);
 
   function handleSelectBlur(event) {
     updateCurrentSelectEvent('Blur');
@@ -1079,7 +1076,7 @@ The `type` property in the `changes` object that is returned from the `onStateCh
 corresponds to a `stateChangeTypes` property. The list of all the possible types for a `select` or a
 `multi-select` are listed below.
 
-<Alert variant="info">
+<Alert variant="info" style={{ maxWidth: '100%', overflow: 'scroll' }}>
   In the development environment these types equate to strings
   <br />
   (eg:{' '}
@@ -1097,45 +1094,153 @@ corresponds to a `stateChangeTypes` property. The list of all the possible types
 
 ### Select
 
-- `SelectStateChangeTypes.MenuKeyDownArrowDown`
-- `SelectStateChangeTypes.MenuKeyDownArrowUp`
-- `SelectStateChangeTypes.MenuKeyDownEscape`
-- `SelectStateChangeTypes.MenuKeyDownHome`
-- `SelectStateChangeTypes.MenuKeyDownEnd`
-- `SelectStateChangeTypes.MenuKeyDownEnter`
-- `SelectStateChangeTypes.MenuKeyDownSpaceButton`
-- `SelectStateChangeTypes.MenuKeyDownCharacter`
-- `SelectStateChangeTypes.MenuBlur`
-- `SelectStateChangeTypes.MenuMouseLeave`
-- `SelectStateChangeTypes.ItemMouseMove`
-- `SelectStateChangeTypes.ItemClick`
-- `SelectStateChangeTypes.ToggleButtonKeyDownCharacter`
-- `SelectStateChangeTypes.ToggleButtonKeyDownArrowDown`
-- `SelectStateChangeTypes.ToggleButtonKeyDownArrowUp`
-- `SelectStateChangeTypes.ToggleButtonClick`
-- `SelectStateChangeTypes.FunctionToggleMenu`
-- `SelectStateChangeTypes.FunctionOpenMenu`
-- `SelectStateChangeTypes.FunctionCloseMenu`
-- `SelectStateChangeTypes.FunctionSetHighlightedIndex`
-- `SelectStateChangeTypes.FunctionSelectItem`
-- `SelectStateChangeTypes.FunctionSetInputValue`
-- `SelectStateChangeTypes.FunctionReset`
+<div style={{ overflowX: 'scroll' }}>
+  <ul>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuKeyDownArrowDown</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuKeyDownArrowUp</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuKeyDownEscape</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuKeyDownHome</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuKeyDownEnd</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuKeyDownEnter</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuKeyDownSpaceButton</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuKeyDownCharacter</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuBlur</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.MenuMouseLeave</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.ItemMouseMove</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.ItemClick</inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        SelectStateChangeTypes.ToggleButtonKeyDownCharacter
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        SelectStateChangeTypes.ToggleButtonKeyDownArrowDown
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.ToggleButtonKeyDownArrowUp</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.ToggleButtonClick</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.FunctionToggleMenu</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.FunctionOpenMenu</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.FunctionCloseMenu</inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        SelectStateChangeTypes.FunctionSetHighlightedIndex
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.FunctionSelectItem</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.FunctionSetInputValue</inlineCode>
+    </li>
+    <li>
+      <inlineCode>SelectStateChangeTypes.FunctionReset</inlineCode>
+    </li>
+  </ul>
+</div>
 
 ### MultiSelect
 
-- `MultipleSelectionStateChangeTypes.SelectedItemClick`
-- `MultipleSelectionStateChangeTypes.SelectedItemKeyDownDelete`
-- `MultipleSelectionStateChangeTypes.SelectedItemKeyDownBackspace`
-- `MultipleSelectionStateChangeTypes.SelectedItemKeyDownNavigationNext`
-- `MultipleSelectionStateChangeTypes.SelectedItemKeyDownNavigationPrevious`
-- `MultipleSelectionStateChangeTypes.DropdownKeyDownNavigationPrevious`
-- `MultipleSelectionStateChangeTypes.DropdownKeyDownBackspace`
-- `MultipleSelectionStateChangeTypes.DropdownClick`
-- `MultipleSelectionStateChangeTypes.FunctionAddSelectedItem`
-- `MultipleSelectionStateChangeTypes.FunctionRemoveSelectedItem`
-- `MultipleSelectionStateChangeTypes.FunctionSetSelectedItems`
-- `MultipleSelectionStateChangeTypes.FunctionSetActiveIndex`
-- `MultipleSelectionStateChangeTypes.FunctionReset`
+<div style={{ overflowX: 'scroll' }}>
+  <ul>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemClick
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemKeyDownDelete
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemKeyDownBackspace
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemKeyDownNavigationNext
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.SelectedItemKeyDownNavigationPrevious
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.DropdownKeyDownNavigationPrevious
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.DropdownKeyDownBackspace
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>MultipleSelectionStateChangeTypes.DropdownClick</inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.FunctionAddSelectedItem
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.FunctionRemoveSelectedItem
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.FunctionSetSelectedItems
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>
+        MultipleSelectionStateChangeTypes.FunctionSetActiveIndex
+      </inlineCode>
+    </li>
+    <li>
+      <inlineCode>MultipleSelectionStateChangeTypes.FunctionReset</inlineCode>
+    </li>
+  </ul>
+</div>
 
 ## Select Props
 


### PR DESCRIPTION
Issue: #894

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

- Add `flex-wrap: wrap` to ButtonGroup
- Update API pages that scroll horizontally on small screens.

## Screenshots (if appropriate):
**Before**
![image](https://user-images.githubusercontent.com/91160746/190007040-748cc2d5-3eb4-49e0-8d93-cdd4e1d17dd5.png)
**After**
![image](https://user-images.githubusercontent.com/91160746/190006951-98bc9b8a-d0ac-46a2-bc31-d23f37bb0ea3.png)


## Checklist 
- [X] changeset has been added
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
- Test the ButtonGroup
- Test each of the following pages in all screen sizes, especially mobile:
https://next--upbeat-sinoussi-f675aa.netlify.app/api/button/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/dropdown/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/button-group/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/combobox/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/flex/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/icon-button/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/loading-indicator/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/modal/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/select/
https://next--upbeat-sinoussi-f675aa.netlify.app/api/toast/

_Notes: Missing Grid example._