### PR TITLE
fix(input): fix placement of `children` inside Input component 

### DIFF
--- a/.changeset/fix-helpicon.md
+++ b/.changeset/fix-helpicon.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Input): Fix placement of `children` inside Input component (ex: help icon).

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -38,6 +38,12 @@ export default {
         type: 'boolean',
       },
     },
+    type: {
+      control: {
+        type: 'select',
+        options: InputType
+      }
+    }
   },
   errorMessage: '',
 } as Meta;
@@ -49,6 +55,7 @@ Default.args = {
   isClearable: true,
   isInverse: false,
   placeholder: 'Placeholder text...',
+  type: InputType.text,
 };
 Default.parameters = { controls: { exclude: ['iconPosition'] } };
 
@@ -185,9 +192,35 @@ export const WithChildren = args => {
           />
         </Tooltip>
       </Input>
+      <br/>
+      <hr/>
+      <Input
+        labelText="With two icons"
+        icon={<NotificationsIcon />}
+        {...args}
+      >
+        <Tooltip content={helpLinkLabel}>
+          <IconButton
+            aria-label={helpLinkLabel}
+            icon={<HelpIcon />}
+            onClick={onHelpLinkClick}
+            type={ButtonType.button}
+            size={ButtonSize.small}
+            variant={ButtonVariant.link}
+          />
+        </Tooltip>
+      </Input>
+      <br/>
+      <hr/>
+      <Input
+        labelText="With 1 icon, not child"
+        icon={<NotificationsIcon />}
+        iconPosition={InputIconPosition.right}
+        {...args}
+      />
     </>
   );
 };
 WithChildren.parameters = {
-  controls: { exclude: ['iconPosition', 'isInverse'] },
+  controls: { exclude: ['iconPosition', 'isInverse', 'type'] },
 };

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -77,7 +77,7 @@ export const File = Template.bind({});
 File.args = {
   type: InputType.file,
 };
-File.parameters = { controls: { exclude: ['iconPosition'] } };
+File.parameters = { controls: { exclude: ['iconPosition', 'isClearable'] } };
 
 export const IconTop = Template.bind({});
 IconTop.args = {
@@ -210,14 +210,6 @@ export const WithChildren = args => {
           />
         </Tooltip>
       </Input>
-      <br/>
-      <hr/>
-      <Input
-        labelText="With 1 icon, not child"
-        icon={<NotificationsIcon />}
-        iconPosition={InputIconPosition.right}
-        {...args}
-      />
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -4,6 +4,9 @@ import { InputIconPosition, InputSize, InputType } from '../InputBase';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { HelpIcon, NotificationsIcon } from 'react-magma-icons';
 import { Card, CardBody } from '../Card';
+import { Tooltip } from '../Tooltip';
+import { IconButton } from '../IconButton';
+import { ButtonSize, ButtonType, ButtonVariant } from '../Button';
 
 const Template: Story<InputProps> = args => (
   <Input {...args} labelText="Example" />
@@ -142,3 +145,49 @@ Inverse.decorators = [
     </Card>
   ),
 ];
+
+export const WithChildren = args => {
+  const helpLinkLabel = 'Learn more';
+  const onHelpLinkClick = () => {
+    alert('Help link clicked!');
+  };
+  return (
+    <>
+      <Input
+        labelText="Help link - top"
+        iconPosition={InputIconPosition.top}
+        {...args}
+      >
+        <Tooltip content={helpLinkLabel}>
+          <IconButton
+            aria-label={helpLinkLabel}
+            icon={<HelpIcon />}
+            onClick={onHelpLinkClick}
+            type={ButtonType.button}
+            size={ButtonSize.small}
+            variant={ButtonVariant.link}
+          />
+        </Tooltip>
+      </Input>
+      <Input
+        labelText="Help link - right"
+        iconPosition={InputIconPosition.right}
+        {...args}
+      >
+        <Tooltip content={helpLinkLabel}>
+          <IconButton
+            aria-label={helpLinkLabel}
+            icon={<HelpIcon />}
+            onClick={onHelpLinkClick}
+            type={ButtonType.button}
+            size={ButtonSize.small}
+            variant={ButtonVariant.link}
+          />
+        </Tooltip>
+      </Input>
+    </>
+  );
+};
+WithChildren.parameters = {
+  controls: { exclude: ['iconPosition', 'isInverse'] },
+};

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -339,10 +339,60 @@ const IconWrapper = styled.span<{
     `}
 `;
 
+function getIconButtonSVGSize(props) {
+  const { hasChildren, inputSize, theme } = props;
+  if (hasChildren) {
+    if (inputSize === InputSize.large) {
+      return `${theme.iconSizes.medium}px`;
+    }
+    return `${theme.iconSizes.small}px`;
+  }
+  if (inputSize === InputSize.large) {
+    return `${theme.iconSizes.large}px`;
+  }
+  return `${theme.iconSizes.medium}px`;
+}
+
+function getIconButtonTransform(props) {
+  const { hasChildren, iconPosition, inputSize, theme } = props;
+  let position = { x: '', y: '' };
+
+  if (hasChildren) {
+    if (inputSize === InputSize.large) {
+      if (iconPosition === InputIconPosition.top) {
+        position.x = '-26px';
+        position.y = '0';
+      } else {
+        position.x = '-44px';
+        position.y = '14px';
+      }
+    } else if (inputSize === InputSize.medium) {
+      if (iconPosition === InputIconPosition.top) {
+        position.x = '-26px';
+        position.y = '6px';
+      } else {
+        position.x = '-34px';
+        position.y = '6px';
+      }
+    }
+    return position;
+  }
+
+  if (inputSize === InputSize.large) {
+    position.x = `-${theme.spaceScale.spacing10}`;
+    position.y = theme.spaceScale.spacing03;
+  } else if (inputSize === InputSize.medium) {
+    position.x = '-24px';
+    position.y = '7px';
+  }
+  return position;
+}
+
 const IconButtonContainer = styled.span<{
   iconPosition?: InputIconPosition;
   inputSize?: InputSize;
   theme: ThemeInterface;
+  hasChildren?: boolean;
 }>`
   background-color: transparent;
   bottom: ${props => (props.iconPosition === 'top' ? '40px' : 'inherit')};
@@ -351,21 +401,12 @@ const IconButtonContainer = styled.span<{
   position: relative;
   width: 0;
   transform: translate(
-    -${props => (props.inputSize === InputSize.large ? props.theme.spaceScale.spacing10 : '34px')},
-    ${props =>
-      props.inputSize === InputSize.large
-        ? props.theme.spaceScale.spacing03
-        : '7px'}
+    ${props => getIconButtonTransform(props).x},
+    ${props => getIconButtonTransform(props).y}
   );
   svg {
-    height: ${props =>
-      props.inputSize === InputSize.large
-        ? `${props.theme.iconSizes.large}px`
-        : `${props.theme.iconSizes.medium}px`};
-    width: ${props =>
-      props.inputSize === InputSize.large
-        ? `${props.theme.iconSizes.large}px`
-        : `${props.theme.iconSizes.medium}px`};
+    height: ${props => getIconButtonSVGSize(props)};
+    width: ${props => getIconButtonSVGSize(props)};
   }
 `;
 
@@ -615,6 +656,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             iconPosition={iconPosition}
             inputSize={inputSize ? inputSize : InputSize.medium}
             theme={theme}
+            hasChildren={true}
           >
             {children}
           </IconButtonContainer>

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -102,6 +102,10 @@ export interface InputBaseProps
    * @default InputType.text
    */
   type?: InputType;
+  /**
+   * Boolean for whether this is a Password Input or not
+   */
+  isPasswordInput?: boolean;
 }
 
 export interface InputWrapperStylesProps {
@@ -182,8 +186,7 @@ function getInputPadding(props: InputBaseStylesProps) {
         padding.left = props.theme.spaceScale.spacing10;
       }
     }
-  }
-  else if (inputSize === 'medium') {
+  } else if (inputSize === 'medium') {
     if (isClearable) {
       if (iconPosition === 'right') {
         padding.right = '68px';
@@ -380,6 +383,14 @@ const PasswordButtonContainer = styled.span<{
 `;
 
 function getClearablePosition(props) {
+  if (props.hasChildren) {
+    if (props.iconPosition === 'right') {
+      if (props.inputSize === 'large') {
+        return '92px';
+      }
+      return props.theme.spaceScale.spacing12;
+    }
+  }
   if (props.iconPosition === 'right' && props.icon) {
     if (props.inputSize === 'large') {
       return '88px';
@@ -398,6 +409,7 @@ const IsClearableContainer = styled.span<{
   iconPosition?: InputIconPosition;
   inputSize?: InputSize;
   onIconClick?: () => void;
+  hasChildren?: boolean;
 }>`
   background-color: transparent;
   margin: 0;
@@ -434,6 +446,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       iconAriaLabel,
       iconRef,
       isClearable,
+      isPasswordInput,
       isPredictive,
       onClear,
       onIconClick,
@@ -539,6 +552,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             inputSize={inputSize}
             onIconClick={onIconClick}
             icon={icon}
+            hasChildren={!!children && !isPasswordInput}
           >
             <IconButton
               aria-label={i18n.input.isClearableAriaLabel}
@@ -560,7 +574,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             />
           </IsClearableContainer>
         )}
-        {onIconClick ? (
+        {onIconClick && (
           <IconButtonContainer
             iconPosition={iconPosition}
             inputSize={
@@ -586,7 +600,8 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
               variant={ButtonVariant.link}
             />
           </IconButtonContainer>
-        ) : (
+        )}
+        {isPasswordInput ? (
           <PasswordButtonContainer
             size={
               inputSize === InputSize.large ? InputSize.large : InputSize.medium
@@ -595,6 +610,14 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
           >
             {children}
           </PasswordButtonContainer>
+        ) : (
+          <IconButtonContainer
+            iconPosition={iconPosition}
+            inputSize={inputSize ? inputSize : InputSize.medium}
+            theme={theme}
+          >
+            {children}
+          </IconButtonContainer>
         )}
       </InputContainer>
     );

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -324,7 +324,7 @@ const IconWrapper = styled.span<{
   ${props =>
     props.inputSize === 'large' &&
     css`
-      bottom: ${props.iconPosition === 'top' ? '56px' : 'inherit'};
+      bottom: ${props.iconPosition === 'top' ? '62px' : 'inherit'};
       left: ${props.iconPosition === 'left'
         ? props.theme.spaceScale.spacing04
         : 'auto'};
@@ -340,8 +340,9 @@ const IconWrapper = styled.span<{
 `;
 
 function getIconButtonSVGSize(props) {
-  const { hasChildren, inputSize, theme } = props;
-  if (hasChildren) {
+  const { isClickable, iconPosition, inputSize, theme } = props;
+
+  if (isClickable && iconPosition === InputIconPosition.top) {
     if (inputSize === InputSize.large) {
       return `${theme.iconSizes.medium}px`;
     }
@@ -354,26 +355,32 @@ function getIconButtonSVGSize(props) {
 }
 
 function getIconButtonTransform(props) {
-  const { hasChildren, iconPosition, inputSize, theme } = props;
+  const { isClickable, iconPosition, inputSize, hasChildren, theme } = props;
   let position = { x: '', y: '' };
 
-  if (hasChildren) {
+  if (iconPosition === InputIconPosition.top) {
     if (inputSize === InputSize.large) {
-      if (iconPosition === InputIconPosition.top) {
-        position.x = '-26px';
-        position.y = '0';
-      } else {
-        position.x = '-44px';
+      position.x = '-30px';
+      position.y = '2px';
+    } else if (inputSize === InputSize.medium) {
+      position.x = '-28px';
+      position.y = '5px';
+    }
+    return position;
+  }
+
+  if (isClickable) {
+    if (inputSize === InputSize.large) {
+      if (hasChildren) {
+        position.x = '-43px';
         position.y = '14px';
+      } else {
+        position.x = '-49px';
+        position.y = '8px';
       }
     } else if (inputSize === InputSize.medium) {
-      if (iconPosition === InputIconPosition.top) {
-        position.x = '-26px';
-        position.y = '6px';
-      } else {
-        position.x = '-34px';
-        position.y = '6px';
-      }
+      position.x = '-35px';
+      position.y = '6px';
     }
     return position;
   }
@@ -392,6 +399,7 @@ const IconButtonContainer = styled.span<{
   iconPosition?: InputIconPosition;
   inputSize?: InputSize;
   theme: ThemeInterface;
+  isClickable?: boolean;
   hasChildren?: boolean;
 }>`
   background-color: transparent;
@@ -466,11 +474,21 @@ const IsClearableContainer = styled.span<{
   );
 `;
 
-function getIconSize(size: string, theme: ThemeInterface) {
+function getIconSize(
+  size: string,
+  theme: ThemeInterface,
+  iconPosition: InputIconPosition
+) {
   switch (size) {
     case 'large':
+      if (iconPosition === InputIconPosition.top) {
+        return theme.iconSizes.medium;
+      }
       return theme.iconSizes.large;
     default:
+      if (iconPosition === InputIconPosition.top) {
+        return theme.iconSizes.small;
+      }
       return theme.iconSizes.medium;
   }
 }
@@ -579,7 +597,8 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
                 React.cloneElement(icon, {
                   size: getIconSize(
                     inputSize ? inputSize : InputSize.medium,
-                    theme
+                    theme,
+                    iconPosition
                   ),
                 })
               )}
@@ -622,6 +641,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
               inputSize === InputSize.large ? InputSize.large : InputSize.medium
             }
             theme={theme}
+            isClickable={true}
           >
             <IconButton
               aria-label={iconAriaLabel}
@@ -656,6 +676,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             iconPosition={iconPosition}
             inputSize={inputSize ? inputSize : InputSize.medium}
             theme={theme}
+            isClickable={true}
             hasChildren={true}
           >
             {children}

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -138,6 +138,7 @@ export const PasswordInput = React.forwardRef<
         isInverse={isInverse}
         ref={ref}
         type={passwordShown ? InputType.text : InputType.password}
+        isPasswordInput={true}
       >
         {!isPasswordMaskButtonHidden && (
           <>


### PR DESCRIPTION
Issue #909

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix placement of `children` passed to Input component. Made it compatible with `isClearable` (which it wasn't previously)

## Screenshots (if appropriate):

**before**
![image](https://user-images.githubusercontent.com/91160746/192299878-6c201ba0-31d2-46bf-bda4-ea2f4d2a266f.png)
![image](https://user-images.githubusercontent.com/91160746/192300123-f6781fd2-a2a2-4f17-959b-ab74026791d1.png)


**after**
![image](https://user-images.githubusercontent.com/91160746/192299923-a8727911-89b0-4795-afee-0219ae8f2aa6.png)
![image](https://user-images.githubusercontent.com/91160746/192300009-8d370fc6-3dd1-45ca-af55-a848a565f9a0.png)


## Checklist 
- [x] changeset has been added
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
- Test all Inputs (Input, PasswordInput, DatePicker) and ensure they are behaving as expected
- Specifically, test Input > With Children and confirm that the component visually looks how we expect. Test `medium`, `large`, `isClearable`.