### PR TITLE
docs(appbar): fix components overlapping in AppBar Tabs example

### DIFF
--- a/.changeset/appbar-spacing.md
+++ b/.changeset/appbar-spacing.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+docs(appbar): Fix components overlapping in AppBar Tabs example.

--- a/packages/react-magma-dom/src/components/AppBar/AppBar.stories.tsx
+++ b/packages/react-magma-dom/src/components/AppBar/AppBar.stories.tsx
@@ -33,7 +33,10 @@ Default.args = {
 };
 
 const TabsTemplate: Story<AppBarProps> = args => (
-  <AppBar {...args}>
+  <AppBar
+    style={{ display: 'flex', justifyContent: 'space-between', gap: '48px' }}
+    {...args}
+  >
     <div
       style={{
         alignItems: 'center',
@@ -45,21 +48,23 @@ const TabsTemplate: Story<AppBarProps> = args => (
       <Spacer size={magma.spaceScale.spacing03} />
       <strong>LOGO</strong>
     </div>
-    <Spacer size={magma.spaceScale.spacing12} />
-    <Search onSearch={() => {}} placeholder="Search for content..." />
-    <Spacer size={magma.spaceScale.spacing06} />
-    <NavTabs
-      aria-label="Navigation"
-      backgroundColor="transparent"
-      iconPosition={TabsIconPosition.left}
-    >
-      <NavTab icon={<FavoriteIcon />} isActive to="#">
-        Favorites
-      </NavTab>
-      <NavTab icon={<WorkIcon />} to="#">
-        Workspace
-      </NavTab>
-    </NavTabs>
+    <div style={{ flex: '0 0 auto' }}>
+      <Search onSearch={() => {}} placeholder="Search for content..." />
+    </div>
+    <div style={{ flex: '1 1 auto' }}>
+      <NavTabs
+        aria-label="Navigation"
+        backgroundColor="transparent"
+        iconPosition={TabsIconPosition.left}
+      >
+        <NavTab icon={<FavoriteIcon />} isActive to="#">
+          Favorites
+        </NavTab>
+        <NavTab icon={<WorkIcon />} to="#">
+          Workspace
+        </NavTab>
+      </NavTabs>
+    </div>
   </AppBar>
 );
 

--- a/website/react-magma-docs/src/pages/api/appbar.mdx
+++ b/website/react-magma-docs/src/pages/api/appbar.mdx
@@ -118,7 +118,10 @@ import { ImageIcon, FavoriteIcon, WorkIcon } from 'react-magma-icons';
 
 export function Example() {
   return (
-    <AppBar isInverse>
+    <AppBar
+      isInverse
+      style={{ display: 'flex', justifyContent: 'space-between', gap: '48px' }}
+    >
       <div
         style={{
           alignItems: 'center',
@@ -130,21 +133,23 @@ export function Example() {
         <Spacer size={magma.spaceScale.spacing03} />
         <strong>LOGO</strong>
       </div>
-      <Spacer size={magma.spaceScale.spacing12} />
-      <Search onSearch={() => {}} placeholder="Search for content..." />
-      <Spacer size={magma.spaceScale.spacing06} />
-      <NavTabs
-        aria-label="Navigation"
-        backgroundColor="transparent"
-        iconPosition={TabsIconPosition.left}
-      >
-        <NavTab icon={<FavoriteIcon />} isActive to="#">
-          Favorites
-        </NavTab>
-        <NavTab icon={<WorkIcon />} to="#">
-          Workspace
-        </NavTab>
-      </NavTabs>
+      <div style={{ flex: '0 0 auto' }}>
+        <Search onSearch={() => {}} placeholder="Search for content..." />
+      </div>
+      <div style={{ flex: '1 1 auto' }}>
+        <NavTabs
+          aria-label="Navigation"
+          backgroundColor="transparent"
+          iconPosition={TabsIconPosition.left}
+        >
+          <NavTab icon={<FavoriteIcon />} isActive to="#">
+            Favorites
+          </NavTab>
+          <NavTab icon={<WorkIcon />} to="#">
+            Workspace
+          </NavTab>
+        </NavTabs>
+      </div>
     </AppBar>
   );
 }


### PR DESCRIPTION
Issue: #881

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

Fix the storybook and react-magma-docs example for AppBar Tabs so that components no longer overlap

## Screenshots (if appropriate):
**before**
![image](https://user-images.githubusercontent.com/91160746/192580064-122d1030-7e1b-408f-8841-50dc86a343bb.png)


**after**
![image](https://user-images.githubusercontent.com/91160746/192580029-d17fae1b-e827-4070-9b9d-8c4d936c2c6e.png)


## Checklist 
- [x] changeset has been added
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
