### PR TITLE
fix(table): add keyboard only focus to tables without a focusable element

### DIFF
--- a/.changeset/table-a11y-focus.md
+++ b/.changeset/table-a11y-focus.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(table): Add keyboard only focus to tables without a focusable element.

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -111,6 +111,16 @@ export const TableContainer = styled.div<{
   border-radius: ${props =>
     props.hasSquareCorners ? 0 : props.theme.borderRadius};
   overflow: ${props => (props.minWidth ? 'auto' : 'visible')};
+  &:focus {
+    outline: none;
+  }
+  &:focus-visible {
+    outline: 2px solid
+      ${props =>
+        props.isInverse
+          ? props.theme.colors.focusInverse
+          : props.theme.colors.focus};
+  }
 `;
 
 export const StyledTable = styled.table<{
@@ -172,6 +182,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           isInverse={isInverse}
           minWidth={minWidth}
           theme={theme}
+          tabIndex={0}
         >
           <StyledTable
             {...other}


### PR DESCRIPTION
Issue: #874, #875, #878

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Added a `tabIndex` to the Table container. This makes Tables focusable, but also added styles so that the table is only focusable with keyboard navigation and not when clicked on with a mouse. This removes the a11y violation for Table and DataGrid.

Indirectly, this also addresses #271.

## Screenshots (if appropriate):
**before**
![image](https://user-images.githubusercontent.com/91160746/196518229-b3f20bdf-3ca9-4215-87f2-70190ba1605b.png)
**after**
![image](https://user-images.githubusercontent.com/91160746/196518053-8b3e1b3c-b7cb-47e9-9ae0-b46b28b97793.png)


## Checklist 
- [X] changeset has been added
- [-] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
Test the following components in different browses, in mobile and desktop screens. Confirm there are no accessibility issues
- DataGrid: https://storybook-preview-938--upbeat-sinoussi-f675aa.netlify.app/?path=/story/datagrid--default
- Table: https://storybook-preview-938--upbeat-sinoussi-f675aa.netlify.app/?path=/story/table--default