### PR TITLE
docs(table): Storybook example with adjustable number of rows

### DIFF
--- a/.changeset/table-stories.md
+++ b/.changeset/table-stories.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+docs(table): Storybook example with adjustable number of rows

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -731,3 +731,37 @@ export const WithDropdown = args => {
 WithDropdown.args = {
   ...Default.args,
 };
+
+export const AdjustableRowNumber = args => {
+  function getTableRows() {
+    const tableRows = [];
+    for (let i = 0; i < args.numberRows; i++) {
+      tableRows.push(
+        <TableRow key={`row${i}`}>
+          <TableCell key={`cell${i}-left`}>{i}</TableCell>
+          <TableCell key={`cell${i}-middle`}>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</TableCell>
+          <TableCell key={`cell${i}-right`}>Nullam bibendum diam vel felis consequat lacinia.</TableCell>
+        </TableRow>
+      );
+    }
+    return tableRows;
+  };
+
+  return (
+    <Table {...args}>
+      <TableHead>
+        <TableRow>
+          <TableHeaderCell>Number</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {getTableRows()}
+      </TableBody>
+    </Table>
+  );
+};
+AdjustableRowNumber.args = {
+  numberRows: 300,
+};


### PR DESCRIPTION
## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Storybook example for tables where the number of rows is adjustable. For @hkrishna29 and testing purposes.
