### PR TITLE
fix(combobox): items have a default `type="button"` to prevent issues inside form

### DIFF
--- a/.changeset/combobox-inside-form.md
+++ b/.changeset/combobox-inside-form.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+fix(combobox): Combobox items have a default `type="button"` to prevent issues when used inside a form.

--- a/.changeset/combobox-inside-form.md
+++ b/.changeset/combobox-inside-form.md
@@ -1,5 +1,5 @@
 ---
-'react-magma-dom': minor
+'react-magma-dom': patch
 ---
 
 fix(combobox): Combobox items have a default `type="button"` to prevent issues when used inside a form.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
@@ -5,9 +5,10 @@ import { SelectOptions } from '../Select';
 import { LabelPosition } from '../Label';
 import { Card } from '../Card';
 import { CardBody } from '../Card/CardBody';
-import { Heading } from '../Heading';
 import { Input } from '../Input';
 import { Spacer } from '../Spacer';
+import { Form } from '../Form';
+import { Button, ButtonType } from '../Button';
 
 const Template: Story<ComboboxProps<SelectOptions>> = args => (
   <Combobox {...args} />
@@ -1204,59 +1205,68 @@ Typeahead.args = {
 };
 
 export const FullPageExample = args => {
+  function handleSubmit() {
+    alert('Form Submitted');
+  }
   return (
     <>
-      <Heading level={1}>Confirm Adoption</Heading>
-      <Combobox
-        labelText="Select the format(s) for which you would like to review pricing *"
-        defaultItems={[
-          { label: 'eBook', value: 'eBook' },
-          { label: 'Paperback', value: 'paperback' },
-          { label: 'Hardcover', value: 'hardcover' },
-          {
-            label: 'Online Homework Platform',
-            value: 'onlinehomeworkplatform',
-          },
-        ]}
-        isMulti
-        hasPersistentMenu
-        placeholder="Select format(s)"
-        isClearable
-        disableCreateItem
-      />
-      <Spacer size={16} />
-      <Input
-        labelText="What is the name and number of the course you are requesting this title for? *"
-        maxLength={100}
-        placeholder="SWEN101"
-      />
-      <Spacer size={16} />
-      <Combobox
-        labelText="What term will you be teaching? *"
-        defaultItems={[
-          { label: 'Spring', value: 'Spring' },
-          { label: 'Summer', value: 'Summer' },
-          { label: 'Fall', value: 'Fall' },
-          { label: 'Winter', value: 'Winter' },
-        ]}
-        isMulti
-        hasPersistentMenu
-        placeholder="Select term"
-        disableCreateItem
-      />
-      <Spacer size={16} />
-      <Combobox
-        labelText="What is your role in selecting a title for this course?"
-        defaultItems={[
-          { label: 'One', value: 'one' },
-          { label: 'Two', value: 'two' },
-          { label: 'Three', value: 'three' },
-          { label: 'Four', value: 'four' },
-        ]}
-        placeholder="Select role"
-        disableCreateItem
-      />
-      <Spacer size={16} />
+      <Form
+        onSubmit={handleSubmit}
+        header="Confirm Adoption"
+        description="Example of comboboxes inside a form"
+        actions={<Button type={ButtonType.submit}>Submit</Button>}
+      >
+        <Combobox
+          labelText="Select the format(s) for which you would like to review pricing *"
+          defaultItems={[
+            { label: 'eBook', value: 'eBook' },
+            { label: 'Paperback', value: 'paperback' },
+            { label: 'Hardcover', value: 'hardcover' },
+            {
+              label: 'Online Homework Platform',
+              value: 'onlinehomeworkplatform',
+            },
+          ]}
+          isMulti
+          hasPersistentMenu
+          placeholder="Select format(s)"
+          isClearable
+          disableCreateItem
+        />
+        <Spacer size={16} />
+        <Input
+          labelText="What is the name and number of the course you are requesting this title for? *"
+          maxLength={100}
+          placeholder="SWEN101"
+        />
+        <Spacer size={16} />
+        <Combobox
+          labelText="What term will you be teaching? *"
+          defaultItems={[
+            { label: 'Spring', value: 'Spring' },
+            { label: 'Summer', value: 'Summer' },
+            { label: 'Fall', value: 'Fall' },
+            { label: 'Winter', value: 'Winter' },
+          ]}
+          isMulti
+          hasPersistentMenu
+          placeholder="Select term"
+          disableCreateItem
+        />
+        <Spacer size={16} />
+        <Combobox
+          labelText="What is your role in selecting a title for this course?"
+          defaultItems={[
+            { label: 'One', value: 'one' },
+            { label: 'Two', value: 'two' },
+            { label: 'Three', value: 'three' },
+            { label: 'Four', value: 'four' },
+          ]}
+          placeholder="Select role"
+          disableCreateItem
+        />
+        <Spacer size={16} />
+      </Form>
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
@@ -9,6 +9,7 @@ import { Input } from '../Input';
 import { Spacer } from '../Spacer';
 import { Form } from '../Form';
 import { Button, ButtonType } from '../Button';
+import { action } from '@storybook/addon-actions';
 
 const Template: Story<ComboboxProps<SelectOptions>> = args => (
   <Combobox {...args} />
@@ -1205,13 +1206,10 @@ Typeahead.args = {
 };
 
 export const FullPageExample = args => {
-  function handleSubmit() {
-    alert('Form Submitted');
-  }
   return (
     <>
       <Form
-        onSubmit={handleSubmit}
+        onSubmit={action('form submitted')}
         header="Confirm Adoption"
         description="Example of comboboxes inside a form"
         actions={<Button type={ButtonType.submit}>Submit</Button>}

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -545,6 +545,19 @@ describe('MultiCombobox', () => {
     expect(getByText('Red', { selector: 'button' })).toBeInTheDocument();
   });
 
+  it('should render items with button type button', () => {
+    const { getByText } = render(
+      <MultiCombobox
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red']}
+      />
+    );
+
+    expect(getByText('Red', { selector: 'button' })).toHaveAttribute('type', 'button');
+  });
+
   describe('isTypeahead', () => {
     describe('when isTypeahead is true,', () => {
       it('should be able to select an item that is not in the items list', () => {

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -13,7 +13,7 @@ import { useForkedRef } from '../../utils';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { I18nContext } from '../../i18n';
 import { MultiComboboxProps } from '.';
-import { ButtonShape, ButtonSize, ButtonVariant } from '../Button';
+import { ButtonShape, ButtonSize, ButtonType, ButtonVariant } from '../Button';
 
 export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
   const [inputValue, setInputValue] = React.useState('');
@@ -331,6 +331,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
               onFocus={() => setActiveIndex(index)}
               theme={theme}
               isInverse={isInverse}
+              type={ButtonType.button}
             >
               {itemToString(multiSelectedItem)}
               <IconWrapper>


### PR DESCRIPTION
Issue: #953 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

Added `type="button"` to the items inside a combobox. This should prevent the whole form submitting when an item gets removed.

## Screenshots (if appropriate):
_No visual change, just a change in the DOM_
![image](https://user-images.githubusercontent.com/91160746/199261091-cbabaf04-2be5-435f-90ae-913b6e7f6362.png)


## Checklist 
- [X] changeset has been added
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
- Confirm that after selecting more than one item, clicking one item to delete it does not submit the form