### PR TITLE
docs(changelog): broken link to the 2.3.0 release

### DIFF
--- a/.changeset/small-jokes-hide.md
+++ b/.changeset/small-jokes-hide.md
@@ -1,0 +1,5 @@
+---
+"react-magma-docs": patch
+---
+
+docs(changelog): broken link to the 2.3.0 release

--- a/website/react-magma-docs/src/pages/api-intro/changelog.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/changelog.mdx
@@ -3,7 +3,7 @@ title: Changelog
 order: 4
 ---
 
-## [2.3.0](https://github.com/cengage/react-magma/compare/react-magma-dom@2.3.0...react-magma-dom@2.3.0) (2020-12-08)
+## 2.3.0 (2020-12-08)
 
 ### Features
 


### PR DESCRIPTION
fix #463

Issue: #463

## What I did
-removed the markup for a link to allow for the sidebar link to navigate to the correct section in the changelog

## Screenshots (if appropriate):

## Checklist 
- [x] changeset has been added
- [x] I have made corresponding changes to the documentation

## How to test
- From Sidebar > Components > Changelog 
- Click 2.3.0 (2020-12-08)
- Verify the page navigates to the correct section. 

