### PR TITLE
fix(tabs): disabled tabs have the disabled cursor

### DIFF
--- a/.changeset/tabs-disabled.md
+++ b/.changeset/tabs-disabled.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix(tabs): Disabled tabs have the disabled cursor

--- a/packages/react-magma-dom/src/components/Tabs/Tab.test.js
+++ b/packages/react-magma-dom/src/components/Tabs/Tab.test.js
@@ -80,6 +80,7 @@ describe('Tab', () => {
 
     expect(component).toHaveProperty('disabled', true);
     expect(component).toBeDisabled();
+    expect(getByTestId('tabContainer')).toHaveStyleRule('cursor', 'not-allowed');
 
     rerender(
       <Tabs>
@@ -91,6 +92,7 @@ describe('Tab', () => {
 
     expect(component).toHaveProperty('disabled', false);
     expect(component).not.toBeDisabled();
+    expect(getByTestId('tabContainer')).toHaveStyleRule('cursor', 'pointer');
   });
 
   it('should render icon', () => {

--- a/packages/react-magma-dom/src/components/Tabs/Tab.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/Tab.tsx
@@ -37,12 +37,14 @@ export const StyledTabsChild = styled('li', {
   shouldForwardProp: isPropValid,
 })<{
   borderPosition?: TabsBorderPosition;
+  disabled?: boolean;
   isActive?: boolean;
   isFullWidth?: boolean;
   isInverse?: boolean;
   orientation: TabsOrientation;
   theme: ThemeInterface;
 }>`
+  cursor: ${props => props.disabled ? 'not-allowed' : 'pointer'};
   flex-grow: 0;
   flex-shrink: ${props => (props.isFullWidth ? '1' : '0')};
   height: ${props => (props.orientation === 'vertical' ? 'auto' : '100%')};
@@ -283,6 +285,7 @@ export const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
       <StyledTabsChild
         borderPosition={borderPosition}
         data-testid="tabContainer"
+        disabled={disabled}
         isActive={isActive}
         isFullWidth={isFullWidth}
         isInverse={isInverse}


### PR DESCRIPTION
Issue: #836

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Updated the cursor for disabled tabs to be `not-allowed`

## Screenshots (if appropriate):
![chrome-capture-2022-10-3](https://user-images.githubusercontent.com/91160746/199799447-b83b5193-7238-4d9a-a073-1670c18cb703.gif)


## Checklist 
- [x] changeset has been added
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
