### PR TITLE
fix(search): components with long placeholders && `isClearable` have appropriate padding

### DIFF
--- a/.changeset/search-placeholder.md
+++ b/.changeset/search-placeholder.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix(search): Search components with long placeholders && `isClearable` have appropriate padding

--- a/packages/react-magma-dom/src/components/Search/index.tsx
+++ b/packages/react-magma-dom/src/components/Search/index.tsx
@@ -75,6 +75,7 @@ export const Search = React.forwardRef<HTMLInputElement, SearchProps>(
       labelText,
       placeholder,
       onSearch,
+      onClear,
       ...other
     } = props;
 
@@ -109,6 +110,11 @@ export const Search = React.forwardRef<HTMLInputElement, SearchProps>(
       onSearch(value);
     }
 
+    function handleClear() {
+      onClear && typeof onClear === 'function' && onClear();
+      setCharacterLength(0);
+    }
+
     return (
       <InputBase
         {...other}
@@ -121,6 +127,7 @@ export const Search = React.forwardRef<HTMLInputElement, SearchProps>(
         isInverse={useIsInverse(props.isInverse)}
         inputLength={characterLength}
         onChange={handleChange}
+        onClear={handleClear}
         onIconClick={
           props.isPredictive ? null : isLoading ? null : handleSearch
         }


### PR DESCRIPTION
Issue: #955

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Addressing one more use case for #955 where the Search component placeholder spacing needed adjustments when the user clicked on `isClearable` button.

## Screenshots (if appropriate):
![chrome-capture-2022-10-16](https://user-images.githubusercontent.com/91160746/202229643-5f7b3637-5a9c-4614-99c5-96064e4460e6.gif)

## Checklist 
- [X] changeset has been added
- [N/A] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
- On the Search component with `isClearable` prop set to true, enter a long placeholder
- Type into the input
- Click the isClearable X
- Notice the spacing is correct