### PR TITLE
feat - Support adding children on the right side of Alerts

### DIFF
--- a/.changeset/feat-alertChildren.md
+++ b/.changeset/feat-alertChildren.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Alert): New additionalContent prop to enable adding styled children within an Alert or Banner.

--- a/packages/react-magma-dom/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-magma-dom/src/components/Alert/Alert.stories.tsx
@@ -25,7 +25,7 @@ export const Default = () => {
     <>
       <Alert>Default</Alert>
       <Alert variant={AlertVariant.success} additionalContent={AdditionalBadge}>
-        Success
+        Success&nbsp;
         <Hyperlink to="#">hyperlink</Hyperlink>
       </Alert>
       <Alert

--- a/packages/react-magma-dom/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-magma-dom/src/components/Alert/Alert.stories.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 import { Alert } from './index';
 import { AlertVariant } from '../AlertBase';
+import { Badge } from '../Badge';
+import { Button, ButtonSize } from '../Button';
 import { Card, CardBody } from '../Card';
 import { Hyperlink } from '../Hyperlink';
 
@@ -10,20 +12,46 @@ export default {
   component: Alert,
 } as Meta;
 
+const AdditionalBadge = (
+  <>
+    <Badge>Badgery</Badge>
+    <Badge>More Badgery</Badge>
+  </>
+);
+const AdditionalButton = <Button size={ButtonSize.small}>Button it up</Button>;
+
 export const Default = () => {
   return (
     <>
       <Alert>Default</Alert>
-      <Alert variant={AlertVariant.success}>Success <Hyperlink to="#">hyperlink</Hyperlink></Alert>
-      <Alert variant={AlertVariant.warning}>Warning <Hyperlink to="#">hyperlink</Hyperlink></Alert>
-      <Alert variant={AlertVariant.danger}>Danger <Hyperlink to="#">hyperlink</Hyperlink></Alert>
+      <Alert variant={AlertVariant.success} additionalContent={AdditionalBadge}>
+        Success
+        <Hyperlink to="#">hyperlink</Hyperlink>
+      </Alert>
+      <Alert
+        variant={AlertVariant.warning}
+        additionalContent={AdditionalButton}
+      >
+        Warning <Hyperlink to="#">hyperlink</Hyperlink>
+      </Alert>
+      <Alert variant={AlertVariant.danger}>
+        Danger <Hyperlink to="#">hyperlink</Hyperlink>
+      </Alert>
       <Alert isDismissible>
         Default dismissible with <Hyperlink to="#">hyperlink</Hyperlink>
       </Alert>
-      <Alert isDismissible variant={AlertVariant.success}>
+      <Alert
+        isDismissible
+        variant={AlertVariant.success}
+        additionalContent={AdditionalBadge}
+      >
         Success dismissible with <Hyperlink to="#">hyperlink</Hyperlink>
       </Alert>
-      <Alert isDismissible variant={AlertVariant.warning}>
+      <Alert
+        isDismissible
+        variant={AlertVariant.warning}
+        additionalContent={AdditionalButton}
+      >
         Warning dismissible with <Hyperlink to="#">hyperlink</Hyperlink>
       </Alert>
       <Alert isDismissible variant={AlertVariant.danger}>

--- a/packages/react-magma-dom/src/components/Alert/Alert.test.js
+++ b/packages/react-magma-dom/src/components/Alert/Alert.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { axe } from '../../../axe-helper';
 import { Alert } from '.';
 import { AlertVariant } from '../AlertBase';
+import { Badge } from '../Badge';
 import { act, render, fireEvent } from '@testing-library/react';
 import { magma } from '../../theme/magma';
 import { I18nContext } from '../../i18n';
@@ -192,5 +193,15 @@ describe('Alert', () => {
     return axe(container.innerHTML).then(result => {
       return expect(result).toHaveNoViolations();
     });
+  });
+
+  it('should render right aligned children passed in by the additionalContent prop', () => {
+    const { getByText } = render(
+      <Alert additionalContent={<Badge>Test Component</Badge>}>
+        Alert with additional right aligned children
+      </Alert>
+    );
+
+    expect(getByText('Test Component')).toBeInTheDocument();
   });
 });

--- a/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -564,7 +564,9 @@ exports[`Alert Variants should render an alert with danger variant 1`] = `
       <div
         class="emotion-1"
       >
-        Test Alert Text
+        <span>
+          Test Alert Text
+        </span>
       </div>
     </div>
   </div>
@@ -809,7 +811,9 @@ exports[`Alert Variants should render an alert with info variant 1`] = `
       <div
         class="emotion-1"
       >
-        Test Alert Text
+        <span>
+          Test Alert Text
+        </span>
       </div>
     </div>
   </div>
@@ -1054,7 +1058,9 @@ exports[`Alert Variants should render an alert with warning variant 1`] = `
       <div
         class="emotion-1"
       >
-        Test Alert Text
+        <span>
+          Test Alert Text
+        </span>
       </div>
     </div>
   </div>
@@ -1299,7 +1305,9 @@ exports[`Alert should render an alert with default variant 1`] = `
       <div
         class="emotion-1"
       >
-        Test Alert Text
+        <span>
+          Test Alert Text
+        </span>
       </div>
     </div>
   </div>

--- a/packages/react-magma-dom/src/components/Alert/index.tsx
+++ b/packages/react-magma-dom/src/components/Alert/index.tsx
@@ -5,6 +5,7 @@ import { AlertBase, AlertVariant } from '../AlertBase';
  * @children required
  */
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  additionalContent?: React.ReactNode;
   /**
    * The text read by screen readers for the close button
    * @default "Close this message"

--- a/packages/react-magma-dom/src/components/Alert/index.tsx
+++ b/packages/react-magma-dom/src/components/Alert/index.tsx
@@ -5,6 +5,9 @@ import { AlertBase, AlertVariant } from '../AlertBase';
  * @children required
  */
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Enables additional right aligned children within the Alert.
+   */
   additionalContent?: React.ReactNode;
   /**
    * The text read by screen readers for the close button

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -295,9 +295,10 @@ const AlertContents = styled.div<{
 `;
 
 export const AdditionalContentWrapper = styled.div`
-  flex: 1;
+  flex: 1 0 auto;
   justify-content: flex-end;
   display: flex;
+  margin-left: ${props => props.theme.spaceScale.spacing04};
 `;
 
 const IconWrapperStyles = css`

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -289,10 +289,6 @@ const AlertContents = styled.div<{
     props.additionalContent && !props.isDismissible
       ? props.theme.spaceScale.spacing03
       : ''};
-  * {
-    margin-left: ${props => (props.additionalContent ? '7px' : '')};
-  }
-
   @media (max-width: ${props => props.theme.breakpoints.small}px) {
     padding-left: 0;
   }
@@ -302,11 +298,6 @@ export const AdditionalContentWrapper = styled.div`
   flex: 1;
   justify-content: flex-end;
   display: flex;
-  * {
-    display: table-cell;
-    margin: 0;
-    margin-left: ${props => props.theme.spaceScale.spacing03};
-  }
 `;
 
 const IconWrapperStyles = css`
@@ -471,7 +462,6 @@ export const AlertBase = React.forwardRef<HTMLDivElement, AlertBaseProps>(
         theme={theme}
         variant={variant}
       >
-        {console.log(additionalContent)}
         <InverseContext.Provider value={{ isInverse }}>
           <StyledAlertInner
             isInverse={isInverse}

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -36,6 +36,7 @@ export enum AlertVariant {
 }
 
 export interface AlertBaseProps extends React.HTMLAttributes<HTMLDivElement> {
+  additionalContent?: React.ReactNode;
   closeAriaLabel?: string;
   forceDismiss?: () => void;
   hasTimerRing?: boolean;
@@ -275,13 +276,36 @@ const StyledAlertInner = styled.div<AlertBaseProps>`
     `}
 `;
 
-const AlertContents = styled.div`
+const AlertContents = styled.div<{
+  additionalContent?: React.ReactNode;
+  isDismissible?: boolean;
+}>`
+  align-items: ${props => (props.additionalContent ? 'center' : '')};
   align-self: center;
   flex-grow: 1;
   padding: ${props => props.theme.spaceScale.spacing04} 0;
+  display: ${props => (props.additionalContent ? 'flex' : '')};
+  margin-right: ${props =>
+    props.additionalContent && !props.isDismissible
+      ? props.theme.spaceScale.spacing03
+      : ''};
+  * {
+    margin-left: ${props => (props.additionalContent ? '7px' : '')};
+  }
 
   @media (max-width: ${props => props.theme.breakpoints.small}px) {
     padding-left: 0;
+  }
+`;
+
+export const AdditionalContentWrapper = styled.div`
+  flex: 1;
+  justify-content: flex-end;
+  display: flex;
+  * {
+    display: table-cell;
+    margin: 0;
+    margin-left: ${props => props.theme.spaceScale.spacing03};
   }
 `;
 
@@ -314,6 +338,8 @@ const ProgressRingWrapper = styled.div`
 
 const DismissibleIconWrapper = styled.span<AlertBaseProps>`
   ${IconWrapperStyles}
+  margin-left: ${props =>
+    props.additionalContent ? props.theme.spaceScale.spacing03 : ''};
 `;
 
 const whitelistProps = ['icon', 'isInverse', 'theme', 'variant'];
@@ -371,6 +397,7 @@ function renderIcon(variant = 'info', isToast?: boolean, theme?: any) {
 export const AlertBase = React.forwardRef<HTMLDivElement, AlertBaseProps>(
   (props, ref) => {
     const {
+      additionalContent,
       children,
       closeAriaLabel,
       forceDismiss,
@@ -444,6 +471,7 @@ export const AlertBase = React.forwardRef<HTMLDivElement, AlertBaseProps>(
         theme={theme}
         variant={variant}
       >
+        {console.log(additionalContent)}
         <InverseContext.Provider value={{ isInverse }}>
           <StyledAlertInner
             isInverse={isInverse}
@@ -452,7 +480,18 @@ export const AlertBase = React.forwardRef<HTMLDivElement, AlertBaseProps>(
             variant={variant}
           >
             {renderIcon(variant, isToast, theme)}
-            <AlertContents theme={theme}>{children}</AlertContents>
+            <AlertContents
+              additionalContent={additionalContent}
+              isDismissible={isDismissible}
+              theme={theme}
+            >
+              {children}
+              {additionalContent && (
+                <AdditionalContentWrapper theme={theme}>
+                  {additionalContent}
+                </AdditionalContentWrapper>
+              )}
+            </AlertContents>
             {isDismissible && (
               <DismissibleIconWrapper
                 isInverse={isInverse}

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -298,7 +298,7 @@ export const AdditionalContentWrapper = styled.div`
   flex: 1 0 auto;
   justify-content: flex-end;
   display: flex;
-  margin-left: ${props => props.theme.spaceScale.spacing04};
+  margin-left: ${props => props.theme.spaceScale.spacing05};
 `;
 
 const IconWrapperStyles = css`

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -475,7 +475,7 @@ export const AlertBase = React.forwardRef<HTMLDivElement, AlertBaseProps>(
               isDismissible={isDismissible}
               theme={theme}
             >
-              {children}
+              <span>{children}</span>
               {additionalContent && (
                 <AdditionalContentWrapper theme={theme}>
                   {additionalContent}

--- a/packages/react-magma-dom/src/components/Banner/Banner.stories.tsx
+++ b/packages/react-magma-dom/src/components/Banner/Banner.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Banner, BannerProps } from '.';
 import { AlertVariant } from '../AlertBase';
+import { Badge } from '../Badge';
 import { Card, CardBody } from '../Card';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { Hyperlink } from '../Hyperlink';
@@ -9,9 +10,16 @@ function handleActionButtonClick() {
   alert('action button clicked!');
 }
 
+const AdditionalBadge = (
+  <>
+    <Badge>Badgery</Badge>
+    <Badge>More Badgery</Badge>
+  </>
+);
+
 const Template: Story<BannerProps> = args => (
   <>
-    <Banner {...args}>
+    <Banner {...args} additionalContent={AdditionalBadge}>
       Default (info) banner with&nbsp;
       <Hyperlink to="#" isInverse={args.isInverse}>
         hyperlink
@@ -64,6 +72,7 @@ const Template: Story<BannerProps> = args => (
       Dismissible (warning) banner
     </Banner>
     <Banner
+      additionalContent={AdditionalBadge}
       isDismissible
       actionButtonText="Action"
       actionButtonOnClick={handleActionButtonClick}

--- a/packages/react-magma-dom/src/components/Banner/Banner.test.js
+++ b/packages/react-magma-dom/src/components/Banner/Banner.test.js
@@ -3,7 +3,7 @@ import { axe } from '../../../axe-helper';
 import { Banner } from '.';
 import { render, fireEvent } from '@testing-library/react';
 import { magma } from '../../theme/magma';
-import { Button } from '../Button';
+import { Badge } from '../Badge';
 
 describe('Banner', () => {
   it('should find element by testId', () => {
@@ -284,5 +284,15 @@ describe('Banner', () => {
     return axe(container.innerHTML).then(result => {
       return expect(result).toHaveNoViolations();
     });
+  });
+
+  it('should render right aligned children passed in by the additionalContent prop', () => {
+    const { getByText } = render(
+      <Banner additionalContent={<Badge>Test Component</Badge>}>
+        Alert with additional right aligned children
+      </Banner>
+    );
+
+    expect(getByText('Test Component')).toBeInTheDocument();
   });
 });

--- a/packages/react-magma-dom/src/components/Banner/index.tsx
+++ b/packages/react-magma-dom/src/components/Banner/index.tsx
@@ -3,6 +3,7 @@ import styled from '../../theme/styled';
 import isPropValid from '@emotion/is-prop-valid';
 import { AlertProps } from '../Alert';
 import {
+  AdditionalContentWrapper,
   AlertVariant,
   buildAlertBackground,
   buildAlertBorder,
@@ -57,7 +58,10 @@ const StyledBanner = styled.div<AlertProps>`
 `;
 
 const BannerContents = styled.div<{
+  additionalContent?: React.ReactNode;
   variant?: AlertVariant;
+  isDismissible?: boolean;
+
   isInverse?: boolean;
 }>`
   align-items: center;
@@ -65,7 +69,10 @@ const BannerContents = styled.div<{
   display: flex;
   flex-grow: 1;
   justify-content: flex-start;
-  padding: ${props => props.theme.spaceScale.spacing04};
+  padding: ${props =>
+    props.additionalContent && props.isDismissible
+      ? `${props.theme.spaceScale.spacing04} 0 ${props.theme.spaceScale.spacing04} ${props.theme.spaceScale.spacing04}`
+      : props.theme.spaceScale.spacing04};
 
   @media (max-width: ${props => props.theme.breakpoints.small}px) {
     justify-content: flex-start;
@@ -187,6 +194,7 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
     const {
       actionButtonText,
       actionButtonOnClick,
+      additionalContent,
       children,
       closeAriaLabel,
       isDismissible,
@@ -208,7 +216,13 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
         theme={theme}
         variant={variant}
       >
-        <BannerContents theme={theme} variant={variant} isInverse={isInverse}>
+        <BannerContents
+          additionalContent={additionalContent}
+          isDismissible={isDismissible}
+          theme={theme}
+          variant={variant}
+          isInverse={isInverse}
+        >
           {renderIcon(variant, theme)}
           {children}
           {actionButtonText && actionButtonOnClick && (
@@ -221,6 +235,11 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
             >
               {actionButtonText}
             </Button>
+          )}
+          {additionalContent && (
+            <AdditionalContentWrapper theme={theme}>
+              {additionalContent}
+            </AdditionalContentWrapper>
           )}
         </BannerContents>
 

--- a/packages/react-magma-dom/src/components/Banner/index.tsx
+++ b/packages/react-magma-dom/src/components/Banner/index.tsx
@@ -228,7 +228,7 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
           isInverse={isInverse}
         >
           {renderIcon(variant, theme)}
-          {children}
+          <span>{children}</span>
           {actionButtonText && actionButtonOnClick && (
             <Button
               color={getButtonColor(variant)}

--- a/packages/react-magma-dom/src/components/Banner/index.tsx
+++ b/packages/react-magma-dom/src/components/Banner/index.tsx
@@ -32,6 +32,10 @@ export interface BannerProps extends AlertProps {
    */
   actionButtonOnClick?: () => void;
   /**
+   * Enables additional right aligned children within the Banner.
+   */
+  additionalContent?: React.ReactNode;
+  /**
    * If true, the component will be able to be dismissed and will include a close button
    * @default false
    */

--- a/website/react-magma-docs/src/pages/api/alert.mdx
+++ b/website/react-magma-docs/src/pages/api/alert.mdx
@@ -96,6 +96,31 @@ export function Example() {
 }
 ```
 
+## Additional Content
+
+Using the `additionalContent` prop will let you include right aligned children within Alerts.
+
+```tsx
+import React from 'react';
+import { Alert, Badge, Button } from 'react-magma-dom';
+
+const AdditionalBadge = <Badge>Badge</Badge>;
+const AdditionalButton = <Button>Button</Button>;
+
+export function Example() {
+  return (
+    <>
+      <Alert additionalContent={AdditionalBadge}>
+        Alert with additional Badge.
+      </Alert>
+      <Alert additionalContent={AdditionalButton}>
+        Alert with additional Button.
+      </Alert>
+    </>
+  );
+}
+```
+
 ## Inverse
 
 ```tsx
@@ -104,7 +129,7 @@ import { Alert, AlertVariant, Container } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <Container isInverse style={{padding: '12px 12px 0'}}>
+    <Container isInverse style={{ padding: '12px 12px 0' }}>
       <Alert variant={AlertVariant.info} isInverse>
         Inverse Info Alert
       </Alert>

--- a/website/react-magma-docs/src/pages/api/banner.mdx
+++ b/website/react-magma-docs/src/pages/api/banner.mdx
@@ -88,6 +88,31 @@ export function Example() {
 }
 ```
 
+## Additional Content
+
+Using the `additionalContent` prop will let you include right aligned children within Banners.
+
+```tsx
+import React from 'react';
+import { Banner, Badge, Button } from 'react-magma-dom';
+
+const AdditionalBadge = <Badge>Badge</Badge>;
+const AdditionalButton = <Button>Button</Button>;
+
+export function Example() {
+  return (
+    <>
+      <Banner additionalContent={AdditionalBadge}>
+        Banner with additional Badge.
+      </Banner>
+      <Banner additionalContent={AdditionalButton}>
+        Banner with additional Button.
+      </Banner>
+    </>
+  );
+}
+```
+
 ## Action Button
 
 A single button can be added to a Banner Alert to provide the user with an action to take. The `actionButtonText` prop is a string that sets the text of the button.
@@ -114,6 +139,7 @@ export function Example() {
 ```
 
 ## Inverse
+
 ```tsx
 import React from 'react';
 import { Banner, AlertVariant, Container } from 'react-magma-dom';
@@ -123,15 +149,38 @@ export function Example() {
     alert('action button clicked!');
   }
   return (
-    <Container isInverse style={{padding: '12px'}}>
-      <Banner actionButtonText="Action"
-      actionButtonOnClick={handleActionButtonClick} isInverse>Default (info) banner</Banner>
-      <Banner variant={AlertVariant.success} actionButtonText="Action"
-      actionButtonOnClick={handleActionButtonClick} isInverse>Success banner</Banner>
-      <Banner variant={AlertVariant.warning} actionButtonText="Action"
-      actionButtonOnClick={handleActionButtonClick} isInverse>Warning banner</Banner>
-      <Banner variant={AlertVariant.danger} actionButtonText="Action"
-      actionButtonOnClick={handleActionButtonClick} isInverse>Danger banner</Banner>
+    <Container isInverse style={{ padding: '12px' }}>
+      <Banner
+        actionButtonText="Action"
+        actionButtonOnClick={handleActionButtonClick}
+        isInverse
+      >
+        Default (info) banner
+      </Banner>
+      <Banner
+        variant={AlertVariant.success}
+        actionButtonText="Action"
+        actionButtonOnClick={handleActionButtonClick}
+        isInverse
+      >
+        Success banner
+      </Banner>
+      <Banner
+        variant={AlertVariant.warning}
+        actionButtonText="Action"
+        actionButtonOnClick={handleActionButtonClick}
+        isInverse
+      >
+        Warning banner
+      </Banner>
+      <Banner
+        variant={AlertVariant.danger}
+        actionButtonText="Action"
+        actionButtonOnClick={handleActionButtonClick}
+        isInverse
+      >
+        Danger banner
+      </Banner>
     </Container>
   );
 }


### PR DESCRIPTION
Issue: # [992](https://github.com/cengage/react-magma/issues/992)

## What I did
Added `additionalContent` prop to Alerts and Banners for right aligned children elements such as buttons and badges.

## Screenshots (if appropriate):
![example](https://user-images.githubusercontent.com/77400920/216376941-08f5b756-526d-4a88-84b7-9cc7e7c5b237.png)


## Checklist 
- [x] changeset has been added
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
