### PR TITLE
docs(select): Reorganize docs

### DIFF
--- a/.changeset/docs-select.md
+++ b/.changeset/docs-select.md
@@ -1,0 +1,5 @@
+---
+"react-magma-docs": patch
+---
+
+Reorganize Select docs

--- a/.changeset/multiselect-align.md
+++ b/.changeset/multiselect-align.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(select): Fix Multi Select placeholder text alignment

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -98,10 +98,8 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
         {isOpen && hasItems ? (
           items.map((item, index) => {
             const itemString = instanceOfToBeCreatedItemObject(item)
-            ? item.label
-            : itemToString(item);
-            
-            console.log('item', item, itemString)
+              ? item.label
+              : itemToString(item);
 
             const { ref, ...otherDownshiftItemProps } = getItemProps({
               item,
@@ -109,7 +107,6 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
             });
 
             const key = `${itemString}${index}`;
-            console.log(key)
 
             const itemProps: ItemRenderOptions<T> = {
               isFocused: highlightedIndex === index,

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -98,8 +98,10 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
         {isOpen && hasItems ? (
           items.map((item, index) => {
             const itemString = instanceOfToBeCreatedItemObject(item)
-              ? item.label
-              : itemToString(item);
+            ? item.label
+            : itemToString(item);
+            
+            console.log('item', item, itemString)
 
             const { ref, ...otherDownshiftItemProps } = getItemProps({
               item,
@@ -107,6 +109,7 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
             });
 
             const key = `${itemString}${index}`;
+            console.log(key)
 
             const itemProps: ItemRenderOptions<T> = {
               isFocused: highlightedIndex === index,

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -5,7 +5,7 @@ import { CloseIcon } from 'react-magma-icons';
 import { ItemsList } from './ItemsList';
 import { SelectContainer } from './SelectContainer';
 import { SelectTriggerButton } from './SelectTriggerButton';
-import { SelectedItemButton, IconWrapper } from './shared';
+import { SelectText, SelectedItemButton, IconWrapper } from './shared';
 
 import { ThemeContext } from '../../theme/ThemeContext';
 import { I18nContext } from '../../i18n';
@@ -180,37 +180,39 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
         isInverse={isInverse}
         style={inputStyle}
       >
-        {selectedItems && selectedItems.length > 0
-          ? selectedItems.map((multiSelectedItem, index) => {
-              const multiSelectedItemString = itemToString(multiSelectedItem);
-              return (
-                <SelectedItemButton
-                  aria-label={i18n.multiSelect.selectedItemButtonAriaLabel.replace(
-                    /\{selectedItem\}/g,
-                    multiSelectedItemString
-                  )}
-                  key={`selected-item-${index}`}
-                  {...getSelectedItemProps({
-                    selectedItem: multiSelectedItem,
-                    index,
-                  })}
-                  onClick={event =>
-                    handleRemoveSelectedItem(event, multiSelectedItem)
-                  }
-                  onFocus={() => setActiveIndex(index)}
-                  theme={theme}
-                  isInverse={isInverse}
-                >
-                  {multiSelectedItemString}
-                  <IconWrapper>
-                    <CloseIcon size={theme.iconSizes.xSmall} />
-                  </IconWrapper>
-                </SelectedItemButton>
-              );
-            })
-          : typeof placeholder === 'string'
-          ? placeholder
-          : i18n.multiSelect.placeholder}
+        {selectedItems && selectedItems.length > 0 ? (
+          selectedItems.map((multiSelectedItem, index) => {
+            const multiSelectedItemString = itemToString(multiSelectedItem);
+            return (
+              <SelectedItemButton
+                aria-label={i18n.multiSelect.selectedItemButtonAriaLabel.replace(
+                  /\{selectedItem\}/g,
+                  multiSelectedItemString
+                )}
+                key={`selected-item-${index}`}
+                {...getSelectedItemProps({
+                  selectedItem: multiSelectedItem,
+                  index,
+                })}
+                onClick={event =>
+                  handleRemoveSelectedItem(event, multiSelectedItem)
+                }
+                onFocus={() => setActiveIndex(index)}
+                theme={theme}
+                isInverse={isInverse}
+              >
+                {multiSelectedItemString}
+                <IconWrapper>
+                  <CloseIcon size={theme.iconSizes.xSmall} />
+                </IconWrapper>
+              </SelectedItemButton>
+            );
+          })
+        ) : typeof placeholder === 'string' ? (
+          <SelectText>{placeholder}</SelectText>
+        ) : (
+          <SelectText>{i18n.multiSelect.placeholder}</SelectText>
+        )}
       </SelectTriggerButton>
       <ItemsList
         customComponents={customComponents}

--- a/website/react-magma-docs/src/components/PageContent/index.js
+++ b/website/react-magma-docs/src/components/PageContent/index.js
@@ -28,7 +28,7 @@ const NAV_TABS = {
 };
 
 // Special case pages that don't have secondary navigation.
-const PAGES_NO_NAV = ['contribution_guidelines', 'getting_started_patterns'];
+const PAGES_NO_NAV = ['contribution_guidelines', 'getting_started_patterns', 'select_migration'];
 
 const TabsWrapper = styled.div`
   position: sticky;

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -459,6 +459,7 @@ import {
   DropdownDivider,
   DropdownHeader,
   Input,
+  InputType,
   magma,
   PasswordInput,
   ButtonGroup,
@@ -471,7 +472,7 @@ export function Example() {
         <DropdownButton>Dropdown with Login Form</DropdownButton>
         <DropdownContent>
           <form style={{ margin: 0, padding: magma.spaceScale.spacing05 }}>
-            <Input type="email" labelText="Email Address" />
+            <Input type={InputType.email} labelText="Email Address" />
             <PasswordInput labelText="Password" />
             <div style={{ textAlign: 'center' }}>
               <p>

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -44,9 +44,9 @@ export function Example() {
 
 ```tsx
 import React from 'react';
-import { Input } from 'react-magma-dom';
+import { Input, InputType } from 'react-magma-dom';
 export function Example() {
-  return <Input labelText="Number" type="number" />;
+  return <Input labelText="Number" type={InputType.number} />;
 }
 ```
 
@@ -212,7 +212,7 @@ The `iconPosition` position prop is optional and takes the values `left` and `ri
 
 ```tsx
 import React from 'react';
-import { Input, Spinner } from 'react-magma-dom';
+import { Input, InputType, Spinner } from 'react-magma-dom';
 import { EventIcon, MailOutlineIcon } from 'react-magma-icons';
 export function Example() {
   return (
@@ -220,7 +220,7 @@ export function Example() {
       <Input
         labelText="Input with icon on left"
         icon={<MailOutlineIcon />}
-        type="email"
+        type={InputType.email}
       />
 
       <Input
@@ -249,7 +249,7 @@ The `inputSize` prop can be used to control the input size. Options are `medium`
 
 ```tsx
 import React from 'react';
-import { Input } from 'react-magma-dom';
+import { Input, InputType } from 'react-magma-dom';
 import { EventIcon, MailOutlineIcon } from 'react-magma-icons';
 export function Example() {
   return (
@@ -258,7 +258,7 @@ export function Example() {
         labelText="Large input with icon on left"
         inputSize="large"
         icon={<MailOutlineIcon />}
-        type="email"
+        type={InputType.email}
       />
 
       <Input
@@ -373,7 +373,7 @@ will appear to the right of the field.
 
 ```tsx
 import React from 'react';
-import { IconButton, Input, Tooltip } from 'react-magma-dom';
+import { IconButton, Input, Tooltip, InputType } from 'react-magma-dom';
 import { HelpIcon } from 'react-magma-icons';
 export function Example() {
   const helpLinkLabel = 'Learn more';
@@ -388,7 +388,7 @@ export function Example() {
           aria-label={helpLinkLabel}
           icon={<HelpIcon />}
           onClick={onHelpLinkClick}
-          type="button"
+          type={InputType.button}
           size="small"
           variant="link"
         />

--- a/website/react-magma-docs/src/pages/api/select.mdx
+++ b/website/react-magma-docs/src/pages/api/select.mdx
@@ -22,7 +22,7 @@ If you are migrating from the Legacy Select, please see the <Link to="/select-mi
 
 By default when passing in a `selectedItem` it will be checked to make sure it is in your `items` array. The check will use the
 `itemToString` function on both the `selectedItem` and each `item` in the array. The default `itemToString` function
-is able to be used for `items` that are either `strings` or an object with the shape `{item: string; label: string;}`.
+is able to be used for `items` that are either `strings` or an object with the shape `{label: string; value: string;}`.
 If you are using a custom items format see the [Custom Items example](/api/select/#custom_items).
 
 ```tsx
@@ -40,7 +40,6 @@ export function Example() {
     <>
       <Select
         id="basicSelectId"
-        name="basic"
         labelText="Basic"
         items={[
           { label: 'Red', value: 'red' },
@@ -53,7 +52,6 @@ export function Example() {
 
       <Select
         id="badSelectedItemId"
-        name="badSelectedItem"
         labelText="Bad selected item"
         items={[
           { label: 'Red', value: 'red' },
@@ -91,7 +89,6 @@ export function Example() {
     <>
       <Select
         id="initialSelectedByItemSelectId"
-        name="initialSelectedByItem"
         labelText="Initial selected by item"
         items={[
           { label: 'Red', value: 'red' },
@@ -103,7 +100,6 @@ export function Example() {
 
       <Select
         id="initialHighlightedIndexSelectId"
-        name="initialHighlightedIndex"
         labelText="Initial highlighted index"
         items={[
           { label: 'Red', value: 'red' },
@@ -113,6 +109,340 @@ export function Example() {
         initialHighlightedIndex={1}
       />
     </>
+  );
+}
+```
+
+## Label Position
+
+The `labelPosition` prop can be used to set the position of the text label relative to the form field. It accepts either `top` or `left`, with `top` as the default.
+Left-aligned lables are not recommended for use in standard forms; instead they are designed for smaller spaces where vertical space is limited, such as in a toolbar.
+
+```tsx
+import React from 'react';
+import { Select, LabelPosition } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Select
+      labelPosition={LabelPosition.top}
+      labelText="Left-aligned label"
+      items={[
+        { label: 'Red', value: 'red' },
+        { label: 'Blue', value: 'blue' },
+        { label: 'Green', value: 'green' },
+      ]}
+    />
+  );
+}
+```
+
+## Disabled
+
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Select
+      id="disabledSelectId"
+      disabled
+      labelText="Disabled"
+      items={[
+        { label: 'Red', value: 'red' },
+        { label: 'Blue', value: 'blue' },
+        { label: 'Green', value: 'green' },
+      ]}
+    />
+  );
+}
+```
+
+## Clearable
+
+The optional `isClearable` prop allows the user to clear the field once a selection has been made.
+
+When using the `isClearable` prop you can choose a default selected item to be set once the `select` is cleared
+using the `defaultSelectedItem` prop.
+
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <Select
+        id="clearableSelectId"
+        labelText="Clearable"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        initialSelectedItem={{ label: 'Green', value: 'green' }}
+        isClearable
+      />
+
+      <Select
+        id="clearableWithDefaultsId"
+        labelText="Clearable with defaults"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        isClearable
+        defaultSelectedItem={{ label: 'Blue', value: 'blue' }}
+      />
+    </>
+  );
+}
+```
+
+## Error Message
+
+If a select has an `errorMessage`, the select will be styled to highlight its error state and the error message will appear below the field.
+If an error message is present, it will replace the helper text. Can be a node or a string.
+
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <Select
+        id="errorMessage"
+        labelText="Error message"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        errorMessage="Please select a color"
+      />
+    </>
+  );
+}
+```
+
+## Helper Message
+
+The `helperMessage` appears underneath the select field. It will not appear if an error message is present. Can be a node or a string.
+
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <Select
+        id="helperMessage"
+        labelText="Helper message"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        helperMessage="Helper text goes here"
+      />
+    </>
+  );
+}
+```
+
+## Placeholder
+
+The `placeholder` prop can be used to replace the default text shown before an item is chosen.
+Placeholder text should be used to provide supplemental information about the input field. It should not be
+relied upon to take the place of the label text.
+
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Select
+      id="placeholderSelect"
+      labelText="Placeholder example"
+      items={[
+        { label: 'Red', value: 'red' },
+        { label: 'Blue', value: 'blue' },
+        { label: 'Green', value: 'green' },
+      ]}
+      placeholder="Choose a color"
+    />
+  );
+}
+```
+
+## Accessibility
+
+The `getA11yStatusMessage` prop is a passed in function that allows for customization of the screen-reader accessible message whenever the following props
+are changed: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
+
+The `getA11ySelectionMessage` prop is a passed in function that allows for customization of the screen-reader accessible message
+whenever an item has been selected.
+
+For both the `getA11yStatusMessage` and `getA11ySelectionMessage` functions there is an
+[object passed with internal state data](https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect#geta11yselectionmessage).
+
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <Select
+        id="newA11yStatusMessageId"
+        labelText="New accessibility status message"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        getA11yStatusMessage={({ highlightedItem }) =>
+          `custom message saying that ${highlightedItem} is highlighted`
+        }
+        getA11ySelectionMessage={({ selectedItem }) =>
+          `custom message saying that ${selectedItem} is now selected`
+        }
+      />
+    </>
+  );
+}
+```
+
+## Multi Select
+
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  const [selectedItems, updateSelectedItems] = React.useState([]);
+
+  function handleSelectedItemsChange(changes) {
+    updateSelectedItems(changes.selectedItems);
+  }
+
+  function handleRemoveSelectedItem(removedItem) {
+    updateSelectedItems(selectedItems.filter(item => item !== removedItem));
+  }
+
+  return (
+    <>
+      <Select
+        id="multiSelectId"
+        isMulti
+        labelText="Multi select"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+          { label: 'Orange', value: 'orange' },
+          { label: 'Aqua', value: 'aqua' },
+          { label: 'Gold', value: 'gold' },
+          { label: 'Periwinkle', value: 'periwinkle' },
+          { label: 'Lavender', value: 'lavender' },
+          { label: 'Marigold', value: 'marigold' },
+          { label: 'Yellow', value: 'yellow' },
+          { label: 'Purple', value: 'purple' },
+          { label: 'Dusty Rose', value: 'dusty_rose' },
+          { label: 'Burnt Sienna', value: 'burnt_sienna' },
+        ]}
+        initialSelectedItems={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Blah', value: 'blah' },
+        ]}
+      />
+
+      <Select
+        id="multiSelectControlledId"
+        isMulti
+        labelText="Multi select controlled"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+          { label: 'Orange', value: 'orange' },
+          { label: 'Aqua', value: 'aqua' },
+          { label: 'Gold', value: 'gold' },
+          { label: 'Periwinkle', value: 'periwinkle' },
+          { label: 'Lavender', value: 'lavender' },
+          { label: 'Marigold', value: 'marigold' },
+          { label: 'Yellow', value: 'yellow' },
+          { label: 'Purple', value: 'purple' },
+          { label: 'Dusty Rose', value: 'dusty_rose' },
+          { label: 'Burnt Sienna', value: 'burnt_sienna' },
+        ]}
+        selectedItems={selectedItems}
+        onSelectedItemsChange={handleSelectedItemsChange}
+        onRemoveSelectedItem={handleRemoveSelectedItem}
+      />
+    </>
+  );
+}
+```
+
+## Inverse
+
+```tsx
+import React from 'react';
+import { Select, Card, CardBody } from 'react-magma-dom';
+
+export function Example() {
+  const [selectedItem, updateSelectedItem] = React.useState('');
+
+  function onSelectedItemChange(changes) {
+    updateSelectedItem(changes.selectedItem);
+  }
+
+  const [selectedItems, updateSelectedItems] = React.useState([]);
+
+  function handleSelectedItemsChange(changes) {
+    updateSelectedItems(changes.selectedItems);
+  }
+
+  function handleRemoveSelectedItem(removedItem) {
+    updateSelectedItems(selectedItems.filter(item => item !== removedItem));
+  }
+
+  return (
+    <Card isInverse>
+      <CardBody>
+        <Select
+          id="basicSelectInverseId"
+          isInverse
+          labelText="Basic"
+          items={[
+            { label: 'Red', value: 'red' },
+            { label: 'Blue', value: 'blue' },
+            { label: 'Green', value: 'green' },
+          ]}
+          selectedItem={selectedItem}
+          onSelectedItemChange={onSelectedItemChange}
+        />
+
+        <Select
+          id="multiSelectInverseId"
+          isInverse
+          isMulti
+          labelText="Multi select"
+          items={[
+            { label: 'Red', value: 'red' },
+            { label: 'Blue', value: 'blue' },
+            { label: 'Green', value: 'green' },
+          ]}
+        />
+      </CardBody>
+    </Card>
   );
 }
 ```
@@ -160,7 +490,6 @@ export function Example() {
 
       <Select
         id="stateChangesId1"
-        name="stateChanges"
         labelText="State changes"
         items={[
           { label: 'Red', value: 'red' },
@@ -236,7 +565,6 @@ export function Example() {
 
       <Select
         id="stateChangesId2"
-        name="stateChanges"
         labelText="State changes"
         items={[
           { label: 'Red', value: 'red' },
@@ -295,7 +623,6 @@ export function Example() {
 
       <Select
         id="controlledId"
-        name="controlled"
         labelText="Controlled"
         items={[
           { label: 'Red', value: 'red' },
@@ -308,268 +635,6 @@ export function Example() {
         onHighlightedIndexChange={onHighlightedIndexChange}
         onIsOpenChange={onIsOpenChange}
         onSelectedItemChange={onSelectedItemChange}
-      />
-    </>
-  );
-}
-```
-
-## Disabled
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <Select
-      id="disabledSelectId"
-      disabled
-      name="disabled"
-      labelText="Disabled"
-      items={[
-        { label: 'Red', value: 'red' },
-        { label: 'Blue', value: 'blue' },
-        { label: 'Green', value: 'green' },
-      ]}
-    />
-  );
-}
-```
-
-## Clearable
-
-The optional `isClearable` prop allows the user to clear the field once a selection has been made.
-
-When using the `isClearable` prop you can choose a default selected item to be set once the `select` is cleared
-using the `defaultSelectedItem` prop.
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <>
-      <Select
-        id="clearableSelectId"
-        name="clearable"
-        labelText="Clearable"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-        ]}
-        initialSelectedItem={{ label: 'Green', value: 'green' }}
-        isClearable
-      />
-
-      <Select
-        id="clearableWithDefaultsId"
-        name="clearableWithDefaults"
-        labelText="Clearable with defaults"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-        ]}
-        isClearable
-        defaultSelectedItem={{ label: 'Blue', value: 'blue' }}
-      />
-    </>
-  );
-}
-```
-
-## Error Message
-
-If a select has an `errorMessage`, the select will be styled to highlight it's error state and the error message will appear below the field.
-If an error message is present, it will replace the helper text. Can be a node or a string.
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <>
-      <Select
-        id="errorMessage"
-        name="error"
-        labelText="Error message"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-        ]}
-        errorMessage="Please select a color"
-      />
-    </>
-  );
-}
-```
-
-## Helper Message
-
-The `helperMessage` appears underneath the select field. It will not appear if an error message is present. Can be a node or a string.
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <>
-      <Select
-        id="helperMessage"
-        name="helper"
-        labelText="Helper message"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-        ]}
-        helperMessage="Helper text goes here"
-      />
-    </>
-  );
-}
-```
-
-## Placeholder
-
-The `placeholder` prop can be used to replace the default text shown before an item is chosen.
-Placeholder text should be used to provide supplemental information about the input field. It should not be
-relied upon to take the place of the label text.
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <Select
-      id="placeholderSelect"
-      labelText="Placeholder example"
-      items={[
-        { label: 'Red', value: 'red' },
-        { label: 'Blue', value: 'blue' },
-        { label: 'Green', value: 'green' },
-      ]}
-      placeholder="Choose a color"
-    />
-  );
-}
-```
-
-## Accessibility
-
-The `getA11yStatusMessage` prop is a passed in function that allows for customization of the screen-reader accessible message whenever the following props
-are changed: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
-
-The `getA11ySelectionMessage` prop is a passed in function that allows for customization of the screen-reader accessible message
-whenever an item has been selected.
-
-For both the `getA11yStatusMessage` and `getA11ySelectionMessage` functions there is an
-[object passed with internal state data](https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect#geta11yselectionmessage).
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <>
-      <Select
-        id="newA11yStatusMessageId"
-        name="newA11yStatusMessage"
-        labelText="New accessibility status message"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-        ]}
-        getA11yStatusMessage={({ highlightedItem }) =>
-          `custom message saying that ${highlightedItem} is highlighted`
-        }
-        getA11ySelectionMessage={({ selectedItem }) =>
-          `custom message saying that ${selectedItem} is now selected`
-        }
-      />
-    </>
-  );
-}
-```
-
-## Multi Select
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  const [selectedItems, updateSelectedItems] = React.useState([]);
-
-  function handleSelectedItemsChange(changes) {
-    updateSelectedItems(changes.selectedItems);
-  }
-
-  function handleRemoveSelectedItem(removedItem) {
-    updateSelectedItems(selectedItems.filter(item => item !== removedItem));
-  }
-
-  return (
-    <>
-      <Select
-        id="multiSelectId"
-        isMulti
-        name="multiSelect"
-        labelText="Multi select"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-          { label: 'Orange', value: 'orange' },
-          { label: 'Aqua', value: 'aqua' },
-          { label: 'Gold', value: 'gold' },
-          { label: 'Periwinkle', value: 'periwinkle' },
-          { label: 'Lavender', value: 'lavender' },
-          { label: 'Marigold', value: 'marigold' },
-          { label: 'Yellow', value: 'yellow' },
-          { label: 'Purple', value: 'purple' },
-          { label: 'Dusty Rose', value: 'dusty_rose' },
-          { label: 'Burnt Sienna', value: 'burnt_sienna' },
-        ]}
-        initialSelectedItems={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Blah', value: 'blah' },
-        ]}
-      />
-
-      <Select
-        id="multiSelectControlledId"
-        isMulti
-        name="multiSelectControlled"
-        labelText="Multi select controlled"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-          { label: 'Orange', value: 'orange' },
-          { label: 'Aqua', value: 'aqua' },
-          { label: 'Gold', value: 'gold' },
-          { label: 'Periwinkle', value: 'periwinkle' },
-          { label: 'Lavender', value: 'lavender' },
-          { label: 'Marigold', value: 'marigold' },
-          { label: 'Yellow', value: 'yellow' },
-          { label: 'Purple', value: 'purple' },
-          { label: 'Dusty Rose', value: 'dusty_rose' },
-          { label: 'Burnt Sienna', value: 'burnt_sienna' },
-        ]}
-        selectedItems={selectedItems}
-        onSelectedItemsChange={handleSelectedItemsChange}
-        onRemoveSelectedItem={handleRemoveSelectedItem}
       />
     </>
   );
@@ -606,7 +671,6 @@ export function Example() {
 
       <Select
         id="selectFocusEventId"
-        name="selectFocusEvent"
         labelText="Select focus events"
         items={[
           { label: 'Red', value: 'red' },
@@ -618,64 +682,6 @@ export function Example() {
         onKeyPress={handleSelectKeyPress}
       />
     </>
-  );
-}
-```
-
-## Inverse
-
-```tsx
-import React from 'react';
-import { Select, Card, CardBody } from 'react-magma-dom';
-
-export function Example() {
-  const [selectedItem, updateSelectedItem] = React.useState('');
-
-  function onSelectedItemChange(changes) {
-    updateSelectedItem(changes.selectedItem);
-  }
-
-  const [selectedItems, updateSelectedItems] = React.useState([]);
-
-  function handleSelectedItemsChange(changes) {
-    updateSelectedItems(changes.selectedItems);
-  }
-
-  function handleRemoveSelectedItem(removedItem) {
-    updateSelectedItems(selectedItems.filter(item => item !== removedItem));
-  }
-
-  return (
-    <Card isInverse>
-      <CardBody>
-        <Select
-          id="basicSelectInverseId"
-          isInverse
-          name="basic"
-          labelText="Basic"
-          items={[
-            { label: 'Red', value: 'red' },
-            { label: 'Blue', value: 'blue' },
-            { label: 'Green', value: 'green' },
-          ]}
-          selectedItem={selectedItem}
-          onSelectedItemChange={onSelectedItemChange}
-        />
-
-        <Select
-          id="multiSelectInverseId"
-          isInverse
-          isMulti
-          name="multiSelect"
-          labelText="Multi select"
-          items={[
-            { label: 'Red', value: 'red' },
-            { label: 'Blue', value: 'blue' },
-            { label: 'Green', value: 'green' },
-          ]}
-        />
-      </CardBody>
-    </Card>
   );
 }
 ```
@@ -698,30 +704,6 @@ export function Example() {
         { label: 'Green', value: 'green' },
       ]}
       itemListMaxHeight="50px"
-    />
-  );
-}
-```
-
-## Label Position
-
-The `labelPosition` prop can be used to set the position of the text label relative to the form field. It accepts either `top` or `left`, with `top` as the default.
-Left-aligned lables are not recommended for use in standard forms; instead they are designed for smaller spaces where vertical space is limited, such as in a toolbar.
-
-```tsx
-import React from 'react';
-import { Select, LabelPosition } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <Select
-      labelPosition={LabelPosition.top}
-      labelText="Left-aligned label"
-      items={[
-        { label: 'Red', value: 'red' },
-        { label: 'Blue', value: 'blue' },
-        { label: 'Green', value: 'green' },
-      ]}
     />
   );
 }
@@ -858,7 +840,6 @@ export function Example() {
     <>
       <Select
         id="itemToStringId"
-        name="itemToString"
         labelText="Item to string"
         items={[
           {
@@ -1043,7 +1024,7 @@ export function Example() {
 }
 ```
 
-## Other Custom Components
+### Other Custom Components
 
 ```tsx
 import React from 'react';
@@ -1053,7 +1034,6 @@ export function Example() {
   return (
     <Select
       id="customComponentsId"
-      name="customComponents"
       labelText="Custom components"
       items={[
         { label: 'Red', value: 'red' },

--- a/website/react-magma-docs/src/pages/api/select.mdx
+++ b/website/react-magma-docs/src/pages/api/select.mdx
@@ -20,9 +20,8 @@ If you are migrating from the Legacy Select, please see the <Link to="/select-mi
 
 ## Basic Usage
 
-By default when passing in a `selectedItem` it will be checked to make sure it is in your `items` array. The check will use the
-`itemToString` function on both the `selectedItem` and each `item` in the array. The default `itemToString` function
-is able to be used for `items` that are either `strings` or an object with the shape `{label: string; value: string;}`.
+By default when passing in a `selectedItem` it will be checked to make sure it is in your `items` array. The check will use the `itemToString` function on both the `selectedItem` and each `item` in the array. The default `itemToString` function is able to be used for `items` that are either `strings` or an object with the shape `{label: string; value: string;}`.
+
 If you are using a custom items format see the [Custom Items example](/api/select/#custom_items).
 
 ```tsx
@@ -116,6 +115,7 @@ export function Example() {
 ## Label Position
 
 The `labelPosition` prop can be used to set the position of the text label relative to the form field. It accepts either `top` or `left`, with `top` as the default.
+
 Left-aligned lables are not recommended for use in standard forms; instead they are designed for smaller spaces where vertical space is limited, such as in a toolbar.
 
 ```tsx
@@ -125,7 +125,7 @@ import { Select, LabelPosition } from 'react-magma-dom';
 export function Example() {
   return (
     <Select
-      labelPosition={LabelPosition.top}
+      labelPosition={LabelPosition.left}
       labelText="Left-aligned label"
       items={[
         { label: 'Red', value: 'red' },
@@ -276,44 +276,6 @@ export function Example() {
       ]}
       placeholder="Choose a color"
     />
-  );
-}
-```
-
-## Accessibility
-
-The `getA11yStatusMessage` prop is a passed in function that allows for customization of the screen-reader accessible message whenever the following props
-are changed: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
-
-The `getA11ySelectionMessage` prop is a passed in function that allows for customization of the screen-reader accessible message
-whenever an item has been selected.
-
-For both the `getA11yStatusMessage` and `getA11ySelectionMessage` functions there is an
-[object passed with internal state data](https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect#geta11yselectionmessage).
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <>
-      <Select
-        id="newA11yStatusMessageId"
-        labelText="New accessibility status message"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-        ]}
-        getA11yStatusMessage={({ highlightedItem }) =>
-          `custom message saying that ${highlightedItem} is highlighted`
-        }
-        getA11ySelectionMessage={({ selectedItem }) =>
-          `custom message saying that ${selectedItem} is now selected`
-        }
-      />
-    </>
   );
 }
 ```
@@ -641,6 +603,100 @@ export function Example() {
 }
 ```
 
+## Accessibility
+
+The `getA11yStatusMessage` prop is a passed in function that allows for customization of the screen-reader accessible message whenever the following props
+are changed: `items`, `highlightedIndex`, `inputValue` or `isOpen`.
+
+The `getA11ySelectionMessage` prop is a passed in function that allows for customization of the screen-reader accessible message
+whenever an item has been selected.
+
+For both the `getA11yStatusMessage` and `getA11ySelectionMessage` functions there is an
+[object passed with internal state data](https://github.com/downshift-js/downshift/tree/master/src/hooks/useSelect#geta11yselectionmessage).
+
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <Select
+        id="newA11yStatusMessageId"
+        labelText="New accessibility status message"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        getA11yStatusMessage={({ highlightedItem }) =>
+          `custom message saying that ${highlightedItem} is highlighted`
+        }
+        getA11ySelectionMessage={({ selectedItem }) =>
+          `custom message saying that ${selectedItem} is now selected`
+        }
+      />
+    </>
+  );
+}
+```
+
+## Internationalization
+
+Some of the internationalization overrides use placeholders to insert selected values in to the message.
+Placeholders are specific keywords surrounded by curly braces.
+
+- `{labelText}` will be replaced with the comboboxes `labelText`.
+- `{selectedItem}` will be replaced by the current `itemToString` representation of the `selectedItem` of the `select`.
+
+Full example of <Link to="/api/internationalization">internationalization override options</Link>
+
+```tsx
+import React from 'react';
+import { Select, I18nContext, defaultI18n } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <I18nContext.Provider
+      value={{
+        ...defaultI18n,
+        select: {
+          placeholder: 'Custom Select Placeholder...',
+          clearIndicatorAriaLabel:
+            'Click to reset selection for {labelText}. {selectedItem} is currently selected',
+        },
+        multiSelect: {
+          selectedItemButtonAriaLabel:
+            'Click to reset the selected item {selectedItem}',
+        },
+      }}
+    >
+      <Select
+        labelText="Internationalization"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        initialSelectedItem={{ label: 'Red', value: 'red' }}
+        isClearable
+      />
+
+      <Select
+        labelText="Multi internationalization"
+        isMulti
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        initialSelectedItems={[{ label: 'Red', value: 'red' }]}
+      />
+    </I18nContext.Provider>
+  );
+}
+```
+
 ## Events
 
 ```tsx
@@ -705,110 +761,6 @@ export function Example() {
       ]}
       itemListMaxHeight="50px"
     />
-  );
-}
-```
-
-## Custom Styles
-
-Custom styles can be passed into the Select component. The `containerStyle` property will apply to the container.
-Additional `labelStyle`, `inputStyle` and `messageStyle` properties are available to style the respective elements.
-Please use discretion when adding custom styles.
-
-```tsx
-import React from 'react';
-import { Select } from 'react-magma-dom';
-
-export function Example() {
-  const [selectedItem, updateSelectedItem] = React.useState('');
-
-  function onSelectedItemChange(changes) {
-    updateSelectedItem(changes.selectedItem);
-  }
-
-  return (
-    <>
-      <Select
-        containerStyle={{ marginBottom: '32px' }}
-        helperMessage="Helper message"
-        inputStyle={{ border: '2px dotted green', width: '200px' }}
-        items={['Red', 'Blue', 'Green']}
-        labelStyle={{ fontStyle: 'italic' }}
-        labelText="Basic with custom styles"
-        messageStyle={{ border: '1px solid blue' }}
-        selectedItem={selectedItem}
-        onSelectedItemChange={onSelectedItemChange}
-      />
-
-      <Select
-        containerStyle={{ marginBottom: '32px' }}
-        helperMessage="Helper message"
-        inputStyle={{ border: '2px dotted green', width: '200px' }}
-        isMulti
-        items={['Red', 'Blue', 'Green']}
-        labelStyle={{ fontStyle: 'italic' }}
-        labelText="Multi with custom styles"
-        messageStyle={{ border: '1px solid blue' }}
-        selectedItem={selectedItem}
-        onSelectedItemChange={onSelectedItemChange}
-      />
-    </>
-  );
-}
-```
-
-## Internationalization
-
-Some of the internationalization overrides use placeholders to insert selected values in to the message.
-Placeholders are specific keywords surrounded by curly braces.
-
-- `{labelText}` will be replaced with the comboboxes `labelText`.
-- `{selectedItem}` will be replaced by the current `itemToString` representation of the `selectedItem` of the `select`.
-
-Full example of <Link to="/api/internationalization">internationalization override options</Link>
-
-```tsx
-import React from 'react';
-import { Select, I18nContext, defaultI18n } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <I18nContext.Provider
-      value={{
-        ...defaultI18n,
-        select: {
-          placeholder: 'Custom Select Placeholder...',
-          clearIndicatorAriaLabel:
-            'Click to reset selection for {labelText}. {selectedItem} is currently selected',
-        },
-        multiSelect: {
-          selectedItemButtonAriaLabel:
-            'Click to reset the selected item {selectedItem}',
-        },
-      }}
-    >
-      <Select
-        labelText="Internationalization"
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-        ]}
-        initialSelectedItem={{ label: 'Red', value: 'red' }}
-        isClearable
-      />
-
-      <Select
-        labelText="Multi internationalization"
-        isMulti
-        items={[
-          { label: 'Red', value: 'red' },
-          { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
-        ]}
-        initialSelectedItems={[{ label: 'Red', value: 'red' }]}
-      />
-    </I18nContext.Provider>
   );
 }
 ```
@@ -923,12 +875,55 @@ export function Example() {
 }
 ```
 
-## Custom Components
+## Custom Styles
 
-Out of the box, the `Select` component uses React Magma-styled iconography for the button used to clear the selection and the caret for the dropdown.
-However, these can be overridden by providing custom components to the `components` prop, in an object containing a `ClearIndicator` and a `DropdownIndicator`.
+Custom styles can be passed into the Select component. The `containerStyle` property will apply to the container.
+Additional `labelStyle`, `inputStyle` and `messageStyle` properties are available to style the respective elements.
+Please use discretion when adding custom styles.
 
-### Custom Item Component
+```tsx
+import React from 'react';
+import { Select } from 'react-magma-dom';
+
+export function Example() {
+  const [selectedItem, updateSelectedItem] = React.useState('');
+
+  function onSelectedItemChange(changes) {
+    updateSelectedItem(changes.selectedItem);
+  }
+
+  return (
+    <>
+      <Select
+        containerStyle={{ marginBottom: '32px' }}
+        helperMessage="Helper message"
+        inputStyle={{ border: '2px dotted green', width: '200px' }}
+        items={['Red', 'Blue', 'Green']}
+        labelStyle={{ fontStyle: 'italic' }}
+        labelText="Basic with custom styles"
+        messageStyle={{ border: '1px solid blue' }}
+        selectedItem={selectedItem}
+        onSelectedItemChange={onSelectedItemChange}
+      />
+
+      <Select
+        containerStyle={{ marginBottom: '32px' }}
+        helperMessage="Helper message"
+        inputStyle={{ border: '2px dotted green', width: '200px' }}
+        isMulti
+        items={['Red', 'Blue', 'Green']}
+        labelStyle={{ fontStyle: 'italic' }}
+        labelText="Multi with custom styles"
+        messageStyle={{ border: '1px solid blue' }}
+        selectedItem={selectedItem}
+        onSelectedItemChange={onSelectedItemChange}
+      />
+    </>
+  );
+}
+```
+
+## Custom Item Component
 
 By default each item will be rendered with the `itemToString` value in a styled `li`. If you would like to add more information or
 would just like to be able to fully customize the look of your items you can pass in an `Item` component that uses the `props` that
@@ -1024,7 +1019,10 @@ export function Example() {
 }
 ```
 
-### Other Custom Components
+## Custom Components
+
+Out of the box, the `Select` component uses React Magma-styled iconography for the button used to clear the selection and the caret for the dropdown.
+However, these can be overridden by providing custom components to the `components` prop, in an object containing a `ClearIndicator` and a `DropdownIndicator`.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
_Issue: none_

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Updated Select docs to be in a more coherent order (basic props at the top, all customizations together, etc.)
- Updated Multi Select placeholder spacing
- Updated Input doc examples to use the InputType enum (instead of a string)

## Screenshots (if appropriate):
**before**
![image](https://user-images.githubusercontent.com/91160746/228357256-051b0fe2-5300-49a1-91e6-11821475e769.png)

**after**
![image](https://user-images.githubusercontent.com/91160746/228357594-46b17309-0c76-4f38-9c31-832a50249993.png)


## Checklist 
- [X] changeset has been added
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
- Navigate to the Select docs site and make sure the content flows better
- Confirm that the spacing is updated for multi selects
