### PR TITLE
docs(tooltip): Update docs

### DIFF
--- a/.changeset/tooltip-docs.md
+++ b/.changeset/tooltip-docs.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+Update Tooltip docs to remove reference to old `trigger` prop.

--- a/website/react-magma-docs/src/pages/api/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/api/tooltip.mdx
@@ -16,7 +16,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 ## Basic Usage
 
-The Tooltip component should wrap the trigger. 
+The Tooltip component should wrap the triggerring element. This trigger should be a focusable element for accessibility, such as a button.
 
 
 ```tsx
@@ -277,7 +277,7 @@ export function Example() {
 
 ## Tooltip Props
 
-**This component uses `forwardRef`. The ref is applied to the tooltip trigger element element.**
+**This component uses `forwardRef`. The ref is applied to the tooltip trigger element (the children).**
 
 All of the [global HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes) can be provided as props and will be applied to the outer-most `div` element that gets rendered.
 

--- a/website/react-magma-docs/src/pages/api/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/api/tooltip.mdx
@@ -16,9 +16,8 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 ## Basic Usage
 
-The children of the tooltip, determines the content inside of the tooltip bubble.
+The Tooltip component should wrap the trigger. 
 
-The `trigger` prop must take a react element (not just a string), and determines the content that triggers the tooltip on hover or on focus. Note: in order to trigger the content on focus (a requirement for accessibility), the `trigger` should be a focusable element.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
Issue: none

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
The docs referenced a `trigger` prop that has not existed in 3 years. So, I removed that :) 

## How to test
Ensure there are no references to `trigger` prop in the tooltip docs.
