### PR TITLE
fix(dropdown): Dropdowns without `DropdownMenuItem` will get focused on open

### DIFF
--- a/.changeset/dropdown-noitems.md
+++ b/.changeset/dropdown-noitems.md
@@ -1,0 +1,6 @@
+---
+'react-magma-dom': patch
+---
+
+fix(dropdown): Dropdowns without `DropdownMenuItem` will get focused on open.
+Fixes issue where these dropdowns could not be closed on Escape in Safari, and should be readable by screenreaders.

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1127,6 +1127,11 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
   transition: opacity 0.3s;
   white-space: nowrap;
   z-index: 2;
+  outline-offset: 0;
+}
+
+.emotion-11:focus {
+  outline: 2px solid #0074B7;
 }
 
 .emotion-10 {
@@ -1464,6 +1469,11 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
   transition: opacity 0.3s;
   white-space: nowrap;
   z-index: 2;
+  outline-offset: 0;
+}
+
+.emotion-11:focus {
+  outline: 2px solid #0074B7;
 }
 
 .emotion-10 {
@@ -1945,6 +1955,11 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
   transition: opacity 0.3s;
   white-space: nowrap;
   z-index: 2;
+  outline-offset: 0;
+}
+
+.emotion-11:focus {
+  outline: 2px solid #0074B7;
 }
 
 .emotion-10 {
@@ -2289,6 +2304,11 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
   transition: opacity 0.3s;
   white-space: nowrap;
   z-index: 2;
+  outline-offset: 0;
+}
+
+.emotion-11:focus {
+  outline: 2px solid #0074B7;
 }
 
 .emotion-10 {
@@ -2809,6 +2829,11 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
   transition: opacity 0.3s;
   white-space: nowrap;
   z-index: 2;
+  outline-offset: 0;
+}
+
+.emotion-11:focus {
+  outline: 2px solid #0074B7;
 }
 
 .emotion-10 {
@@ -3192,6 +3217,11 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
   transition: opacity 0.3s;
   white-space: nowrap;
   z-index: 2;
+  outline-offset: 0;
+}
+
+.emotion-11:focus {
+  outline: 2px solid #0074B7;
 }
 
 .emotion-10 {

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -20,6 +20,7 @@ import { PasswordInput } from '../PasswordInput';
 import { SettingsIcon, MenuIcon } from 'react-magma-icons';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { Paragraph, Spacer } from '../..';
+import { ButtonGroup } from '../ButtonGroup';
 
 const Template: Story<DropdownProps> = args => (
   <div style={{ margin: '150px auto', textAlign: 'center' }}>
@@ -351,10 +352,10 @@ Inverse.decorators = [
   ),
 ];
 
-export const Content = args => {
+export const NoItems = args => {
   return (
-    <div style={{ margin: '150px auto', textAlign: 'center' }}>
-      <Dropdown width="500px" {...args}>
+    <ButtonGroup>
+      <Dropdown width="500px" {...args} testId="dropdown">
         <DropdownButton>Dropdown without items</DropdownButton>
         <DropdownContent style={{ padding: '12px' }}>
           <>
@@ -390,6 +391,19 @@ export const Content = args => {
           </>
         </DropdownContent>
       </Dropdown>
-    </div>
+      <Dropdown width="500px" {...args}>
+        <DropdownButton>Dropdown without items, with button</DropdownButton>
+        <DropdownContent style={{ padding: '12px' }}>
+          <>
+            <Paragraph noMargins isInverse={args.isInverse}>
+              Bacon ipsum dolor amet capicola turkey chicken cupim pastrami pork
+              spare ribs shankle ball tip. Shank doner burgdoggen tri-tip corned
+              beef meatloaf pig ground round. Ball tip t-bone cow chicken.{' '}
+            </Paragraph>
+            <Button isInverse={args.isInverse}>Foo</Button>
+          </>
+        </DropdownContent>
+      </Dropdown>
+    </ButtonGroup>
   );
 };

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -354,41 +354,40 @@ Inverse.decorators = [
 export const Content = args => {
   return (
     <div style={{ margin: '150px auto', textAlign: 'center' }}>
-      <Dropdown width="500px" {...args} onClose={() => console.log('closee')}>
-        <DropdownButton>Dropdown with Content, no items</DropdownButton>
+      <Dropdown width="500px" {...args}>
+        <DropdownButton>Dropdown without items</DropdownButton>
         <DropdownContent style={{ padding: '12px' }}>
-          <span
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-            }}
-          >
-            <span style={{ flex: '1 1 auto' }}>
-              <Paragraph noMargins isInverse={args.isInverse}>
-                Current take: 1 of 3
-              </Paragraph>
+          <>
+            <span
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+              }}
+            >
+              <span style={{ flex: '1 1 auto' }}>
+                <Paragraph noMargins isInverse={args.isInverse}>
+                  Current take: 1 of 3
+                </Paragraph>
+              </span>
+              <span style={{ flex: '0 0 auto' }}>
+                <Paragraph noMargins isInverse={args.isInverse}>
+                  Points possible: 10
+                </Paragraph>
+              </span>
             </span>
-            <span style={{ flex: '0 0 auto' }}>
-              <Paragraph noMargins isInverse={args.isInverse}>
-                Points possible: 10
-              </Paragraph>
-            </span>
-          </span>
-          <Paragraph noMargins isInverse={args.isInverse}>
-            Grade uses: Best attempt
-          </Paragraph>
-          <Spacer size={12} />
-          <DropdownDivider />
-          <Spacer size={12} />
-          <Paragraph noMargins isInverse={args.isInverse}>
-            Credit/No Credit Activity
-          </Paragraph>
-          In this activity you must achieve 80% or higher to receive credit
-          <Spacer size={12} />
-          <Button onClick={() => {}} size={ButtonSize.small}>
-            this does nothing
-          </Button>
+            <Paragraph noMargins isInverse={args.isInverse}>
+              Grade uses: Best attempt
+            </Paragraph>
+            <Spacer size={12} />
+            <DropdownDivider />
+            <Spacer size={12} />
+            <Paragraph noMargins isInverse={args.isInverse}>
+              Credit/No Credit Activity
+            </Paragraph>
+            In this activity you must achieve 80% or higher to receive credit
+            <Spacer size={12} />
+          </>
         </DropdownContent>
       </Dropdown>
     </div>

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -19,6 +19,7 @@ import { Checkbox } from '../Checkbox';
 import { PasswordInput } from '../PasswordInput';
 import { SettingsIcon, MenuIcon } from 'react-magma-icons';
 import { Story, Meta } from '@storybook/react/types-6-0';
+import { Paragraph, Spacer } from '../..';
 
 const Template: Story<DropdownProps> = args => (
   <div style={{ margin: '150px auto', textAlign: 'center' }}>
@@ -349,3 +350,47 @@ Inverse.decorators = [
     </Card>
   ),
 ];
+
+export const Content = args => {
+  return (
+    <div style={{ margin: '150px auto', textAlign: 'center' }}>
+      <Dropdown width="500px" {...args} onClose={() => console.log('closee')}>
+        <DropdownButton>Dropdown with Content, no items</DropdownButton>
+        <DropdownContent style={{ padding: '12px' }}>
+          <span
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+            }}
+          >
+            <span style={{ flex: '1 1 auto' }}>
+              <Paragraph noMargins isInverse={args.isInverse}>
+                Current take: 1 of 3
+              </Paragraph>
+            </span>
+            <span style={{ flex: '0 0 auto' }}>
+              <Paragraph noMargins isInverse={args.isInverse}>
+                Points possible: 10
+              </Paragraph>
+            </span>
+          </span>
+          <Paragraph noMargins isInverse={args.isInverse}>
+            Grade uses: Best attempt
+          </Paragraph>
+          <Spacer size={12} />
+          <DropdownDivider />
+          <Spacer size={12} />
+          <Paragraph noMargins isInverse={args.isInverse}>
+            Credit/No Credit Activity
+          </Paragraph>
+          In this activity you must achieve 80% or higher to receive credit
+          <Spacer size={12} />
+          <Button onClick={() => {}} size={ButtonSize.small}>
+            this does nothing
+          </Button>
+        </DropdownContent>
+      </Dropdown>
+    </div>
+  );
+};

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -703,4 +703,84 @@ describe('Dropdown', () => {
 
     expect(getByText('Google').querySelector('svg')).toBeInTheDocument();
   });
+
+  describe('dropdown without items', () => {
+    it('should focus the entire container when button is clicked', () => {
+      const { getByText, getByTestId } = render(
+        <Dropdown testId="dropdown">
+          <DropdownButton>Toggle me</DropdownButton>
+          <DropdownContent>
+            <p>test content</p>
+          </DropdownContent>
+        </Dropdown>
+      );
+
+      fireEvent.click(getByText('Toggle me'));
+      expect(getByTestId('dropdownContent')).toHaveStyleRule(
+        'display',
+        'block'
+      );
+      fireEvent.keyDown(getByTestId('dropdown'), {
+        key: 'ArrowDown',
+        code: 40,
+      });
+      expect(getByTestId('dropdownContent')).toHaveFocus();
+    });
+
+    it('should close the menu on blur', () => {
+      jest.useFakeTimers();
+
+      const onClose = jest.fn();
+      const { getByText, getByTestId } = render(
+        <Dropdown testId="dropdown" onClose={onClose}>
+          <DropdownButton>Toggle me</DropdownButton>
+          <DropdownContent>
+            <p>test</p>
+          </DropdownContent>
+        </Dropdown>
+      );
+
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+      userEvent.click(getByText('Toggle me'));
+      expect(getByTestId('dropdownContent')).toHaveStyleRule(
+        'display',
+        'block'
+      );
+
+      userEvent.click(document.body);
+      act(jest.runAllTimers);
+
+      expect(onClose).toHaveBeenCalled();
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+      jest.useRealTimers();
+    });
+
+    it('should close the menu when escape key is pressed', () => {
+      const { getByText, getByTestId } = render(
+        <Dropdown testId="dropdown">
+          <DropdownButton>Toggle me</DropdownButton>
+          <DropdownContent>
+            <p>test</p>
+          </DropdownContent>
+        </Dropdown>
+      );
+  
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+  
+      fireEvent.click(getByText('Toggle me'));
+  
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'block');
+  
+      fireEvent.keyDown(getByTestId('dropdown'), {
+        key: 'ArrowDown',
+      });
+  
+      fireEvent.keyDown(getByTestId('dropdown'), {
+        key: 'Escape',
+        code: 27,
+      });
+  
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -706,25 +706,61 @@ describe('Dropdown', () => {
 
   describe('dropdown without items', () => {
     it('should focus the entire container when button is clicked', () => {
+      jest.useFakeTimers();
+
       const { getByText, getByTestId } = render(
         <Dropdown testId="dropdown">
           <DropdownButton>Toggle me</DropdownButton>
           <DropdownContent>
             <p>test content</p>
+            <button>something</button>
           </DropdownContent>
         </Dropdown>
       );
 
       fireEvent.click(getByText('Toggle me'));
+
+      act(jest.runAllTimers);
+
       expect(getByTestId('dropdownContent')).toHaveStyleRule(
         'display',
         'block'
       );
+
+      expect(getByTestId('dropdownContent')).toHaveFocus();
+
+      jest.useRealTimers();
+    });
+
+    it('should close the menu when escape key is pressed', () => {
+      const { getByText, getByTestId } = render(
+        <Dropdown testId="dropdown">
+          <DropdownButton>Toggle me</DropdownButton>
+          <DropdownContent>
+            <p>test</p>
+          </DropdownContent>
+        </Dropdown>
+      );
+
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+
+      fireEvent.click(getByText('Toggle me'));
+
+      expect(getByTestId('dropdownContent')).toHaveStyleRule(
+        'display',
+        'block'
+      );
+
       fireEvent.keyDown(getByTestId('dropdown'), {
         key: 'ArrowDown',
-        code: 40,
       });
-      expect(getByTestId('dropdownContent')).toHaveFocus();
+
+      fireEvent.keyDown(getByTestId('dropdown'), {
+        key: 'Escape',
+        code: 27,
+      });
+
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
     });
 
     it('should close the menu on blur', () => {
@@ -753,34 +789,6 @@ describe('Dropdown', () => {
       expect(onClose).toHaveBeenCalled();
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
       jest.useRealTimers();
-    });
-
-    it('should close the menu when escape key is pressed', () => {
-      const { getByText, getByTestId } = render(
-        <Dropdown testId="dropdown">
-          <DropdownButton>Toggle me</DropdownButton>
-          <DropdownContent>
-            <p>test</p>
-          </DropdownContent>
-        </Dropdown>
-      );
-  
-      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
-  
-      fireEvent.click(getByText('Toggle me'));
-  
-      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'block');
-  
-      fireEvent.keyDown(getByTestId('dropdown'), {
-        key: 'ArrowDown',
-      });
-  
-      fireEvent.keyDown(getByTestId('dropdown'), {
-        key: 'Escape',
-        code: 27,
-      });
-  
-      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
     });
   });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -182,7 +182,6 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         const [filteredItems, filteredItemIndex] = getFilteredItem();
 
         if (filteredItems.length === 0) {
-          menuRef.current.focus();
           return;
         }
 
@@ -202,7 +201,6 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         const [filteredItems, filteredItemIndex] = getFilteredItem();
 
         if (filteredItems.length === 0) {
-          menuRef.current.focus();
           return;
         }
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -140,11 +140,16 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
 
       setIsOpen(true);
 
-      setTimeout(() => {
-        filteredItems.length > 0 &&
-          filteredItems[0].current &&
-          filteredItems[0].current.focus();
-      }, 0);
+      if (filteredItems.length > 0) {
+        setTimeout(() => {
+            filteredItems[0].current &&
+            filteredItems[0].current.focus();
+        }, 0);
+      } else {
+        setTimeout(() => {
+          menuRef.current.focus();
+        }, 0);
+      }
 
       onOpen && typeof onOpen === 'function' && onOpen();
     }
@@ -177,6 +182,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         const [filteredItems, filteredItemIndex] = getFilteredItem();
 
         if (filteredItems.length === 0) {
+          menuRef.current.focus();
           return;
         }
 
@@ -196,6 +202,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         const [filteredItems, filteredItemIndex] = getFilteredItem();
 
         if (filteredItems.length === 0) {
+          menuRef.current.focus();
           return;
         }
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -100,7 +100,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
   (props, forwardedRef) => {
     const contextProps = React.useContext(ButtonGroupContext);
     const resolvedProps = resolveProps(contextProps, props);
-    
+
     const {
       activeIndex,
       alignment,
@@ -142,8 +142,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
 
       if (filteredItems.length > 0) {
         setTimeout(() => {
-            filteredItems[0].current &&
-            filteredItems[0].current.focus();
+          filteredItems[0].current && filteredItems[0].current.focus();
         }, 0);
       } else {
         setTimeout(() => {

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -115,6 +115,18 @@ export const DropdownContent = React.forwardRef<
   const theme = React.useContext(ThemeContext);
   const ref = useForkedRef(forwardedRef, context.menuRef);
 
+  let hasItemChildren = false;
+
+  React.Children.forEach(children, (child: any) => {
+    if (
+      child.type?.displayName === 'DropdownMenuItem' ||
+      child.type?.displayName === 'DropdownMenuGroup'
+    ) {
+      hasItemChildren = true;
+      return;
+    }
+  });
+
   return (
     <StyledCard
       {...other}
@@ -132,7 +144,7 @@ export const DropdownContent = React.forwardRef<
     >
       <StyledDiv
         aria-labelledby={context.dropdownButtonId.current}
-        role="menu"
+        role={hasItemChildren ? 'menu' : null}
         theme={theme}
       >
         {children}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -46,6 +46,14 @@ const StyledCard = styled(Card)<{
   transition: opacity 0.3s;
   white-space: nowrap;
   z-index: 2;
+  &:focus {
+    outline: 2px solid ${props =>
+      props.isInverse
+        ? props.theme.colors.focusInverse
+        : props.theme.colors.focus};
+    }
+    outline-offset: 0;
+  }
 
   ${props =>
     props.width &&
@@ -86,12 +94,12 @@ const StyledCard = styled(Card)<{
     `}
 
  ${props =>
-    props.alignment === 'end' &&
-    (props.dropDirection === 'left' || props.dropDirection === 'right') &&
-    css`
-      bottom: ${props.theme.spaceScale.spacing02};
-      top: auto;
-    `}
+   props.alignment === 'end' &&
+   (props.dropDirection === 'left' || props.dropDirection === 'right') &&
+   css`
+     bottom: ${props.theme.spaceScale.spacing02};
+     top: auto;
+   `}
 `;
 
 const StyledDiv = styled.div`

--- a/packages/react-magma-dom/src/index.ts
+++ b/packages/react-magma-dom/src/index.ts
@@ -246,3 +246,5 @@ export * from './components/ButtonGroup';
 export * from './components/CharacterCounter';
 export * from './components/ToggleButton';
 export * from './components/ToggleButtonGroup';
+
+export * from './components/Popover'

--- a/packages/react-magma-dom/src/index.ts
+++ b/packages/react-magma-dom/src/index.ts
@@ -246,5 +246,3 @@ export * from './components/ButtonGroup';
 export * from './components/CharacterCounter';
 export * from './components/ToggleButton';
 export * from './components/ToggleButtonGroup';
-
-export * from './components/Popover'

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -442,8 +442,7 @@ export function Example() {
 
 ## Dropdown without Menu Items
 
-Dropdowns can contain elements other than `DropdownMenuItem` components.
-The following examples include form elements, styled with inline styles including variables from the Magma theme.
+Dropdowns can contain elements other than `DropdownMenuItem` components. They can be used to wrap a form, filters, or informational content.
 
 While users may navigate between `DropdownMenuItem` components using up and down arrow keys,
 browser default keyboard behavior applies to other content.
@@ -507,15 +506,26 @@ import {
   Dropdown,
   DropdownButton,
   DropdownContent,
-  DropdownDivider,
   DropdownHeader,
   magma,
 } from 'react-magma-dom';
 
 export function Example() {
+  const [checkedItems, setCheckedItems] = React.useState([]);
+
+  function updateCheckedItems(e) {
+    if (e.target.checked) {
+      if (!checkedItems.includes(e.target.value)) {
+        setCheckedItems([...checkedItems, e.target.value]);
+      }
+    } else if (!e.target.checked) {
+      setCheckedItems(checkedItems.filter(i => i !== e.target.value));
+    }
+  }
+
   return (
     <Dropdown width="300px">
-      <DropdownButton>Filter Dropdown</DropdownButton>
+      <DropdownButton>Filter Dropdown ({checkedItems.length})</DropdownButton>
       <DropdownContent>
         <DropdownHeader id="checkboxGroup">Checkbox Group Label</DropdownHeader>
         <form
@@ -527,15 +537,28 @@ export function Example() {
           }}
         >
           <div role="group" aria-labelledby="checkboxGroup">
-            <Checkbox labelText="Option 1" />
-            <Checkbox labelText="Option 2" />
-            <Checkbox labelText="Option 3" />
+            <Checkbox
+              value="1"
+              labelText="Option 1"
+              onClick={updateCheckedItems}
+            />
+            <Checkbox
+              value="2"
+              labelText="Option 2"
+              onClick={updateCheckedItems}
+            />
+            <Checkbox
+              value="3"
+              labelText="Option 3"
+              onClick={updateCheckedItems}
+            />
           </div>
         </form>
       </DropdownContent>
     </Dropdown>
   );
 }
+
 ```
 
 ### Dropdown with Informational Content
@@ -555,8 +578,10 @@ export function Example() {
   return (
     <Dropdown width="300px">
       <DropdownButton>Informational Dropdown</DropdownButton>
-      <DropdownContent style={{padding: magma.spaceScale.spacing05}}>
-        <Paragraph noMargins>In this activity you must achieve 80% or higher to receive credit</Paragraph>
+      <DropdownContent style={{ padding: magma.spaceScale.spacing05 }}>
+        <Paragraph noMargins>
+          In this activity you must achieve 80% or higher to receive credit
+        </Paragraph>
       </DropdownContent>
     </Dropdown>
   );

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -440,7 +440,7 @@ export function Example() {
 }
 ```
 
-## Dropdown with Form
+## Dropdown without Menu Items
 
 Dropdowns can contain elements other than `DropdownMenuItem` components.
 The following examples include form elements, styled with inline styles including variables from the Magma theme.
@@ -448,77 +448,117 @@ The following examples include form elements, styled with inline styles includin
 While users may navigate between `DropdownMenuItem` components using up and down arrow keys,
 browser default keyboard behavior applies to other content.
 
+### Dropdown with Form
+
 ```tsx
 import React from 'react';
 import {
   Button,
+  Dropdown,
+  DropdownButton,
+  DropdownContent,
+  DropdownDivider,
+  Input,
+  InputType,
+  magma,
+  PasswordInput,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Dropdown width="300px">
+      <DropdownButton>Dropdown with Login Form</DropdownButton>
+      <DropdownContent>
+        <form style={{ margin: 0, padding: magma.spaceScale.spacing05 }}>
+          <Input type={InputType.email} labelText="Email Address" />
+          <PasswordInput labelText="Password" />
+          <div style={{ textAlign: 'center' }}>
+            <p>
+              By signing in, you agree to our <a href="#">Terms of use</a>.
+            </p>
+            <Button isFullWidth>Sign In</Button>
+            <p>
+              <a>Forgot password?</a>
+            </p>
+          </div>
+        </form>
+        <DropdownDivider />
+        <div
+          style={{ textAlign: 'center', padding: magma.spaceScale.spacing05 }}
+        >
+          <p>
+            Don't have an account?
+            <br />
+            <a href="#">Register today!</a>
+          </p>
+        </div>
+      </DropdownContent>
+    </Dropdown>
+  );
+}
+```
+
+### Dropdown with Filter
+
+```tsx
+import React from 'react';
+import {
   Checkbox,
   Dropdown,
   DropdownButton,
   DropdownContent,
   DropdownDivider,
   DropdownHeader,
-  Input,
-  InputType,
   magma,
-  PasswordInput,
-  ButtonGroup,
 } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <ButtonGroup>
-      <Dropdown width="300px">
-        <DropdownButton>Dropdown with Login Form</DropdownButton>
-        <DropdownContent>
-          <form style={{ margin: 0, padding: magma.spaceScale.spacing05 }}>
-            <Input type={InputType.email} labelText="Email Address" />
-            <PasswordInput labelText="Password" />
-            <div style={{ textAlign: 'center' }}>
-              <p>
-                By signing in, you agree to our <a href="#">Terms of use</a>.
-              </p>
-              <Button isFullWidth>Sign In</Button>
-              <p>
-                <a>Forgot password?</a>
-              </p>
-            </div>
-          </form>
-          <DropdownDivider />
-          <div
-            style={{ textAlign: 'center', padding: magma.spaceScale.spacing05 }}
-          >
-            <p>
-              Don't have an account?
-              <br />
-              <a href="#">Register today!</a>
-            </p>
+    <Dropdown width="300px">
+      <DropdownButton>Filter Dropdown</DropdownButton>
+      <DropdownContent>
+        <DropdownHeader id="checkboxGroup">Checkbox Group Label</DropdownHeader>
+        <form
+          style={{
+            color: magma.colors.neutral,
+            margin: 0,
+            paddingLeft: magma.spaceScale.spacing05,
+            paddingRight: magma.spaceScale.spacing05,
+          }}
+        >
+          <div role="group" aria-labelledby="checkboxGroup">
+            <Checkbox labelText="Option 1" />
+            <Checkbox labelText="Option 2" />
+            <Checkbox labelText="Option 3" />
           </div>
-        </DropdownContent>
-      </Dropdown>
-      <Dropdown width="300px">
-        <DropdownButton>Dropdown with Form 2</DropdownButton>
-        <DropdownContent>
-          <DropdownHeader id="checkboxGroup">
-            Checkbox Group Label
-          </DropdownHeader>
-          <form
-            style={{
-              color: magma.colors.neutral,
-              margin: 0,
-              paddingLeft: magma.spaceScale.spacing05,
-              paddingRight: magma.spaceScale.spacing05,
-            }}
-          >
-            <div role="group" aria-labelledby="checkboxGroup">
-              <Checkbox labelText="Option 1" />
-              <Checkbox labelText="Option 2" />
-              <Checkbox labelText="Option 3" />
-            </div>
-          </form>
-        </DropdownContent>
-      </Dropdown>
-    </ButtonGroup>
+        </form>
+      </DropdownContent>
+    </Dropdown>
+  );
+}
+```
+
+### Dropdown with Informational Content
+
+```tsx
+import React from 'react';
+import {
+  Checkbox,
+  Dropdown,
+  DropdownButton,
+  DropdownContent,
+  Paragraph,
+  magma,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Dropdown width="300px">
+      <DropdownButton>Informational Dropdown</DropdownButton>
+      <DropdownContent style={{padding: magma.spaceScale.spacing05}}>
+        <Paragraph noMargins>In this activity you must achieve 80% or higher to receive credit</Paragraph>
+      </DropdownContent>
+    </Dropdown>
   );
 }
 ```


### PR DESCRIPTION
Issue: #1013

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

This should fix two issues:
- Dropdowns without items should get focus on the entire content
- In Safari, Dropdowns without items should be closable when the Escape button is clicked

Update documentation to separate Dropdowns with filters, forms and informational content.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/91160746/229890047-b584b75a-4d0b-4a91-89f4-b73d4275b801.png)


## Checklist 
- [X] changeset has been added
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
- Confirm that focus goes to the dropdown menu
- Confirm with a screenreader that content inside the dropdown without items is read
- Confirm that the dropdown without items can be properly navigated with a keyboard
- Confirm that in Safari, clicking escape after opening a dropdown without items closes the menu
- Test these changes in all the browsers 