### PR TITLE
Fix/modal close

### DIFF
--- a/.changeset/fix-modals.md
+++ b/.changeset/fix-modals.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal): Added support for closing individual nested modals with escape key.

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -241,7 +241,7 @@ export const NoHeaderOrFocusableContent = () => {
         <p>This modal has no header and nothing focusable.</p>
         <p>
           Consider the usability implications before implementing a modal like
-          this this. A modal should have something actionable inside it.
+          this. A modal should have something actionable inside it.
         </p>
       </Modal>
       <Button onClick={onModalNoFocusShow} ref={buttonRef}>
@@ -264,7 +264,6 @@ export const ModalInAModal = () => {
           setShowModal(false);
           buttonRef.current.focus();
         }}
-        id="First Modal"
         isOpen={showModal}
       >
         <p>This is a modal, doing modal things.</p>
@@ -283,20 +282,18 @@ export const ModalInAModal = () => {
         <p>
           <Button onClick={() => setShowModal2(true)}>Show Modal 2</Button>
         </p>
-
-        <Modal
-          size={ModalSize.small}
-          header="Modal 2 Title"
-          onClose={() => setShowModal2(false)}
-          id="Second Modal"
-          isOpen={showModal2}
-        >
-          <p>This is modal 2</p>
-        </Modal>
       </Modal>
       <Button onClick={() => setShowModal(true)} ref={buttonRef}>
         Show Modal
       </Button>
+      <Modal
+        size={ModalSize.small}
+        header="Modal 2 Title"
+        onClose={() => setShowModal2(false)}
+        isOpen={showModal2}
+      >
+        <p>This is modal 2</p>
+      </Modal>
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -264,6 +264,7 @@ export const ModalInAModal = () => {
           setShowModal(false);
           buttonRef.current.focus();
         }}
+        id="First Modal"
         isOpen={showModal}
       >
         <p>This is a modal, doing modal things.</p>
@@ -287,6 +288,7 @@ export const ModalInAModal = () => {
           size={ModalSize.small}
           header="Modal 2 Title"
           onClose={() => setShowModal2(false)}
+          id="Second Modal"
           isOpen={showModal2}
         >
           <p>This is modal 2</p>

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -100,7 +100,9 @@ export const LongContentWithScrolling = () => {
           culpa qui officia deserunt mollit anim id est laborum.
         </p>
       </Modal>
-      <Button onClick={onModalShow} ref={buttonRef}>Show Modal</Button>
+      <Button onClick={onModalShow} ref={buttonRef}>
+        Show Modal
+      </Button>
     </>
   );
 };
@@ -127,7 +129,9 @@ export const RadioInModal = () => {
           <Radio labelText="Option two label" value="2" />
         </RadioGroup>
       </Modal>
-      <Button onClick={onModalShow} ref={buttonRef}>Show Modal</Button>
+      <Button onClick={onModalShow} ref={buttonRef}>
+        Show Modal
+      </Button>
     </>
   );
 };
@@ -206,7 +210,9 @@ export const ModalContentUpdate = () => {
           )}
         </div>
       </Modal>
-      <Button onClick={onModalShow} ref={buttonRef}>Show Modal</Button>
+      <Button onClick={onModalShow} ref={buttonRef}>
+        Show Modal
+      </Button>
     </>
   );
 };
@@ -259,6 +265,7 @@ export const ModalInAModal = () => {
           buttonRef.current.focus();
         }}
         isOpen={showModal}
+        id={'outer'}
       >
         <p>This is a modal, doing modal things.</p>
         <p>
@@ -279,6 +286,7 @@ export const ModalInAModal = () => {
 
         <Modal
           size={ModalSize.small}
+          id={'inner'}
           header="Modal 2 Title"
           onClose={() => setShowModal2(false)}
           isOpen={showModal2}
@@ -286,7 +294,9 @@ export const ModalInAModal = () => {
           <p>This is modal 2</p>
         </Modal>
       </Modal>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>Show Modal</Button>
+      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
+        Show Modal
+      </Button>
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -265,7 +265,6 @@ export const ModalInAModal = () => {
           buttonRef.current.focus();
         }}
         isOpen={showModal}
-        id={'outer'}
       >
         <p>This is a modal, doing modal things.</p>
         <p>
@@ -286,7 +285,6 @@ export const ModalInAModal = () => {
 
         <Modal
           size={ModalSize.small}
-          id={'inner'}
           header="Modal 2 Title"
           onClose={() => setShowModal2(false)}
           isOpen={showModal2}

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -212,6 +212,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     const [isModalOpen, setIsModalOpen] = React.useState<boolean>(props.isOpen);
     const [isExiting, setIsExiting] = React.useState<boolean>(false);
     const [currentTarget, setCurrentTarget] = React.useState(null);
+    const [modalCount, setModalCount] = React.useState<number>(0);
 
     const focusTrapElement = useFocusLock(
       isModalOpen,
@@ -232,6 +233,8 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     React.useEffect(() => {
       if (isModalOpen) {
         lastFocus.current = document.activeElement;
+        const count = document.querySelectorAll('[aria-modal="true"]').length;
+        setModalCount(count);
 
         if (!props.isEscKeyDownDisabled) {
           document.body.addEventListener('keydown', handleEscapeKeyDown, false);
@@ -264,15 +267,24 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       if (event.key === 'Escape') {
         event.preventDefault();
         event.stopPropagation();
+
         props.onEscKeyDown &&
           typeof props.onEscKeyDown === 'function' &&
           props.onEscKeyDown(event);
-        if (
-          document.getElementById(id).contains(event.target as HTMLDivElement)
-        ) {
+
+        const modalsInDom = document.querySelectorAll(
+          '[aria-modal="true"]'
+        ).length;
+        if (modalCount <= 1 && modalsInDom !== 1) {
+          if (
+            document.getElementById(id).contains(event.target as HTMLDivElement)
+          ) {
+            handleClose(event);
+          } else {
+            headingRef.current.focus();
+          }
+        } else {
           handleClose(event);
-        } else if (contentId === contentId) {
-          headingRef.current.focus();
         }
       }
     }

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -204,7 +204,6 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     const lastFocus = React.useRef<any>();
     const headingRef = React.useRef<any>();
     const bodyRef = React.useRef<any>();
-    const containerRef = React.useRef<any>();
 
     const id = useGenerateId(props.id);
     const headingId = `${id}_heading`;
@@ -273,7 +272,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         ) {
           handleClose(event);
         }
-        containerRef.current.focus();
+        bodyRef.current.focus();
       }
     }
 
@@ -348,7 +347,6 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
               onMouseDown={
                 isBackgroundClickDisabled ? null : handleModalOnMouseDown
               }
-              ref={containerRef}
               role="dialog"
               style={containerStyle}
               theme={theme}

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -222,6 +222,10 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     const prevOpen = usePrevious(props.isOpen);
 
     React.useEffect(() => {
+      console.log(id);
+    }, []);
+
+    React.useEffect(() => {
       if (!prevOpen && props.isOpen) {
         setIsModalOpen(true);
       } else if (prevOpen && !props.isOpen && isModalOpen) {
@@ -264,12 +268,17 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       if (event.key === 'Escape') {
         event.preventDefault();
         event.stopPropagation();
-
         props.onEscKeyDown &&
           typeof props.onEscKeyDown === 'function' &&
           props.onEscKeyDown(event);
-
-        handleClose(event);
+        if (
+          document.getElementById(id).contains(event.target as HTMLDivElement)
+        ) {
+          handleClose(event);
+        }
+        if (lastFocus.current) {
+          lastFocus.current.focus();
+        }
       }
     }
 

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -271,8 +271,9 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
           document.getElementById(id).contains(event.target as HTMLDivElement)
         ) {
           handleClose(event);
+        } else if (contentId === contentId) {
+          headingRef.current.focus();
         }
-        bodyRef.current.focus();
       }
     }
 

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -204,6 +204,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     const lastFocus = React.useRef<any>();
     const headingRef = React.useRef<any>();
     const bodyRef = React.useRef<any>();
+    const containerRef = React.useRef<any>();
 
     const id = useGenerateId(props.id);
     const headingId = `${id}_heading`;
@@ -220,10 +221,6 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     );
 
     const prevOpen = usePrevious(props.isOpen);
-
-    React.useEffect(() => {
-      console.log(id);
-    }, []);
 
     React.useEffect(() => {
       if (!prevOpen && props.isOpen) {
@@ -276,9 +273,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         ) {
           handleClose(event);
         }
-        if (lastFocus.current) {
-          lastFocus.current.focus();
-        }
+        containerRef.current.focus();
       }
     }
 
@@ -353,6 +348,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
               onMouseDown={
                 isBackgroundClickDisabled ? null : handleModalOnMouseDown
               }
+              ref={containerRef}
               role="dialog"
               style={containerStyle}
               theme={theme}

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -275,6 +275,50 @@ export function Example() {
 }
 ```
 
+## Nested Modals
+
+Although we don't recommend using nested modals, the ability for one nested modal is supported. Take note of the DOM layout as two `Modal`'s need to be siblings, otherwise mouse behavior will break.
+
+```tsx
+import React from 'react';
+import { Button, Modal, VisuallyHidden } from 'react-magma-dom';
+export function Example() {
+  const [showModal, setShowModal] = React.useState(false);
+  const [showModal2, setShowModal2] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
+
+  return (
+    <>
+      <Modal
+        header="Modal Title"
+        onClose={() => {
+          setShowModal(false);
+        }}
+        isOpen={showModal}
+      >
+        <p>This is a modal, doing modal things.</p>
+
+        <Button onClick={() => setShowModal2(true)} ref={buttonRef}>
+          Show Modal 2
+        </Button>
+      </Modal>
+      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
+        Show Modal
+        <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+      </Button>
+      <Modal
+        size={ModalSize.small}
+        header="Modal 2 Title"
+        onClose={() => setShowModal2(false)}
+        isOpen={showModal2}
+      >
+        <p>This is modal 2</p>
+      </Modal>
+    </>
+  );
+}
+```
+
 ## isInverse
 
 ```tsx


### PR DESCRIPTION
Issue: # [264](https://github.com/cengage/react-magma/issues/264)

## What we did

- Added support for closing nested modals individually with escape key.

## Film:
https://user-images.githubusercontent.com/77400920/230079877-af815d9a-f5ce-4340-9ea7-ca23b9676cad.mov


## Checklist 
- [ ] changeset has been added
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
Go to "Nested Modal" in the doc site: open the first modal, then open the second modal (Show Modal 2), press escape, verify that the first modal still remains on screen, then press escape again
