### PR TITLE
fix(CharCounter): Update calculation for character length on rerender

### DIFF
--- a/.changeset/charcounter-initialvalue.md
+++ b/.changeset/charcounter-initialvalue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(CharCounter): Update calculation for character length on rerender.

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
@@ -18,7 +18,6 @@ const Template: Story<CharacterCounterProps> = args => (
       {...args}
       testId="test-this-id"
       labelText={labelText}
-      value="Default"
     />
   </>
 );
@@ -65,6 +64,11 @@ export default {
         type: 'number',
       },
     },
+    value: {
+      control: {
+        type: 'text'
+      }
+    }
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.test.js
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.test.js
@@ -37,6 +37,7 @@ describe('CharacterCounter', () => {
       return expect(result).toHaveNoViolations();
     });
   });
+
   describe('Titles', () => {
     describe('Characters Allowed', () => {
       it('Shows the default label of "characters allowed" if maxLength is 0', () => {
@@ -120,6 +121,7 @@ describe('CharacterCounter', () => {
       });
     });
   });
+  
   describe('accessibility', () => {
     it('Should have the aria-live attribute "off" until inputLength gets to 80%', () => {
       const { getByText } = render(

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -498,6 +498,15 @@ describe('Input', () => {
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
     });
 
+    it('should update the character length on rerender', () => {
+      const { getByText, rerender } = render(
+        <Input maxLength={5} value="hi" />
+      );
+      expect(getByText('3 ' + charactersLeft)).toBeInTheDocument();
+      rerender(<Input maxLength={5} value="hello" />);
+      expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
+    });
+
     it('Shows the label "characters allowed" equal to the maxLength if the user clears the input by backspacing', () => {
       const onChange = jest.fn();
       const { getByText, getByLabelText } = render(

--- a/packages/react-magma-dom/src/components/Input/index.tsx
+++ b/packages/react-magma-dom/src/components/Input/index.tsx
@@ -41,9 +41,13 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
     const isInverse = useIsInverse(props.isInverse);
 
-    const initialValueLength = value ? value.toString().length : 0;
+    const [characterLength, setCharacterLength] = useState(
+      value?.toString().length
+    );
 
-    const [characterLength, setCharacterLength] = useState(initialValueLength);
+    React.useEffect(() => {
+      setCharacterLength(value?.toString().length);
+    }, [value]);
 
     function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
       props.onChange &&

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.stories.tsx
@@ -8,7 +8,6 @@ import { Textarea, TextareaProps } from '.';
 
 const Template: Story<TextareaProps> = args => (
   <Textarea
-    value="how many of these things"
     {...args}
     labelText="Textarea label"
   />
@@ -36,6 +35,11 @@ export default {
         type: 'number',
       },
     },
+    value: {
+      control: {
+        type: 'text'
+      }
+    }
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
@@ -135,5 +135,14 @@ describe('Textarea', () => {
       const { getByText } = render(<Textarea maxLength={2} value="hi" />);
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
     });
+
+    it('should update the character length on rerender', () => {
+      const { getByText, rerender } = render(
+        <Textarea maxLength={5} value="hi" />
+      );
+      expect(getByText('3 ' + charactersLeft)).toBeInTheDocument();
+      rerender(<Textarea maxLength={5} value="hello" />);
+      expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -78,13 +78,15 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       string | ReadonlyArray<string> | number
     >(props.defaultValue || props.value || '');
 
-    const initialValueLength = value ? value.toString().length : 0;
-
-    const [characterLength, setCharacterLength] = useState(initialValueLength);
+    const [characterLength, setCharacterLength] = useState(
+      props.value?.toString().length
+    );
 
     React.useEffect(() => {
       setValue(props.value);
+      setCharacterLength(props.value?.toString().length);
     }, [props.value]);
+
     function handleChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
       props.onChange &&
         typeof props.onChange === 'function' &&


### PR DESCRIPTION
_Issue: none_

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

Update Input and Textarea to update the character length when the default value changes. This way, when the component with a character counter gets re-rendered with a different default value, the count will be up to date.

## Checklist 
- [X] changeset has been added
- [n/a] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
Test the following for both the Input and Textarea:
- Confirm that on Storybook, if the default value is changed, the character counter is updating consistently
- Try to recreate the reported use case (https://screenpal.com/watch/c0fqouVzjFj) on CodeSandbox and confirm this would no longer be an issue:
Test changing `hi` to `hiiiiii`
```
export function Example() {
  return (
    <Input
      maxLength={4}
      value={"hi"}
      labelText="Initial Value Character Counter"
    />
  );
}
```