### PR TITLE
fix(combobox): Disabled Multi Combobox disables the buttons inside it

### DIFF
--- a/.changeset/disabled-multiCombo.md
+++ b/.changeset/disabled-multiCombo.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(combobox): Disabled Multi Combobox disables the buttons inside it

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
@@ -30,6 +30,11 @@ export default {
         type: 'number',
       },
     },
+    disabled: {
+      control: {
+        type: 'boolean'
+      }
+    }
   },
 } as Meta;
 
@@ -48,6 +53,7 @@ Default.args = {
   isClearable: false,
   isMulti: false,
   isLoading: false,
+  disabled: false,
 };
 
 export const Multi = (props: MultiComboboxProps<SelectOptions>) => {

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -698,6 +698,46 @@ describe('MultiCombobox', () => {
     );
   });
 
+  it('when disabled, selected items should not be removable', () => {
+    const { getByLabelText, getByText } = render(
+      <MultiCombobox
+        isMulti
+        labelText={labelText}
+        items={items}
+        disabled
+        initialSelectedItems={['Red']}
+      />
+    );
+
+    expect(getByLabelText(labelText, { selector: 'input' })).toHaveAttribute(
+      'disabled'
+    );
+    const selectedItem = getByText('Red', { selector: 'button' });
+    expect(selectedItem).toBeInTheDocument();
+    fireEvent.click(selectedItem);
+
+    expect(selectedItem).toBeInTheDocument();
+  });
+
+  it('when disabled, isClearable button should not be clickable', () => {
+    const { getByLabelText, getByText } = render(
+      <MultiCombobox
+        isMulti
+        labelText={labelText}
+        items={items}
+        disabled
+        isClearable
+        initialSelectedItems={['Red']}
+      />
+    );
+
+    expect(getByLabelText(labelText, { selector: 'input' })).toHaveAttribute(
+      'disabled'
+    );
+    fireEvent.click(getByLabelText(/reset selection/i));
+    expect(getByText('Red', { selector: 'button' })).toBeInTheDocument();
+  });
+
   it('should allow a selection to be cleared with isClearable prop', () => {
     const { getByLabelText, getByText, queryByText } = render(
       <MultiCombobox

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -326,6 +326,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
                 selectedItem: multiSelectedItem,
                 index,
               })}
+              disabled={disabled}
               onClick={event =>
                 handleRemoveSelectedItem(event, multiSelectedItem)
               }
@@ -398,6 +399,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
             shape={ButtonShape.fill}
             size={ButtonSize.small}
             variant={ButtonVariant.link}
+            disabled={disabled}
           />
         )}
       </ComboboxInput>

--- a/packages/react-magma-dom/src/components/Select/shared.ts
+++ b/packages/react-magma-dom/src/components/Select/shared.ts
@@ -4,7 +4,7 @@ import { inputBaseStyles } from '../InputBase';
 import { Card } from '../Card';
 import { transparentize } from 'polished';
 
-function buildListHoverColor (props) {
+function buildListHoverColor(props) {
   if (props.isFocused) {
     if (props.isInverse) {
       return props.theme.colors.primary600;
@@ -14,7 +14,7 @@ function buildListHoverColor (props) {
   return 'transparent';
 }
 
-function buildListFocusColor (props) {
+function buildListFocusColor(props) {
   if (props.isFocused) {
     if (props.isInverse) {
       return props.theme.colors.focusInverse;
@@ -45,9 +45,15 @@ export const StyledCard = styled(Card)<{
   isInverse?: boolean;
 }>`
   display: ${props => (props.isOpen ? 'block' : 'none')};
-  background: ${props => props.isInverse ? props.theme.colors.primary500 : props.theme.colors.neutral100};
+  background: ${props =>
+    props.isInverse
+      ? props.theme.colors.primary500
+      : props.theme.colors.neutral100};
   border: 1x solid;
-  border-color: ${props => props.isInverse ? transparentize(0.5, props.theme.colors.tertiary) : props.theme.colors.neutral300};
+  border-color: ${props =>
+    props.isInverse
+      ? transparentize(0.5, props.theme.colors.tertiary)
+      : props.theme.colors.neutral300};
   left: 4px;
   margin-top: 4px;
   padding: 4px 0 0;
@@ -67,13 +73,19 @@ export const StyledList = styled('ul')<{ isOpen?: boolean; maxHeight: string }>`
   overflow-y: auto;
 `;
 
-export const StyledItem = styled('li')<{ isInverse?: boolean; isFocused?: boolean }>`
+export const StyledItem = styled('li')<{
+  isInverse?: boolean;
+  isFocused?: boolean;
+}>`
   align-self: center;
   background: ${props => buildListHoverColor(props)};
   border: 2px solid;
   border-color: ${props => buildListFocusColor(props)};
   cursor: default;
-  color: ${props => props.isInverse ? props.theme.colors.neutral100 : props.theme.colors.neutral700};
+  color: ${props =>
+    props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral700};
   line-height: 24px;
   margin: 0;
   padding: 8px 16px;
@@ -90,13 +102,45 @@ export const SelectedItemsWrapper = styled.span`
   padding: 0 0 0 4px;
 `;
 
-export const SelectedItemButton = styled.button<{ isInverse?: boolean }>`
+function buildSelectedItemButtonBackground(props) {
+  const { isInverse, disabled } = props;
+  if (disabled) {
+    if (isInverse) {
+      return transparentize(0.7, props.theme.colors.neutral100);
+    }
+    return props.theme.colors.neutral300;
+  }
+  if (isInverse) {
+    return props.theme.colors.tertiary;
+  }
+  return props.theme.colors.primary;
+}
+
+function buildSelectedItemButtonColor(props) {
+  const { isInverse, disabled } = props;
+  if (disabled) {
+    if (isInverse) {
+      return transparentize(0.6, props.theme.colors.neutral100);
+    }
+    return transparentize(0.4, props.theme.colors.neutral500);
+  }
+  if (isInverse) {
+    return props.theme.colors.primary600;
+  }
+  return props.theme.colors.neutral100;
+}
+
+export const SelectedItemButton = styled.button<{
+  isInverse?: boolean;
+  disabled?: boolean;
+}>`
   align-self: center;
-  background: ${props => props.isInverse ? props.theme.colors.tertiary : props.theme.colors.primary};
+  background: ${props => buildSelectedItemButtonBackground(props)};
   border-radius: 4px;
   border: 0;
   box-shadow: 0 0 0;
-  color: ${props => props.isInverse ? props.theme.colors.primary600 : props.theme.colors.neutral100};
+  color: ${props => buildSelectedItemButtonColor(props)};
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
   display: flex;
   font-size: 12px;
   line-height: 16px;


### PR DESCRIPTION
Issue: #1057

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fixed the Multi Combobox so that all interactive items inside it cannot be clicked when disabled

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/91160746/236257607-4d6eb77c-c4cc-4a1a-add0-d8e07dc7bd9b.png)
![image](https://user-images.githubusercontent.com/91160746/236257655-1f05c298-35b5-4e8d-bb1e-3bca605ca3dc.png)


## Checklist 
- [X] changeset has been added
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
- Confirm that multi comboboxes with selected items can't be deselected 
- Confirm the inverse state
- Confirm the styles of the disabled, selected items
- Confirm that when using isClearable, that button also cannot be clicked
