### PR TITLE
fix(CharacterCounter): Replace `maxLength` prop with `maxCount` and add `hasCharacterCounter` prop

### DIFF
--- a/.changeset/fix-characterCounterProp.md
+++ b/.changeset/fix-characterCounterProp.md
@@ -2,6 +2,8 @@
 'react-magma-dom': patch
 ---
 
-fix(Character Counter): Added two new props 'maxCount' and 'hasCharacterCounter'. The prop of 'maxCount' replaces 'maxLength'. Now 'maxLength' works as the native HTML attribute.
+fix(Character Counter): Two new props have been added. The `hasCharacterCounter` prop which defaults to `true` and the `maxCount` prop which replaces `maxLength` and enables the Character Counter.
 
-Note: This update is a breaking change and all uses of the Character Counter need to update to the 'maxCount' prop name.
+In the interim if an input needs a native `maxlength` and not a Character Counter, set `hasCharacterCounter={false}` and then use `maxLength`.
+
+Please note that in the meantime, `maxLength` is still supported but will need to be changed to `maxCount` as future releases will remove `maxLength` and `hasCharacterCounter`.

--- a/.changeset/fix-characterCounterProp.md
+++ b/.changeset/fix-characterCounterProp.md
@@ -1,0 +1,7 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Character Counter): Added two new props 'maxCount' and 'hasCharacterCounter'. The prop of 'maxCount' replaces 'maxLength'. Now 'maxLength' works as the native HTML attribute.
+
+Note: This update is a breaking change and all uses of the Character Counter need to update to the 'maxCount' prop name.

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
@@ -34,6 +34,11 @@ export default {
         type: 'text',
       },
     },
+    hasCharacterCounter: {
+      control: {
+        type: 'boolean',
+      },
+    },
     helperMessage: {
       control: {
         type: 'text',
@@ -55,6 +60,11 @@ export default {
         options: LabelPosition,
       },
     },
+    maxLength: {
+      control: {
+        type: 'number',
+      },
+    },
     maxCount: {
       control: {
         type: 'number',
@@ -70,8 +80,8 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {
-  maxCount: 4,
   isInverse: false,
+  maxLength: 4,
 };
 
 export const WithChildren = args => {

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
@@ -55,12 +55,7 @@ export default {
         options: LabelPosition,
       },
     },
-    maxlength: {
-      control: {
-        type: 'text',
-      },
-    },
-    maxLength: {
+    maxCount: {
       control: {
         type: 'number',
       },
@@ -75,7 +70,7 @@ export default {
 
 export const Default = Template.bind({});
 Default.args = {
-  maxLength: 4,
+  maxCount: 4,
   isInverse: false,
 };
 

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
@@ -81,7 +81,7 @@ export default {
 export const Default = Template.bind({});
 Default.args = {
   isInverse: false,
-  maxLength: 4,
+  maxCount: 4,
 };
 
 export const WithChildren = args => {

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
@@ -14,11 +14,7 @@ const labelText = 'Character Counter';
 
 const Template: Story<CharacterCounterProps> = args => (
   <>
-    <Input
-      {...args}
-      testId="test-this-id"
-      labelText={labelText}
-    />
+    <Input {...args} testId="test-this-id" labelText={labelText} />
   </>
 );
 
@@ -59,6 +55,11 @@ export default {
         options: LabelPosition,
       },
     },
+    maxlength: {
+      control: {
+        type: 'text',
+      },
+    },
     maxLength: {
       control: {
         type: 'number',
@@ -66,9 +67,9 @@ export default {
     },
     value: {
       control: {
-        type: 'text'
-      }
-    }
+        type: 'text',
+      },
+    },
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.test.js
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.test.js
@@ -102,23 +102,23 @@ describe('CharacterCounter', () => {
         expect(getByText('2 ' + charactersOver)).toBeInTheDocument();
       });
     });
+  });
 
-    describe('styling', () => {
-      it('Should render an input with a correctly styled error message', () => {
-        const testId = 'inputMessageErrror';
-        const { getByText, getByTestId } = render(
-          <CharacterCounter testId={testId} inputLength={4} maxCount={2} />
-        );
+  describe('styling', () => {
+    it('Should render an input with a correctly styled error message', () => {
+      const testId = 'inputMessageErrror';
+      const { getByText, getByTestId } = render(
+        <CharacterCounter testId={testId} inputLength={4} maxCount={2} />
+      );
 
-        const errorMessage = getByTestId(testId);
+      const errorMessage = getByTestId(testId);
 
-        expect(getByText('2 ' + charactersOver)).toBeInTheDocument();
+      expect(getByText('2 ' + charactersOver)).toBeInTheDocument();
 
-        expect(errorMessage.querySelector('svg')).toHaveAttribute(
-          'height',
-          magma.iconSizes.small.toString()
-        );
-      });
+      expect(errorMessage.querySelector('svg')).toHaveAttribute(
+        'height',
+        magma.iconSizes.small.toString()
+      );
     });
   });
 

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.test.js
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.test.js
@@ -22,7 +22,7 @@ const charactersOver = defaultI18n.characterCounter.charactersOver;
 describe('CharacterCounter', () => {
   it('should find element by testId', () => {
     const { getByTestId } = render(
-      <CharacterCounter inputLength={45} maxLength={231} testId={testId} />
+      <CharacterCounter inputLength={45} maxCount={231} testId={testId} />
     );
 
     expect(getByTestId(testId)).toBeInTheDocument();
@@ -30,7 +30,7 @@ describe('CharacterCounter', () => {
 
   it('Does not violate accessibility standards', () => {
     const { container } = render(
-      <CharacterCounter inputLength={2} maxLength={22} />
+      <CharacterCounter inputLength={2} maxCount={22} />
     );
 
     return axe(container.innerHTML).then(result => {
@@ -40,24 +40,24 @@ describe('CharacterCounter', () => {
 
   describe('Titles', () => {
     describe('Characters Allowed', () => {
-      it('Shows the default label of "characters allowed" if maxLength is 0', () => {
+      it('Shows the default label of "characters allowed" if maxCount is 0', () => {
         const { getByText } = render(
-          <CharacterCounter inputLength={0} maxLength={0} />
+          <CharacterCounter inputLength={0} maxCount={0} />
         );
 
         expect(getByText('0 ' + charactersAllowed)).toBeInTheDocument();
       });
 
-      it('Shows the default label of "character allowed" if maxLength is 1', () => {
+      it('Shows the default label of "character allowed" if maxCount is 1', () => {
         const { getByText } = render(
-          <CharacterCounter inputLength={0} maxLength={1} />
+          <CharacterCounter inputLength={0} maxCount={1} />
         );
 
         expect(getByText('1 ' + characterAllowed)).toBeInTheDocument();
       });
-      it('Shows the default label of "characters allowed" if maxLength > 1', () => {
+      it('Shows the default label of "characters allowed" if maxCount > 1', () => {
         const { getByText } = render(
-          <CharacterCounter inputLength={0} maxLength={2} />
+          <CharacterCounter inputLength={0} maxCount={2} />
         );
 
         expect(getByText('2 ' + charactersAllowed)).toBeInTheDocument();
@@ -67,37 +67,37 @@ describe('CharacterCounter', () => {
     describe('Characters Left', () => {
       it('Shows the label "characters left" when inputLength > 1', () => {
         const { getByText } = render(
-          <CharacterCounter inputLength={2} maxLength={4} />
+          <CharacterCounter inputLength={2} maxCount={4} />
         );
         expect(getByText('2 ' + charactersLeft)).toBeInTheDocument();
       });
 
-      it('Shows the label "characters left" when maxLength is equal to inputLength', () => {
+      it('Shows the label "characters left" when maxCount is equal to inputLength', () => {
         const { getByText } = render(
-          <CharacterCounter inputLength={4} maxLength={4} />
+          <CharacterCounter inputLength={4} maxCount={4} />
         );
         expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
       });
 
-      it('Shows the label "character left" when inputLength < maxLength by 1', () => {
+      it('Shows the label "character left" when inputLength < maxCount by 1', () => {
         const { getByText } = render(
-          <CharacterCounter inputLength={3} maxLength={4} />
+          <CharacterCounter inputLength={3} maxCount={4} />
         );
         expect(getByText('1 ' + characterLeft)).toBeInTheDocument();
       });
     });
 
     describe('Characters Over Limit', () => {
-      it('Shows the label "character over limit" when inputLength > maxLength by 1', () => {
+      it('Shows the label "character over limit" when inputLength > maxCount by 1', () => {
         const { getByText } = render(
-          <CharacterCounter inputLength={5} maxLength={4} />
+          <CharacterCounter inputLength={5} maxCount={4} />
         );
         expect(getByText('1 ' + characterOver)).toBeInTheDocument();
       });
 
-      it('Shows the label "characters over limit" when inputLength > maxLength by 2', () => {
+      it('Shows the label "characters over limit" when inputLength > maxCount by 2', () => {
         const { getByText } = render(
-          <CharacterCounter inputLength={6} maxLength={4} />
+          <CharacterCounter inputLength={6} maxCount={4} />
         );
         expect(getByText('2 ' + charactersOver)).toBeInTheDocument();
       });
@@ -107,7 +107,7 @@ describe('CharacterCounter', () => {
       it('Should render an input with a correctly styled error message', () => {
         const testId = 'inputMessageErrror';
         const { getByText, getByTestId } = render(
-          <CharacterCounter testId={testId} inputLength={4} maxLength={2} />
+          <CharacterCounter testId={testId} inputLength={4} maxCount={2} />
         );
 
         const errorMessage = getByTestId(testId);
@@ -121,11 +121,11 @@ describe('CharacterCounter', () => {
       });
     });
   });
-  
+
   describe('accessibility', () => {
     it('Should have the aria-live attribute "off" until inputLength gets to 80%', () => {
       const { getByText } = render(
-        <CharacterCounter inputLength={2} maxLength={4} />
+        <CharacterCounter inputLength={2} maxCount={4} />
       );
 
       const characterCounter = getByText('2 ' + charactersLeft).parentElement;
@@ -135,7 +135,7 @@ describe('CharacterCounter', () => {
 
     it('Should have the aria-live attribute "polite" when inputLength is 80% or more', () => {
       const { getByText } = render(
-        <CharacterCounter inputLength={4} maxLength={4} />
+        <CharacterCounter inputLength={4} maxCount={4} />
       );
 
       const characterCounter = getByText('0 ' + charactersLeft).parentElement;
@@ -145,7 +145,7 @@ describe('CharacterCounter', () => {
 
     it('Should have the aria-live attribute "assertive" when inputLength exceeds 100%', () => {
       const { getByText } = render(
-        <CharacterCounter inputLength={5} maxLength={4} />
+        <CharacterCounter inputLength={5} maxCount={4} />
       );
 
       const characterCounter = getByText('1 ' + characterOver).parentElement;

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
@@ -6,6 +6,12 @@ import { I18nContext } from '../../i18n';
 
 export interface CharacterCounterProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  /** 
+   * Enables Character Counter by default. When set to false, the default HTML attribute of 'maxlength' will work. 
+   * Note: This is a temporary prop and will be removed in future releases.
+    @default true 
+  */
+  hasCharacterCounter?: boolean;
   /**
    * Identifier to associate Character Counter with Input.
    */
@@ -20,9 +26,10 @@ export interface CharacterCounterProps
    */
   maxCount: number;
   /**
-   * Limits the amount of characters in an input.
+   * Sets the maximum amount of characters allowed.
+   * @deprecated = true
    */
-  maxLength?: number;
+  maxLength: number;
   /**
    * @internal
    */
@@ -43,6 +50,7 @@ function buildFontWeight(props: Omit<CharacterCounterProps, 'id'>) {
 const StyledInputMessage = styled(InputMessage)<{
   hasCharacterCounter?: boolean;
   inputLength: number;
+  maxLength: number;
   maxCount: number;
 }>`
   font-weight: ${buildFontWeight};
@@ -53,8 +61,17 @@ export const CharacterCounter = React.forwardRef<
   HTMLDivElement,
   CharacterCounterProps
 >((props, ref) => {
-  const { children, id, inputLength, maxCount, testId, isInverse, ...rest } =
-    props;
+  const {
+    children,
+    hasCharacterCounter,
+    id,
+    inputLength,
+    maxCount,
+    maxLength,
+    testId,
+    isInverse,
+    ...rest
+  } = props;
 
   const i18n = React.useContext(I18nContext);
 
@@ -114,10 +131,12 @@ export const CharacterCounter = React.forwardRef<
     <div data-testid={testId} id={id} ref={ref} {...rest}>
       <StyledInputMessage
         aria-live={getAriaLiveState()}
+        hasCharacterCounter={hasCharacterCounter}
         hasError={isOverMaxCount}
         isInverse={isInverse}
         inputLength={inputLength}
         maxCount={maxCount}
+        maxLength={maxLength}
       >
         {characterTitle()}
       </StyledInputMessage>

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
@@ -7,7 +7,8 @@ import { I18nContext } from '../../i18n';
 export interface CharacterCounterProps
   extends React.HTMLAttributes<HTMLDivElement> {
   /** 
-   * Enables Character Counter by default. When set to false, the default HTML attribute of 'maxlength' will work. 
+   * Enables Character Counter by default. 
+   * When set to false, the default HTML attribute of 'maxlength' will work. 
    * Note: This is a temporary prop and will be removed in future releases.
     @default true 
   */

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
@@ -76,10 +76,13 @@ export const CharacterCounter = React.forwardRef<
 
   const i18n = React.useContext(I18nContext);
 
-  const isOverMaxCount = inputLength > maxCount;
+  // Temporary while both 'maxLength' and 'maxCount' are supported. To be removed in future iterations.
+  const maxCharacters = typeof maxCount === 'number' ? maxCount : maxLength;
+
+  const isOverMaxCount = inputLength > maxCharacters;
 
   // Gets percentage value of total characters within Input to let aria-live have dynamic states.
-  const getPercentage = (inputLength / maxCount) * 100;
+  const getPercentage = (inputLength / maxCharacters) * 100;
 
   // Returns aria-live states based on percentage of characters within Input.
   function getAriaLiveState() {
@@ -94,7 +97,9 @@ export const CharacterCounter = React.forwardRef<
 
   // As the user types, this calculates the remaining characters set by maxCount which counts down to zero then counts up if over the limit.
   const characterLimit =
-    maxCount > inputLength ? maxCount - inputLength : inputLength - maxCount;
+    maxCharacters > inputLength
+      ? maxCharacters - inputLength
+      : inputLength - maxCharacters;
 
   /*
    * Returns the character counter description.
@@ -104,27 +109,27 @@ export const CharacterCounter = React.forwardRef<
    */
   function characterTitle() {
     if (inputLength > 0) {
-      if (inputLength < maxCount) {
-        if (inputLength === maxCount - 1) {
+      if (inputLength < maxCharacters) {
+        if (inputLength === maxCharacters - 1) {
           return `${characterLimit} ${i18n.characterCounter.characterLeft}`;
         } else if (characterLimit > 1) {
           return `${characterLimit} ${i18n.characterCounter.charactersLeft}`;
         }
       }
-      if (inputLength > maxCount) {
-        if (inputLength === maxCount + 1) {
+      if (inputLength > maxCharacters) {
+        if (inputLength === maxCharacters + 1) {
           return `${characterLimit} ${i18n.characterCounter.characterOver}`;
         }
         return `${characterLimit} ${i18n.characterCounter.charactersOver}`;
       }
-      if (inputLength === maxCount) {
+      if (inputLength === maxCharacters) {
         return `0 ${i18n.characterCounter.charactersLeft}`;
       }
     } else {
-      if (maxCount === 1) {
-        return `${maxCount} ${i18n.characterCounter.characterAllowed}`;
+      if (maxCharacters === 1) {
+        return `${maxCharacters} ${i18n.characterCounter.characterAllowed}`;
       }
-      return `${maxCount} ${i18n.characterCounter.charactersAllowed}`;
+      return `${maxCharacters} ${i18n.characterCounter.charactersAllowed}`;
     }
   }
 

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
@@ -1239,7 +1239,7 @@ export const FullPageExample = args => {
         <Spacer size={16} />
         <Input
           labelText="What is the name and number of the course you are requesting this title for? *"
-          maxLength={100}
+          maxCount={100}
           placeholder="SWEN101"
         />
         <Spacer size={16} />

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -210,8 +210,8 @@ export const FormFieldContainer = React.forwardRef<
               id={descriptionId}
               inputLength={inputLength}
               isInverse={isInverse}
-              maxCount={countProps}
-              maxLength={countProps}
+              maxCount={maxCount}
+              maxLength={maxLength}
               testId={testId && `${testId}-character-counter`}
             />
           )}

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -77,6 +77,11 @@ export interface FormFieldContainerBaseProps {
   /**
    * Enables the Character Counter and sets the maximum amount of characters allowed within the Input.
    */
+  maxCount?: number;
+  /**
+   * Enables the Character Counter and sets the maximum amount of characters allowed within the Input.
+   * @deprecated true
+   */
   maxLength?: number;
   /**
    * Style properties for the helper or error message
@@ -143,6 +148,7 @@ export const FormFieldContainer = React.forwardRef<
     labelStyle,
     labelText,
     labelWidth,
+    maxCount,
     maxLength,
     messageStyle,
     testId,
@@ -152,7 +158,9 @@ export const FormFieldContainer = React.forwardRef<
   const isInverse = useIsInverse(isInverseProp);
 
   const descriptionId =
-    errorMessage || helperMessage || maxLength ? `${fieldId}__desc` : null;
+    errorMessage || helperMessage || maxLength || maxCount
+      ? `${fieldId}__desc`
+      : null;
 
   return (
     <InverseContext.Provider value={{ isInverse }}>
@@ -188,15 +196,17 @@ export const FormFieldContainer = React.forwardRef<
           labelWidth={labelWidth}
         >
           {children}
-          {typeof maxLength === 'number' && (
-            <CharacterCounter
-              id={descriptionId}
-              inputLength={inputLength}
-              isInverse={isInverse}
-              maxLength={maxLength}
-              testId={testId && `${testId}-character-counter`}
-            />
-          )}
+          {typeof maxCount === 'number' ||
+            (typeof maxLength === 'number' && (
+              <CharacterCounter
+                id={descriptionId}
+                inputLength={inputLength}
+                isInverse={isInverse}
+                maxCount={maxCount}
+                maxLength={maxLength}
+                testId={testId && `${testId}-character-counter`}
+              />
+            ))}
 
           {(errorMessage || helperMessage) && (
             <InputMessage

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -33,6 +33,12 @@ export interface FormFieldContainerBaseProps {
    * ID of the form field.  Also used in the descrption ID.
    */
   fieldId: string;
+  /** 
+   * Enables Character Counter by default. When set to false, the default HTML attribute of 'maxlength' will work. 
+   * Note: This is a temporary prop and will be removed in future releases.
+    @default true 
+  */
+  hasCharacterCounter?: boolean;
   /**
    * Content of the helper message.
    */
@@ -79,8 +85,7 @@ export interface FormFieldContainerBaseProps {
    */
   maxCount?: number;
   /**
-   * Enables the Character Counter and sets the maximum amount of characters allowed within the Input.
-   * @deprecated true
+   * Limits the amount of characters in an input.
    */
   maxLength?: number;
   /**
@@ -138,6 +143,7 @@ export const FormFieldContainer = React.forwardRef<
     containerStyle,
     errorMessage,
     fieldId,
+    hasCharacterCounter = true,
     helperMessage,
     iconPosition,
     inputSize,
@@ -158,9 +164,7 @@ export const FormFieldContainer = React.forwardRef<
   const isInverse = useIsInverse(isInverseProp);
 
   const descriptionId =
-    errorMessage || helperMessage || maxLength || maxCount
-      ? `${fieldId}__desc`
-      : null;
+    errorMessage || helperMessage || maxCount ? `${fieldId}__desc` : null;
 
   return (
     <InverseContext.Provider value={{ isInverse }}>
@@ -196,17 +200,16 @@ export const FormFieldContainer = React.forwardRef<
           labelWidth={labelWidth}
         >
           {children}
-          {typeof maxCount === 'number' ||
-            (typeof maxLength === 'number' && (
-              <CharacterCounter
-                id={descriptionId}
-                inputLength={inputLength}
-                isInverse={isInverse}
-                maxCount={maxCount}
-                maxLength={maxLength}
-                testId={testId && `${testId}-character-counter`}
-              />
-            ))}
+          {typeof maxCount === 'number' && hasCharacterCounter && (
+            <CharacterCounter
+              id={descriptionId}
+              inputLength={inputLength}
+              isInverse={isInverse}
+              maxCount={maxCount}
+              maxLength={!hasCharacterCounter && maxLength}
+              testId={testId && `${testId}-character-counter`}
+            />
+          )}
 
           {(errorMessage || helperMessage) && (
             <InputMessage

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -85,7 +85,8 @@ export interface FormFieldContainerBaseProps {
    */
   maxCount?: number;
   /**
-   * Limits the amount of characters in an input.
+   * Enables the Character Counter and sets the maximum amount of characters allowed within the Input.
+   * @deprecated = true
    */
   maxLength?: number;
   /**
@@ -163,8 +164,10 @@ export const FormFieldContainer = React.forwardRef<
   const theme = React.useContext(ThemeContext);
   const isInverse = useIsInverse(isInverseProp);
 
+  const countProps = maxCount || maxLength;
+
   const descriptionId =
-    errorMessage || helperMessage || maxCount ? `${fieldId}__desc` : null;
+    errorMessage || helperMessage || countProps ? `${fieldId}__desc` : null;
 
   return (
     <InverseContext.Provider value={{ isInverse }}>
@@ -200,13 +203,14 @@ export const FormFieldContainer = React.forwardRef<
           labelWidth={labelWidth}
         >
           {children}
-          {typeof maxCount === 'number' && hasCharacterCounter && (
+          {typeof countProps === 'number' && hasCharacterCounter && (
             <CharacterCounter
+              hasCharacterCounter={hasCharacterCounter}
               id={descriptionId}
               inputLength={inputLength}
               isInverse={isInverse}
-              maxCount={maxCount}
-              maxLength={!hasCharacterCounter && maxLength}
+              maxCount={countProps}
+              maxLength={countProps}
               testId={testId && `${testId}-character-counter`}
             />
           )}

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -34,7 +34,8 @@ export interface FormFieldContainerBaseProps {
    */
   fieldId: string;
   /** 
-   * Enables Character Counter by default. When set to false, the default HTML attribute of 'maxlength' will work. 
+   * Enables Character Counter by default. 
+   * When set to false, the default HTML attribute of 'maxlength' will work. 
    * Note: This is a temporary prop and will be removed in future releases.
     @default true 
   */

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -493,6 +493,15 @@ describe('Input', () => {
       expect(errorMessage).toHaveStyleRule('color', magma.colors.danger);
     });
 
+    it('should disable the Character Counter and allow for the native HTML attribute `maxlength` when `hasCharacterCounter` is set to false', () => {
+      const testId = 'test-id';
+
+      const { getByTestId } = render(
+        <Input testId={testId} hasCharacterCounter={false} maxLength={2} />
+      );
+      expect(getByTestId(testId)).toHaveAttribute('maxlength', '2');
+    });
+
     it('should render an input with an initial value set by the user', () => {
       const { getByText } = render(<Input maxCount={2} value="hi" />);
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -477,7 +477,7 @@ describe('Input', () => {
 
     it('should render an input with a correctly styled error message', () => {
       const { getByTestId, getByLabelText } = render(
-        <Input labelText={labelText} maxLength={2} />
+        <Input labelText={labelText} maxCount={2} />
       );
 
       fireEvent.change(getByLabelText(labelText), {
@@ -494,23 +494,21 @@ describe('Input', () => {
     });
 
     it('should render an input with an initial value set by the user', () => {
-      const { getByText } = render(<Input maxLength={2} value="hi" />);
+      const { getByText } = render(<Input maxCount={2} value="hi" />);
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
     });
 
     it('should update the character length on rerender', () => {
-      const { getByText, rerender } = render(
-        <Input maxLength={5} value="hi" />
-      );
+      const { getByText, rerender } = render(<Input maxCount={5} value="hi" />);
       expect(getByText('3 ' + charactersLeft)).toBeInTheDocument();
-      rerender(<Input maxLength={5} value="hello" />);
+      rerender(<Input maxCount={5} value="hello" />);
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
     });
 
-    it('Shows the label "characters allowed" equal to the maxLength if the user clears the input by backspacing', () => {
+    it('Shows the label "characters allowed" equal to the maxCount if the user clears the input by backspacing', () => {
       const onChange = jest.fn();
       const { getByText, getByLabelText } = render(
-        <Input labelText={labelText} maxLength={4} onChange={onChange} />
+        <Input labelText={labelText} maxCount={4} onChange={onChange} />
       );
 
       fireEvent.change(getByLabelText(labelText), {
@@ -528,14 +526,14 @@ describe('Input', () => {
       expect(getByText('4 ' + charactersAllowed)).toBeInTheDocument();
     });
 
-    it('Shows the label "characters allowed" equal to the maxLength if the user clears the input by clicking the onClear button', () => {
+    it('Shows the label "characters allowed" equal to the maxCount if the user clears the input by clicking the onClear button', () => {
       const onClear = jest.fn();
       const { getByText, getByLabelText, getByTestId } = render(
         <Input
           labelText={labelText}
           onClear={onClear}
           isClearable
-          maxLength={4}
+          maxCount={4}
         />
       );
 

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -502,6 +502,29 @@ describe('Input', () => {
       expect(getByTestId(testId)).toHaveAttribute('maxlength', '2');
     });
 
+    it('should show the Character Counter with the deprecated prop of `maxLength`', () => {
+      const testId = 'test-id';
+
+      const { getByText } = render(
+        <Input testId={testId} hasCharacterCounter={true} maxLength={2} />
+      );
+      expect(getByText('2 ' + charactersAllowed)).toBeInTheDocument();
+    });
+
+    it('should show the Character Counter with the deprecated prop of `maxLength` but give the priority to `maxCount` if both used simultaneously', () => {
+      const testId = 'test-id';
+
+      const { getByText } = render(
+        <Input
+          testId={testId}
+          hasCharacterCounter={true}
+          maxLength={2}
+          maxCount={4}
+        />
+      );
+      expect(getByText('4 ' + charactersAllowed)).toBeInTheDocument();
+    });
+
     it('should render an input with an initial value set by the user', () => {
       const { getByText } = render(<Input maxCount={2} value="hi" />);
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();

--- a/packages/react-magma-dom/src/components/Input/InputMessage.tsx
+++ b/packages/react-magma-dom/src/components/Input/InputMessage.tsx
@@ -15,7 +15,7 @@ export interface InputMessageProps
    */
   inputSize?: InputSize;
   isInverse?: boolean;
-  maxLength?: number;
+  maxCount?: number;
 }
 
 function BuildMessageColor(props) {
@@ -55,14 +55,14 @@ export const InputMessage: React.FunctionComponent<InputMessageProps> = ({
   id,
   isInverse,
   hasError,
-  maxLength,
+  maxCount,
   ...other
 }: InputMessageProps) => {
   const theme = React.useContext(ThemeContext);
 
-  //Conditional wrapper based on maxLength, allows Character Counter to render without the Announce component for accessibility purposes.
+  //Conditional wrapper based on maxCount, allows Character Counter to render without the Announce component for accessibility purposes.
   function AnnounceWrapper(props) {
-    if (maxLength) {
+    if (maxCount) {
       return props.children;
     }
     return <Announce>{props.children}</Announce>;

--- a/packages/react-magma-dom/src/components/Input/index.tsx
+++ b/packages/react-magma-dom/src/components/Input/index.tsx
@@ -27,6 +27,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       labelStyle,
       labelText,
       labelWidth,
+      maxCount,
+      maxlength,
       maxLength,
       messageStyle,
       testId,
@@ -37,7 +39,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const id = useGenerateId(defaultId);
 
     const descriptionId =
-      errorMessage || helperMessage || maxLength ? `${id}__desc` : null;
+      errorMessage || helperMessage || maxLength || maxCount
+        ? `${id}__desc`
+        : null;
 
     const isInverse = useIsInverse(props.isInverse);
 
@@ -77,6 +81,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         labelText={labelText}
         labelWidth={labelWidth}
         maxLength={maxLength}
+        maxCount={maxCount}
         messageStyle={messageStyle}
         testId={testId && `${testId}-formFieldContainer`}
       >
@@ -86,12 +91,17 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             descriptionId ? descriptionId : props['aria-describedby']
           }
           aria-invalid={!!errorMessage}
-          hasError={!!errorMessage || characterLength > maxLength}
+          hasError={
+            !!errorMessage ||
+            characterLength > maxCount ||
+            characterLength > maxLength
+          }
           iconPosition={iconPosition}
           id={id}
           inputSize={inputSize}
           inputLength={characterLength}
           isInverse={isInverse}
+          maxlength={maxlength}
           onChange={handleChange}
           onClear={handleClear}
           ref={ref}

--- a/packages/react-magma-dom/src/components/Input/index.tsx
+++ b/packages/react-magma-dom/src/components/Input/index.tsx
@@ -39,7 +39,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const id = useGenerateId(defaultId);
 
     const descriptionId =
-      errorMessage || helperMessage || maxCount ? `${id}__desc` : null;
+      errorMessage || helperMessage || maxCount || maxLength
+        ? `${id}__desc`
+        : null;
 
     const isInverse = useIsInverse(props.isInverse);
 
@@ -90,13 +92,17 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             descriptionId ? descriptionId : props['aria-describedby']
           }
           aria-invalid={!!errorMessage}
-          hasError={!!errorMessage || characterLength > maxCount}
+          hasError={
+            !!errorMessage ||
+            characterLength > maxCount ||
+            characterLength > maxLength
+          }
           iconPosition={iconPosition}
           id={id}
           inputSize={inputSize}
           inputLength={characterLength}
           isInverse={isInverse}
-          maxLength={maxLength}
+          maxLength={!hasCharacterCounter && maxLength}
           onChange={handleChange}
           onClear={handleClear}
           ref={ref}

--- a/packages/react-magma-dom/src/components/Input/index.tsx
+++ b/packages/react-magma-dom/src/components/Input/index.tsx
@@ -18,6 +18,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       children,
       containerStyle,
       errorMessage,
+      hasCharacterCounter = true,
       helperMessage,
       iconPosition,
       id: defaultId,
@@ -28,7 +29,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       labelText,
       labelWidth,
       maxCount,
-      maxlength,
       maxLength,
       messageStyle,
       testId,
@@ -39,9 +39,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const id = useGenerateId(defaultId);
 
     const descriptionId =
-      errorMessage || helperMessage || maxLength || maxCount
-        ? `${id}__desc`
-        : null;
+      errorMessage || helperMessage || maxCount ? `${id}__desc` : null;
 
     const isInverse = useIsInverse(props.isInverse);
 
@@ -70,6 +68,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         containerStyle={containerStyle}
         errorMessage={errorMessage}
         fieldId={id}
+        hasCharacterCounter={hasCharacterCounter}
         helperMessage={helperMessage}
         iconPosition={iconPosition}
         isLabelVisuallyHidden={isLabelVisuallyHidden}
@@ -91,17 +90,13 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             descriptionId ? descriptionId : props['aria-describedby']
           }
           aria-invalid={!!errorMessage}
-          hasError={
-            !!errorMessage ||
-            characterLength > maxCount ||
-            characterLength > maxLength
-          }
+          hasError={!!errorMessage || characterLength > maxCount}
           iconPosition={iconPosition}
           id={id}
           inputSize={inputSize}
           inputLength={characterLength}
           isInverse={isInverse}
-          maxlength={maxlength}
+          maxLength={maxLength}
           onChange={handleChange}
           onClear={handleClear}
           ref={ref}

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -38,7 +38,8 @@ export interface InputBaseProps
    */
   containerStyle?: React.CSSProperties;
   /** 
-   * Enables Character Counter by default. When set to false, the default HTML attribute of 'maxlength' will work. 
+   * Enables Character Counter by default. 
+   * When set to false, the default HTML attribute of 'maxlength' will work. 
    * Note: This is a temporary prop and will be removed in future releases.
     @default true 
   */

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -96,8 +96,10 @@ export interface InputBaseProps
    */
   maxCount?: number;
   /**
-   * Please continue to use this maxLength prop only for HTML native behavior moving forward, and maxCount for character counter functionality.
+   * A number value which gives Character Counter the maximum length of allowable characters in an Input.
+   * @deprecated = true
    */
+
   maxLength?: number;
   /**
    * Action that will fire when icon is clicked
@@ -620,7 +622,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             isPredictive={isPredictive}
             hasError={hasError}
             ref={ref}
-            maxLength={maxLength}
+            maxLength={!hasCharacterCounter && maxLength}
             onChange={handleChange}
             style={inputStyle}
             theme={theme}

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -37,6 +37,12 @@ export interface InputBaseProps
    * Style properties for the component container element
    */
   containerStyle?: React.CSSProperties;
+  /** 
+   * Enables Character Counter by default. When set to false, the default HTML attribute of 'maxlength' will work. 
+   * Note: This is a temporary prop and will be removed in future releases.
+    @default true 
+  */
+  hasCharacterCounter?: boolean;
   /**
    * @internal
    */
@@ -89,10 +95,8 @@ export interface InputBaseProps
    * A number value which gives Character Counter the maximum length of allowable characters in an Input.
    */
   maxCount?: number;
-  maxlength?: string;
   /**
-   * A number value which gives Character Counter the maximum length of allowable characters in an Input.
-   * @deprecated true
+   * Please continue to use this maxLength prop only for HTML native behavior moving forward, and maxCount for character counter functionality.
    */
   maxLength?: number;
   /**
@@ -229,11 +233,11 @@ function getInputPadding(props: InputBaseStylesProps) {
 }
 
 export interface InputBaseStylesProps {
+  hasCharacterCounter?: boolean;
   isInverse?: boolean;
   iconPosition?: InputIconPosition;
   inputSize?: InputSize;
   isPredictive?: boolean;
-  maxlength?: string;
   theme?: ThemeInterface;
   disabled?: boolean;
   hasError?: boolean;
@@ -533,6 +537,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       containerStyle,
       defaultValue,
       disabled,
+      hasCharacterCounter,
       hasError,
       icon,
       iconAriaLabel,
@@ -541,7 +546,6 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       isPasswordInput,
       isPredictive,
       maxCount,
-      maxlength,
       maxLength,
       onClear,
       onIconClick,
@@ -608,6 +612,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             aria-invalid={hasError}
             disabled={disabled}
             data-testid={testId}
+            hasCharacterCounter={hasCharacterCounter}
             iconPosition={iconPosition}
             inputSize={inputSize ? inputSize : InputSize.medium}
             isClearable={isClearable && inputLength > 0}
@@ -615,7 +620,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             isPredictive={isPredictive}
             hasError={hasError}
             ref={ref}
-            maxlength={maxlength}
+            maxLength={maxLength}
             onChange={handleChange}
             style={inputStyle}
             theme={theme}

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -88,6 +88,12 @@ export interface InputBaseProps
   /**
    * A number value which gives Character Counter the maximum length of allowable characters in an Input.
    */
+  maxCount?: number;
+  maxlength?: string;
+  /**
+   * A number value which gives Character Counter the maximum length of allowable characters in an Input.
+   * @deprecated true
+   */
   maxLength?: number;
   /**
    * Action that will fire when icon is clicked
@@ -227,6 +233,7 @@ export interface InputBaseStylesProps {
   iconPosition?: InputIconPosition;
   inputSize?: InputSize;
   isPredictive?: boolean;
+  maxlength?: string;
   theme?: ThemeInterface;
   disabled?: boolean;
   hasError?: boolean;
@@ -533,6 +540,8 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       isClearable,
       isPasswordInput,
       isPredictive,
+      maxCount,
+      maxlength,
       maxLength,
       onClear,
       onIconClick,
@@ -606,6 +615,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             isPredictive={isPredictive}
             hasError={hasError}
             ref={ref}
+            maxlength={maxlength}
             onChange={handleChange}
             style={inputStyle}
             theme={theme}

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.stories.tsx
@@ -7,10 +7,7 @@ import { Spacer } from '../Spacer';
 import { Textarea, TextareaProps } from '.';
 
 const Template: Story<TextareaProps> = args => (
-  <Textarea
-    {...args}
-    labelText="Textarea label"
-  />
+  <Textarea {...args} labelText="Textarea label" />
 );
 
 export default {
@@ -37,16 +34,16 @@ export default {
     },
     value: {
       control: {
-        type: 'text'
-      }
-    }
+        type: 'text',
+      },
+    },
   },
 } as Meta;
 
 export const Default = Template.bind({});
 Default.args = {
   isInverse: false,
-  maxLength: 4,
+  maxCount: 4,
 };
 
 export const OnClear = args => {

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
@@ -136,6 +136,15 @@ describe('Textarea', () => {
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
     });
 
+    it('should disable the Character Counter and allow for the native HTML attribute `maxlength` when `hasCharacterCounter` is set to false', () => {
+      const testId = 'test-id';
+
+      const { getByTestId } = render(
+        <Textarea testId={testId} hasCharacterCounter={false} maxLength={2} />
+      );
+      expect(getByTestId(testId)).toHaveAttribute('maxlength', '2');
+    });
+
     it('should update the character length on rerender', () => {
       const { getByText, rerender } = render(
         <Textarea maxCount={5} value="hi" />

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
@@ -116,9 +116,9 @@ describe('Textarea', () => {
     const charactersAllowed = defaultI18n.characterCounter.charactersAllowed;
     const charactersLeft = defaultI18n.characterCounter.charactersLeft;
 
-    it('Shows the label "characters allowed" equal to the maxLength if the user clears the textarea', () => {
+    it('Shows the label "characters allowed" equal to the maxCount if the user clears the textarea', () => {
       const { getByTestId, getByText } = render(
-        <Textarea maxLength={4} testId={testId} />
+        <Textarea maxCount={4} testId={testId} />
       );
       const textarea = getByTestId(testId);
 
@@ -132,16 +132,16 @@ describe('Textarea', () => {
     });
 
     it('should render a textarea with an initial value set by the user', () => {
-      const { getByText } = render(<Textarea maxLength={2} value="hi" />);
+      const { getByText } = render(<Textarea maxCount={2} value="hi" />);
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
     });
 
     it('should update the character length on rerender', () => {
       const { getByText, rerender } = render(
-        <Textarea maxLength={5} value="hi" />
+        <Textarea maxCount={5} value="hi" />
       );
       expect(getByText('3 ' + charactersLeft)).toBeInTheDocument();
-      rerender(<Textarea maxLength={5} value="hello" />);
+      rerender(<Textarea maxCount={5} value="hello" />);
       expect(getByText('0 ' + charactersLeft)).toBeInTheDocument();
     });
   });

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
@@ -145,6 +145,29 @@ describe('Textarea', () => {
       expect(getByTestId(testId)).toHaveAttribute('maxlength', '2');
     });
 
+    it('should show the Character Counter with the deprecated prop of `maxLength`', () => {
+      const testId = 'test-id';
+
+      const { getByText } = render(
+        <Textarea testId={testId} hasCharacterCounter={true} maxLength={2} />
+      );
+      expect(getByText('2 ' + charactersAllowed)).toBeInTheDocument();
+    });
+
+    it('should show the Character Counter with the deprecated prop of `maxLength` but give the priority to `maxCount` if both used simultaneously', () => {
+      const testId = 'test-id';
+
+      const { getByText } = render(
+        <Textarea
+          testId={testId}
+          hasCharacterCounter={true}
+          maxLength={2}
+          maxCount={4}
+        />
+      );
+      expect(getByText('4 ' + charactersAllowed)).toBeInTheDocument();
+    });
+
     it('should update the character length on rerender', () => {
       const { getByText, rerender } = render(
         <Textarea maxCount={5} value="hi" />

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -26,7 +26,7 @@ export interface TextareaProps
   /**
    * A number value which gives Character Counter the maximum length of allowable characters in an Textarea.
    */
-  maxLength?: number;
+  maxCount?: number;
   /**
    * @internal
    */
@@ -62,7 +62,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       labelStyle,
       labelText,
       labelWidth,
-      maxLength,
+      maxCount,
       messageStyle,
       testId,
       textareaStyle,
@@ -111,7 +111,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         labelText={labelText}
         labelPosition={labelPosition}
         labelWidth={labelWidth}
-        maxLength={maxLength}
+        maxCount={maxCount}
       >
         <StyledTextArea
           {...other}
@@ -120,7 +120,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           }
           aria-invalid={!!errorMessage}
           data-testid={testId}
-          hasError={!!errorMessage || characterLength > maxLength}
+          hasError={!!errorMessage || characterLength > maxCount}
           id={id}
           isInverse={isInverse}
           onChange={handleChange}

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -55,6 +55,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const {
       containerStyle,
       errorMessage,
+      hasCharacterCounter,
       helperMessage,
       id: defaultId,
       isLabelVisuallyHidden,
@@ -63,6 +64,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       labelText,
       labelWidth,
       maxCount,
+      maxLength,
       messageStyle,
       testId,
       textareaStyle,
@@ -103,6 +105,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         containerStyle={containerStyle}
         errorMessage={errorMessage}
         fieldId={id}
+        hasCharacterCounter={hasCharacterCounter}
         helperMessage={helperMessage}
         isLabelVisuallyHidden={isLabelVisuallyHidden}
         isInverse={isInverse}
@@ -112,6 +115,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         labelPosition={labelPosition}
         labelWidth={labelWidth}
         maxCount={maxCount}
+        maxLength={maxLength}
       >
         <StyledTextArea
           {...other}
@@ -122,6 +126,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           data-testid={testId}
           hasError={!!errorMessage || characterLength > maxCount}
           id={id}
+          maxLength={!hasCharacterCounter && maxLength}
           isInverse={isInverse}
           onChange={handleChange}
           ref={ref}

--- a/website/react-magma-docs/src/pages/api/character-counter.mdx
+++ b/website/react-magma-docs/src/pages/api/character-counter.mdx
@@ -45,6 +45,23 @@ export function Example() {
 }
 ```
 
+## New Character Counter props
+
+Two new props have been added. The `hasCharacterCounter` prop which defaults to `true` and the `maxCount` prop which replaces `maxLength` and enables the Character Counter.
+
+In the interim if an input needs a native `maxlength` and not a Character Counter, set `hasCharacterCounter={false}` and then use `maxLength`.
+
+Please note that in the meantime, `maxLength` is still supported but will need to be changed to `maxCount` as future releases will remove `maxLength` and `hasCharacterCounter`.
+
+```typescript
+import React from 'react';
+import { Input } from 'react-magma-dom';
+
+export function Example() {
+  return <Input maxCount={4} labelText="Default Character Counter" />;
+}
+```
+
 ## Inverse
 
 `isInverse` is an optional boolean prop, that may be passed in when inputs are to be displayed on a dark background.

--- a/website/react-magma-docs/src/pages/api/character-counter.mdx
+++ b/website/react-magma-docs/src/pages/api/character-counter.mdx
@@ -45,13 +45,11 @@ export function Example() {
 }
 ```
 
-## New Character Counter props
+## maxLength vs maxCount
 
-Two new props have been added. The `hasCharacterCounter` prop which defaults to `true` and the `maxCount` prop which replaces `maxLength` and enables the Character Counter.
+The `maxLength` prop temporarily controlled the Character Counter, but moving forward it should exclusively be used for the HTML native behavior of preventing users from typing beyond the set maximum length.
 
-In the interim if an input needs a native `maxlength` and not a Character Counter, set `hasCharacterCounter={false}` and then use `maxLength`.
-
-Please note that in the meantime, `maxLength` is still supported but will need to be changed to `maxCount` as future releases will remove `maxLength` and `hasCharacterCounter`.
+To enable the Character Counter, use `maxCount` (preferred) or **both** `maxLength` and `hasCharacterCounter` (to be deprecated in future versions).
 
 ```typescript
 import React from 'react';

--- a/website/react-magma-docs/src/pages/api/character-counter.mdx
+++ b/website/react-magma-docs/src/pages/api/character-counter.mdx
@@ -17,7 +17,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 ## Basic Usage
 
-The Character Counter is called when the prop of `maxLength` is set within an <Link to="/api/input">Input</Link> or a <Link to="/api/textarea">Textarea</Link>.
+The Character Counter is called when the prop of `maxCount` is set within an <Link to="/api/input">Input</Link> or a <Link to="/api/textarea">Textarea</Link>.
 
 As the user types, a counter is displayed below the Input or Textarea counting down to the allowable length. Once this is exceeded, an error message shows in place counting the overrage of characters.
 
@@ -26,7 +26,7 @@ import React from 'react';
 import { Input } from 'react-magma-dom';
 
 export function Example() {
-  return <Input maxLength={4} labelText="Default Character Counter" />;
+  return <Input maxCount={4} labelText="Default Character Counter" />;
 }
 ```
 
@@ -40,11 +40,7 @@ import { Input } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <Input
-      maxLength={4}
-      value="hi"
-      labelText="Inital Value Character Counter"
-    />
+    <Input maxCount={4} value="hi" labelText="Inital Value Character Counter" />
   );
 }
 ```
@@ -60,7 +56,7 @@ import { Container, Input } from 'react-magma-dom';
 export function Example() {
   return (
     <Container isInverse style={{ padding: '12px' }}>
-      <Input isInverse maxLength={4} labelText="Character Counter" />
+      <Input isInverse maxCount={4} labelText="Character Counter" />
     </Container>
   );
 }
@@ -91,7 +87,7 @@ export function Example() {
         },
       }}
     >
-      <Input maxLength={4} labelText="Character Counter" />
+      <Input maxCount={4} labelText="Character Counter" />
     </I18nContext.Provider>
   );
 }

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -191,14 +191,14 @@ export function Example() {
 
 ## Character Counter
 
-Character Counter is enabled when using the `maxLength` prop. As the user types past the allowable length, an error state appears showing the overrage.
+Character Counter is enabled when using the `maxCount` prop. As the user types past the allowable length, an error state appears showing the overrage.
 
 ```typescript
 import React from 'react';
 import { Input } from 'react-magma-dom';
 
 export function Example() {
-  return <Input maxLength={4} labelText="Default Character Counter" />;
+  return <Input maxCount={4} labelText="Default Character Counter" />;
 }
 ```
 

--- a/website/react-magma-docs/src/pages/api/textarea.mdx
+++ b/website/react-magma-docs/src/pages/api/textarea.mdx
@@ -72,7 +72,7 @@ import React from 'react';
 import { Textarea } from 'react-magma-dom';
 
 export function Example() {
-  return <Textarea maxLength={4} labelText="Character Counter" />;
+  return <Textarea maxCount={4} labelText="Character Counter" />;
 }
 ```
 


### PR DESCRIPTION
Issue: # [1037](https://github.com/cengage/react-magma/issues/1037)

## What I did
- Added two new props of 'maxCount' replacing 'maxLength' for enabling the Character Counter and 'hasCharacterCounter'. If 'hasCharacterCounter' is set to false, it hides the Character Counter.

## Checklist 
- [x] changeset has been added
- [x] NA
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test

Test both the regular **Input** and **Textarea** components:
- Confirm the Character Counter appears when `maxCount` is set.
- Confirm `maxLength` still works as a Character Counter.
- Confirm `maxLength` works as a native maxlength when `hasCharacterCounter` is set to false.
