### PR TITLE
Fix border radius on table pagination

### DIFF
--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -300,7 +300,7 @@ export const ControlledPagination = args => {
   );
 
   return (
-    <Card isInverse={args.isInverse}>
+    <Card>
       <Table {...args}>
         <TableHead>
           <TableRow>

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -108,6 +108,7 @@ const StyledContainer = styled.div<{
   display: flex;
   justify-content: flex-end;
   padding: ${props => props.theme.spaceScale.spacing02};
+  border-radius: 0 0 ${props => props.theme.borderRadius} ${props => props.theme.borderRadius};
 `;
 
 const PageCount = styled(Label) <{ theme: ThemeInterface }>`


### PR DESCRIPTION
Issue: #

## What I did
The TablePagination component does not use rounded corners by default even though the Table component does. This can cause a visual problem when the Table and TablePagination components are placed inside a Card with the intention of giving the entire display a border with rounded corners since the TablePagination component will spill over the Card boundary. 

<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Screenshots (if appropriate):
Before:
<img width="127" alt="Screenshot 2023-05-18 at 12 23 48 PM" src="https://github.com/cengage/react-magma/assets/88386737/4a9369b2-5a29-4167-8516-f882b6953902">

After: 
<img width="107" alt="Screenshot 2023-05-18 at 12 24 32 PM" src="https://github.com/cengage/react-magma/assets/88386737/01bf1385-fbeb-4042-877b-1e8a96716ec2">

## Checklist 
- [ ] changeset has been added
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, edge cases, etc. -->
