### PR TITLE
feat: Allow hiding RowsPerPageController when no onRowsPerPageChange …

### DIFF
--- a/.changeset/feat-optionalPerPageSelect.md
+++ b/.changeset/feat-optionalPerPageSelect.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TablePagination): TablePagination component will hide rows per page select when no handleRowsPerPageChange argument passed

--- a/.changeset/feat-optionalPerPageSelect.md
+++ b/.changeset/feat-optionalPerPageSelect.md
@@ -2,4 +2,4 @@
 'react-magma-dom': minor
 ---
 
-feat(TablePagination): TablePagination component will hide rows per page select when no handleRowsPerPageChange argument passed
+feat(TablePagination): TablePagination component will hide rows per page select when no onRowsPerPageChange argument passed

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -823,3 +823,49 @@ export const AdjustableRowNumber = args => {
 AdjustableRowNumber.args = {
   numberRows: 300,
 };
+
+export const NoRowsPerPageControl = args => {
+  const [pageIndex, setPageIndex] = React.useState<number>(1);
+  const rowsPerPage = 5;
+
+  function handlePageChange(_, page) {
+    setPageIndex(page);
+  }
+
+  const rowsToShow = rowsLong.slice(
+    (pageIndex - 1) * rowsPerPage,
+    (pageIndex - 1) * rowsPerPage + rowsPerPage
+  );
+
+  return (
+    <Card isInverse={args.isInverse}>
+      <Table {...args}>
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rowsToShow.map((row, i) => (
+            <TableRow key={`row${i}`}>
+              {row.map((cell, j) => (
+                <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <TablePagination
+        itemCount={rowsLong.length}
+        onPageChange={handlePageChange}
+        page={pageIndex}
+        rowsPerPage={rowsPerPage}
+        isInverse={args.isInverse}
+        hasSquareCorners={args.hasSquareCorners}
+      />
+    </Card>
+  );
+};

--- a/packages/react-magma-dom/src/components/Table/TablePagination.test.js
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.test.js
@@ -193,4 +193,20 @@ describe('Table Pagination', () => {
       return expect(result).toHaveNoViolations();
     });
   });
+
+  it('should hide rows per page component when no onRowsPerPageChanged function passed', () => {
+    const { queryByText } = render(
+      <TablePagination itemCount={20}/>
+    );
+
+    expect(queryByText('Rows per page:')).not.toBeInTheDocument();
+  });
+
+  it('should show rows per page component when onRowsPerPageChanged function passed', () => {
+    const { queryByText } = render(
+      <TablePagination itemCount={20} onRowsPerPageChange={() => {}} />
+    );
+
+    expect(queryByText('Rows per page:')).toBeInTheDocument();
+  });
 });

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -14,7 +14,7 @@ import { useControlled } from '../../hooks/useControlled';
 import { transparentize } from 'polished';
 import { ButtonGroup, ButtonGroupAlignment } from '../ButtonGroup';
 import { NativeSelect } from '../NativeSelect';
-import { Dropdown, DropdownAlignment, DropdownButton, DropdownContent, DropdownDropDirection, DropdownMenuItem } from '../Dropdown';
+import { DropdownDropDirection } from '../Dropdown';
 
 export interface BaseTablePaginationProps
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -136,6 +136,55 @@ const RowsPerPageLabel = styled.span<{
   color: ${props => (props.isInverse ? props.theme.colors.neutral100 : '')};
 `;
 
+interface RowsPerPageControllerProps {
+  /**
+   * Event that fires when the number of rows per page changes
+   */
+  handleRowsPerPageChange?: (value: any) => void;
+  rowsPerPageValues: number[];
+  isInverse?: boolean;
+}
+
+const RowsPerPageController = ((props: RowsPerPageControllerProps) => {
+  const {
+    handleRowsPerPageChange,
+    rowsPerPageValues,
+    isInverse,
+  } = props;
+
+    const theme = React.useContext(ThemeContext);
+    const i18n = React.useContext(I18nContext);
+
+    const rowsPerPageItems = rowsPerPageValues.map(value => ({
+      label: value.toString(),
+      value,
+    }));
+
+  return (
+    <>
+      <RowsPerPageLabel isInverse={isInverse} theme={theme}>
+          {i18n.table.pagination.rowsPerPageLabel}:
+      </RowsPerPageLabel> 
+      <NativeSelect
+        onChange={(event) => handleRowsPerPageChange(event.target.value)}
+        aria-label={i18n.table.pagination.rowsPerPageLabel}
+        style={{minWidth: 80}}
+        testId="rowPerPageSelect" 
+        fieldId={''}
+      >
+        {rowsPerPageItems.map((row, index) => (
+          <option
+            key={index}
+            value={row.value}
+          >
+            {row.label}
+          </option>
+        ))}
+      </NativeSelect> 
+    </>
+  )
+});
+
 export const TablePagination = React.forwardRef<
   HTMLDivElement,
   TablePaginationProps
@@ -147,7 +196,7 @@ export const TablePagination = React.forwardRef<
     defaultRowsPerPage = 10,
     itemCount,
     onPageChange,
-    onRowsPerPageChange,
+    onRowsPerPageChange = null,
     page: pageProp,
     rowsPerPage: rowsPerPageProp,
     rowsPerPageValues = [10, 20, 50, 100],
@@ -157,6 +206,8 @@ export const TablePagination = React.forwardRef<
 
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
+
+  const hasRowPerPageChangeFunction = onRowsPerPageChange && typeof onRowsPerPageChange === 'function';
 
   const isInverse = useIsInverse(props.isInverse);
 
@@ -174,18 +225,12 @@ export const TablePagination = React.forwardRef<
     page: pageProp,
   });
 
-  const [activeIndex, setActiveIndex] = React.useState(rowsPerPage);
   const isLastPage = page * rowsPerPage >= itemCount;
 
   const displayPageStart = (page - 1) * rowsPerPage + 1;
   const displayPageEnd = isLastPage ? itemCount : page * rowsPerPage;
 
-  const rowsPerPageItems = rowsPerPageValues.map(value => ({
-    label: value.toString(),
-    value,
-  }));
-
-  function handleRowsPerPageChange(event) {
+  function handleRowsPerPageChange(value) {
     if (!pageProp) {
       setPageState(1);
 
@@ -195,15 +240,11 @@ export const TablePagination = React.forwardRef<
     }
 
     if (!rowsPerPageProp) {
-      setRowsPerPageState(event.target.value);
+      setRowsPerPageState(value);
     }
 
-    onRowsPerPageChange &&
-      typeof onRowsPerPageChange === 'function' &&
-      onRowsPerPageChange(event.target.value);
-      if(dropdownDropDirection) {
-        setActiveIndex(rowsPerPage);
-      }
+    hasRowPerPageChangeFunction &&
+      onRowsPerPageChange(value);
   }
 
   const previousButton = pageButtons[0];
@@ -218,55 +259,14 @@ export const TablePagination = React.forwardRef<
       ref={ref}
       theme={theme}
     >
-      <RowsPerPageLabel isInverse={isInverse} theme={theme}>
-        {i18n.table.pagination.rowsPerPageLabel}:
-      </RowsPerPageLabel>
-      {dropdownDropDirection ? 
-        <Dropdown
-          alignment={DropdownAlignment.end}
-          dropDirection={dropdownDropDirection}
-          activeIndex={activeIndex}
-          isInverse={isInverse}
-        >
-          <DropdownButton
-            aria-label={i18n.table.pagination.rowsPerPageLabel}
-            color={ButtonColor.secondary}
-            style={{ minWidth: 0 }}
-            testId="rowPerPageDropdownButton"
-          >
-            {rowsPerPageItems.find(item => item.value === rowsPerPage).label}
-          </DropdownButton>
-          <DropdownContent>
-            {rowsPerPageItems.map((row, index) => (
-              <DropdownMenuItem
-                key={index}
-                onClick={handleRowsPerPageChange}
-                value={row.value}
-              >
-                {row.label}
-              </DropdownMenuItem>
-            ))}
-          </DropdownContent>
-        </Dropdown> : 
-        <NativeSelect
-          onChange={handleRowsPerPageChange}
-          aria-label={i18n.table.pagination.rowsPerPageLabel}
-          style={{minWidth: 80}}
-          testId="rowPerPageSelect" 
-          fieldId={''}
-        >
-          {rowsPerPageItems.map((row, index) => (
-            <option
-              key={index}
-              value={row.value}
-            >
-              {row.label}
-            </option>
-          ))}
-        </NativeSelect> 
+      { hasRowPerPageChangeFunction &&
+          <RowsPerPageController
+            isInverse={isInverse}
+            handleRowsPerPageChange={handleRowsPerPageChange}
+            rowsPerPageValues={rowsPerPageValues}
+        />
       }
       
-
       <PageCount isInverse={isInverse} theme={theme}>
         {`${displayPageStart}-${displayPageEnd} ${i18n.table.pagination.ofLabel} ${itemCount}`}
       </PageCount>

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -141,6 +141,9 @@ interface RowsPerPageControllerProps {
    * Event that fires when the number of rows per page changes
    */
   handleRowsPerPageChange?: (value: any) => void;
+    /**
+   * Values added to the rows per page select
+   */
   rowsPerPageValues: number[];
   isInverse?: boolean;
 }

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -34,7 +34,8 @@ export interface BaseTablePaginationProps
    */
   onPageChange?: (event: React.SyntheticEvent, newPage: number) => void;
   /**
-   * Event that fires when the number of rows per page changes
+   * Event that fires when the number of rows per page changes.
+   * If no function is passed, the rows per page select will be hidden
    */
   onRowsPerPageChange?: (newRowsPerPage: number) => void;
   /**
@@ -141,7 +142,7 @@ interface RowsPerPageControllerProps {
    * Event that fires when the number of rows per page changes
    */
   handleRowsPerPageChange?: (value: any) => void;
-    /**
+  /**
    * Values added to the rows per page select
    */
   rowsPerPageValues: number[];


### PR DESCRIPTION
…function passed

Issue: #1072

## What I did
I extracted the "Rows Per Page" label and selector of the TablePagination component into a local React functional component so that it could be conditionally rendered depending on whether the caller passed an `onRowsPerChange` function. If no `onRowsPerChange` function is passed, the controller should not display. 

In the course of refactoring the code I deleted the branch of code that rendered the controller differently when a `dropdownDropDirection` value was passed to the TablePagination code. Since the event handler function for the two branches was different, the alternate implementation was non-functional. To be more explicit, passing a `dropdownDropDirection` value would cause the controller to break so that you could select new "Rows Per Page" values, but the state would not propagate to the rest of the paginator component. Since the `dropdownDropDirection` property is marked as deprecated, I figured this was a safe decision and better than continuing to bring cruft forward. 

## Screenshots (if appropriate):

Before:
![Screenshot 2023-05-31 at 12 07 43 PM](https://github.com/cengage/react-magma/assets/88386737/ff213e35-f974-4a84-9d31-b18703cf5fac)

After:
![Screenshot 2023-05-31 at 12 08 34 PM](https://github.com/cengage/react-magma/assets/88386737/b97c2057-8bbf-4fdd-b65e-1f73b314d837)


## Checklist 
- [x] changeset has been added
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
- Verify that when you don't pass any function to the `onRowsPerPageChange` property of TablePagination, the label and selector are hidden.
- Verify that when you do pass a function, the label and selector are rendered.
- Verify that `rowsPerPage` is respected, even for non-standard values (i.e. 15, 25, etc.)
