### PR TITLE
Fix/character counter styles and maxLength conflict

### DIFF
--- a/.changeset/fix-characterCounterStyling.md
+++ b/.changeset/fix-characterCounterStyling.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Character Counter): Fixed bold text in Character Counter before user input, red error border on maxLength only Inputs and Textareas with hasCharacterCounter set to false, then removed unintentional maxLength limit on Textarea using maxLength or maxCount with hasCharacterCounter set to true.

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.stories.tsx
@@ -81,7 +81,6 @@ export default {
 export const Default = Template.bind({});
 Default.args = {
   isInverse: false,
-  maxCount: 4,
 };
 
 export const WithChildren = args => {

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
@@ -141,8 +141,8 @@ export const CharacterCounter = React.forwardRef<
         hasError={isOverMaxCount}
         isInverse={isInverse}
         inputLength={inputLength}
-        maxCount={maxCount}
-        maxLength={maxLength}
+        maxCount={maxCount || maxLength}
+        maxLength={maxLength || maxCount}
       >
         {characterTitle()}
       </StyledInputMessage>

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
@@ -141,8 +141,8 @@ export const CharacterCounter = React.forwardRef<
         hasError={isOverMaxCount}
         isInverse={isInverse}
         inputLength={inputLength}
-        maxCount={maxCount || maxLength}
-        maxLength={maxLength || maxCount}
+        maxCount={maxCharacters}
+        maxLength={maxCharacters}
       >
         {characterTitle()}
       </StyledInputMessage>

--- a/packages/react-magma-dom/src/components/Input/index.tsx
+++ b/packages/react-magma-dom/src/components/Input/index.tsx
@@ -94,7 +94,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           aria-invalid={!!errorMessage}
           hasError={
             !!errorMessage ||
-            characterLength > maxCount ||
+            (characterLength > maxCount && hasCharacterCounter) ||
             characterLength > maxLength
           }
           iconPosition={iconPosition}

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.stories.tsx
@@ -21,6 +21,11 @@ export default {
     ),
   ],
   argTypes: {
+    hasCharacterCounter: {
+      control: {
+        type: 'boolean',
+      },
+    },
     labelPosition: {
       control: {
         type: 'select',
@@ -28,6 +33,16 @@ export default {
       },
     },
     labelWidth: {
+      control: {
+        type: 'number',
+      },
+    },
+    maxCount: {
+      control: {
+        type: 'number',
+      },
+    },
+    maxLength: {
       control: {
         type: 'number',
       },
@@ -43,7 +58,6 @@ export default {
 export const Default = Template.bind({});
 Default.args = {
   isInverse: false,
-  maxCount: 4,
 };
 
 export const OnClear = args => {

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -124,7 +124,6 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           }
           aria-invalid={!!errorMessage}
           data-testid={testId}
-          hasCharacterCounter={hasCharacterCounter}
           hasError={
             !!errorMessage ||
             (characterLength > maxCount && hasCharacterCounter) ||

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -100,6 +100,16 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     const isInverse = useIsInverse(props.isInverse);
 
+    function maxLengthSwitch() {
+      if (
+        (typeof maxLength === 'number' && hasCharacterCounter) ||
+        (typeof maxCount === 'number' && hasCharacterCounter)
+      ) {
+        return;
+      }
+      return maxLength;
+    }
+
     return (
       <FormFieldContainer
         containerStyle={containerStyle}
@@ -127,12 +137,10 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           hasError={
             !!errorMessage ||
             (characterLength > maxCount && hasCharacterCounter) ||
-            characterLength > maxLength
+            (characterLength > maxLength && hasCharacterCounter)
           }
           id={id}
-          maxLength={
-            hasCharacterCounter && maxLength ? props.maxCount : maxLength
-          }
+          maxLength={maxLengthSwitch()}
           isInverse={isInverse}
           onChange={handleChange}
           ref={ref}

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -55,7 +55,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const {
       containerStyle,
       errorMessage,
-      hasCharacterCounter,
+      hasCharacterCounter = true,
       helperMessage,
       id: defaultId,
       isLabelVisuallyHidden,
@@ -124,9 +124,16 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           }
           aria-invalid={!!errorMessage}
           data-testid={testId}
-          hasError={!!errorMessage || characterLength > maxCount}
+          hasCharacterCounter={hasCharacterCounter}
+          hasError={
+            !!errorMessage ||
+            (characterLength > maxCount && hasCharacterCounter) ||
+            characterLength > maxLength
+          }
           id={id}
-          maxLength={!hasCharacterCounter && maxLength}
+          maxLength={
+            hasCharacterCounter && maxLength ? props.maxCount : maxLength
+          }
           isInverse={isInverse}
           onChange={handleChange}
           ref={ref}


### PR DESCRIPTION
Issue: # [1037](https://github.com/cengage/react-magma/issues/1037)

## What I did
- Fixed bugs for Character Counter involving:
- Unintentional red error border when `hasCharacterCounter` is `false` and `maxCount` is `true`.
- Bold text on Character Counter before user input removed.
- `maxLength` native behavior overriding `maxCount` or `maxLength` if `hasCharacterCounter` is `true`.

## Screenshots (if appropriate):

## Checklist 
- [x] changeset has been added
- [ NA ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ NA ] I have added tests that prove my fix is effective or that my feature works

## How to test

- Verify that before you enter a value in Character Counter that the text weight is normal and _**not**_ bold.
- In `Input` set `hasCharacterCounter` to `false` and then set a numeric value for `maxCount` and verify that no red border appears after you exceed the set numbered character limit.
- - In `Textarea` set `hasCharacterCounter` to `false` and then set a numeric value for `maxCount` and verify that no red border appears after you exceed the set numbered character limit.
- Set either `maxCount` or `maxLength` on a `Textarea` and verify you can exceed the set numbered character limit.
