### PR TITLE
fix(Button): Update button z-index when it's in focus to bring the focus outline to the front.

### DIFF
--- a/.changeset/button-focus-stack.md
+++ b/.changeset/button-focus-stack.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Button): Update button z-index when it's in focus to bring the focus outline to the front.

--- a/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -83,6 +83,7 @@ exports[`Alert Dismissible should render a dismissible icon button with the warn
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -230,6 +231,7 @@ exports[`Alert Dismissible should render a dismissible icon button with the warn
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,

--- a/packages/react-magma-dom/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/packages/react-magma-dom/src/components/Button/__snapshots__/Button.test.js.snap
@@ -64,6 +64,7 @@ exports[`Button Base Button Snapshot should render with large size 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -175,6 +176,7 @@ exports[`Button Base Button Snapshot should render with large size 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -304,6 +306,7 @@ exports[`Button Base Button Snapshot should render with small size 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -415,6 +418,7 @@ exports[`Button Base Button Snapshot should render with small size 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -544,6 +548,7 @@ exports[`Button Base Button Snapshot should render with updated color 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -655,6 +660,7 @@ exports[`Button Base Button Snapshot should render with updated color 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -784,6 +790,7 @@ exports[`Button Base Button Snapshot should render with updated shape 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -895,6 +902,7 @@ exports[`Button Base Button Snapshot should render with updated shape 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1024,6 +1032,7 @@ exports[`Button Base Button Snapshot should render with updated textTransform 1`
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1135,6 +1144,7 @@ exports[`Button Base Button Snapshot should render with updated textTransform 1`
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1252,6 +1262,7 @@ exports[`Button Base Button Snapshot should render with updated variant 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1363,6 +1374,7 @@ exports[`Button Base Button Snapshot should render with updated variant 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -52,6 +52,7 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -255,6 +256,7 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -509,6 +511,7 @@ exports[`ButtonGroup Vertical No Space Does NOT remove the border radius around 
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -669,6 +672,7 @@ exports[`ButtonGroup Vertical No Space Does NOT remove the border radius around 
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -880,6 +884,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1043,6 +1048,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
 .emotion-7:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-7:not(:disabled):hover,
@@ -1222,6 +1228,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1385,6 +1392,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
 .emotion-7:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-7:not(:disabled):hover,
@@ -1701,6 +1709,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1871,6 +1880,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
 .emotion-7:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-7:not(:disabled):hover,
@@ -2050,6 +2060,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -2220,6 +2231,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
 .emotion-7:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-7:not(:disabled):hover,
@@ -2536,6 +2548,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -2745,6 +2758,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
 .emotion-7:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-7:not(:disabled):hover,
@@ -2924,6 +2938,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -3133,6 +3148,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
 .emotion-7:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-7:not(:disabled):hover,

--- a/packages/react-magma-dom/src/components/IconButton/__snapshots__/IconButton.test.js.snap
+++ b/packages/react-magma-dom/src/components/IconButton/__snapshots__/IconButton.test.js.snap
@@ -75,6 +75,7 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -197,6 +198,7 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -350,6 +352,7 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -472,6 +475,7 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -625,6 +629,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -747,6 +752,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -900,6 +906,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1022,6 +1029,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1163,6 +1171,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1285,6 +1294,7 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
 .emotion-2:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-2:not(:disabled):hover,
@@ -1439,6 +1449,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -1554,6 +1565,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -1705,6 +1717,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -1820,6 +1833,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -1971,6 +1985,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -2086,6 +2101,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -2237,6 +2253,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -2352,6 +2369,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -2503,6 +2521,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -2618,6 +2637,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -2773,6 +2793,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -2888,6 +2909,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -3035,6 +3057,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,
@@ -3150,6 +3173,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
 .emotion-3:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-3:not(:disabled):hover,

--- a/packages/react-magma-dom/src/components/SkipLink/__snapshots__/SkipLink.test.js.snap
+++ b/packages/react-magma-dom/src/components/SkipLink/__snapshots__/SkipLink.test.js.snap
@@ -55,6 +55,7 @@ exports[`SkipLink should render the skip link component 1`] = `
 .emotion-0:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-0:not(:disabled):hover,
@@ -163,6 +164,7 @@ exports[`SkipLink should render the skip link component 1`] = `
 .emotion-0:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
+  z-index: 1;
 }
 
 .emotion-0:not(:disabled):hover,

--- a/packages/react-magma-dom/src/components/StyledButton/index.tsx
+++ b/packages/react-magma-dom/src/components/StyledButton/index.tsx
@@ -71,6 +71,7 @@ export const buttonStyles = props => css`
           ? props.theme.colors.focusInverse
           : props.theme.colors.focus};
       outline-offset: 2px;
+      z-index: 1;
     }
 
     &:hover,


### PR DESCRIPTION
Issue: #1084 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Added `z-index` to focused buttons in order to ensure the focus outline stays fully visible

## Screenshots:
<!-- Include screenshot of your change -->
**before:**
![image](https://github.com/cengage/react-magma/assets/91160746/de6a941f-0a50-4a80-87dc-f7162da226a9)


**after:**
![image](https://github.com/cengage/react-magma/assets/91160746/fff35463-0036-4edd-bf6c-b51bc328ebc5)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Play around with the following components and ensure the focus behaves as expected:
- ButtonGroup
- Pagination
- ToggleButton