### PR TITLE
fix(Input): Update input z-index when it's in focus to bring the outline to front

### DIFF
--- a/.changeset/input-focus-stack.md
+++ b/.changeset/input-focus-stack.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Input): Update input z-index when it's in focus to bring the focus outline to the front.

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -167,6 +167,7 @@ export const inputWrapperStyles = (props: InputWrapperStylesProps) => css`
         ? props.theme.colors.focusInverse
         : props.theme.colors.focus};
     outline-offset: 2px;
+    z-index: 1;
   }
 
   ${props.hasError &&


### PR DESCRIPTION
Issue: none

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Added z-index to focused inputs in order to ensure the focus outline stays fully visible

## Screenshots:
<!-- Include screenshot of your change -->
**before:**
![image](https://github.com/cengage/react-magma/assets/91160746/57e18966-d83c-4b52-a267-32554e71923f)

**after:**
![image](https://github.com/cengage/react-magma/assets/91160746/6e2ccf76-e6ea-4332-8c4d-f00e34c5638d)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
Play around with components that stack inputs next to buttons.
