### PR TITLE
fix(Input Base): Fixed case where default value of `0` did not render the default value in the input field

### DIFF
--- a/.changeset/fix-inputBase.md
+++ b/.changeset/fix-inputBase.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Input Base): Fixed case where default value of `0` did not render the default value in the input field.

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -244,6 +244,26 @@ describe('Input', () => {
     expect(getByLabelText(iconAriaLabel)).toBeDisabled();
   });
 
+  it('should initially render with value of `defaultValue` if no `value` provided', () => {
+    const labelText = 'test label';
+    const defaultValue = 'defaultValue';
+    const { getByLabelText } = render(
+      <Input labelText={labelText} defaultValue={defaultValue} />
+    );
+
+    expect(getByLabelText(labelText)).toHaveAttribute('value', defaultValue);
+  });
+
+  it('should render with value "0" when `defaultValue` is 0', () => {
+    const labelText = 'test label';
+    const defaultValue = 0;
+    const { getByLabelText } = render(
+      <Input labelText={labelText} defaultValue={defaultValue} />
+    );
+
+    expect(getByLabelText(labelText)).toHaveAttribute('value', '0');
+  });
+
   it('should render an input with a value passed through', () => {
     const labelText = 'test label';
     const value = 'Test Value';

--- a/packages/react-magma-dom/src/components/InputBase/InputBase.stories.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/InputBase.stories.tsx
@@ -46,6 +46,11 @@ export const Default = args => {
           labelText="Input"
           isClearable
         />
+        <Input
+          defaultValue={0}
+          labelText="Default value `0`"
+          isClearable
+        />
         <PasswordInput
           errorMessage="danger will robinson."
           labelText="PasswordInput"
@@ -138,6 +143,12 @@ export const Inverse = args => {
         <Input
           errorMessage="danger will robinson."
           labelText="Input"
+          isClearable
+          isInverse
+        />
+        <Input
+          defaultValue={0}
+          labelText="Default value `0`"
           isClearable
           isInverse
         />

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -573,7 +573,12 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
 
     const [value, setValue] = React.useState<
       string | ReadonlyArray<string> | number
-    >(props.defaultValue || props.value || '');
+    >(
+      props.defaultValue !== undefined &&
+        props.defaultValue !== null 
+        ? props.defaultValue
+        : props.value || ''
+    );
 
     const maxLengthNum = !hasCharacterCounter && maxLength ? maxLength : undefined;
 
@@ -654,7 +659,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             </IconWrapper>
           )}
         </InputWrapper>
-        {isClearable && value && (
+        {isClearable && value !== '' && (
           <IsClearableContainer
             theme={theme}
             iconPosition={iconPosition}


### PR DESCRIPTION
Issue: #1027

## What I did
-Fixed case where defaultValue is 0

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
-Navigate to storybook for InputBase, and observe that the input where defaultValue is set to `0` shows a `0`
