### PR TITLE
fix(input/textarea): Fix `maxLength` console warning

### DIFF
--- a/.changeset/maxLength-warnings.md
+++ b/.changeset/maxLength-warnings.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Input/Textarea): Fix `maxLength` console warning regarding passing a boolean attribute

--- a/packages/react-magma-dom/src/components/Input/index.tsx
+++ b/packages/react-magma-dom/src/components/Input/index.tsx
@@ -45,6 +45,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
     const maxCharacters = typeof maxCount === 'number' ? maxCount : maxLength;
 
+    const maxLengthNum = !hasCharacterCounter && maxLength ? maxLength : undefined;
+
     const isInverse = useIsInverse(props.isInverse);
 
     const [characterLength, setCharacterLength] = useState(
@@ -103,7 +105,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
           inputSize={inputSize}
           inputLength={characterLength}
           isInverse={isInverse}
-          maxLength={!hasCharacterCounter && maxLength}
+          maxLength={maxLengthNum}
           onChange={handleChange}
           onClear={handleClear}
           ref={ref}

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -575,6 +575,8 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       string | ReadonlyArray<string> | number
     >(props.defaultValue || props.value || '');
 
+    const maxLengthNum = !hasCharacterCounter && maxLength ? maxLength : undefined;
+
     React.useEffect(() => {
       if (props.value !== undefined && props.value !== null) {
         setValue(props.value);
@@ -623,7 +625,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             isPredictive={isPredictive}
             hasError={hasError}
             ref={ref}
-            maxLength={!hasCharacterCounter && maxLength}
+            maxLength={maxLengthNum}
             onChange={handleChange}
             style={inputStyle}
             theme={theme}

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -77,6 +77,8 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const descriptionId = errorMessage || helperMessage ? `${id}__desc` : null;
     const maxCharacters = typeof maxCount === 'number' ? maxCount : maxLength;
 
+    const maxLengthNum = !hasCharacterCounter && maxLength ? maxLength : undefined;
+
     const [value, setValue] = React.useState<
       string | ReadonlyArray<string> | number
     >(props.defaultValue || props.value || '');
@@ -130,7 +132,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             (hasCharacterCounter && characterLength > maxCharacters)
           }
           id={id}
-          maxLength={!hasCharacterCounter && maxLength}
+          maxLength={maxLengthNum}
           isInverse={isInverse}
           onChange={handleChange}
           ref={ref}


### PR DESCRIPTION
Issue: #

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Screenshots:
<!-- Include screenshot of your change -->
![image](https://github.com/cengage/react-magma/assets/91160746/0cbce0b7-0e8a-414d-a660-93abf38097a9)


## Checklist 
- [ ] changeset has been added
- [ ] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
