### PR TITLE
fix/SubPageTabs mishandling page navigation and window.history manipu…

### DIFF
--- a/.changeset/fix-subPageTabs
+++ b/.changeset/fix-subPageTabs
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(SubPageTabs): Fixed automatic browser scrolling from bottom of page, and fixed window.history manipulation

--- a/website/react-magma-docs/src/components/SubPageTabs/index.js
+++ b/website/react-magma-docs/src/components/SubPageTabs/index.js
@@ -70,18 +70,7 @@ export const SubPageTabs = ({ pageData, hasHorizontalNav }) => {
 
     window.scrollBy({ top: originalTop, left: 0, behavior: 'smooth' });
 
-    const checkIfDone = setInterval(function () {
-      const atBottom =
-        window.innerHeight + window.pageYOffset >=
-        document.body.offsetHeight - 2;
-      if (distanceToTop(targetAnchor) === 0 || atBottom) {
-        targetAnchor.tabIndex = '-1';
-        targetAnchor.focus();
-        window.history.pushState('', '', '#' + targetID);
-        clearInterval(checkIfDone);
-      }
-    }, 100);
-
+    window.history.pushState('', '', '#' + targetID);
     setActiveTab(index);
   };
 


### PR DESCRIPTION
Issue: #1034 

## What I did
- Corrected mishandling of browser url when clicking on navTabs in docs
- Removed automatic scrolling when user reaches the bottom of the page

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [N/A] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
- In the docs, navigate to Components > Accordion:
- Click on various right side nav tabs, and observe:
   - Observe the browser url change to include the navTab clicked
- Click on the AccordionPanel Props navTab, and observe:
   - Automatic scrolling identified in issue #1034 does not occur