### PR TITLE
fix(DatePicker): Escape key only closes the panel

### DIFF
--- a/.changeset/fix-datePickerEscape.md
+++ b/.changeset/fix-datePickerEscape.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Escape key only closes the panel

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -400,28 +400,53 @@ describe('Date Picker', () => {
     expect(getByTestId('calendarContainer')).toHaveStyleRule('display', 'none');
   });
 
-  it('should close the calendar month when the escape key is pressed, and retain the active modal', () => {
-    const defaultDate = new Date();
-    const { getByTestId } = render(
+  it('inside a modal, should close the calendar month when no date is selected and the escape key is pressed, and retain the active modal', () => {
+    const { getByTestId, getByLabelText } = render(
       <Modal testId="modal" isOpen>
-        <DatePicker defaultDate={defaultDate} labelText="Date Picker Label" />
+        <DatePicker labelText="Date Picker inside a modal" />
       </Modal>
     );
 
-    const labelText = 'Date picker label';
+    const calendarButton = getByLabelText('Toggle Calendar Widget');
 
-    const { container } = render(
-      <DatePicker defaultDate={defaultDate} labelText={labelText} />
+    fireEvent.click(calendarButton);
+    expect(getByTestId('calendarContainer')).toHaveStyleRule(
+      'display',
+      'block'
     );
-
-    fireEvent.focus(container.querySelector('input'));
-    fireEvent.keyDown(container.querySelector('table'), {
+    fireEvent.keyDown(calendarButton, {
       key: 'Escape',
       code: 27,
     });
 
-    expect(container.querySelector('table')).not.toBeVisible();
+    expect(getByTestId('calendarContainer')).toHaveStyleRule('display', 'none');
+    expect(getByTestId('modal')).toBeInTheDocument();
+  });
 
+  it('inside a modal, should close the calendar month when date is selected and the escape key is pressed, and retain the active modal', () => {
+    const { getByTestId, getByLabelText } = render(
+      <Modal testId="modal" isOpen>
+        <DatePicker labelText="Date Picker inside a modal" />
+      </Modal>
+    );
+
+    const calendarButton = getByLabelText('Toggle Calendar Widget');
+
+    fireEvent.click(calendarButton);
+    expect(getByTestId('calendarContainer')).toHaveStyleRule(
+      'display',
+      'block'
+    );
+    fireEvent.change(getByLabelText('Date Picker inside a modal'), {
+      target: { value: '12' },
+    });
+    fireEvent.click(calendarButton);
+    fireEvent.keyDown(calendarButton, {
+      key: 'Escape',
+      code: 27,
+    });
+
+    expect(getByTestId('calendarContainer')).toHaveStyleRule('display', 'none');
     expect(getByTestId('modal')).toBeInTheDocument();
   });
 

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -330,6 +330,11 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
     }
 
     function handleKeyDown(event: React.KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.nativeEvent.stopImmediatePropagation();
+        setCalendarOpened(false);
+        iconRef.current.focus();
+      }
       if (dateFocused && document.activeElement.closest('table')) {
         const newChosenDate = handleKeyPress(
           event,
@@ -343,12 +348,6 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
           setFocusedDate(newChosenDate);
         }
       } else {
-        if (event.key === 'Escape') {
-          event.nativeEvent.stopImmediatePropagation();
-          setCalendarOpened(false);
-          iconRef.current.focus();
-        }
-
         if (event.key === '?') {
           showHelperInformation();
         }


### PR DESCRIPTION
Issue: #264

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Update DatePicker component to close only the panel when placed inside a modal despite a date being selected or not.

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Test a DatePicker inside a modal:
- Without selecting a date, navigate to the calendar. Press ESC
- After selecting a date, navigate to the calendar. Press ESC
Both scenarios should only close the calendar panel

Confirm that the datepicker continues to work as expected when not used inside a modal