### PR TITLE
fix(input): Update input height to 40px/56px

### DIFF
--- a/.changeset/inputHeight.md
+++ b/.changeset/inputHeight.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Input): Update Input height to match button sizes: 40px (instead of 42px) and 56px (instead of 58px)

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -143,6 +143,7 @@ export interface InputWrapperStylesProps {
   theme?: ThemeInterface;
   hasError?: boolean;
   disabled?: boolean;
+  inputSize?: InputSize;
 }
 
 export const inputWrapperStyles = (props: InputWrapperStylesProps) => css`
@@ -160,6 +161,7 @@ export const inputWrapperStyles = (props: InputWrapperStylesProps) => css`
     ${props.isInverse
       ? transparentize(0.5, props.theme.colors.neutral100)
       : props.theme.colors.neutral500};
+  height: ${props.theme.spaceScale.spacing09};
 
   &:focus-within {
     outline: 2px solid
@@ -184,6 +186,11 @@ export const inputWrapperStyles = (props: InputWrapperStylesProps) => css`
     background-color: ${props.isInverse
       ? transparentize(0.9, props.theme.colors.neutral900)
       : props.theme.colors.neutral200};
+  `}
+
+  ${props.inputSize === 'large' &&
+  css`
+    height: ${props.theme.spaceScale.spacing11};
   `}
 `;
 
@@ -611,6 +618,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
           disabled={disabled}
           iconPosition={iconPosition}
           isInverse={props.isInverse}
+          inputSize={inputSize ? inputSize : InputSize.medium}
           theme={theme}
           style={containerStyle}
           hasError={hasError}


### PR DESCRIPTION
Issue: none

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Update Input height to match button sizes: 40px (instead of 42px) and 56px (instead of 58px)

## Screenshots:
<!-- Include screenshot of your change -->
Before:
![image](https://github.com/cengage/react-magma/assets/91160746/6cad94d4-ee6e-44e7-8ff2-ec60934a45ae)
![image](https://github.com/cengage/react-magma/assets/91160746/0ddb82ce-8beb-43a5-89d5-921511d9d5a8)


After:
![image](https://github.com/cengage/react-magma/assets/91160746/b6f3649a-4188-4189-83c1-99db6bb476ea)

![image](https://github.com/cengage/react-magma/assets/91160746/2bce53c2-7ffe-473f-932f-531debd901ea)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
- Test all components that use inputs and ensure nothing is broken. 
- Test the 2 input sizes