### PR TITLE
fix(NativeSelect): Update NativeSelect height to match button sizes

### DIFF
--- a/.changeset/nativeSelectHeight.md
+++ b/.changeset/nativeSelectHeight.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(NativeSelect): Update NativeSelect height to match button sizes: 40px (instead of 42px)

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -101,16 +101,16 @@ export const IconPositions = args => {
         icon={<NotificationsIcon />}
         iconPosition={InputIconPosition.left}
       />
-      <br/>
-      <br/>
+      <br />
+      <br />
       <Input
         {...args}
         labelText="Icon Right"
         icon={<WorkIcon />}
         iconPosition={InputIconPosition.right}
       />
-        <br/>
-        <br/>
+      <br />
+      <br />
       <Input
         {...args}
         labelText="Icon Top"
@@ -184,6 +184,7 @@ export const WithChildren = args => {
           />
         </Tooltip>
       </Input>
+      <br />
       <Input
         labelText="Help link - right"
         iconPosition={InputIconPosition.right}
@@ -200,9 +201,28 @@ export const WithChildren = args => {
           />
         </Tooltip>
       </Input>
-      <br />
-      <hr />
-      <Input labelText="With two icons" icon={<NotificationsIcon />} {...args}>
+    </>
+  );
+};
+WithChildren.args = {
+  ...Default.args,
+};
+WithChildren.parameters = {
+  controls: { exclude: ['isInverse', 'type', 'iconPosition'] },
+};
+
+export const WithTwoIcons = args => {
+  const helpLinkLabel = 'Learn more';
+  const onHelpLinkClick = () => {
+    alert('Help link clicked!');
+  };
+  return (
+    <>
+      <Input
+        labelText="With two icons"
+        icon={<NotificationsIcon />}
+        iconPosition={InputIconPosition.left}
+      >
         <Tooltip content={helpLinkLabel}>
           <IconButton
             aria-label={helpLinkLabel}
@@ -217,10 +237,9 @@ export const WithChildren = args => {
     </>
   );
 };
-WithChildren.args = {
+WithTwoIcons.args = {
   ...Default.args,
-  iconPosition: InputIconPosition.right,
 };
-WithChildren.parameters = {
-  controls: { exclude: ['isInverse', 'type'] },
+WithTwoIcons.parameters = {
+  controls: { exclude: ['isInverse', 'type', 'iconPosition'] },
 };

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -66,6 +66,7 @@ const StyledNativeSelect = styled.select<{
   theme: ThemeInterface;
 }>`
   ${inputBaseStyles};
+  height: 38px;
   // Required for Windows && Chrome support
   background: inherit;
   > option {


### PR DESCRIPTION
Issue: none

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

1. Updated NativeSelect so that the border is fully visible (had to make the component 38px + 2px of borders for a total of 40px
2. The Input story `with children` was confusing but nothing was broken:
- For example, we support icons for top, right and left (see  Icon Positions story). However, if the user wants to make the button interactive (like to use a tooltip like in the examples), we only support that for top and right. 
- If the user wants to use 2 icons, it can only be done with one to the left and one to the right.
- I created a new story for `with two icons` and made some modifications to the `with children` story to clear this up.

## Screenshots:
Before:
![image](https://github.com/cengage/react-magma/assets/91160746/0f90e02e-6ba2-417e-a852-29a2b1739e27)

After:
![image](https://github.com/cengage/react-magma/assets/91160746/502c7629-bae9-48d9-9764-da84aafbe2be)
![image](https://github.com/cengage/react-magma/assets/91160746/1a27fd6a-6c3d-4310-84b1-ccf365b3f3c2)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
Test Native Select and other components that use input