### PR TITLE
fix(PasswordInput): Update placement of Show/Hide button on Large input size

### DIFF
--- a/.changeset/fix-passInputLarge.md
+++ b/.changeset/fix-passInputLarge.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(PasswordInput): Update placement of Show/Hide button on Large input size

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -459,9 +459,8 @@ const PasswordButtonContainer = styled.span<{
   background-color: transparent;
   width: 0;
   transform: translate(
-    -${props => (props.size === InputSize.large ? props.theme.spaceScale.spacing10 : '60px')},
-    ${props =>
-      props.size === InputSize.large ? props.theme.spaceScale.spacing03 : '5px'}
+    -${props => (props.size === InputSize.large ? '58px' : '60px')},
+    ${props => props.theme.spaceScale.spacing02}
   );
 `;
 
@@ -581,13 +580,13 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
     const [value, setValue] = React.useState<
       string | ReadonlyArray<string> | number
     >(
-      props.defaultValue !== undefined &&
-        props.defaultValue !== null 
+      props.defaultValue !== undefined && props.defaultValue !== null
         ? props.defaultValue
         : props.value || ''
     );
 
-    const maxLengthNum = !hasCharacterCounter && maxLength ? maxLength : undefined;
+    const maxLengthNum =
+      !hasCharacterCounter && maxLength ? maxLength : undefined;
 
     React.useEffect(() => {
       if (props.value !== undefined && props.value !== null) {

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -459,12 +459,15 @@ const IconButtonContainer = styled.span<{
 const PasswordButtonContainer = styled.span<{
   size?: InputSize;
   theme: ThemeInterface;
-  buttonWidth: string;
+  buttonWidth: number;
 }>`
   background-color: transparent;
   width: 0;
   transform: translate(
-    -${props => props.buttonWidth},
+    ${props =>
+      props.size === InputSize.large
+        ? `${-props.buttonWidth - 8}px`
+        : `${-props.buttonWidth - 6}px`},
     ${props =>
       props.size === InputSize.large ? props.theme.spaceScale.spacing03 : '6px'}
   );
@@ -617,6 +620,10 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       setValue(event.target.value);
     }
 
+    const passwordBtnWidth = Number(
+      children?.props?.children[0].ref?.current?.offsetWidth
+    );
+
     return (
       <InputContainer>
         <InputWrapper
@@ -735,9 +742,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
               inputSize === InputSize.large ? InputSize.large : InputSize.medium
             }
             theme={theme}
-            buttonWidth={
-              children?.props?.children[0].ref?.current?.offsetWidth + 6 + 'px'
-            }
+            buttonWidth={passwordBtnWidth}
           >
             {children}
           </PasswordButtonContainer>

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -621,7 +621,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
     }
 
     const passwordBtnWidth = Number(
-      children?.props?.children[0].ref?.current?.offsetWidth
+      children?.props?.children[0]?.ref?.current?.offsetWidth
     );
 
     return (

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -621,12 +621,12 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
     }
 
     const passwordBtnWidth = () => {
-      const btnWidth = Number(
-        children?.props?.children?.[0]?.ref?.current?.offsetWidth
-      );
-      if (typeof btnWidth === Number) {
+      const btnWidth = children?.props?.children?.[0]?.ref?.current?.offsetWidth;
+      if (typeof btnWidth === 'number') {
         return btnWidth;
       } else {
+        // When PasswordButton is used inside SchemaRenderer, it doesn't have children.
+        // We'll use the default button sizes.
         if (props.inputSize === InputSize.large) {
           return 64;
         }

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -34,6 +34,10 @@ export enum InputIconPosition {
 export interface InputBaseProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   /**
+   * @internal
+   */
+  children: any;
+  /**
    * Style properties for the component container element
    */
   containerStyle?: React.CSSProperties;
@@ -455,12 +459,14 @@ const IconButtonContainer = styled.span<{
 const PasswordButtonContainer = styled.span<{
   size?: InputSize;
   theme: ThemeInterface;
+  buttonWidth: string;
 }>`
   background-color: transparent;
   width: 0;
   transform: translate(
-    -${props => (props.size === InputSize.large ? '58px' : '60px')},
-    ${props => props.theme.spaceScale.spacing02}
+    -${props => props.buttonWidth},
+    ${props =>
+      props.size === InputSize.large ? props.theme.spaceScale.spacing03 : '6px'}
   );
 `;
 
@@ -729,6 +735,9 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
               inputSize === InputSize.large ? InputSize.large : InputSize.medium
             }
             theme={theme}
+            buttonWidth={
+              children?.props?.children[0].ref?.current?.offsetWidth + 6 + 'px'
+            }
           >
             {children}
           </PasswordButtonContainer>

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -36,7 +36,7 @@ export interface InputBaseProps
   /**
    * @internal
    */
-  children: any;
+  children?: any;
   /**
    * Style properties for the component container element
    */

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -620,9 +620,19 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       setValue(event.target.value);
     }
 
-    const passwordBtnWidth = Number(
-      children?.props?.children[0]?.ref?.current?.offsetWidth
-    );
+    const passwordBtnWidth = () => {
+      const btnWidth = Number(
+        children?.props?.children?.[0]?.ref?.current?.offsetWidth
+      );
+      if (typeof btnWidth === Number) {
+        return btnWidth;
+      } else {
+        if (props.inputSize === InputSize.large) {
+          return 64;
+        }
+        return 54;
+      }
+    };
 
     return (
       <InputContainer>
@@ -742,7 +752,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
               inputSize === InputSize.large ? InputSize.large : InputSize.medium
             }
             theme={theme}
-            buttonWidth={passwordBtnWidth}
+            buttonWidth={passwordBtnWidth()}
           >
             {children}
           </PasswordButtonContainer>

--- a/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -41,7 +41,13 @@ export default {
         type: 'select',
         options: InputSize,
       }
-    }
+    },
+    isPasswordMaskButtonHidden: {
+      defaultValue: false,
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 } as Meta;
 
@@ -66,3 +72,9 @@ Inverse.decorators = [
     </Card>
   ),
 ];
+
+export const CustomText = Template.bind({});
+CustomText.args = {
+  showPasswordButtonText: 'Mostrar',
+  hidePasswordButtonText: 'Esconder'
+};

--- a/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -3,6 +3,7 @@ import { PasswordInput, PasswordInputProps } from '.';
 import { Card, CardBody } from '../Card';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { LabelPosition } from '../Label';
+import { InputSize } from '../InputBase';
 
 const Template: Story<PasswordInputProps> = args => (
   <PasswordInput {...args} labelText="Password" />
@@ -35,6 +36,12 @@ export default {
         type: 'number',
       },
     },
+    inputSize: {
+      control: {
+        type: 'select',
+        options: InputSize,
+      }
+    }
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -127,6 +127,17 @@ export const PasswordInput = React.forwardRef<
     HIDE_PASSWORD_BUTTON_TEXT === i18n.password.hidden.buttonText;
 
   const buttonRef = React.useRef<HTMLButtonElement>();
+  
+  const getButtonWidth = () => {
+    if (usesDefaultText) {
+      if (inputSize === InputSize.large) {
+        return '64px';
+      }
+      return '54px';
+    } else {
+      return `${buttonRef?.current?.offsetWidth}px`;
+    }
+  }
 
   const getInputStyle = () => {
     if (isPasswordMaskButtonHidden) {
@@ -134,7 +145,7 @@ export const PasswordInput = React.forwardRef<
     } else if (inputSize === InputSize.medium && usesDefaultText) {
       return { width: 'calc(100% - 52px)' };
     } else if (inputSize === InputSize.large && usesDefaultText) {
-      return { width: 'calc(100% - 56px)' };
+      return { width: 'calc(100% - 64px)' };
     } else {
       return { width: `calc(100% - ${buttonRef?.current?.offsetWidth}px)` };
     }
@@ -190,11 +201,11 @@ export const PasswordInput = React.forwardRef<
                   : ButtonSize.medium
               }
               style={{
-                borderRadius: theme.borderRadius,
+                borderRadius: theme.borderRadiusSmall,
                 margin: '0 3px 0 0',
-                width: usesDefaultText ? '54px' : null,
+                width: getButtonWidth(),
                 minWidth: 0,
-                maxWidth: `${buttonRef?.current?.offsetWidth}px`,
+                maxWidth: getButtonWidth(),
               }}
               type={ButtonType.button}
               variant={ButtonVariant.link}

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -27,6 +27,11 @@ export interface PasswordInputProps
    * @default "Hide"
    */
   hidePasswordButtonText?: string;
+  /**
+   * Relative size of the component
+   * @default InputSize.medium
+   */
+    inputSize?: InputSize;
   isInverse?: boolean;
   /**
    * If true, label text will be hidden visually, but will still be read by assistive technology

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -31,7 +31,7 @@ export interface PasswordInputProps
    * Relative size of the component
    * @default InputSize.medium
    */
-    inputSize?: InputSize;
+  inputSize?: InputSize;
   isInverse?: boolean;
   /**
    * If true, label text will be hidden visually, but will still be read by assistive technology

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -122,6 +122,24 @@ export const PasswordInput = React.forwardRef<
 
   const isInverse = useIsInverse(props.isInverse);
 
+  const usesDefaultText =
+    SHOW_PASSWORD_BUTTON_TEXT === i18n.password.shown.buttonText &&
+    HIDE_PASSWORD_BUTTON_TEXT === i18n.password.hidden.buttonText;
+
+  const buttonRef = React.useRef<HTMLButtonElement>();
+
+  const getInputStyle = () => {
+    if (isPasswordMaskButtonHidden) {
+      return {};
+    } else if (inputSize === InputSize.medium && usesDefaultText) {
+      return { width: 'calc(100% - 52px)' };
+    } else if (inputSize === InputSize.large && usesDefaultText) {
+      return { width: 'calc(100% - 56px)' };
+    } else {
+      return { width: `calc(100% - ${buttonRef?.current?.offsetWidth}px)` };
+    }
+  };
+
   return (
     <FormFieldContainer
       containerStyle={containerStyle}
@@ -148,7 +166,7 @@ export const PasswordInput = React.forwardRef<
         hasError={!!errorMessage}
         id={id}
         inputSize={inputSize}
-        inputStyle={{ width: 'calc(100% - 52px)' }}
+        inputStyle={getInputStyle()}
         isInverse={isInverse}
         ref={ref}
         type={passwordShown ? InputType.text : InputType.password}
@@ -166,17 +184,21 @@ export const PasswordInput = React.forwardRef<
               disabled={disabled}
               isInverse={isInverse}
               onClick={togglePasswordShown}
-              size={ButtonSize.small}
+              size={
+                inputSize === InputSize.medium
+                  ? ButtonSize.small
+                  : ButtonSize.medium
+              }
               style={{
                 borderRadius: theme.borderRadius,
-                height:
-                  inputSize == InputSize.large
-                    ? theme.spaceScale.spacing10
-                    : theme.spaceScale.spacing08,
-                margin: ' 0 3px 0 0 ',
+                margin: '0 3px 0 0',
+                width: usesDefaultText ? '54px' : null,
+                minWidth: 0,
+                maxWidth: `${buttonRef?.current?.offsetWidth}px`,
               }}
               type={ButtonType.button}
               variant={ButtonVariant.link}
+              ref={buttonRef}
             >
               {passwordShown
                 ? HIDE_PASSWORD_BUTTON_TEXT


### PR DESCRIPTION
Issue: #1088

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix placement of show / hide button in large password input. Also added input size to storybook and to the list of the component's props.

## Screenshots:
<!-- Include screenshot of your change -->
Before:
![image](https://github.com/cengage/react-magma/assets/91160746/8217fe2d-caea-4ddc-8e63-9a8de51d1fa2)

After:
![image](https://github.com/cengage/react-magma/assets/91160746/e32f9650-b6e7-484c-967c-986f8cc13c8c)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [n/a] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Test PasswordInput component in both the small and large size
