### PR TITLE
fix(DropdownContent): Handle `false` as child

### DIFF
--- a/.changeset/dropdownContent-falseChild.md
+++ b/.changeset/dropdownContent-falseChild.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DropdownContent): Handle `false` as child

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -827,4 +827,20 @@ describe('Dropdown', () => {
       jest.useRealTimers();
     });
   });
+
+  it('should not render the false child', () => {
+    const visible = false;
+    const { queryByText } = render(
+      <Dropdown>
+        <DropdownButton>Toggle me</DropdownButton>
+        <DropdownMenuGroup header="header">
+          {visible && <DropdownMenuItem>Menu Item 1</DropdownMenuItem>}
+          <DropdownMenuItem>Menu Item 2</DropdownMenuItem>
+        </DropdownMenuGroup>
+      </Dropdown>
+    );
+
+    expect(queryByText('Menu Item 1')).not.toBeInTheDocument();
+    expect(queryByText('Menu Item 2')).toBeInTheDocument();
+  });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -119,8 +119,8 @@ export const DropdownContent = React.forwardRef<
 
   React.Children.forEach(children, (child: any) => {
     if (
-      child.type?.displayName === 'DropdownMenuItem' ||
-      child.type?.displayName === 'DropdownMenuGroup'
+      child?.type?.displayName === 'DropdownMenuItem' ||
+      child?.type?.displayName === 'DropdownMenuGroup'
     ) {
       hasItemChildren = true;
       return;


### PR DESCRIPTION
Issue: #1131

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add support for `false` as a child of DropdownContent

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
Ensure that the following code works:
```
<Dropdown>
  <DropdownButton>Basic Dropdown</DropdownButton>
    <DropdownContent>
    {false && <DropdownMenuItem>Menu item 1</DropdownMenuItem>}
    <DropdownMenuItem>Menu item number two</DropdownMenuItem>
    <DropdownMenuItem disabled>Disabled item</DropdownMenuItem>
  </DropdownContent>
</Dropdown>
```