### PR TITLE
fix(Modal): Update padding so it's equal on all sides

### DIFF
--- a/.changeset/update-modalPadding.md
+++ b/.changeset/update-modalPadding.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal): Update padding so it's equal on all sides (16px small viewport or 24px for large)

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -160,14 +160,10 @@ const ModalContent = styled.div<ModalProps & { isExiting?: boolean }>`
   }
 `;
 
-const ModalHeader = styled.div<{ theme?: ThemeInterface }>`
-  padding: ${props => props.theme.spaceScale.spacing03}
-    ${props => props.theme.spaceScale.spacing05} 0
-    ${props => props.theme.spaceScale.spacing05};
+const ModalWrapper = styled.div<{ theme?: ThemeInterface }>`
+  padding: ${props => props.theme.spaceScale.spacing05};
   @media (min-width: ${props => props.theme.breakpoints.small}px) {
-    padding: ${props => props.theme.spaceScale.spacing05}
-      ${props => props.theme.spaceScale.spacing06} 0
-      ${props => props.theme.spaceScale.spacing06};
+    padding: ${props => props.theme.spaceScale.spacing06};
   }
 `;
 
@@ -190,13 +186,6 @@ const CloseBtn = styled.span<{ theme?: ThemeInterface }>`
   top: 0;
   right: 0;
   margin: ${props => props.theme.spaceScale.spacing02};
-`;
-const ModalBody = styled.div<{ theme?: ThemeInterface }>`
-  padding: ${props => props.theme.spaceScale.spacing05};
-
-  @media (min-width: ${props => props.theme.breakpoints.small}px) {
-    padding: ${props => props.theme.spaceScale.spacing06};
-  }
 `;
 
 export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
@@ -377,7 +366,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                 theme={theme}
               >
                 {header && (
-                  <ModalHeader theme={theme}>
+                  <ModalWrapper theme={theme}>
                     {header && (
                       <H1
                         id={headingId}
@@ -391,11 +380,11 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                         {header}
                       </H1>
                     )}
-                  </ModalHeader>
+                  </ModalWrapper>
                 )}
-                <ModalBody ref={bodyRef} theme={theme}>
+                <ModalWrapper ref={bodyRef} theme={theme}>
                   {children}
-                </ModalBody>
+                </ModalWrapper>
                 {!isCloseButtonHidden && (
                   <CloseBtn theme={theme}>
                     <IconButton


### PR DESCRIPTION
Issue: #1118

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Update the padding on modals so it is equal on all four sides (previously we had a smaller amount of padding on top to account for the line-height of the title)

## Screenshots:
<!-- Include screenshot of your change -->
![image](https://github.com/cengage/react-magma/assets/91160746/74e99745-645d-4b08-85c9-88e71b1acea8)
![image](https://github.com/cengage/react-magma/assets/91160746/c7936254-b105-4038-8b89-a3ecbd5578f5)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [-] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm that for the different viewport sizes, the modal padding is the expected size