### PR TITLE
fix(RadioGroup): Radio Group label is now a span to improve a11y

### DIFF
--- a/.changeset/fix-radioGroup.md
+++ b/.changeset/fix-radioGroup.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(RadioGroup): Radio Group label is now a span to improve a11y

--- a/packages/react-magma-dom/src/components/RadioGroup/index.tsx
+++ b/packages/react-magma-dom/src/components/RadioGroup/index.tsx
@@ -165,6 +165,7 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
 
           {labelText && !isTextVisuallyHidden && (
             <Label
+              actionable={false}
               id={id}
               style={labelStyle}
               isInverse={isInverse}


### PR DESCRIPTION
Issue: #

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Label inside RadioGroup is a span instead of a label.

## Screenshots:
<!-- Include screenshot of your change -->
![image](https://github.com/cengage/react-magma/assets/91160746/0038e828-cd07-4c2c-aea4-0f5700ff83f6)

![image](https://github.com/cengage/react-magma/assets/91160746/f7d7ebe8-6ff9-4f91-aebe-a1e4747ee442)
![image](https://github.com/cengage/react-magma/assets/91160746/55b0b47a-be0d-4c25-bf15-ee9f0f41ea9c)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm a11y passes for RadioGroup