### PR TITLE
fix(StyledLabel/TabPanel): Update various labels and TabPanel content to be neutral700

### DIFF
--- a/.changeset/fix-labelsColors.md
+++ b/.changeset/fix-labelsColors.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(StyledLabel/TabPanel): Update various labels and TabPanel content to be neutral700 (instead of neutral500)

--- a/packages/react-magma-dom/src/components/SelectionControls/StyledLabel.tsx
+++ b/packages/react-magma-dom/src/components/SelectionControls/StyledLabel.tsx
@@ -12,7 +12,9 @@ export interface StyledLabelProps {
 const StyledLabelComponent = styled.label<StyledLabelProps>`
   align-items: flex-start;
   color: ${props =>
-    props.isInverse ? props.theme.colors.neutral100 : 'inherit'};
+    props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral700};
   display: flex;
   font-size: ${props => props.theme.typeScale.size03.fontSize};
   font-family: ${props => props.theme.bodyFont};

--- a/packages/react-magma-dom/src/components/Tabs/TabPanel.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/TabPanel.tsx
@@ -12,7 +12,7 @@ const StyledTabPanel = styled.div<{
   color: ${props =>
     props.isInverse
       ? props.theme.colors.neutral100
-      : props.theme.colors.neutral};
+      : props.theme.colors.neutral700};
   font-family: ${props => props.theme.bodyFont};
   flex: 1;
   height: 100%;


### PR DESCRIPTION
Issue: none

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Our docs site content, which is inside a TabPanel was using neutral500 instead of neutral700
- Labels for our form elements were using neutral500 instead of neutral700

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
This change affects:
- Checkbox
- IndeterminateCheckbox
- Label
- Radio
- Toggle
- Tabs