### PR TITLE
Dropdown Expandable - QA review fixing disabled states

### DIFF
--- a/.changeset/fix-expandableDropdown.md
+++ b/.changeset/fix-expandableDropdown.md
@@ -2,4 +2,4 @@
 'react-magma-dom': patch
 ---
 
-fix(Dropdown): Fixes from QA review of the Dropdown Expandable sub component.
+fix(Dropdown): Fixes from QA review of the Dropdown Expandable sub component disabled states.

--- a/.changeset/fix-expandableDropdownDisabled.md
+++ b/.changeset/fix-expandableDropdownDisabled.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(DropdownExpandableMenu): A new menu item display for the Dropdown component which enables expandable lists by one level.

--- a/.changeset/fix-expandableDropdownDisabled.md
+++ b/.changeset/fix-expandableDropdownDisabled.md
@@ -1,5 +1,5 @@
 ---
-'react-magma-dom': minor
+'react-magma-dom': patch
 ---
 
 feat(DropdownExpandableMenu): A new menu item display for the Dropdown component which enables expandable lists by one level.

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -467,7 +467,7 @@ export const ExpandableItemsWithIcons = args => {
               DropdownExpandableMenuButton component
             </DropdownExpandableMenuButton>
             <DropdownExpandableMenuPanel>
-              <DropdownExpandableMenuListItem>
+              <DropdownExpandableMenuListItem disabled>
                 Fresh
               </DropdownExpandableMenuListItem>
               <DropdownExpandableMenuListItem>

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -1170,6 +1170,38 @@ describe('Dropdown', () => {
         );
       });
 
+      it(`DropdownExpandableMenuListItem should support disabled`, () => {
+        const { getByText } = render(
+          <Dropdown>
+            <DropdownButton>Expandable Items Dropdown</DropdownButton>
+            <DropdownContent>
+              <DropdownExpandableMenuGroup>
+                <DropdownExpandableMenuItem>
+                  <DropdownExpandableMenuButton>
+                    Pasta
+                  </DropdownExpandableMenuButton>
+                  <DropdownExpandableMenuPanel>
+                    <DropdownExpandableMenuListItem disabled>
+                      Fresh
+                    </DropdownExpandableMenuListItem>
+                    <DropdownExpandableMenuListItem>
+                      Processed
+                    </DropdownExpandableMenuListItem>
+                  </DropdownExpandableMenuPanel>
+                </DropdownExpandableMenuItem>
+              </DropdownExpandableMenuGroup>
+            </DropdownContent>
+          </Dropdown>
+        );
+        fireEvent.click(getByText('Pasta'));
+
+        expect(getByText('Fresh')).toHaveStyleRule('cursor', 'not-allowed');
+        expect(getByText('Fresh')).toHaveStyleRule(
+          'color',
+          transparentize(0.4, magma.colors.neutral500)
+        );
+      });
+
       it(`DropdownExpandableMenuPanel items should have additional padding if DropdownExpandableMenuButton has an icon and a text only menu item`, () => {
         const { getByTestId, getByText } = render(
           <Dropdown>

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
@@ -15,6 +15,36 @@ export interface DropdownExpandableMenuButtonProps
   testId?: string;
 }
 
+const StyledAccordionButton = styled(AccordionButton)<{
+  expandableMenuButtonHasIcon?: boolean;
+  icon?: React.ReactElement<IconProps>;
+  isMenuItemContextDisabled?: boolean;
+}>`
+  font-weight: 400;
+  overflow-wrap: anywhere;
+  padding: ${props =>
+    !props.icon && props.expandableMenuButtonHasIcon
+      ? `${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing05} ${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing11}`
+      : `${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing05}`};
+  margin: 0;
+  border-top: 0;
+  &:focus {
+    outline-offset: -2px;
+  }
+  &:hover,
+  &:focus {
+    background: ${props =>
+      props.isMenuItemContextDisabled ? '' : menuBackground};
+  }
+  > span {
+    display: flex;
+  }
+`;
+
+const StyledIconWrapper = styled(IconWrapper)`
+  justify-content: center;
+`;
+
 export const DropdownExpandableMenuButton = React.forwardRef<
   HTMLDivElement,
   DropdownExpandableMenuButtonProps
@@ -33,34 +63,6 @@ export const DropdownExpandableMenuButton = React.forwardRef<
 
   const ownRef = React.useRef<HTMLDivElement>();
   const ref = useForkedRef(forwardedRef, ownRef);
-
-  const StyledAccordionButton = styled(AccordionButton)<{
-    expandableMenuButtonHasIcon?: boolean;
-    icon?: React.ReactElement<IconProps>;
-  }>`
-    font-weight: 400;
-    overflow-wrap: anywhere;
-    padding: ${props =>
-      !props.icon && props.expandableMenuButtonHasIcon
-        ? `${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing05} ${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing11}`
-        : `${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing05}`};
-    margin: 0;
-    border-top: 0;
-    &:focus {
-      outline-offset: -2px;
-    }
-    &:hover,
-    &:focus {
-      background: ${expandableMenuItemContext.disabled ? '' : menuBackground};
-    }
-    > span {
-      display: flex;
-    }
-  `;
-
-  const StyledIconWrapper = styled(IconWrapper)`
-    justify-content: center;
-  `;
 
   React.useEffect(() => {
     if (!expandableMenuItemContext.disabled) {
@@ -86,6 +88,7 @@ export const DropdownExpandableMenuButton = React.forwardRef<
         expandableMenuGroupContext.expandableMenuButtonHasIcon
       }
       isInverse={context.isInverse}
+      isMenuItemContextDisabled={expandableMenuItemContext.disabled}
       testId={testId}
     >
       {icon && (

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
@@ -86,6 +86,7 @@ export const DropdownExpandableMenuButton = React.forwardRef<
         expandableMenuGroupContext.expandableMenuButtonHasIcon
       }
       isInverse={context.isInverse}
+      style={expandableMenuItemContext.disabled ? { background: 'none' } : {}}
       testId={testId}
     >
       {icon && (

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
@@ -15,34 +15,6 @@ export interface DropdownExpandableMenuButtonProps
   testId?: string;
 }
 
-const StyledAccordionButton = styled(AccordionButton)<{
-  expandableMenuButtonHasIcon?: boolean;
-  icon?: React.ReactElement<IconProps>;
-}>`
-  font-weight: 400;
-  overflow-wrap: anywhere;
-  padding: ${props =>
-    !props.icon && props.expandableMenuButtonHasIcon
-      ? `${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing05} ${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing11}`
-      : `${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing05}`};
-  margin: 0;
-  border-top: 0;
-  &:focus {
-    outline-offset: -2px;
-  }
-  &:hover,
-  &:focus {
-    background: ${menuBackground};
-  }
-  > span {
-    display: flex;
-  }
-`;
-
-const StyledIconWrapper = styled(IconWrapper)`
-  justify-content: center;
-`;
-
 export const DropdownExpandableMenuButton = React.forwardRef<
   HTMLDivElement,
   DropdownExpandableMenuButtonProps
@@ -61,6 +33,34 @@ export const DropdownExpandableMenuButton = React.forwardRef<
 
   const ownRef = React.useRef<HTMLDivElement>();
   const ref = useForkedRef(forwardedRef, ownRef);
+
+  const StyledAccordionButton = styled(AccordionButton)<{
+    expandableMenuButtonHasIcon?: boolean;
+    icon?: React.ReactElement<IconProps>;
+  }>`
+    font-weight: 400;
+    overflow-wrap: anywhere;
+    padding: ${props =>
+      !props.icon && props.expandableMenuButtonHasIcon
+        ? `${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing05} ${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing11}`
+        : `${props.theme.spaceScale.spacing03} ${props.theme.spaceScale.spacing05}`};
+    margin: 0;
+    border-top: 0;
+    &:focus {
+      outline-offset: -2px;
+    }
+    &:hover,
+    &:focus {
+      background: ${expandableMenuItemContext.disabled ? '' : menuBackground};
+    }
+    > span {
+      display: flex;
+    }
+  `;
+
+  const StyledIconWrapper = styled(IconWrapper)`
+    justify-content: center;
+  `;
 
   React.useEffect(() => {
     if (!expandableMenuItemContext.disabled) {
@@ -86,7 +86,6 @@ export const DropdownExpandableMenuButton = React.forwardRef<
         expandableMenuGroupContext.expandableMenuButtonHasIcon
       }
       isInverse={context.isInverse}
-      style={expandableMenuItemContext.disabled ? { background: 'none' } : {}}
       testId={testId}
     >
       {icon && (

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
@@ -8,7 +8,8 @@ import { DropdownMenuItem, DropdownMenuItemProps } from './DropdownMenuItem';
 import { DropdownExpandableMenuItemContext } from './DropdownExpandableMenuItem';
 
 export interface DropdownExpandableMenuListItemProps
-  extends Omit<DropdownMenuItemProps, 'icon' | 'disabled'> {
+  extends Omit<DropdownMenuItemProps, 'icon'> {
+  disabled?: boolean;
   testId?: string;
 }
 
@@ -32,7 +33,7 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
   HTMLDivElement,
   DropdownExpandableMenuListItemProps
 >((props, forwardedRef) => {
-  const { children, ...other } = props;
+  const { children, disabled, ...other } = props;
 
   const ownRef = React.useRef<HTMLDivElement>();
   const theme = React.useContext(ThemeContext);
@@ -54,6 +55,7 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
   return (
     <StyledDropdownMenuItem
       {...other}
+      disabled={disabled}
       expandableMenuButtonHasIcon={menuGroupContext.expandableMenuButtonHasIcon}
       isExpandablePanel={menuGroupContext.isExpandablePanel}
       ref={expandableMenuItemContext.disabled ? null : ref}


### PR DESCRIPTION
Issue: # [1014](https://github.com/cengage/react-magma/issues/1014)

## What I did

- Fixed disabled state on 'DropdownExpandableMenuListItem'.
- Fixed disabled hover background on 'DropdownExpandableMenuGroup'.

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
Confirm 'DropdownExpandableMenuListItem' supports a disabled state.
Verify 'DropdownExpandableMenuGroup' hover does **not** have a background.
