### PR TITLE
Fix - Dropdown - Removing docs and storybook examples of the Dropdown form

### DIFF
--- a/.changeset/fix-dropdownDocsStorybook.md
+++ b/.changeset/fix-dropdownDocsStorybook.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Dropdown): Removing Dropdown password examples from docs and Storybook in lieu of future fix to UI bug pertaining to the show / hide button.

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -320,33 +320,6 @@ const LinkMenuTemplate: Story<DropdownProps> = args => (
 export const LinkMenu = LinkMenuTemplate.bind({});
 LinkMenu.args = { ...Default.args };
 
-const FormTemplate: Story<DropdownProps> = args => (
-  <div style={{ margin: '150px auto', textAlign: 'center' }}>
-    <Dropdown {...args}>
-      <DropdownButton>Dropdown with form</DropdownButton>
-      <DropdownContent>
-        <form style={{ margin: 0, padding: '16px' }}>
-          <Input labelText="Email Address" />
-          <PasswordInput labelText="Password" />
-          <Checkbox labelText="Remember me" />
-          <div style={{ textAlign: 'center' }}>
-            <p>
-              By signing in, you agree to our <a href="#terms">Terms of use</a>.
-            </p>
-            <Button isFullWidth>Sign In</Button>
-            <p>
-              <a href="#password">Forgot password?</a>
-            </p>
-          </div>
-        </form>
-      </DropdownContent>
-    </Dropdown>
-  </div>
-);
-
-export const Form = FormTemplate.bind({});
-Form.args = { ...Default.args };
-
 export const Inverse = HeaderIconTemplate.bind({});
 Inverse.args = {
   ...Default.args,

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -648,56 +648,6 @@ Dropdowns can contain elements other than `DropdownMenuItem` components. They ca
 While users may navigate between `DropdownMenuItem` components using up and down arrow keys,
 browser default keyboard behavior applies to other content.
 
-### Dropdown with Form
-
-```tsx
-import React from 'react';
-import {
-  Button,
-  Dropdown,
-  DropdownButton,
-  DropdownContent,
-  DropdownDivider,
-  Input,
-  InputType,
-  magma,
-  PasswordInput,
-} from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <Dropdown width="300px">
-      <DropdownButton>Dropdown with Login Form</DropdownButton>
-      <DropdownContent>
-        <form style={{ margin: 0, padding: magma.spaceScale.spacing05 }}>
-          <Input type={InputType.email} labelText="Email Address" />
-          <PasswordInput labelText="Password" />
-          <div style={{ textAlign: 'center' }}>
-            <p>
-              By signing in, you agree to our <a href="#">Terms of use</a>.
-            </p>
-            <Button isFullWidth>Sign In</Button>
-            <p>
-              <a>Forgot password?</a>
-            </p>
-          </div>
-        </form>
-        <DropdownDivider />
-        <div
-          style={{ textAlign: 'center', padding: magma.spaceScale.spacing05 }}
-        >
-          <p>
-            Don't have an account?
-            <br />
-            <a href="#">Register today!</a>
-          </p>
-        </div>
-      </DropdownContent>
-    </Dropdown>
-  );
-}
-```
-
 ### Dropdown with Filter
 
 ```tsx


### PR DESCRIPTION
Issue: # [1014](https://github.com/cengage/react-magma/issues/1014)

## What I did
- Removed Dropdown with Form example in docs under Dropdown
- Removed Form example in Storybook under Dropdown

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
-Confirm docs example of Dropdown with Form example is removed under Dropdown without Menu Items.
-Confirm Storybook example of Form is no longer under the Dropdown examples.