### PR TITLE
feat(Paragraph): New `noTopMargin` and `noBottomMargin` props that allow customization of which margin to remove.

### DIFF
--- a/.changeset/feat-paragraphMargins.md
+++ b/.changeset/feat-paragraphMargins.md
@@ -2,4 +2,4 @@
 'react-magma-dom': minor
 ---
 
-feat(Paragraph): Adding more configuration for the Paragraph component margins. `noTopMargin` and `noBottomMargin` both allow a removal of the margin from one side.
+feat(Paragraph): New `noTopMargin` and `noBottomMargin` props that allow customization of which margin to remove.

--- a/.changeset/feat-paragraphMargins.md
+++ b/.changeset/feat-paragraphMargins.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Paragraph): Adding more configuration for the Paragraph component margins. `noTopMargin` and `noBottomMargin` both allow a removal of the margin from one side.

--- a/packages/react-magma-dom/src/components/Paragraph/Paragraph.stories.tsx
+++ b/packages/react-magma-dom/src/components/Paragraph/Paragraph.stories.tsx
@@ -14,6 +14,24 @@ export default {
       },
       defaultValue: false,
     },
+    noMargins: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: false,
+    },
+    noBottomMargin: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: false,
+    },
+    noTopMargin: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: false,
+    },
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/Paragraph/Paragraph.test.js
+++ b/packages/react-magma-dom/src/components/Paragraph/Paragraph.test.js
@@ -140,6 +140,86 @@ describe('Paragraph', () => {
     expect(getByText(text4)).toHaveStyleRule('margin', '0');
   });
 
+  it('should render paragraphs with no top margin', () => {
+    const text1 = 'Test Paragraph 1';
+    const text2 = 'Test Paragraph 2';
+    const text3 = 'Test Paragraph 3';
+    const text4 = 'Test Paragraph 4';
+    const { getByText } = render(
+      <>
+        <Paragraph noTopMargin visualStyle="bodyLarge">
+          {text1}
+        </Paragraph>
+        <Paragraph noTopMargin visualStyle="bodyMedium">
+          {text2}
+        </Paragraph>
+        <Paragraph noTopMargin visualStyle="bodySmall">
+          {text3}
+        </Paragraph>
+        <Paragraph noTopMargin visualStyle="bodyXSmall">
+          {text4}
+        </Paragraph>
+      </>
+    );
+
+    expect(getByText(text1)).toHaveStyleRule(
+      'margin',
+      `0 0 ${magma.spaceScale.spacing06} 0`
+    );
+    expect(getByText(text2)).toHaveStyleRule(
+      'margin',
+      `0 0 ${magma.spaceScale.spacing06} 0`
+    );
+    expect(getByText(text3)).toHaveStyleRule(
+      'margin',
+      `0 0 ${magma.spaceScale.spacing05} 0`
+    );
+    expect(getByText(text4)).toHaveStyleRule(
+      'margin',
+      `0 0 ${magma.spaceScale.spacing03} 0`
+    );
+  });
+
+  it('should render paragraphs with no bottom margin', () => {
+    const text1 = 'Test Paragraph 1';
+    const text2 = 'Test Paragraph 2';
+    const text3 = 'Test Paragraph 3';
+    const text4 = 'Test Paragraph 4';
+    const { getByText } = render(
+      <>
+        <Paragraph noBottomMargin visualStyle="bodyLarge">
+          {text1}
+        </Paragraph>
+        <Paragraph noBottomMargin visualStyle="bodyMedium">
+          {text2}
+        </Paragraph>
+        <Paragraph noBottomMargin visualStyle="bodySmall">
+          {text3}
+        </Paragraph>
+        <Paragraph noBottomMargin visualStyle="bodyXSmall">
+          {text4}
+        </Paragraph>
+      </>
+    );
+
+    expect(getByText(text1)).toHaveStyleRule(
+      'margin',
+      `${magma.spaceScale.spacing06} 0 0 0`
+    );
+    expect(getByText(text2)).toHaveStyleRule(
+      'margin',
+      `${magma.spaceScale.spacing06} 0 0 0`
+    );
+    expect(getByText(text3)).toHaveStyleRule(
+      'margin',
+      `${magma.spaceScale.spacing05} 0 0 0`
+    );
+    expect(getByText(text4)).toHaveStyleRule(
+      'margin',
+      `${magma.spaceScale.spacing03} 0 0 0`
+    );
+  });
+
   it('Does not violate accessibility standards', () => {
     const { container } = render(<Paragraph>test text</Paragraph>);
 

--- a/packages/react-magma-dom/src/components/Paragraph/Paragraph.test.js
+++ b/packages/react-magma-dom/src/components/Paragraph/Paragraph.test.js
@@ -117,6 +117,10 @@ describe('Paragraph', () => {
     const text2 = 'Test Paragraph 2';
     const text3 = 'Test Paragraph 3';
     const text4 = 'Test Paragraph 4';
+    const text5 = 'Test Paragraph 5';
+    const text6 = 'Test Paragraph 6';
+    const text7 = 'Test Paragraph 7';
+    const text8 = 'Test Paragraph 8';
     const { getByText } = render(
       <>
         <Paragraph noMargins visualStyle="bodyLarge">
@@ -131,13 +135,26 @@ describe('Paragraph', () => {
         <Paragraph noMargins visualStyle="bodyXSmall">
           {text4}
         </Paragraph>
+        <Paragraph noBottomMargin noTopMargin visualStyle="bodyLarge">
+          {text5}
+        </Paragraph>
+        <Paragraph noBottomMargin noTopMargin visualStyle="bodyMedium">
+          {text6}
+        </Paragraph>
+        <Paragraph noBottomMargin noTopMargin visualStyle="bodySmall">
+          {text7}
+        </Paragraph>
+        <Paragraph noBottomMargin noTopMargin visualStyle="bodyXSmall">
+          {text8}
+        </Paragraph>
       </>
     );
 
-    expect(getByText(text1)).toHaveStyleRule('margin', '0');
-    expect(getByText(text2)).toHaveStyleRule('margin', '0');
-    expect(getByText(text3)).toHaveStyleRule('margin', '0');
-    expect(getByText(text4)).toHaveStyleRule('margin', '0');
+    expect(
+      getByText(
+        text1 || text2 || text3 || text4 || text5 || text6 || text7 || text8
+      )
+    ).toHaveStyleRule('margin', '0');
   });
 
   it('should render paragraphs with no top margin', () => {

--- a/packages/react-magma-dom/src/components/Paragraph/index.tsx
+++ b/packages/react-magma-dom/src/components/Paragraph/index.tsx
@@ -30,6 +30,16 @@ export interface ParagraphProps
    */
   noMargins?: boolean;
   /**
+   * If true, the component will not have the default bottom margin and instead will have a value of 0
+   * @default false
+   */
+  noBottomMargin?: boolean;
+  /**
+   * If true, the component will not have the default top margin and instead will have a value of 0
+   * @default false
+   */
+  noTopMargin?: boolean;
+  /**
    * @internal
    */
   testId?: string;

--- a/packages/react-magma-dom/src/components/Typography/index.tsx
+++ b/packages/react-magma-dom/src/components/Typography/index.tsx
@@ -672,4 +672,5 @@ function getTypographyStyles(props) {
 
 export const TypographyComponent = styled.p<TypographyProps>`
   ${props => getTypographyStyles(props)}
+  margin: ${props => (props.noBottomMargin && props.noTopMargin ? '0' : '')};
 `;

--- a/packages/react-magma-dom/src/components/Typography/index.tsx
+++ b/packages/react-magma-dom/src/components/Typography/index.tsx
@@ -11,6 +11,8 @@ export interface TypographyProps<T = HTMLParagraphElement>
   element?: string;
   isInverse?: boolean;
   noMargins?: boolean;
+  noBottomMargin?: boolean;
+  noTopMargin?: boolean;
   ref?: any;
   /**
    * @internal
@@ -123,7 +125,13 @@ const baseParagraphStyles = props => css`
 export const paragraphLargeStyles = props => css`
   ${baseParagraphStyles(props)}
 
-  margin: ${props.noMargins ? '0' : `${props.theme.spaceScale.spacing06} 0`};
+  margin: ${props.noMargins
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing06} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing06} 0`
+    : `${props.theme.spaceScale.spacing06} 0`};
 
   font-size: ${props.theme.typographyVisualStyles.bodyLarge.mobile.fontSize};
   line-height: ${props.theme.typographyVisualStyles.bodyLarge.mobile
@@ -157,7 +165,13 @@ export const paragraphMediumStyles = props => css`
   font-size: ${props.theme.typographyVisualStyles.bodyMedium.mobile.fontSize};
   line-height: ${props.theme.typographyVisualStyles.bodyMedium.mobile
     .lineHeight};
-  margin: ${props.noMargins ? '0' : `${props.theme.spaceScale.spacing06} 0`};
+  margin: ${props.noMargins
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing06} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing06} 0`
+    : `${props.theme.spaceScale.spacing06} 0`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {
     font-size: ${props.theme.typographyVisualStyles.bodyMedium.desktop
@@ -175,7 +189,13 @@ export const paragraphSmallStyles = props => css`
     .letterSpacing};
   line-height: ${props.theme.typographyVisualStyles.bodySmall.mobile
     .lineHeight};
-  margin: ${props.noMargins ? '0' : `${props.theme.spaceScale.spacing05} 0`};
+  margin: ${props.noMargins
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing05} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing05} 0`
+    : `${props.theme.spaceScale.spacing05} 0`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {
     font-size: ${props.theme.typographyVisualStyles.bodySmall.desktop.fontSize};
@@ -194,7 +214,13 @@ export const paragraphXSmallStyles = props => css`
     .letterSpacing};
   line-height: ${props.theme.typographyVisualStyles.bodyXSmall.mobile
     .lineHeight};
-  margin: ${props.noMargins ? '0' : `${props.theme.spaceScale.spacing03} 0`};
+  margin: ${props.noMargins
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing03} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing03} 0`
+    : `${props.theme.spaceScale.spacing03} 0`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {
     font-size: ${props.theme.typographyVisualStyles.bodyXSmall.desktop
@@ -263,7 +289,13 @@ export const headingXLargeStyles = props => css`
   font-weight: ${props.theme.typographyVisualStyles.headingXLarge.fontWeight};
   line-height: ${props.theme.typographyVisualStyles.headingXLarge.mobile
     .lineHeight};
-  margin: ${props.noMargins ? 0 : `0 0 ${props.theme.spaceScale.spacing05}`};
+  margin: ${props.noMargins
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing05} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing05} 0`
+    : `0 0 ${props.theme.spaceScale.spacing05}`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {
     font-size: ${props.theme.typographyVisualStyles.headingXLarge.desktop
@@ -313,8 +345,13 @@ export const headingLargeStyles = props => css`
   font-weight: ${props.theme.typographyVisualStyles.headingLarge.fontWeight};
   line-height: ${props.theme.typographyVisualStyles.headingLarge.mobile
     .lineHeight};
+
   margin: ${props.noMargins
-    ? 0
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing10} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing05} 0`
     : `${props.theme.spaceScale.spacing10} 0 ${props.theme.spaceScale.spacing05}`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {
@@ -366,8 +403,13 @@ export const headingMediumStyles = props => css`
   font-weight: ${props.theme.typographyVisualStyles.headingMedium.fontWeight};
   line-height: ${props.theme.typographyVisualStyles.headingMedium.mobile
     .lineHeight};
+
   margin: ${props.noMargins
-    ? 0
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing09} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing05} 0`
     : `${props.theme.spaceScale.spacing09} 0 ${props.theme.spaceScale.spacing05}`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {
@@ -420,8 +462,13 @@ export const headingSmallStyles = props => css`
   font-weight: ${props.theme.typographyVisualStyles.headingSmall.fontWeight};
   line-height: ${props.theme.typographyVisualStyles.headingSmall.mobile
     .lineHeight};
+
   margin: ${props.noMargins
-    ? 0
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing08} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing05} 0`
     : `${props.theme.spaceScale.spacing08} 0 ${props.theme.spaceScale.spacing05}`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {
@@ -472,8 +519,13 @@ export const headingXSmallStyles = props => css`
   font-weight: ${props.theme.typographyVisualStyles.headingXSmall.fontWeight};
   line-height: ${props.theme.typographyVisualStyles.headingXSmall.mobile
     .lineHeight};
+
   margin: ${props.noMargins
-    ? 0
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing06} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing05} 0`
     : `${props.theme.spaceScale.spacing06} 0 ${props.theme.spaceScale.spacing05}`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {
@@ -528,8 +580,13 @@ export const heading2XSmallStyles = props => css`
   line-height: ${props.theme.typographyVisualStyles.heading2XSmall.mobile
     .lineHeight};
   text-transform: uppercase;
+
   margin: ${props.noMargins
-    ? 0
+    ? '0'
+    : props.noBottomMargin
+    ? `${props.theme.spaceScale.spacing06} 0 0 0`
+    : props.noTopMargin
+    ? `0 0 ${props.theme.spaceScale.spacing03} 0`
     : `${props.theme.spaceScale.spacing06} 0 ${props.theme.spaceScale.spacing03}`};
 
   @media (min-width: ${props.theme.breakpoints.small}px) {

--- a/website/react-magma-docs/src/pages/api/paragraph.mdx
+++ b/website/react-magma-docs/src/pages/api/paragraph.mdx
@@ -254,6 +254,68 @@ export function Example() {
 }
 ```
 
+## No Top Margin
+
+When the `noTopMargin` prop is used, the element will have a top margin value of 0.
+
+```tsx
+import React from 'react';
+import { Paragraph, TypographyVisualStyle } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <Paragraph noTopMargin visualStyle={TypographyVisualStyle.bodyLarge}>
+        Body large. Lorem ipsum dolar sit amet.
+      </Paragraph>
+
+      <Paragraph noTopMargin visualStyle={TypographyVisualStyle.bodyMedium}>
+        Body medium (default). Lorem ipsum dolar sit amet.
+      </Paragraph>
+
+      <Paragraph noTopMargin visualStyle={TypographyVisualStyle.bodySmall}>
+        Body small. Lorem ipsum dolar sit amet.
+      </Paragraph>
+
+      <Paragraph noTopMargin visualStyle={TypographyVisualStyle.bodyXSmall}>
+        Body x-small. Lorem ipsum dolar sit amet.
+      </Paragraph>
+    </>
+  );
+}
+```
+
+## No Bottom Margin
+
+When the `noBottomMargin` prop is used, the element will have a bottom margin value of 0.
+
+```tsx
+import React from 'react';
+import { Paragraph, TypographyVisualStyle } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <Paragraph noBottomMargin visualStyle={TypographyVisualStyle.bodyLarge}>
+        Body large. Lorem ipsum dolar sit amet.
+      </Paragraph>
+
+      <Paragraph noBottomMargin visualStyle={TypographyVisualStyle.bodyMedium}>
+        Body medium (default). Lorem ipsum dolar sit amet.
+      </Paragraph>
+
+      <Paragraph noBottomMargin visualStyle={TypographyVisualStyle.bodySmall}>
+        Body small. Lorem ipsum dolar sit amet.
+      </Paragraph>
+
+      <Paragraph noBottomMargin visualStyle={TypographyVisualStyle.bodyXSmall}>
+        Body x-small. Lorem ipsum dolar sit amet.
+      </Paragraph>
+    </>
+  );
+}
+```
+
 ## Paragraph Props
 
 **This component uses `forwardRef`. The ref is applied to the outer `p` element.**


### PR DESCRIPTION
## What I did
- Added two new props `noBottomMargin` and `noTopMargin` for additional styling options.

## Screenshots:
![no-b](https://github.com/cengage/react-magma/assets/77400920/661681b6-a74f-4e06-99ae-96512e85955a)
![no-t](https://github.com/cengage/react-magma/assets/77400920/cb9cb832-716f-44b1-bdce-5d6d0efb0b78)

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
- Got to Docs > Paragraph
- Ensure both additional examples of No Bottom Margin and No Top Margin appear appropriately
