### PR TITLE
Fix - Modal > Storybook > Inverse example

### DIFF
--- a/.changeset/fix-modalStorybook.md
+++ b/.changeset/fix-modalStorybook.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal): Fixed Storybook Inverse example.

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -422,7 +422,7 @@ export const Inverse = () => {
         isOpen={showModal}
         isInverse
       >
-        <Paragraph noTopMargin>
+        <Paragraph noTopMargin isInverse>
           This is an inverse modal, doing modal things.
         </Paragraph>
         <Paragraph>


### PR DESCRIPTION
Issue: # [1173](https://github.com/cengage/react-magma/issues/1173)

## What I did
- Fixing inverse example in Storybook

## Screenshots:
![Modal](https://github.com/cengage/react-magma/assets/77400920/a5325c8a-3981-4423-ab1f-a672e2bc4da2)

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
- Go to Storybook
- Open Modal > Inverse example
- Verify text is now white in the Modal body
