### PR TITLE
fix(NativeSelect): Fixed related simple pagination issue with selected states not updating after selection.

### DIFF
--- a/.changeset/fix-NativeSelectPagination.md
+++ b/.changeset/fix-NativeSelectPagination.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(NativeSelect): Fixed related simple pagination issue with selected states not updating after selection.

--- a/.changeset/fix-NativeSelectPagination.md
+++ b/.changeset/fix-NativeSelectPagination.md
@@ -2,4 +2,4 @@
 'react-magma-dom': patch
 ---
 
-fix(NativeSelect): Fixed related simple pagination issue with selected states not updating after selection.
+fix(NativeSelect): Fixes the issue with pagination control, rows per page, on Table and Datagrid per ticket: https://github.com/cengage/react-magma/issues/1201

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
 import { NativeSelect } from '.';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { transparentize } from 'polished';
 import { Tooltip } from '../Tooltip';
 import { IconButton } from '../IconButton';
@@ -63,6 +63,20 @@ describe('NativeSelect', () => {
       'border',
       `1px solid ${magma.colors.neutral500}`
     );
+  });
+
+  it('should update the selected option', () => {
+    const { getByTestId, getAllByTestId } = render(
+      <NativeSelect testId={testId}>
+        <option data-testid={`${testId}-option-1`}>1</option>
+        <option data-testid={`${testId}-option-2`}>2</option>
+        <option data-testid={`${testId}-option-3`}>3</option>
+      </NativeSelect>
+    );
+    fireEvent.change(getByTestId(testId), { target: { value: 2 } });
+    expect(getByTestId(`${testId}-option-1`).selected).toBeFalsy();
+    expect(getByTestId(`${testId}-option-2`).selected).toBeTruthy();
+    expect(getByTestId(`${testId}-option-3`).selected).toBeFalsy();
   });
 
   it('should render a default inverse border', () => {
@@ -158,6 +172,37 @@ describe('NativeSelect', () => {
         'display',
         'flex'
       );
+    });
+
+    it(`Shouldn't display an additional wrapper when additionalContent is unset'`, () => {
+      const { rerender, queryByTestId } = render(
+        <NativeSelect
+          labelPosition="left"
+          testId={testId}
+          additionalContent={
+            <Tooltip content={helpLinkLabel}>
+              <IconButton
+                aria-label={helpLinkLabel}
+                icon={<HelpIcon />}
+                onClick={onHelpLinkClick}
+                testId="Icon Button"
+                type={ButtonType.button}
+                size={ButtonSize.small}
+                variant={ButtonVariant.link}
+              />
+            </Tooltip>
+          }
+        />
+      );
+      expect(
+        queryByTestId(`${testId}-additional-content-wrapper`)
+      ).toBeInTheDocument();
+
+      rerender(<NativeSelect labelPosition="left" testId={testId} />);
+
+      expect(
+        queryByTestId(`${testId}-additional-content-wrapper`)
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
@@ -66,17 +66,18 @@ describe('NativeSelect', () => {
   });
 
   it('should update the selected option', () => {
-    const { getByTestId, getAllByTestId } = render(
+    const { getByTestId } = render(
       <NativeSelect testId={testId}>
-        <option data-testid={`${testId}-option-1`}>1</option>
-        <option data-testid={`${testId}-option-2`}>2</option>
-        <option data-testid={`${testId}-option-3`}>3</option>
+        <option>1</option>
+        <option>2</option>
+        <option>3</option>
       </NativeSelect>
     );
+    const activeOption = getByTestId(testId);
+
     fireEvent.change(getByTestId(testId), { target: { value: 2 } });
-    expect(getByTestId(`${testId}-option-1`).selected).toBeFalsy();
-    expect(getByTestId(`${testId}-option-2`).selected).toBeTruthy();
-    expect(getByTestId(`${testId}-option-3`).selected).toBeFalsy();
+
+    expect(activeOption).toHaveDisplayValue('2');
   });
 
   it('should render a default inverse border', () => {
@@ -174,7 +175,7 @@ describe('NativeSelect', () => {
       );
     });
 
-    it(`Shouldn't display an additional wrapper when additionalContent is unset'`, () => {
+    it(`Should display an additional wrapper with additionalContent'`, () => {
       const { rerender, queryByTestId } = render(
         <NativeSelect
           labelPosition="left"
@@ -197,9 +198,12 @@ describe('NativeSelect', () => {
       expect(
         queryByTestId(`${testId}-additional-content-wrapper`)
       ).toBeInTheDocument();
+    });
 
-      rerender(<NativeSelect labelPosition="left" testId={testId} />);
-
+    it(`Shouldn't display an additional wrapper without additionalContent'`, () => {
+      const { rerender, queryByTestId } = render(
+        <NativeSelect labelPosition="left" testId={testId} />
+      );
       expect(
         queryByTestId(`${testId}-additional-content-wrapper`)
       ).not.toBeInTheDocument();

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -202,7 +202,7 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
       return props.children;
     }
 
-    if (labelPosition) {
+    if (additionalContent) {
       return (
         <AdditionalContentWrapper labelPosition={labelPosition}>
           {nativeSelect}

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -194,7 +194,10 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
         (labelPosition === LabelPosition.top && !hasLabel)
       ) {
         return (
-          <StyledAdditionalContentWrapper theme={theme}>
+          <StyledAdditionalContentWrapper
+            data-testid={`${testId}-additional-content-wrapper`}
+            theme={theme}
+          >
             {props.children}
           </StyledAdditionalContentWrapper>
         );
@@ -206,7 +209,7 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
       return (
         <AdditionalContentWrapper labelPosition={labelPosition}>
           {nativeSelect}
-          {(labelPosition === 'left' && additionalContent) ||
+          {(labelPosition === LabelPosition.left && additionalContent) ||
             (!labelText && additionalContent)}
         </AdditionalContentWrapper>
       );

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -139,6 +139,54 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
 
     const hasLabel = !!labelText;
 
+    const nativeSelect = (
+      <StyledFormFieldContainer
+        additionalContent={additionalContent}
+        containerStyle={containerStyle}
+        testId={testId && `${testId}-form-field-container`}
+        errorMessage={errorMessage}
+        fieldId={id}
+        hasLabel={!!labelText}
+        labelPosition={labelPosition}
+        labelStyle={labelStyle}
+        labelText={
+          labelPosition !== LabelPosition.left && additionalContent ? (
+            <>
+              {labelText}
+              {labelText && additionalContent}
+            </>
+          ) : (
+            labelText
+          )
+        }
+        labelWidth={labelWidth}
+        isInverse={isInverse}
+        helperMessage={helperMessage}
+        messageStyle={messageStyle}
+        ref={ref}
+      >
+        <StyledNativeSelectWrapper
+          disabled={disabled}
+          hasError={!!errorMessage}
+          isInverse={isInverse}
+          theme={theme}
+        >
+          <StyledNativeSelect
+            data-testid={testId}
+            hasError={!!errorMessage}
+            disabled={disabled}
+            id={id}
+            isInverse={isInverse}
+            theme={theme}
+            {...other}
+          >
+            {children}
+          </StyledNativeSelect>
+          <DefaultDropdownIndicator disabled={disabled} />
+        </StyledNativeSelectWrapper>
+      </StyledFormFieldContainer>
+    );
+
     // If the labelPosition is set to 'left' then a <div> wraps the FormFieldContainer, NativeSelectWrapper, and NativeSelect for proper styling alignment.
     function AdditionalContentWrapper(props) {
       if (
@@ -154,56 +202,16 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
       return props.children;
     }
 
-    return (
-      <AdditionalContentWrapper labelPosition={labelPosition}>
-        <StyledFormFieldContainer
-          additionalContent={additionalContent}
-          containerStyle={containerStyle}
-          testId={testId && `${testId}-form-field-container`}
-          errorMessage={errorMessage}
-          fieldId={id}
-          hasLabel={!!labelText}
-          labelPosition={labelPosition}
-          labelStyle={labelStyle}
-          labelText={
-            labelPosition !== LabelPosition.left && additionalContent ? (
-              <>
-                {labelText}
-                {labelText && additionalContent}
-              </>
-            ) : (
-              labelText
-            )
-          }
-          labelWidth={labelWidth}
-          isInverse={isInverse}
-          helperMessage={helperMessage}
-          messageStyle={messageStyle}
-          ref={ref}
-        >
-          <StyledNativeSelectWrapper
-            disabled={disabled}
-            hasError={!!errorMessage}
-            isInverse={isInverse}
-            theme={theme}
-          >
-            <StyledNativeSelect
-              data-testid={testId}
-              hasError={!!errorMessage}
-              disabled={disabled}
-              id={id}
-              isInverse={isInverse}
-              theme={theme}
-              {...other}
-            >
-              {children}
-            </StyledNativeSelect>
-            <DefaultDropdownIndicator disabled={disabled} />
-          </StyledNativeSelectWrapper>
-        </StyledFormFieldContainer>
-        {(labelPosition === 'left' && additionalContent) ||
-          (!labelText && additionalContent)}
-      </AdditionalContentWrapper>
-    );
+    if (labelPosition) {
+      return (
+        <AdditionalContentWrapper labelPosition={labelPosition}>
+          {nativeSelect}
+          {(labelPosition === 'left' && additionalContent) ||
+            (!labelText && additionalContent)}
+        </AdditionalContentWrapper>
+      );
+    } else {
+      return nativeSelect;
+    }
   }
 );

--- a/packages/react-magma-dom/src/components/Table/TablePagination.test.js
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.test.js
@@ -77,11 +77,12 @@ describe('Table Pagination', () => {
       );
       const rowsSelect = getByTestId('rowPerPageSelect');
 
-      fireEvent.change(rowsSelect, { target: { value: 20 }});
+      fireEvent.change(rowsSelect, { target: { value: 20 } });
 
       expect(handlePageChange).toHaveBeenCalledWith(expect.any(Object), 1);
       expect(handleRowsPerPageChange).toHaveBeenCalledWith('20');
       expect(getByText(/1-20/i)).toBeInTheDocument();
+      expect(rowsSelect).toHaveDisplayValue('20');
     });
   });
 
@@ -195,9 +196,7 @@ describe('Table Pagination', () => {
   });
 
   it('should hide rows per page component when no onRowsPerPageChanged function passed', () => {
-    const { queryByText } = render(
-      <TablePagination itemCount={20}/>
-    );
+    const { queryByText } = render(<TablePagination itemCount={20} />);
 
     expect(queryByText('Rows per page:')).not.toBeInTheDocument();
   });

--- a/packages/react-magma-dom/src/components/Table/TablePagination.test.js
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.test.js
@@ -77,12 +77,16 @@ describe('Table Pagination', () => {
       );
       const rowsSelect = getByTestId('rowPerPageSelect');
 
+      const appliedSelection = document.querySelector(
+        'select[data-testid=rowPerPageSelect]'
+      );
+
       fireEvent.change(rowsSelect, { target: { value: 20 } });
 
       expect(handlePageChange).toHaveBeenCalledWith(expect.any(Object), 1);
       expect(handleRowsPerPageChange).toHaveBeenCalledWith('20');
       expect(getByText(/1-20/i)).toBeInTheDocument();
-      expect(rowsSelect).toHaveDisplayValue('20');
+      expect(appliedSelection).toHaveDisplayValue('20');
     });
   });
 


### PR DESCRIPTION
Issue: # [1201](https://github.com/cengage/react-magma/issues/1201)

## What I did
- Added a conditional layer to prevent additional wrapping of the `NativeSelect`. This fixes the selection issue documented in the bug ticket.

## Screenshots:
![Selection](https://github.com/cengage/react-magma/assets/77400920/5009531c-2442-44be-9fa1-a9c0ef769e83)

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test

- Go to Storybook
- Go to Datagrid > default
- Within the table click on the Rows Per Page select and change from 10 to anything else
- Verify the new selection appears in the dropdown and the data in the table updates accordingly
