### PR TITLE
Fix issue with 'ReferenceError: _styled is not defined'

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,9 @@
+import styled from '@emotion/styled/';
+
 const emotion = require('@emotion/core');
 const { createSerializer, matchers } = require('jest-emotion');
+
+global._styled = styled;
 
 expect.addSnapshotSerializer(createSerializer(emotion));
 expect.extend(matchers);


### PR DESCRIPTION
Issue: ReferenceError: _styled is not defined

## What I did
Updated jest.setup.js file.

## Screenshots:
![Screenshot from 2024-03-27 15-22-50](https://github.com/cengage/react-magma/assets/165167848/9fa36a27-a3fe-4874-88c3-46eec1f8d62f)

## How to test
1. npm ci
2. npm run test
