### PR TITLE
Fix(Badge): Fixes the Badge height for the label version. Both label and counter variants are now 24px in height.

### DIFF
--- a/.changeset/fix-BadgeHeight.md
+++ b/.changeset/fix-BadgeHeight.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Badge): Fixes the Badge height for the label version. Both label and counter variants are now 24px in height.

--- a/packages/react-magma-dom/src/components/Badge/Badge.test.js
+++ b/packages/react-magma-dom/src/components/Badge/Badge.test.js
@@ -115,6 +115,10 @@ describe('Badge', () => {
         'background',
         magma.colors.primary
       );
+      expect(getByText(TEXT)).toHaveStyleRule(
+        'padding',
+        `3px ${magma.spaceScale.spacing02}`
+      );
     });
 
     describe('inverse', () => {

--- a/packages/react-magma-dom/src/components/Badge/index.tsx
+++ b/packages/react-magma-dom/src/components/Badge/index.tsx
@@ -141,7 +141,7 @@ export const baseBadgeStyles = props => css`
   min-width: ${props.theme.spaceScale.spacing06};
   padding: ${props.variant === BadgeVariant.counter
     ? `1px ${props.theme.spaceScale.spacing02}`
-    : `${props.theme.spaceScale.spacing01} ${props.theme.spaceScale.spacing02}`};
+    : `3px  ${props.theme.spaceScale.spacing02}`};
   text-align: ${props.variant == BadgeVariant.counter ? 'center' : 'inherit'};
 `;
 


### PR DESCRIPTION
Issue: # TBD

## What I did
- Updates the `label` Badge height to properly align between the two variants, now both `label` and `counter` match.

## Screenshots:
![Alignment](https://github.com/cengage/react-magma/assets/77400920/7109ea14-b008-4980-b899-93f9e34bfe89)

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
- Open either Docs or Storybook
- Go to Badge
- Ensure the `label` version (default) shows a total pixel height of 24px.
- Ensure the `number` version shows a total pixel height of 24px.
