### PR TITLE
fix(Search): Reset the value for clearable search when the X is click…

### DIFF
--- a/.changeset/cold-birds-appear.md
+++ b/.changeset/cold-birds-appear.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix(Search): Reset the value for clearable search when the X is click…

--- a/packages/react-magma-dom/src/components/Search/Search.test.js
+++ b/packages/react-magma-dom/src/components/Search/Search.test.js
@@ -56,7 +56,7 @@ describe('Search', () => {
     });
 
     fireEvent.click(container.querySelector('button'));
-    expect(onSearchSpy).toBeCalledWith(targetValue);
+    expect(onSearchSpy).toHaveBeenCalledWith(targetValue);
   });
 
   it('should fire the onSearch event when enter is pressed', () => {
@@ -70,7 +70,7 @@ describe('Search', () => {
       keyCode: 13,
     });
 
-    expect(onSearchSpy).toBeCalledWith('test value');
+    expect(onSearchSpy).toHaveBeenCalledWith('test value');
   });
 
   it('should trigger the passed in onChange when value of the input is changed', () => {
@@ -94,6 +94,38 @@ describe('Search', () => {
     );
 
     expect(getByLabelText(defaultI18n.spinner.ariaLabel)).toBeInTheDocument();
+  });
+
+  it('should clear the state for uncontrolled Search when the clear input button is clicked', () => {
+    const onClear = jest.fn();
+    const labelText = 'Search input';
+    const value = 'Test Value';
+    
+    const { getByTestId, getByLabelText } = render(
+      <Search
+        labelText={labelText}
+        onSearch={onSearchSpy}
+        onClear={onClear}
+        isClearable
+      />
+    );
+
+    const searchButton = getByLabelText('Search', { selector: 'button' })
+    
+    fireEvent.click(searchButton);
+    expect(onSearchSpy).toHaveBeenCalledWith(undefined);
+
+    fireEvent.change(getByLabelText(labelText), {
+      target: { value },
+    });
+    fireEvent.click(searchButton);
+    expect(onSearchSpy).toHaveBeenCalledWith(value);
+
+    fireEvent.click(getByTestId('clear-button'));
+    expect(onClear).toHaveBeenCalled();
+    expect(getByLabelText(labelText)).toHaveAttribute('value', '');
+    fireEvent.click(searchButton);
+    expect(onSearchSpy).toHaveBeenCalledWith(undefined);
   });
 
   describe('i18n', () => {

--- a/packages/react-magma-dom/src/components/Search/index.tsx
+++ b/packages/react-magma-dom/src/components/Search/index.tsx
@@ -110,6 +110,7 @@ export const Search = React.forwardRef<HTMLInputElement, SearchProps>(
 
     function handleClear() {
       onClear && typeof onClear === 'function' && onClear();
+      setValue(undefined);
     }
 
     return (


### PR DESCRIPTION
Issue: #1264

## What I did
Fixed the issue where the value state was not cleared when using the Search component with isClearable.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [ ] changeset has been added
- [ ] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
