### PR TITLE
fix(TimePicker): Returns empty when backspace is pressed

### DIFF
--- a/.changeset/time-picker-onchange.md
+++ b/.changeset/time-picker-onchange.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(TimePicker): Returns empty when backspace is pressed

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.stories.tsx
@@ -4,6 +4,7 @@ import { Card, CardBody } from '../Card';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { LabelPosition } from '../Label';
 import { Button } from '../Button';
+import { Paragraph } from '../Paragraph';
 
 const Template: Story<TimePickerProps> = args => (
   <TimePicker {...args} labelText="Time Due" />
@@ -59,16 +60,27 @@ Inverse.decorators = [
   ),
 ];
 
-export const Clearable = () => {
+export const Events = () => {
   const [timeValue, setTimeValue] = React.useState<string | undefined>('');
+  const [onChangeCalledTimes, setOnChangeCalledTimes] = React.useState(0);
 
   function handleOnChange(value) {
     setTimeValue(value);
+    setOnChangeCalledTimes(onChangeCalledTimes + 1);
   }
 
   return (
     <>
-      <TimePicker labelText="Time Due" onChange={handleOnChange} value={timeValue} />
+      <Paragraph noMargins>
+        <strong>Time Value:</strong> {timeValue}
+      </Paragraph>
+      <Paragraph>onChange called {onChangeCalledTimes} times</Paragraph>
+
+      <TimePicker
+        labelText="Time Due"
+        onChange={handleOnChange}
+        value={timeValue}
+      />
       <br />
       <Button onClick={() => handleOnChange(undefined)}>Clear Time</Button>
     </>

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
@@ -59,7 +59,7 @@ describe('TimePicker', () => {
       expect(hoursInput.value).toEqual('');
     });
 
-    it('should call the onChange when backspace is clicked on the hours input', () => {
+    it('should call the onKeyDown when backspace is clicked on the hours input', () => {
       const onKeyDown = jest.fn();
       const { getByTestId } = render(
         <TimePicker label="label" onKeyDown={onKeyDown} />
@@ -70,19 +70,19 @@ describe('TimePicker', () => {
       fireEvent.keyDown(hoursInput, { key: 'Backspace' });
 
       expect(onKeyDown).toHaveBeenCalled();
-    });
-
-    it('should call the onChange when backspace is clicked on the minutes input', () => {
-      const onKeyDown = jest.fn();
+    });    
+    
+    it('should call the onChange when backspace is clicked on the hours input', () => {
+      const onChange = jest.fn();
       const { getByTestId } = render(
-        <TimePicker label="label" onKeyDown={onKeyDown} />
+        <TimePicker label="label" onChange={onChange} value={'02:04 AM'}/>
       );
 
-      const minsInput = getByTestId('minutesTimeInput');
+      const hoursInput = getByTestId('hoursTimeInput');
 
-      fireEvent.keyDown(minsInput, { key: 'Backspace' });
+      fireEvent.keyDown(hoursInput, { key: 'Backspace' });
 
-      expect(onKeyDown).toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalledWith('');
     });
 
     it('should focus the minute input if the right arrow key is clicked', () => {
@@ -163,6 +163,7 @@ describe('TimePicker', () => {
       fireEvent.keyDown(minutesInput, { key: 'Backspace' });
 
       expect(minutesInput.value).toEqual('');
+
     });
 
     it('should focus the hour input if the left arrow key is clicked', () => {
@@ -185,6 +186,32 @@ describe('TimePicker', () => {
       fireEvent.keyDown(minutesInput, { key: 'ArrowRight' });
 
       expect(getByTestId('amPmTimeButton')).toHaveFocus();
+    });
+
+    it('should call the onKeyDown when backspace is clicked on the minutes input', () => {
+      const onKeyDown = jest.fn();
+      const { getByTestId } = render(
+        <TimePicker label="label" onKeyDown={onKeyDown} />
+      );
+
+      const minsInput = getByTestId('minutesTimeInput');
+
+      fireEvent.keyDown(minsInput, { key: 'Backspace' });
+
+      expect(onKeyDown).toHaveBeenCalled();
+    });
+    
+    it('should call the onChange when backspace is clicked on the minutes input', () => {
+      const onChange = jest.fn();
+      const { getByTestId } = render(
+        <TimePicker label="label" onChange={onChange} value={'02:04 AM'}/>
+      );
+
+      const minsInput = getByTestId('minutesTimeInput');
+
+      fireEvent.keyDown(minsInput, { key: 'Backspace' });
+
+      expect(onChange).toHaveBeenCalledWith('');
     });
 
     it('should call the onChange for a valid minute entered', () => {

--- a/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
+++ b/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
@@ -140,6 +140,7 @@ export function useTimePicker(props: UseTimePickerProps) {
     if (event.key === 'Backspace') {
       hourChangeFunc(event);
       setHour('');
+      updateTime('');
     }
 
     if (event.key === 'ArrowRight') {
@@ -151,6 +152,7 @@ export function useTimePicker(props: UseTimePickerProps) {
     if (event.key === 'Backspace') {
       minChangeFunc(event);
       setMinute('');
+      updateTime('');
     }
 
     if (event.key === 'ArrowLeft') {


### PR DESCRIPTION
Issue: #1270 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Calling `updateTime('')` on `handleHourKeyDown` and `handleMinuteKeyDown`

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Navigate to the TimePicker events story or docs site and confirm that pressing backspace clears the time value visually and on the event.