### PR TITLE
Fix(Datagrid): Fixed the state of pagination select not updating the newly selected value.

### DIFF
--- a/.changeset/fix-datagrid.md
+++ b/.changeset/fix-datagrid.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Datagrid): Fixed the state of pagination select not updating the new selected value.

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -4,7 +4,7 @@ import { Datagrid } from '.';
 import { TableRowColor } from '../Table';
 import { Button } from '../Button';
 import { usePagination } from '../Pagination/usePagination';
-import { render, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { magma } from '../../theme/magma';
 
 const columns = [
@@ -722,7 +722,15 @@ describe('Datagrid', () => {
         />
       );
 
-      fireEvent.change(getByTestId('rowPerPageSelect'), { target: { value: 20 }});
+      fireEvent.change(getByTestId('rowPerPageSelect'), {
+        target: { value: 20 },
+      });
+
+      const appliedSelection = document.querySelector(
+        'select[data-testid=rowPerPageSelect]'
+      );
+
+      expect(appliedSelection).toHaveDisplayValue('20');
 
       expect(onRowsPerPageChange).toBeCalledWith(
         pagination.rowsPerPageValues[1].toString()

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -188,12 +188,12 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
     });
 
     React.useEffect(() => {
-      setRowsToShow(hasPagination ? getPageItems(currentPage) : rows);
-    }, [currentPage, rowsPerPage]);
-
-    React.useEffect(() => {
       setRowsToShow(rows);
     }, [rows]);
+
+    React.useEffect(() => {
+      setRowsToShow(hasPagination ? getPageItems(currentPage) : rows);
+    }, [currentPage, rowsPerPage]);
 
     const { Pagination } = defaultComponents({
       ...customComponents,


### PR DESCRIPTION
Issue: # [1201](https://github.com/cengage/react-magma/issues/1201)

## What I did
- Fixed the select not updating when selected with a new value in Datagrid.

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test

- Open Storybook
- Go to Datagrid
- Select a new value from the pagination select
- Confirm the newly selected value updates the visible rows
- Confirm select contains the proper value

- Open Docs
- Go to Datagrid
- Select a new value from the pagination select
- Confirm the newly selected value updates the visible rows
- Confirm select contains the proper value
