### PR TITLE
fix(Input): Add `inputWrapperStyle` prop

### DIFF
--- a/.changeset/input-wrapperStyle.md
+++ b/.changeset/input-wrapperStyle.md
@@ -2,4 +2,4 @@
 "react-magma-dom": patch
 ---
 
-fix(Input): Add `wrapperContainerStyle` prop to allow more flexibility with Input widths
+fix(Input): Add `inputWrapperStyle` prop to allow more flexibility with Input widths

--- a/.changeset/input-wrapperStyle.md
+++ b/.changeset/input-wrapperStyle.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix(Input): Add `wrapperContainerStyle` prop to allow more flexibility with Input widths

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -283,7 +283,7 @@ export const NumberInput = args => {
 NumberInput.args = {
   disabled: false,
   helperMessage: 'Enter a number 1 - 40',
-  isClearable: true,
+  isClearable: false,
 };
 
 NumberInput.parameters = {

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -266,8 +266,8 @@ export const NumberInput = args => {
       isInverse={args.isInverse}
     >
       <Input
-        labelText="Number 1-40"
-        wrapperContainerStyle={{ width: '60px' }}
+        labelText="Number 1-40 with long long long long label"
+        inputWrapperStyle={{ width: '64px' }}
         type={InputType.number}
         errorMessage={hasError ? 'Please enter a number between 1 - 40' : null}
         min={1}
@@ -283,6 +283,7 @@ export const NumberInput = args => {
 NumberInput.args = {
   disabled: false,
   helperMessage: 'Enter a number 1 - 40',
+  isClearable: true,
 };
 
 NumberInput.parameters = {

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -243,3 +243,48 @@ WithTwoIcons.args = {
 WithTwoIcons.parameters = {
   controls: { exclude: ['isInverse', 'type', 'iconPosition'] },
 };
+
+export const NumberInput = args => {
+  const [inputVal, setInputVal] = React.useState(1);
+  const [hasError, setHasError] = React.useState(false);
+
+  function handleChange(event) {
+    setInputVal(event.target.value);
+  }
+
+  React.useEffect(() => {
+    if (inputVal > 40 || inputVal < 1) {
+      setHasError(true);
+    } else {
+      setHasError(false);
+    }
+  }, [inputVal]);
+
+  return (
+    <Card
+      style={{ width: '250px', padding: '12px' }}
+      isInverse={args.isInverse}
+    >
+      <Input
+        labelText="Number 1-40"
+        wrapperContainerStyle={{ width: '60px' }}
+        type={InputType.number}
+        errorMessage={hasError ? 'Please enter a number between 1 - 40' : null}
+        min={1}
+        max={40}
+        value={inputVal}
+        onChange={handleChange}
+        {...args}
+      />
+    </Card>
+  );
+};
+
+NumberInput.args = {
+  disabled: false,
+  helperMessage: 'Enter a number 1 - 40',
+};
+
+NumberInput.parameters = {
+  controls: { exclude: ['type', 'iconPosition', 'labelWidth'] },
+};

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -57,23 +57,28 @@ describe('Input', () => {
     const divColor = '#000000';
     const inputColor = '#cccccc';
     const labelColor = '#ffffff';
+    const wrapperWidth = '60px';
 
-    const { container, getByText, getByLabelText } = render(
+    const { container, getByText, getByLabelText, getByTestId } = render(
       <Input
         labelText={labelText}
         inputStyle={{ color: inputColor }}
         labelStyle={{ color: labelColor }}
         containerStyle={{ color: divColor }}
+        inputWrapperStyle={{ width: wrapperWidth }}
+        testId="input"
       />
     );
 
     const div = container.querySelector('div');
     const label = getByText(labelText);
     const input = getByLabelText(labelText);
+    const wrapper = getByTestId('input-wrapper');
 
     expect(div).toHaveStyle(`color: ${divColor}`);
     expect(input).toHaveStyle(`color: ${inputColor}`);
     expect(label).toHaveStyle(`color: ${labelColor}`);
+    expect(wrapper).toHaveStyle(`width: ${wrapperWidth}`);
   });
 
   it('should render an inverse input with the correct styles', () => {

--- a/packages/react-magma-dom/src/components/Input/InputMessage.tsx
+++ b/packages/react-magma-dom/src/components/Input/InputMessage.tsx
@@ -32,7 +32,7 @@ function BuildMessageColor(props) {
 }
 
 const Message = typedStyled.div<InputMessageProps>`
-  align-items: center;
+  align-items: flex-start;
   border-radius: ${props => props.theme.borderRadius};
   color: ${props => BuildMessageColor(props)};
   display: flex;

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -108,7 +108,6 @@ export interface InputBaseProps
    * A number value which gives Character Counter the maximum length of allowable characters in an Input.
    * @deprecated = true
    */
-
   maxLength?: number;
   /**
    * Action that will fire when icon is clicked

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -79,6 +79,10 @@ export interface InputBaseProps
    */
   inputStyle?: React.CSSProperties;
   /**
+   * Style properties for input wrapper element
+   */
+  inputWrapperStyle?: React.CSSProperties;
+  /**
    * Total number of characters in an input.
    */
   inputLength?: number;
@@ -136,10 +140,6 @@ export interface InputBaseProps
    * @default "auto"
    */
   width?: string;
- /**
-   * Style properties for the outmost component container element
-   */
-    wrapperContainerStyle?: React.CSSProperties;
 }
 
 export interface InputWrapperStylesProps {
@@ -577,9 +577,9 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       inputLength,
       inputSize,
       inputStyle,
+      inputWrapperStyle,
       testId,
       type,
-      wrapperContainerStyle,
       ...other
     } = props;
 
@@ -643,7 +643,10 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
     };
 
     return (
-      <InputContainer style={wrapperContainerStyle}>
+      <InputContainer
+        style={inputWrapperStyle}
+        data-testid={`${testId}-wrapper`}
+      >
         <InputWrapper
           disabled={disabled}
           iconPosition={iconPosition}
@@ -663,7 +666,11 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             hasCharacterCounter={hasCharacterCounter}
             iconPosition={iconPosition}
             inputSize={inputSize ? inputSize : InputSize.medium}
-            isClearable={isClearable && inputLength > 0}
+            isClearable={
+              inputWrapperStyle?.width
+                ? isClearable
+                : isClearable && inputLength > 0
+            }
             isInverse={useIsInverse(props.isInverse)}
             isPredictive={isPredictive}
             hasError={hasError}

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -136,6 +136,10 @@ export interface InputBaseProps
    * @default "auto"
    */
   width?: string;
+ /**
+   * Style properties for the outmost component container element
+   */
+    wrapperContainerStyle?: React.CSSProperties;
 }
 
 export interface InputWrapperStylesProps {
@@ -575,6 +579,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       inputStyle,
       testId,
       type,
+      wrapperContainerStyle,
       ...other
     } = props;
 
@@ -638,7 +643,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
     };
 
     return (
-      <InputContainer>
+      <InputContainer style={wrapperContainerStyle}>
         <InputWrapper
           disabled={disabled}
           iconPosition={iconPosition}

--- a/packages/react-magma-dom/src/components/Label/index.tsx
+++ b/packages/react-magma-dom/src/components/Label/index.tsx
@@ -69,7 +69,7 @@ const StyledLabel = styled.label<{
     props.iconPosition === InputIconPosition.top ||
     props.labelPosition === LabelPosition.left
       ? 'inherit'
-      : 'nowrap'};
+      : 'normal'};
 `;
 
 const StyledSpan = StyledLabel.withComponent('span');

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -46,7 +46,34 @@ export function Example() {
 import React from 'react';
 import { Input, InputType } from 'react-magma-dom';
 export function Example() {
-  return <Input labelText="Number" type={InputType.number} />;
+  const [inputVal, setInputVal] = React.useState(1);
+  const [hasError, setHasError] = React.useState(false);
+
+  function handleChange(event) {
+    setInputVal(event.target.value);
+  }
+
+  React.useEffect(() => {
+    if (inputVal > 40 || inputVal < 1) {
+      setHasError(true);
+    } else {
+      setHasError(false);
+    }
+  }, [inputVal]);
+
+  return (
+    <Input
+      type={InputType.number}
+      labelText="Number 1-40"
+      inputWrapperStyle={{ width: '64px' }}
+      errorMessage={hasError ? 'Please enter a number between 1 - 40' : null}
+      helperMessage="Enter a number 1 - 40"
+      min={1}
+      max={40}
+      value={inputVal}
+      onChange={handleChange}
+    />
+  )
 }
 ```
 
@@ -597,6 +624,13 @@ All of the [standard input attributes](https://developer.mozilla.org/en-US/docs/
       },
       required: false,
       description: 'Style properties for the input element',
+    },
+    inputWrapperStyle: {
+      type: {
+        name: 'React.CSSProperties',
+      },
+      required: false,
+      description: 'Style properties for input wrapper element',
     },
     isInverse: {
       type: {


### PR DESCRIPTION
Issue: #

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

Add `inputWrapperStyle` prop to allow more flexibility with Input widths

## Screenshots:
<!-- Include screenshot of your change -->
Before:
![image](https://github.com/cengage/react-magma/assets/91160746/b58bfc6e-b24a-4e95-b400-61301c7fa8c7)

After:
![image](https://github.com/cengage/react-magma/assets/91160746/37c0615b-7a80-457a-98df-d2326e95a827)


## Checklist 
- [ ] changeset has been added
- [ ] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
