### PR TITLE
Hyperlink: Support Icons and toggling underline styling

### DIFF
--- a/.changeset/hyperlink.md
+++ b/.changeset/hyperlink.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Hyperlink): Support Icons and toggling underline styling

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -21,4 +21,5 @@ export const parameters = {
   viewport: {
     viewports: INITIAL_VIEWPORTS,
   },
+  docs: { source: { type: 'code' } }, // required for https://github.com/storybookjs/storybook/issues/19575
 };

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -89,6 +89,7 @@ export const NoUnderline = () => {
           </Hyperlink>
           <br />
           <br />
+
           <Hyperlink
             textTransform={ButtonTextTransform.none}
             target="_blank"
@@ -144,13 +145,42 @@ export const NoUnderline = () => {
         </CardBody>
       </Card>
       <br/>
+      
       <Card>
         <CardBody>
-          <a href="https://www.google.com">
-            This is a link that does not use Hyperlink
-          </a>
+        Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar brownie lemon drops tootsie roll pudding muffin powder pudding. <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.cengage.com/"
+            hasUnderline={false}
+          >
+            I love chocolate cake.
+          </Hyperlink> Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears shortbread.
         </CardBody>
       </Card>
+      <br/>
+      <Card isInverse>
+        <CardBody>
+        Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar brownie lemon drops tootsie roll pudding muffin powder pudding. <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.cengage.com/"
+            hasUnderline={false}
+            isInverse
+          >
+            I love chocolate cake.
+          </Hyperlink> Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears shortbread.
+        </CardBody>
+      </Card>
+      <br/>
+      <Card>
+        <CardBody>
+        Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar brownie lemon drops tootsie roll pudding muffin powder pudding. <a href="https://www.google.com">
+            This is a link that does not use Hyperlink.
+          </a> Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears shortbread.
+        </CardBody>
+      </Card>
+      
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonColor, ButtonSize, ButtonTextTransform } from '../Button';
+import { ButtonColor, ButtonTextTransform } from '../Button';
 import { Card, CardBody } from '../Card';
 import { Hyperlink, HyperlinkIconPosition } from '.';
 import { Flex, FlexBehavior, FlexJustify } from '../Flex';

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -11,6 +11,7 @@ import { TypographyVisualStyle } from '../Typography';
 import {
   CakeIcon,
   CalendarTodayIcon,
+  IcecreamIcon,
   KeyboardArrowLeftIcon,
   KeyboardArrowRightIcon,
   OpenInNewIcon,
@@ -19,9 +20,39 @@ import {
 export default {
   component: Hyperlink,
   title: 'Hyperlink',
+  argTypes: {
+    iconPosition: {
+      control: {
+        type: 'select',
+        options: HyperlinkIconPosition,
+      },
+    },
+    styledAs: {
+      control: {
+        type: 'select',
+        options: ['Button', 'Link'],
+      },
+    },
+  },
 } as Meta;
 
-export const Default = () => {
+export const Default = args => {
+  return (
+    <Hyperlink target="_blank" {...args}>
+      Next
+    </Hyperlink>
+  );
+};
+Default.args = {
+  styledAs: 'Link',
+  isInverse: false,
+  to: 'https://www.google.com',
+  hasUnderline: false,
+  icon: <KeyboardArrowRightIcon aria-hidden={true} />,
+  iconPosition: HyperlinkIconPosition.right,
+};
+
+export const All = args => {
   return (
     <>
       <Card>
@@ -123,12 +154,20 @@ export const Default = () => {
             target="_blank"
             to="https://www.cengage.com/"
             icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
-            iconPosition={HyperlinkIconPosition.left}
+            iconPosition={HyperlinkIconPosition.right}
           >
             I love chocolate cake
           </Hyperlink>{' '}
           Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
-          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
+          plum bonbon. {' '}<Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.cengage.com/"
+            icon={<IcecreamIcon size={magma.iconSizes.small} aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.left}
+          >
+            Ice cream
+          </Hyperlink>{' '}toffee pie macaroon apple pie gummi bears gummi bears
           shortbread.
         </CardBody>
       </Card>
@@ -298,8 +337,10 @@ export const Default = () => {
     </>
   );
 };
+All.args = {};
+All.parameters = { controls: { exclude: ['iconPosition', 'styledAs'] } };
 
-export const Inverse = () => {
+export const Inverse = args => {
   return (
     <>
       <Card isInverse>
@@ -417,7 +458,16 @@ export const Inverse = () => {
             I love chocolate cake
           </Hyperlink>{' '}
           Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
-          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
+          plum bonbon.{' '}<Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.cengage.com/"
+            icon={<IcecreamIcon size={magma.iconSizes.small} aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.left}
+            isInverse
+          >
+            Ice cream
+          </Hyperlink>{' '}toffee pie macaroon apple pie gummi bears gummi bears
           shortbread.
         </CardBody>
       </Card>
@@ -586,3 +636,5 @@ export const Inverse = () => {
     </>
   );
 };
+Inverse.args = {};
+Inverse.parameters = { controls: { exclude: ['iconPosition', 'styledAs'] } };

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -167,7 +167,8 @@ export const All = args => {
             iconPosition={HyperlinkIconPosition.left}
           >
             Ice cream
-          </Hyperlink>{' '}toffee pie macaroon apple pie gummi bears gummi bears
+          </Hyperlink>{' '}toffee pie macaroon <Hyperlink target="_blank"
+            to="https://www.apple.com/">apple</Hyperlink> pie gummi bears gummi bears
           shortbread.
         </CardBody>
       </Card>

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -3,7 +3,18 @@ import { Card, CardBody } from '../Card';
 import { Hyperlink, HyperlinkIconPosition } from '.';
 import { ButtonColor, ButtonTextTransform } from '../Button';
 import { Meta } from '@storybook/react/types-6-0';
-import { CalendarIcon, CheckCircleIcon, KeyboardArrowLeftIcon, KeyboardArrowRightIcon } from 'react-magma-icons';
+import {
+  CakeIcon,
+  CalendarTodayIcon,
+  CheckCircleIcon,
+  KeyboardArrowLeftIcon,
+  KeyboardArrowRightIcon,
+  OpenInNewIcon,
+} from 'react-magma-icons';
+import { Paragraph } from '../Paragraph';
+import { TypographyVisualStyle } from '../Typography';
+import { Flex, FlexBehavior, FlexJustify } from '../Flex';
+import { magma } from '../../theme/magma';
 
 export default {
   component: Hyperlink,
@@ -76,111 +87,290 @@ export const NoUnderline = () => {
     <>
       <Card>
         <CardBody>
-        <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            styledAs="Button"
-            target="_blank"
-            to="https://www.google.com"
-            hasUnderline={false}
-            icon={<KeyboardArrowRightIcon />}
-            iconPosition={HyperlinkIconPosition.right}
+          <Flex
+            behavior={FlexBehavior.container}
+            justify={FlexJustify.spaceBetween}
+          >
+            <span style={{ flex: '0 0 auto' }}>
+              <Hyperlink
+                textTransform={ButtonTextTransform.none}
+                target="_blank"
+                to="https://www.google.com"
+                hasUnderline={false}
+                icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
+                iconPosition={HyperlinkIconPosition.left}
+              >
+                Follow this link
+              </Hyperlink>
+            </span>
+            <span style={{ flex: '0 0 auto' }}>
+              <Hyperlink
+                textTransform={ButtonTextTransform.none}
+                target="_blank"
+                to="https://www.google.com"
+                hasUnderline={false}
+                icon={<KeyboardArrowRightIcon aria-hidden={true} />}
+                iconPosition={HyperlinkIconPosition.right}
+              >
+                Follow this link
+              </Hyperlink>
+            </span>
+          </Flex>
+        </CardBody>
+      </Card>
+      <br />
+      <Flex
+        behavior={FlexBehavior.container}
+        justify={FlexJustify.spaceBetween}
+      >
+        <Flex behavior={FlexBehavior.item}>
+          <Card>
+            <CardBody>
+              <Hyperlink
+                textTransform={ButtonTextTransform.none}
+                styledAs="Button"
+                target="_blank"
+                to="https://www.google.com"
+                hasUnderline={false}
+                icon={<KeyboardArrowRightIcon aria-hidden={true} />}
+                iconPosition={HyperlinkIconPosition.right}
+              >
+                Back Button
+              </Hyperlink>
+              <br />
+              <br />
+              <Hyperlink
+                textTransform={ButtonTextTransform.none}
+                target="_blank"
+                to="https://www.google.com"
+                hasUnderline={false}
+                icon={<CheckCircleIcon aria-hidden={true} />}
+                iconPosition={HyperlinkIconPosition.left}
+              >
+                Powder apple pie sugar plum cupcake
+              </Hyperlink>
+              <br />
+            </CardBody>
+          </Card>
+        </Flex>
+        <Flex behavior={FlexBehavior.item}>
+          <Card isInverse>
+            <CardBody>
+              <Hyperlink
+                textTransform={ButtonTextTransform.none}
+                styledAs="Button"
+                target="_blank"
+                to="https://www.google.com"
+                hasUnderline={false}
+                isInverse
+                icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
+                iconPosition={HyperlinkIconPosition.left}
+              >
+                Back Button
+              </Hyperlink>
+              <br />
+              <br />
+              <Hyperlink
+                textTransform={ButtonTextTransform.none}
+                target="_blank"
+                to="https://www.google.com"
+                hasUnderline={false}
+                isInverse
+                icon={<CheckCircleIcon aria-hidden={true} />}
+                iconPosition={HyperlinkIconPosition.right}
+              >
+                Sweet roll cotton candy carrot cake
+              </Hyperlink>
+            </CardBody>
+          </Card>
+        </Flex>
+      </Flex>
+      <br />
+      <Card>
+        <CardBody>
+          <Paragraph visualStyle={TypographyVisualStyle.headingSmall}>
+            Something something{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.xLarge}
+                  style={{ marginRight: magma.spaceScale.spacing03 }}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.xLarge}
+                  style={{ marginLeft: magma.spaceScale.spacing03 }}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
             >
-            Google as Button
-          </Hyperlink>
-          <br />
-          <br />
-
-          <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.google.com"
-            hasUnderline={false}
-            icon={<CheckCircleIcon />}
-            iconPosition={HyperlinkIconPosition.left}
-          >
-            Google
-          </Hyperlink>
-          <br />
-          <br />
-          <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.google.com"
-            hasUnderline={false}
-            icon={<CalendarIcon />}
-            iconPosition={HyperlinkIconPosition.both}
-          >
-            Schedule an appointment
-          </Hyperlink>
+              Schedule an appointment
+            </Hyperlink>{' '}
+            Other things
+          </Paragraph>
+          <Paragraph visualStyle={TypographyVisualStyle.bodyLarge}>
+            Something something{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.large}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.large}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+            >
+              Schedule an appointment
+            </Hyperlink>{' '}
+            Other things
+          </Paragraph>
+          <Paragraph visualStyle={TypographyVisualStyle.bodyMedium}>
+            Something something{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.medium}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.medium}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+            >
+              Schedule an appointment
+            </Hyperlink>{' '}
+            Other things
+          </Paragraph>
+          <Paragraph visualStyle={TypographyVisualStyle.bodySmall}>
+            Something something{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.small}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.small}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+            >
+              Schedule an appointment
+            </Hyperlink>{' '}
+            Other things
+          </Paragraph>
+          <Paragraph visualStyle={TypographyVisualStyle.bodyXSmall}>
+            Something something{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.xSmall}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.xSmall}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+            >
+              Schedule an appointment
+            </Hyperlink>{' '}
+            Other things
+          </Paragraph>
         </CardBody>
       </Card>
-      <br/>
-      <Card isInverse>
+      <br />
+      <Card>
         <CardBody>
-        <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            styledAs="Button"
-            target="_blank"
-            to="https://www.google.com"
-            hasUnderline={false}
-            isInverse
-            icon={<KeyboardArrowLeftIcon />}
-            iconPosition={HyperlinkIconPosition.left}
-          >
-            Google as Button
-          </Hyperlink>
-          <br/>
-          <br/>
+          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
+          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
           <Hyperlink
             textTransform={ButtonTextTransform.none}
             target="_blank"
-            to="https://www.google.com"
+            to="https://www.cengage.com/"
+            hasUnderline={false}
+            icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.left}
+          >
+            I love chocolate cake.
+          </Hyperlink>{' '}
+          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
+          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
+          shortbread.
+        </CardBody>
+      </Card>
+      <br />
+      <Card isInverse>
+        <CardBody>
+          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
+          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
+          <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.cengage.com/"
             hasUnderline={false}
             isInverse
-            icon={<CheckCircleIcon />}
+            icon={<CakeIcon aria-hidden={true} />}
             iconPosition={HyperlinkIconPosition.right}
           >
-            Google
-          </Hyperlink>
+            I love chocolate cake
+          </Hyperlink>{' '}
+          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
+          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
+          shortbread.
         </CardBody>
       </Card>
-      <br/>
-      
+      <br />
       <Card>
         <CardBody>
-        Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar brownie lemon drops tootsie roll pudding muffin powder pudding. <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.cengage.com/"
-            hasUnderline={false}
-          >
-            I love chocolate cake.
-          </Hyperlink> Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears shortbread.
-        </CardBody>
-      </Card>
-      <br/>
-      <Card isInverse>
-        <CardBody>
-        Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar brownie lemon drops tootsie roll pudding muffin powder pudding. <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.cengage.com/"
-            hasUnderline={false}
-            isInverse
-          >
-            I love chocolate cake.
-          </Hyperlink> Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears shortbread.
-        </CardBody>
-      </Card>
-      <br/>
-      <Card>
-        <CardBody>
-        Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar brownie lemon drops tootsie roll pudding muffin powder pudding. <a href="https://www.google.com">
+          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
+          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
+          <a href="https://www.google.com">
             This is a link that does not use Hyperlink.
-          </a> Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears shortbread.
+          </a>{' '}
+          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
+          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
+          shortbread.
         </CardBody>
       </Card>
-      
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Card, CardBody } from '../Card';
-import { Hyperlink } from '.';
+import { Hyperlink, HyperlinkIconPosition } from '.';
 import { ButtonColor, ButtonTextTransform } from '../Button';
 import { Meta } from '@storybook/react/types-6-0';
+import { CalendarIcon, CheckCircleIcon, KeyboardArrowLeftIcon, KeyboardArrowRightIcon } from 'react-magma-icons';
 
 export default {
   component: Hyperlink,
@@ -61,7 +62,93 @@ export const Default = () => {
       </Card>
       <Card>
         <CardBody>
-          <a href="https://www.google.com">This is a link that does not use Hyperlink</a>
+          <a href="https://www.google.com">
+            This is a link that does not use Hyperlink
+          </a>
+        </CardBody>
+      </Card>
+    </>
+  );
+};
+
+export const NoUnderline = () => {
+  return (
+    <>
+      <Card>
+        <CardBody>
+        <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            styledAs="Button"
+            target="_blank"
+            to="https://www.google.com"
+            hasUnderline={false}
+            icon={<KeyboardArrowRightIcon />}
+            iconPosition={HyperlinkIconPosition.right}
+            >
+            Google as Button
+          </Hyperlink>
+          <br />
+          <br />
+          <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.google.com"
+            hasUnderline={false}
+            icon={<CheckCircleIcon />}
+            iconPosition={HyperlinkIconPosition.left}
+          >
+            Google
+          </Hyperlink>
+          <br />
+          <br />
+          <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.google.com"
+            hasUnderline={false}
+            icon={<CalendarIcon />}
+            iconPosition={HyperlinkIconPosition.both}
+          >
+            Schedule an appointment
+          </Hyperlink>
+        </CardBody>
+      </Card>
+      <br/>
+      <Card isInverse>
+        <CardBody>
+        <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            styledAs="Button"
+            target="_blank"
+            to="https://www.google.com"
+            hasUnderline={false}
+            isInverse
+            icon={<KeyboardArrowLeftIcon />}
+            iconPosition={HyperlinkIconPosition.left}
+          >
+            Google as Button
+          </Hyperlink>
+          <br/>
+          <br/>
+          <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.google.com"
+            hasUnderline={false}
+            isInverse
+            icon={<CheckCircleIcon />}
+            iconPosition={HyperlinkIconPosition.right}
+          >
+            Google
+          </Hyperlink>
+        </CardBody>
+      </Card>
+      <br/>
+      <Card>
+        <CardBody>
+          <a href="https://www.google.com">
+            This is a link that does not use Hyperlink
+          </a>
         </CardBody>
       </Card>
     </>

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -147,29 +147,39 @@ export const All = args => {
       <Spacer size={'12px'} />
       <Card>
         <CardBody>
-          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
-          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
-          <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.cengage.com/"
-            icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
-            iconPosition={HyperlinkIconPosition.right}
-          >
-            I love chocolate cake
-          </Hyperlink>{' '}
-          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
-          plum bonbon. {' '}<Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.cengage.com/"
-            icon={<IcecreamIcon size={magma.iconSizes.small} aria-hidden={true} />}
-            iconPosition={HyperlinkIconPosition.left}
-          >
-            Ice cream
-          </Hyperlink>{' '}toffee pie macaroon <Hyperlink target="_blank"
-            to="https://www.apple.com/">apple</Hyperlink> pie gummi bears gummi bears
-          shortbread.
+          <p>
+            Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
+            brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.cengage.com/"
+              icon={
+                <CakeIcon size={magma.iconSizes.small} aria-hidden={true} />
+              }
+              iconPosition={HyperlinkIconPosition.right}
+            >
+              I love chocolate cake
+            </Hyperlink>{' '}
+            Pastry dragée cheesecake chocolate bar donut jujubes candy canes
+            sugar plum bonbon.{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.cengage.com/"
+              icon={
+                <IcecreamIcon size={magma.iconSizes.small} aria-hidden={true} />
+              }
+              iconPosition={HyperlinkIconPosition.left}
+            >
+              Ice cream
+            </Hyperlink>{' '}
+            toffee pie macaroon{' '}
+            <Hyperlink target="_blank" to="https://www.apple.com/">
+              apple
+            </Hyperlink>{' '}
+            pie gummi bears gummi bears shortbread.
+          </p>
         </CardBody>
       </Card>
       <Spacer size={'12px'} />
@@ -217,6 +227,7 @@ export const All = args => {
             </Hyperlink>{' '}
             to meet with us.
           </Paragraph>
+          <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyLarge}
             style={{ display: 'inline-flex', alignItems: 'center' }}
@@ -246,6 +257,7 @@ export const All = args => {
             </Hyperlink>{' '}
             to meet with us.
           </Paragraph>
+          <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyMedium}
             style={{ display: 'inline-flex', alignItems: 'center' }}
@@ -275,6 +287,7 @@ export const All = args => {
             </Hyperlink>{' '}
             to meet with us.
           </Paragraph>
+          <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodySmall}
             style={{ display: 'inline-flex', alignItems: 'center' }}
@@ -304,6 +317,7 @@ export const All = args => {
             </Hyperlink>{' '}
             to meet with us.
           </Paragraph>
+          <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyXSmall}
             style={{ display: 'inline-flex', alignItems: 'center' }}
@@ -446,30 +460,37 @@ export const Inverse = args => {
       <Spacer size={'12px'} />
       <Card isInverse>
         <CardBody>
-          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
-          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
-          <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.cengage.com/"
-            icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
-            iconPosition={HyperlinkIconPosition.right}
-            isInverse
-          >
-            I love chocolate cake
-          </Hyperlink>{' '}
-          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
-          plum bonbon.{' '}<Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.cengage.com/"
-            icon={<IcecreamIcon size={magma.iconSizes.small} aria-hidden={true} />}
-            iconPosition={HyperlinkIconPosition.left}
-            isInverse
-          >
-            Ice cream
-          </Hyperlink>{' '}toffee pie macaroon apple pie gummi bears gummi bears
-          shortbread.
+          <p>
+            Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
+            brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.cengage.com/"
+              icon={
+                <CakeIcon size={magma.iconSizes.small} aria-hidden={true} />
+              }
+              iconPosition={HyperlinkIconPosition.right}
+              isInverse
+            >
+              I love chocolate cake
+            </Hyperlink>{' '}
+            Pastry dragée cheesecake chocolate bar donut jujubes candy canes
+            sugar plum bonbon.{' '}
+            <Hyperlink
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.cengage.com/"
+              icon={
+                <IcecreamIcon size={magma.iconSizes.small} aria-hidden={true} />
+              }
+              iconPosition={HyperlinkIconPosition.left}
+              isInverse
+            >
+              Ice cream
+            </Hyperlink>{' '}
+            toffee pie macaroon apple pie gummi bears gummi bears shortbread.
+          </p>
         </CardBody>
       </Card>
       <Spacer size={'12px'} />
@@ -508,6 +529,7 @@ export const Inverse = args => {
             </Hyperlink>{' '}
             to meet with us.
           </Paragraph>
+          <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyLarge}
             style={{ display: 'inline-flex', alignItems: 'center' }}
@@ -539,6 +561,7 @@ export const Inverse = args => {
             </Hyperlink>{' '}
             to meet with us.
           </Paragraph>
+          <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyMedium}
             style={{ display: 'inline-flex', alignItems: 'center' }}
@@ -570,6 +593,7 @@ export const Inverse = args => {
             </Hyperlink>{' '}
             to meet with us.
           </Paragraph>
+          <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodySmall}
             style={{ display: 'inline-flex', alignItems: 'center' }}
@@ -601,6 +625,7 @@ export const Inverse = args => {
             </Hyperlink>{' '}
             to meet with us.
           </Paragraph>
+          <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             isInverse
             visualStyle={TypographyVisualStyle.bodyXSmall}

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonColor, ButtonTextTransform } from '../Button';
+import { ButtonColor, ButtonSize, ButtonTextTransform } from '../Button';
 import { Card, CardBody } from '../Card';
 import { Hyperlink, HyperlinkIconPosition } from '.';
 import { Flex, FlexBehavior, FlexJustify } from '../Flex';
@@ -47,7 +47,6 @@ export const Default = () => {
             styledAs="Button"
             target="_blank"
             to="https://www.google.com"
-            hasUnderline={false}
             icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
             iconPosition={HyperlinkIconPosition.left}
           >
@@ -59,7 +58,6 @@ export const Default = () => {
             styledAs="Button"
             target="_blank"
             to="https://www.google.com"
-            hasUnderline={false}
             icon={[
               <KeyboardArrowLeftIcon aria-hidden={true} key={0} />,
               <KeyboardArrowRightIcon aria-hidden={true} key={1} />,
@@ -74,7 +72,6 @@ export const Default = () => {
             styledAs="Button"
             target="_blank"
             to="https://www.google.com"
-            hasUnderline={false}
             icon={<KeyboardArrowRightIcon aria-hidden={true} />}
             iconPosition={HyperlinkIconPosition.right}
           >

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
+import { ButtonColor, ButtonTextTransform } from '../Button';
 import { Card, CardBody } from '../Card';
 import { Hyperlink, HyperlinkIconPosition } from '.';
-import { ButtonColor, ButtonTextTransform } from '../Button';
+import { Flex, FlexBehavior, FlexJustify } from '../Flex';
 import { Meta } from '@storybook/react/types-6-0';
+import { magma } from '../../theme/magma';
+import { Paragraph } from '../Paragraph';
+import { Spacer, SpacerAxis } from '../Spacer';
+import { TypographyVisualStyle } from '../Typography';
 import {
   CakeIcon,
   CalendarTodayIcon,
-  CheckCircleIcon,
   KeyboardArrowLeftIcon,
   KeyboardArrowRightIcon,
   OpenInNewIcon,
 } from 'react-magma-icons';
-import { Paragraph } from '../Paragraph';
-import { TypographyVisualStyle } from '../Typography';
-import { Flex, FlexBehavior, FlexJustify } from '../Flex';
-import { magma } from '../../theme/magma';
 
 export default {
   component: Hyperlink,
@@ -28,28 +28,12 @@ export const Default = () => {
         <CardBody>
           <Hyperlink
             textTransform={ButtonTextTransform.none}
-            styledAs="Button"
             target="_blank"
             to="https://www.google.com"
           >
             Google
           </Hyperlink>
-          <Hyperlink
-            color={ButtonColor.secondary}
-            styledAs="Button"
-            target="_blank"
-            to="https://www.google.com"
-          >
-            Google
-          </Hyperlink>
-          <Hyperlink
-            color={ButtonColor.danger}
-            styledAs="Button"
-            target="_blank"
-            to="https://www.google.com"
-          >
-            Google
-          </Hyperlink>
+          <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
           <Hyperlink
             color={ButtonColor.marketing}
             styledAs="Button"
@@ -58,33 +42,47 @@ export const Default = () => {
           >
             Google
           </Hyperlink>
-        </CardBody>
-      </Card>
-      <Card>
-        <CardBody>
+          <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
           <Hyperlink
-            textTransform={ButtonTextTransform.none}
+            styledAs="Button"
             target="_blank"
             to="https://www.google.com"
+            hasUnderline={false}
+            icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.left}
           >
-            Google
+            Back
+          </Hyperlink>
+          <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
+          <Hyperlink
+            color={ButtonColor.danger}
+            styledAs="Button"
+            target="_blank"
+            to="https://www.google.com"
+            hasUnderline={false}
+            icon={[
+              <KeyboardArrowLeftIcon aria-hidden={true} key={0} />,
+              <KeyboardArrowRightIcon aria-hidden={true} key={1} />,
+            ]}
+            iconPosition={HyperlinkIconPosition.both}
+          >
+            Guess
+          </Hyperlink>
+          <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
+          <Hyperlink
+            color={ButtonColor.secondary}
+            styledAs="Button"
+            target="_blank"
+            to="https://www.google.com"
+            hasUnderline={false}
+            icon={<KeyboardArrowRightIcon aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.right}
+          >
+            Next
           </Hyperlink>
         </CardBody>
       </Card>
-      <Card>
-        <CardBody>
-          <a href="https://www.google.com">
-            This is a link that does not use Hyperlink
-          </a>
-        </CardBody>
-      </Card>
-    </>
-  );
-};
-
-export const NoUnderline = () => {
-  return (
-    <>
+      <Spacer size={'12px'} />
       <Card>
         <CardBody>
           <Flex
@@ -95,101 +93,67 @@ export const NoUnderline = () => {
               <Hyperlink
                 textTransform={ButtonTextTransform.none}
                 target="_blank"
-                to="https://www.google.com"
+                to="#"
                 hasUnderline={false}
                 icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
                 iconPosition={HyperlinkIconPosition.left}
               >
-                Follow this link
+                Brownie
               </Hyperlink>
             </span>
             <span style={{ flex: '0 0 auto' }}>
               <Hyperlink
                 textTransform={ButtonTextTransform.none}
                 target="_blank"
-                to="https://www.google.com"
+                to="#"
                 hasUnderline={false}
                 icon={<KeyboardArrowRightIcon aria-hidden={true} />}
                 iconPosition={HyperlinkIconPosition.right}
               >
-                Follow this link
+                Muffin
               </Hyperlink>
             </span>
           </Flex>
         </CardBody>
       </Card>
-      <br />
-      <Flex
-        behavior={FlexBehavior.container}
-        justify={FlexJustify.spaceBetween}
-      >
-        <Flex behavior={FlexBehavior.item}>
-          <Card>
-            <CardBody>
-              <Hyperlink
-                textTransform={ButtonTextTransform.none}
-                styledAs="Button"
-                target="_blank"
-                to="https://www.google.com"
-                hasUnderline={false}
-                icon={<KeyboardArrowRightIcon aria-hidden={true} />}
-                iconPosition={HyperlinkIconPosition.right}
-              >
-                Back Button
-              </Hyperlink>
-              <br />
-              <br />
-              <Hyperlink
-                textTransform={ButtonTextTransform.none}
-                target="_blank"
-                to="https://www.google.com"
-                hasUnderline={false}
-                icon={<CheckCircleIcon aria-hidden={true} />}
-                iconPosition={HyperlinkIconPosition.left}
-              >
-                Powder apple pie sugar plum cupcake
-              </Hyperlink>
-              <br />
-            </CardBody>
-          </Card>
-        </Flex>
-        <Flex behavior={FlexBehavior.item}>
-          <Card isInverse>
-            <CardBody>
-              <Hyperlink
-                textTransform={ButtonTextTransform.none}
-                styledAs="Button"
-                target="_blank"
-                to="https://www.google.com"
-                hasUnderline={false}
-                isInverse
-                icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
-                iconPosition={HyperlinkIconPosition.left}
-              >
-                Back Button
-              </Hyperlink>
-              <br />
-              <br />
-              <Hyperlink
-                textTransform={ButtonTextTransform.none}
-                target="_blank"
-                to="https://www.google.com"
-                hasUnderline={false}
-                isInverse
-                icon={<CheckCircleIcon aria-hidden={true} />}
-                iconPosition={HyperlinkIconPosition.right}
-              >
-                Sweet roll cotton candy carrot cake
-              </Hyperlink>
-            </CardBody>
-          </Card>
-        </Flex>
-      </Flex>
-      <br />
+      <Spacer size={'12px'} />
       <Card>
         <CardBody>
-          <Paragraph visualStyle={TypographyVisualStyle.headingSmall}>
-            Something something{' '}
+          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
+          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
+          <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.cengage.com/"
+            icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.left}
+          >
+            I love chocolate cake
+          </Hyperlink>{' '}
+          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
+          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
+          shortbread.
+        </CardBody>
+      </Card>
+      <Spacer size={'12px'} />
+      <Card>
+        <CardBody>
+          Apple pie danish apple pie tootsie roll tiramisu dessert danish.{' '}
+          <a href="https://www.google.com">
+            This is a link that does not use Hyperlink.
+          </a>{' '}
+          Marzipan candy danish chupa chups icing jelly-o danish halvah jelly.
+          Cake dragée candy canes liquorice cheesecake tootsie roll danish.
+        </CardBody>
+      </Card>
+      <Spacer size={'12px'} />
+      <Card>
+        <CardBody>
+          <Paragraph
+            visualStyle={TypographyVisualStyle.headingSmall}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            You can{' '}
             <Hyperlink
               textTransform={ButtonTextTransform.none}
               target="_blank"
@@ -210,13 +174,17 @@ export const NoUnderline = () => {
                 />,
               ]}
               iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
             >
-              Schedule an appointment
+              schedule an appointment
             </Hyperlink>{' '}
-            Other things
+            to meet with us.
           </Paragraph>
-          <Paragraph visualStyle={TypographyVisualStyle.bodyLarge}>
-            Something something{' '}
+          <Paragraph
+            visualStyle={TypographyVisualStyle.bodyLarge}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            You can{' '}
             <Hyperlink
               textTransform={ButtonTextTransform.none}
               target="_blank"
@@ -235,13 +203,17 @@ export const NoUnderline = () => {
                 />,
               ]}
               iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
             >
-              Schedule an appointment
+              schedule an appointment
             </Hyperlink>{' '}
-            Other things
+            to meet with us.
           </Paragraph>
-          <Paragraph visualStyle={TypographyVisualStyle.bodyMedium}>
-            Something something{' '}
+          <Paragraph
+            visualStyle={TypographyVisualStyle.bodyMedium}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            You can{' '}
             <Hyperlink
               textTransform={ButtonTextTransform.none}
               target="_blank"
@@ -260,13 +232,17 @@ export const NoUnderline = () => {
                 />,
               ]}
               iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
             >
-              Schedule an appointment
+              schedule an appointment
             </Hyperlink>{' '}
-            Other things
+            to meet with us.
           </Paragraph>
-          <Paragraph visualStyle={TypographyVisualStyle.bodySmall}>
-            Something something{' '}
+          <Paragraph
+            visualStyle={TypographyVisualStyle.bodySmall}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            You can{' '}
             <Hyperlink
               textTransform={ButtonTextTransform.none}
               target="_blank"
@@ -285,13 +261,17 @@ export const NoUnderline = () => {
                 />,
               ]}
               iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
             >
-              Schedule an appointment
+              schedule an appointment
             </Hyperlink>{' '}
-            Other things
+            to meet with us.
           </Paragraph>
-          <Paragraph visualStyle={TypographyVisualStyle.bodyXSmall}>
-            Something something{' '}
+          <Paragraph
+            visualStyle={TypographyVisualStyle.bodyXSmall}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            You can{' '}
             <Hyperlink
               textTransform={ButtonTextTransform.none}
               target="_blank"
@@ -310,65 +290,12 @@ export const NoUnderline = () => {
                 />,
               ]}
               iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
             >
-              Schedule an appointment
+              schedule an appointment
             </Hyperlink>{' '}
-            Other things
+            to meet with us.
           </Paragraph>
-        </CardBody>
-      </Card>
-      <br />
-      <Card>
-        <CardBody>
-          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
-          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
-          <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.cengage.com/"
-            hasUnderline={false}
-            icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
-            iconPosition={HyperlinkIconPosition.left}
-          >
-            I love chocolate cake.
-          </Hyperlink>{' '}
-          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
-          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
-          shortbread.
-        </CardBody>
-      </Card>
-      <br />
-      <Card isInverse>
-        <CardBody>
-          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
-          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
-          <Hyperlink
-            textTransform={ButtonTextTransform.none}
-            target="_blank"
-            to="https://www.cengage.com/"
-            hasUnderline={false}
-            isInverse
-            icon={<CakeIcon aria-hidden={true} />}
-            iconPosition={HyperlinkIconPosition.right}
-          >
-            I love chocolate cake
-          </Hyperlink>{' '}
-          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
-          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
-          shortbread.
-        </CardBody>
-      </Card>
-      <br />
-      <Card>
-        <CardBody>
-          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
-          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
-          <a href="https://www.google.com">
-            This is a link that does not use Hyperlink.
-          </a>{' '}
-          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
-          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
-          shortbread.
         </CardBody>
       </Card>
     </>
@@ -382,31 +309,13 @@ export const Inverse = () => {
         <CardBody>
           <Hyperlink
             textTransform={ButtonTextTransform.none}
-            styledAs="Button"
             target="_blank"
             to="https://www.google.com"
             isInverse
           >
             Google
           </Hyperlink>
-          <Hyperlink
-            color={ButtonColor.secondary}
-            styledAs="Button"
-            target="_blank"
-            to="https://www.google.com"
-            isInverse
-          >
-            Google
-          </Hyperlink>
-          <Hyperlink
-            color={ButtonColor.danger}
-            styledAs="Button"
-            target="_blank"
-            to="https://www.google.com"
-            isInverse
-          >
-            Google
-          </Hyperlink>
+          <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
           <Hyperlink
             color={ButtonColor.marketing}
             styledAs="Button"
@@ -416,18 +325,265 @@ export const Inverse = () => {
           >
             Google
           </Hyperlink>
-        </CardBody>
-      </Card>
-      <Card isInverse>
-        <CardBody>
+          <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
           <Hyperlink
-            textTransform={ButtonTextTransform.none}
+            styledAs="Button"
             target="_blank"
             to="https://www.google.com"
             isInverse
+            hasUnderline={false}
+            icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.left}
           >
-            Google
+            Back
           </Hyperlink>
+          <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
+          <Hyperlink
+            color={ButtonColor.danger}
+            styledAs="Button"
+            target="_blank"
+            to="https://www.google.com"
+            isInverse
+            hasUnderline={false}
+            icon={[
+              <KeyboardArrowLeftIcon aria-hidden={true} key={0} />,
+              <KeyboardArrowRightIcon aria-hidden={true} key={1} />,
+            ]}
+            iconPosition={HyperlinkIconPosition.both}
+          >
+            Guess
+          </Hyperlink>
+          <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
+          <Hyperlink
+            color={ButtonColor.secondary}
+            styledAs="Button"
+            target="_blank"
+            to="https://www.google.com"
+            hasUnderline={false}
+            isInverse
+            icon={<KeyboardArrowRightIcon aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.right}
+          >
+            Next
+          </Hyperlink>
+        </CardBody>
+      </Card>
+      <Spacer size={'12px'} />
+      <Card isInverse>
+        <CardBody>
+          <Flex
+            behavior={FlexBehavior.container}
+            justify={FlexJustify.spaceBetween}
+          >
+            <span style={{ flex: '0 0 auto' }}>
+              <Hyperlink
+                textTransform={ButtonTextTransform.none}
+                target="_blank"
+                to="#"
+                hasUnderline={false}
+                icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
+                iconPosition={HyperlinkIconPosition.left}
+                isInverse
+              >
+                Brownie
+              </Hyperlink>
+            </span>
+            <span style={{ flex: '0 0 auto' }}>
+              <Hyperlink
+                textTransform={ButtonTextTransform.none}
+                target="_blank"
+                to="#"
+                hasUnderline={false}
+                icon={<KeyboardArrowRightIcon aria-hidden={true} />}
+                iconPosition={HyperlinkIconPosition.right}
+                isInverse
+              >
+                Muffin
+              </Hyperlink>
+            </span>
+          </Flex>
+        </CardBody>
+      </Card>
+      <Spacer size={'12px'} />
+      <Card isInverse>
+        <CardBody>
+          Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
+          brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
+          <Hyperlink
+            textTransform={ButtonTextTransform.none}
+            target="_blank"
+            to="https://www.cengage.com/"
+            icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.right}
+            isInverse
+          >
+            I love chocolate cake
+          </Hyperlink>{' '}
+          Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
+          plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
+          shortbread.
+        </CardBody>
+      </Card>
+      <Spacer size={'12px'} />
+      <Card isInverse>
+        <CardBody>
+          <Paragraph
+            visualStyle={TypographyVisualStyle.headingSmall}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+            isInverse
+          >
+            You can{' '}
+            <Hyperlink
+              isInverse
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.xLarge}
+                  style={{ marginRight: magma.spaceScale.spacing03 }}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.xLarge}
+                  style={{ marginLeft: magma.spaceScale.spacing03 }}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
+            >
+              schedule an appointment
+            </Hyperlink>{' '}
+            to meet with us.
+          </Paragraph>
+          <Paragraph
+            visualStyle={TypographyVisualStyle.bodyLarge}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+            isInverse
+          >
+            You can{' '}
+            <Hyperlink
+              isInverse
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.large}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.large}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
+            >
+              schedule an appointment
+            </Hyperlink>{' '}
+            to meet with us.
+          </Paragraph>
+          <Paragraph
+            visualStyle={TypographyVisualStyle.bodyMedium}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+            isInverse
+          >
+            You can{' '}
+            <Hyperlink
+              isInverse
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.medium}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.medium}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
+            >
+              schedule an appointment
+            </Hyperlink>{' '}
+            to meet with us.
+          </Paragraph>
+          <Paragraph
+            visualStyle={TypographyVisualStyle.bodySmall}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+            isInverse
+          >
+            You can{' '}
+            <Hyperlink
+              isInverse
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.small}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.small}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
+            >
+              schedule an appointment
+            </Hyperlink>{' '}
+            to meet with us.
+          </Paragraph>
+          <Paragraph
+            isInverse
+            visualStyle={TypographyVisualStyle.bodyXSmall}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            You can{' '}
+            <Hyperlink
+              isInverse
+              textTransform={ButtonTextTransform.none}
+              target="_blank"
+              to="https://www.google.com"
+              hasUnderline={false}
+              icon={[
+                <CalendarTodayIcon
+                  key={0}
+                  size={magma.iconSizes.xSmall}
+                  aria-hidden={true}
+                />,
+                <OpenInNewIcon
+                  key={1}
+                  size={magma.iconSizes.xSmall}
+                  aria-hidden={true}
+                />,
+              ]}
+              iconPosition={HyperlinkIconPosition.both}
+              style={{ margin: `0 ${magma.spaceScale.spacing03}` }}
+            >
+              schedule an appointment
+            </Hyperlink>{' '}
+            to meet with us.
+          </Paragraph>
         </CardBody>
       </Card>
     </>

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.stories.tsx
@@ -9,9 +9,7 @@ import { Paragraph } from '../Paragraph';
 import { Spacer, SpacerAxis } from '../Spacer';
 import { TypographyVisualStyle } from '../Typography';
 import {
-  CakeIcon,
   CalendarTodayIcon,
-  IcecreamIcon,
   KeyboardArrowLeftIcon,
   KeyboardArrowRightIcon,
   OpenInNewIcon,
@@ -37,10 +35,22 @@ export default {
 } as Meta;
 
 export const Default = args => {
+  const { iconPosition } = args;
+
   return (
-    <Hyperlink target="_blank" {...args}>
-      Next
-    </Hyperlink>
+    <>
+      <Hyperlink
+        target="_blank"
+        {...args}
+        icon={
+          iconPosition === HyperlinkIconPosition.both
+            ? [args.icon, <KeyboardArrowLeftIcon aria-hidden={true} key={0} />]
+            : args.icon
+        }
+      >
+        Next
+      </Hyperlink>
+    </>
   );
 };
 Default.args = {
@@ -155,26 +165,17 @@ export const All = args => {
               target="_blank"
               to="https://www.cengage.com/"
               icon={
-                <CakeIcon size={magma.iconSizes.small} aria-hidden={true} />
+                <OpenInNewIcon
+                  size={magma.iconSizes.small}
+                  aria-hidden={true}
+                />
               }
               iconPosition={HyperlinkIconPosition.right}
             >
               I love chocolate cake
             </Hyperlink>{' '}
             Pastry dragée cheesecake chocolate bar donut jujubes candy canes
-            sugar plum bonbon.{' '}
-            <Hyperlink
-              textTransform={ButtonTextTransform.none}
-              target="_blank"
-              to="https://www.cengage.com/"
-              icon={
-                <IcecreamIcon size={magma.iconSizes.small} aria-hidden={true} />
-              }
-              iconPosition={HyperlinkIconPosition.left}
-            >
-              Ice cream
-            </Hyperlink>{' '}
-            toffee pie macaroon{' '}
+            sugar plum bonbon. Toffee pie macaroon{' '}
             <Hyperlink target="_blank" to="https://www.apple.com/">
               apple
             </Hyperlink>{' '}
@@ -198,7 +199,11 @@ export const All = args => {
         <CardBody>
           <Paragraph
             visualStyle={TypographyVisualStyle.headingSmall}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
           >
             You can{' '}
             <Hyperlink
@@ -230,7 +235,11 @@ export const All = args => {
           <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyLarge}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
           >
             You can{' '}
             <Hyperlink
@@ -260,7 +269,11 @@ export const All = args => {
           <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyMedium}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
           >
             You can{' '}
             <Hyperlink
@@ -290,7 +303,11 @@ export const All = args => {
           <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodySmall}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
           >
             You can{' '}
             <Hyperlink
@@ -320,7 +337,11 @@ export const All = args => {
           <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyXSmall}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
           >
             You can{' '}
             <Hyperlink
@@ -468,7 +489,10 @@ export const Inverse = args => {
               target="_blank"
               to="https://www.cengage.com/"
               icon={
-                <CakeIcon size={magma.iconSizes.small} aria-hidden={true} />
+                <OpenInNewIcon
+                  size={magma.iconSizes.small}
+                  aria-hidden={true}
+                />
               }
               iconPosition={HyperlinkIconPosition.right}
               isInverse
@@ -476,20 +500,11 @@ export const Inverse = args => {
               I love chocolate cake
             </Hyperlink>{' '}
             Pastry dragée cheesecake chocolate bar donut jujubes candy canes
-            sugar plum bonbon.{' '}
-            <Hyperlink
-              textTransform={ButtonTextTransform.none}
-              target="_blank"
-              to="https://www.cengage.com/"
-              icon={
-                <IcecreamIcon size={magma.iconSizes.small} aria-hidden={true} />
-              }
-              iconPosition={HyperlinkIconPosition.left}
-              isInverse
-            >
-              Ice cream
+            sugar plum bonbon. Toffee pie macaroon{' '}
+            <Hyperlink target="_blank" to="https://www.apple.com/" isInverse>
+              apple
             </Hyperlink>{' '}
-            toffee pie macaroon apple pie gummi bears gummi bears shortbread.
+            pie gummi bears gummi bears shortbread.
           </p>
         </CardBody>
       </Card>
@@ -498,7 +513,11 @@ export const Inverse = args => {
         <CardBody>
           <Paragraph
             visualStyle={TypographyVisualStyle.headingSmall}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
             isInverse
           >
             You can{' '}
@@ -532,7 +551,11 @@ export const Inverse = args => {
           <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyLarge}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
             isInverse
           >
             You can{' '}
@@ -564,7 +587,11 @@ export const Inverse = args => {
           <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodyMedium}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
             isInverse
           >
             You can{' '}
@@ -596,7 +623,11 @@ export const Inverse = args => {
           <Spacer size={'8px'} axis={SpacerAxis.vertical} />
           <Paragraph
             visualStyle={TypographyVisualStyle.bodySmall}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
             isInverse
           >
             You can{' '}
@@ -629,7 +660,11 @@ export const Inverse = args => {
           <Paragraph
             isInverse
             visualStyle={TypographyVisualStyle.bodyXSmall}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
           >
             You can{' '}
             <Hyperlink

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.test.js
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.test.js
@@ -1,9 +1,25 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { Hyperlink } from '.';
+import { axe } from '../../../axe-helper';
+import { getByTestId, render } from '@testing-library/react';
+import { Hyperlink, HyperlinkIconPosition } from '.';
 import { magma } from '../../theme/magma';
+import { KeyboardArrowRightIcon } from 'react-magma-icons';
+import { ButtonSize } from '../Button';
 
 describe('Hyperlink', () => {
+  it('does not violate detectible accessibility standards', () => {
+    const testId = 'a11y-test-id';
+    const { container } = render(
+      <Hyperlink to="https://www.google.com" testId={testId}>
+        Google
+      </Hyperlink>
+    );
+
+    return axe(container.innerHTML).then(result => {
+      return expect(result).toHaveNoViolations();
+    });
+  });
+
   it('should find element by testId', () => {
     const testId = 'test-id';
     const { getByTestId } = render(
@@ -16,47 +32,61 @@ describe('Hyperlink', () => {
   });
 
   it('should render a basic anchor element', () => {
-    const { getByText } = render(
-      <Hyperlink to="https://www.google.com">Google</Hyperlink>
+    const testId = 'test-id-basic';
+    const { getByTestId } = render(
+      <Hyperlink to="https://www.google.com" testId={testId}>
+        Google
+      </Hyperlink>
     );
 
-    expect(getByText(/google/i)).toBeInTheDocument();
-    expect(getByText(/google/i)).toHaveAttribute(
+    expect(getByTestId(testId)).toBeInTheDocument();
+    expect(getByTestId(testId)).toHaveAttribute(
       'href',
       'https://www.google.com'
     );
   });
 
   it('should render a basic anchor element with link styles', () => {
-    const { getByText } = render(
-      <Hyperlink to="https://www.google.com">Google</Hyperlink>
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <Hyperlink to="https://www.google.com" testId={testId}>
+        Google
+      </Hyperlink>
     );
 
-    const element = getByText(/google/i);
+    const element = getByTestId(testId);
 
     expect(element).toHaveStyleRule('color', magma.colors.primary);
+    expect(element).toHaveStyleRule('color', magma.colors.primary700, {
+      target: ':hover',
+    });
   });
 
   it('should render an inverse anchor element', () => {
-    const { getByText } = render(
-      <Hyperlink isInverse to="https://www.google.com">
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <Hyperlink isInverse to="https://www.google.com" testId={testId}>
         Google
       </Hyperlink>
     );
 
-    const element = getByText(/google/i);
+    const element = getByTestId(testId);
 
     expect(element).toHaveStyleRule('color', magma.colors.tertiary);
+    expect(element).toHaveStyleRule('color', magma.colors.primary100, {
+      target: ':hover',
+    });
   });
 
   it('should render an anchor element with default button styles', () => {
-    const { getByText } = render(
-      <Hyperlink styledAs="Button" to="https://www.google.com">
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <Hyperlink styledAs="Button" to="https://www.google.com" testId={testId}>
         Google
       </Hyperlink>
     );
 
-    const element = getByText(/google/i);
+    const element = getByTestId(testId);
 
     expect(element).toHaveStyleRule(
       'font-size',
@@ -67,18 +97,20 @@ describe('Hyperlink', () => {
   });
 
   it('should render an anchor element with passed in button styles', () => {
-    const { getByText } = render(
+    const testId = 'test-id';
+    const { getByTestId } = render(
       <Hyperlink
         styledAs="Button"
         size="large"
         shape="round"
         to="https://www.google.com"
+        testId={testId}
       >
         Google
       </Hyperlink>
     );
 
-    const element = getByText(/google/i);
+    const element = getByTestId(testId);
 
     expect(element).toHaveStyleRule(
       'font-size',
@@ -105,5 +137,166 @@ describe('Hyperlink', () => {
         }}
       </Hyperlink>
     );
+  });
+
+  describe('hasUnderline', () => {
+    it('has underline text decoration by default', () => {
+      const testId = 'test-id';
+      const { getByTestId } = render(
+        <Hyperlink to="https://www.google.com" testId={testId}>
+          Google
+        </Hyperlink>
+      );
+      expect(getByTestId(testId)).toHaveStyleRule(
+        'text-decoration',
+        'underline'
+      );
+    });
+    it('can toggle off underline text decoration', () => {
+      const testId = 'test-id';
+      const { getByTestId } = render(
+        <Hyperlink
+          to="https://www.google.com"
+          hasUnderline={false}
+          testId={testId}
+        >
+          Google
+        </Hyperlink>
+      );
+      expect(getByTestId(testId)).toHaveStyleRule('text-decoration', 'none');
+    });
+    it('does not have underline when styled as a button', () => {
+      const testId = 'test-id';
+      const { getByTestId } = render(
+        <Hyperlink
+          styledAs="Button"
+          to="https://www.google.com"
+          hasUnderline={true}
+          testId={testId}
+        >
+          Google
+        </Hyperlink>
+      );
+      expect(getByTestId(testId)).toHaveStyleRule('text-decoration', 'none');
+    });
+  });
+
+  describe('with icons', () => {
+    it('displays icon on the left', () => {
+      const { container, getByText } = render(
+        <Hyperlink
+          to="https://www.google.com"
+          icon={<KeyboardArrowRightIcon />}
+          iconPosition={HyperlinkIconPosition.left}
+        >
+          Back
+        </Hyperlink>
+      );
+      expect(getByText('Back')).toHaveStyleRule(
+        'padding-left',
+        magma.spaceScale.spacing03
+      );
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('displays icon on the right', () => {
+      const { container, getByText } = render(
+        <Hyperlink
+          to="https://www.google.com"
+          icon={<KeyboardArrowRightIcon />}
+          iconPosition={HyperlinkIconPosition.right}
+        >
+          Back
+        </Hyperlink>
+      );
+      expect(getByText('Back')).toHaveStyleRule(
+        'padding-right',
+        magma.spaceScale.spacing03
+      );
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('displays two icons when an array is passed and position is both', () => {
+      const { container, getByText } = render(
+        <Hyperlink
+          to="https://www.google.com"
+          icon={[
+            <KeyboardArrowRightIcon key={0} />,
+            <KeyboardArrowRightIcon key={1} />,
+          ]}
+          iconPosition={HyperlinkIconPosition.both}
+        >
+          Back
+        </Hyperlink>
+      );
+      expect(getByText('Back')).toHaveStyleRule(
+        'padding-right',
+        magma.spaceScale.spacing03
+      );
+      expect(getByText('Back')).toHaveStyleRule(
+        'padding-left',
+        magma.spaceScale.spacing03
+      );
+      expect(container.querySelectorAll('svg').length).toBe(2);
+      expect(container.querySelectorAll('svg')[0]).toBeInTheDocument();
+      expect(container.querySelectorAll('svg')[1]).toBeInTheDocument();
+    });
+
+    it('displays one icon when an array is passed and position is left', () => {
+      const { container, getByText } = render(
+        <Hyperlink
+          to="https://www.google.com"
+          icon={[
+            <KeyboardArrowRightIcon key={0} />,
+            <KeyboardArrowRightIcon key={1} />,
+          ]}
+          iconPosition={HyperlinkIconPosition.left}
+        >
+          Back
+        </Hyperlink>
+      );
+      expect(getByText('Back')).toHaveStyleRule(
+        'padding-left',
+        magma.spaceScale.spacing03
+      );
+      expect(container.querySelectorAll('svg').length).toBe(1);
+      expect(container.querySelectorAll('svg')[0]).toBeInTheDocument();
+    });
+
+    it('has larger padding when size is large', () => {
+      const { container, getByText } = render(
+        <Hyperlink
+          to="https://www.google.com"
+          icon={<KeyboardArrowRightIcon />}
+          iconPosition={HyperlinkIconPosition.left}
+          size={ButtonSize.large}
+        >
+          Back
+        </Hyperlink>
+      );
+      expect(getByText('Back')).toHaveStyleRule(
+        'padding-left',
+        magma.spaceScale.spacing05
+      );
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('has smaller padding when size is large', () => {
+      const { container, getByText } = render(
+        <Hyperlink
+          to="https://www.google.com"
+          icon={<KeyboardArrowRightIcon />}
+          iconPosition={HyperlinkIconPosition.left}
+          size={ButtonSize.small}
+        >
+          Back
+        </Hyperlink>
+      );
+      expect(getByText('Back')).toHaveStyleRule(
+        'padding-left',
+        magma.spaceScale.spacing02
+      );
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.test.js
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.test.js
@@ -73,7 +73,7 @@ describe('Hyperlink', () => {
     const element = getByTestId(testId);
 
     expect(element).toHaveStyleRule('color', magma.colors.tertiary);
-    expect(element).toHaveStyleRule('color', magma.colors.primary100, {
+    expect(element).toHaveStyleRule('color', magma.colors.neutral100, {
       target: ':hover',
     });
   });

--- a/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.test.js
+++ b/packages/react-magma-dom/src/components/Hyperlink/Hyperlink.test.js
@@ -183,7 +183,7 @@ describe('Hyperlink', () => {
 
   describe('with icons', () => {
     it('displays icon on the left', () => {
-      const { container, getByText } = render(
+      const { container } = render(
         <Hyperlink
           to="https://www.google.com"
           icon={<KeyboardArrowRightIcon />}
@@ -192,15 +192,16 @@ describe('Hyperlink', () => {
           Back
         </Hyperlink>
       );
-      expect(getByText('Back')).toHaveStyleRule(
-        'padding-left',
+      const icon = container.querySelector('svg');
+      expect(icon.parentElement).toHaveStyleRule(
+        'padding-right',
         magma.spaceScale.spacing03
       );
-      expect(container.querySelector('svg')).toBeInTheDocument();
+      expect(icon).toBeInTheDocument();
     });
 
     it('displays icon on the right', () => {
-      const { container, getByText } = render(
+      const { container } = render(
         <Hyperlink
           to="https://www.google.com"
           icon={<KeyboardArrowRightIcon />}
@@ -209,15 +210,16 @@ describe('Hyperlink', () => {
           Back
         </Hyperlink>
       );
-      expect(getByText('Back')).toHaveStyleRule(
-        'padding-right',
+      const icon = container.querySelector('svg');
+      expect(icon.parentElement).toHaveStyleRule(
+        'padding-left',
         magma.spaceScale.spacing03
       );
-      expect(container.querySelector('svg')).toBeInTheDocument();
+      expect(icon).toBeInTheDocument();
     });
 
     it('displays two icons when an array is passed and position is both', () => {
-      const { container, getByText } = render(
+      const { container } = render(
         <Hyperlink
           to="https://www.google.com"
           icon={[
@@ -229,21 +231,22 @@ describe('Hyperlink', () => {
           Back
         </Hyperlink>
       );
-      expect(getByText('Back')).toHaveStyleRule(
+      const allIcons = container.querySelectorAll('svg');
+      expect(allIcons[0].parentElement).toHaveStyleRule(
         'padding-right',
         magma.spaceScale.spacing03
       );
-      expect(getByText('Back')).toHaveStyleRule(
+      expect(allIcons[1].parentElement).toHaveStyleRule(
         'padding-left',
         magma.spaceScale.spacing03
       );
-      expect(container.querySelectorAll('svg').length).toBe(2);
-      expect(container.querySelectorAll('svg')[0]).toBeInTheDocument();
-      expect(container.querySelectorAll('svg')[1]).toBeInTheDocument();
+      expect(allIcons.length).toBe(2);
+      expect(allIcons[0]).toBeInTheDocument();
+      expect(allIcons[1]).toBeInTheDocument();
     });
 
     it('displays one icon when an array is passed and position is left', () => {
-      const { container, getByText } = render(
+      const { container } = render(
         <Hyperlink
           to="https://www.google.com"
           icon={[
@@ -255,16 +258,18 @@ describe('Hyperlink', () => {
           Back
         </Hyperlink>
       );
-      expect(getByText('Back')).toHaveStyleRule(
-        'padding-left',
+      const icon = container.querySelector('svg');
+      const allIcons = container.querySelectorAll('svg');
+      expect(icon.parentElement).toHaveStyleRule(
+        'padding-right',
         magma.spaceScale.spacing03
       );
-      expect(container.querySelectorAll('svg').length).toBe(1);
-      expect(container.querySelectorAll('svg')[0]).toBeInTheDocument();
+      expect(allIcons.length).toBe(1);
+      expect(allIcons[0]).toBeInTheDocument();
     });
 
     it('has larger padding when size is large', () => {
-      const { container, getByText } = render(
+      const { container } = render(
         <Hyperlink
           to="https://www.google.com"
           icon={<KeyboardArrowRightIcon />}
@@ -274,11 +279,12 @@ describe('Hyperlink', () => {
           Back
         </Hyperlink>
       );
-      expect(getByText('Back')).toHaveStyleRule(
-        'padding-left',
+      const icon = container.querySelector('svg');
+      expect(icon.parentElement).toHaveStyleRule(
+        'padding-right',
         magma.spaceScale.spacing05
       );
-      expect(container.querySelector('svg')).toBeInTheDocument();
+      expect(icon).toBeInTheDocument();
     });
 
     it('has smaller padding when size is large', () => {
@@ -292,11 +298,12 @@ describe('Hyperlink', () => {
           Back
         </Hyperlink>
       );
-      expect(getByText('Back')).toHaveStyleRule(
-        'padding-left',
+      const icon = container.querySelector('svg');
+      expect(icon.parentElement).toHaveStyleRule(
+        'padding-right',
         magma.spaceScale.spacing02
       );
-      expect(container.querySelector('svg')).toBeInTheDocument();
+      expect(icon).toBeInTheDocument();
     });
   });
 });

--- a/packages/react-magma-dom/src/components/Hyperlink/index.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/index.tsx
@@ -39,7 +39,7 @@ export interface HyperlinkProps
   /**
    * Icon to display within the component
    */
-  icon?: React.ReactElement<IconProps>;
+  icon?: React.ReactElement<IconProps> | Array<React.ReactElement<IconProps>>;
   /**
    * Position within the link for the icon to appear
    * @default HyperlinkIconPosition.right
@@ -53,6 +53,9 @@ const linkStyles = props => css`
     : props.theme.colors.primary};
   text-decoration: ${props.hasUnderline ? 'underline' : 'none'};
   font-family: ${props.theme.bodyFont};
+  width: fit-content;
+  display: inline-flex;
+  align-items: flex-start;
   &:not([disabled]) {
     &:hover,
     &:focus {
@@ -88,10 +91,25 @@ function getIconPadding(props) {
 
 const SpanTextLeft = styled.span`
   padding-right: ${props => getIconPadding(props)};
+  line-height: normal;
+  flex: 0 0 auto;
 `;
 
 const SpanTextRight = styled.span`
   padding-left: ${props => getIconPadding(props)};
+  line-height: normal;
+  flex: 0 0 auto;
+`;
+
+const SpanTextBoth = styled.span`
+  padding-right: ${props => getIconPadding(props)};
+  padding-left: ${props => getIconPadding(props)};
+  line-height: normal;
+  flex: 0 0 auto;
+`;
+
+const SpanFlex = styled.span`
+  flex: 0 0 auto;
 `;
 
 export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
@@ -110,6 +128,8 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
     const other = omit(['positionTop', 'positionLeft', 'type'], rest);
     const theme = React.useContext(ThemeContext);
     const isInverse = useIsInverse(props.isInverse);
+
+    const hasMultiIcons = icon && icon instanceof Array && icon?.length > 0;
 
     if (typeof children === 'function') {
       const composedStyle =
@@ -156,9 +176,7 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
           </LinkStyledAsButton>
         );
       }
-      // TODO: add aria-hidden=true to icons
-      // TODO Dev sets spacing
-      // return (
+
       if (icon && iconPosition !== null) {
         return (
           <HyperlinkComponent
@@ -168,25 +186,21 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
             href={to}
             isInverse={isInverse}
             theme={theme}
-            style={{ display: 'flex', width: 'fit-content' }}
           >
             {iconPosition === HyperlinkIconPosition.right && (
-              <SpanTextLeft theme={theme} style={{ flex: '0 0 auto' }}>
-                {children}
-              </SpanTextLeft>
+              <SpanTextLeft theme={theme}>{children}</SpanTextLeft>
             )}
-            <span style={{ flex: '0 0 auto' }}>{icon}</span>
+
+            <SpanFlex>{hasMultiIcons ? icon[0] : icon}</SpanFlex>
+
             {iconPosition === HyperlinkIconPosition.left && (
-              <SpanTextRight theme={theme} style={{ flex: '0 0 auto' }}>
-                {children}
-              </SpanTextRight>
+              <SpanTextRight theme={theme}>{children}</SpanTextRight>
             )}
-            {iconPosition === HyperlinkIconPosition.both && (
+
+            {iconPosition === HyperlinkIconPosition.both && hasMultiIcons && (
               <>
-                <SpanTextRight theme={theme} style={{ flex: '0 0 auto' }}>
-                  {children}
-                </SpanTextRight>
-                <span style={{ flex: '0 0 auto' }}>{icon}</span>
+                <SpanTextBoth theme={theme}>{children}</SpanTextBoth>
+                <SpanFlex>{icon[1]}</SpanFlex>
               </>
             )}
           </HyperlinkComponent>

--- a/packages/react-magma-dom/src/components/Hyperlink/index.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/index.tsx
@@ -54,6 +54,7 @@ const linkStyles = props => css`
   text-decoration: ${props.hasUnderline ? 'underline' : 'none'};
   font-family: ${props.theme.bodyFont};
   display: inline-flex;
+  align-items: center;
   &:not([disabled]) {
     &:hover,
     &:focus {

--- a/packages/react-magma-dom/src/components/Hyperlink/index.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/index.tsx
@@ -12,7 +12,7 @@ import { IconProps } from 'react-magma-icons';
 export enum HyperlinkIconPosition {
   left = 'left',
   right = 'right',
-  both = 'both'
+  both = 'both',
 }
 
 export interface HyperlinkProps
@@ -103,7 +103,7 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
       testId,
       hasUnderline = true,
       icon,
-      iconPosition,
+      iconPosition = null,
       ...rest
     } = props;
 
@@ -158,34 +158,53 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
       }
       // TODO: add aria-hidden=true to icons
       // TODO Dev sets spacing
-      return (
-        <HyperlinkComponent
-          {...other}
-          ref={ref}
-          data-testid={testId}
-          href={to}
-          isInverse={isInverse}
-          theme={theme}
-          style={{display: 'flex', width: 'fit-content'}}
-        >
-          {iconPosition === HyperlinkIconPosition.right && (
-              <SpanTextLeft theme={theme} style={{flex: '0 0 auto'}}>{children}</SpanTextLeft>
+      // return (
+      if (icon && iconPosition !== null) {
+        return (
+          <HyperlinkComponent
+            {...other}
+            ref={ref}
+            data-testid={testId}
+            href={to}
+            isInverse={isInverse}
+            theme={theme}
+            style={{ display: 'flex', width: 'fit-content' }}
+          >
+            {iconPosition === HyperlinkIconPosition.right && (
+              <SpanTextLeft theme={theme} style={{ flex: '0 0 auto' }}>
+                {children}
+              </SpanTextLeft>
             )}
-            <span style={{flex: '0 0 auto'}}>
-              {icon}
-              </span>
+            <span style={{ flex: '0 0 auto' }}>{icon}</span>
             {iconPosition === HyperlinkIconPosition.left && (
-              <SpanTextRight theme={theme} style={{flex: '0 0 auto'}}>{children}</SpanTextRight>
+              <SpanTextRight theme={theme} style={{ flex: '0 0 auto' }}>
+                {children}
+              </SpanTextRight>
             )}
             {iconPosition === HyperlinkIconPosition.both && (
-              <><SpanTextRight theme={theme} style={{flex: '0 0 auto'}}>{children}</SpanTextRight>
-              <span style={{flex: '0 0 auto'}}>
-              {icon}
-              </span>
+              <>
+                <SpanTextRight theme={theme} style={{ flex: '0 0 auto' }}>
+                  {children}
+                </SpanTextRight>
+                <span style={{ flex: '0 0 auto' }}>{icon}</span>
               </>
             )}
-        </HyperlinkComponent>
-      );
+          </HyperlinkComponent>
+        );
+      } else {
+        return (
+          <HyperlinkComponent
+            {...other}
+            ref={ref}
+            data-testid={testId}
+            href={to}
+            isInverse={isInverse}
+            theme={theme}
+          >
+            {children}
+          </HyperlinkComponent>
+        );
+      }
     }
   }
 );

--- a/packages/react-magma-dom/src/components/Hyperlink/index.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/index.tsx
@@ -53,13 +53,12 @@ const linkStyles = props => css`
     : props.theme.colors.primary};
   text-decoration: ${props.hasUnderline ? 'underline' : 'none'};
   font-family: ${props.theme.bodyFont};
-  display: inline-flex;
-  align-items: center;
+  display: inline;
   &:not([disabled]) {
     &:hover,
     &:focus {
       color: ${props.isInverse
-        ? props.theme.colors.primary100
+        ? props.theme.colors.neutral100
         : props.theme.colors.primary700};
       text-decoration: underline;
     }
@@ -90,20 +89,20 @@ function getIconPadding(props) {
 
 const SpanTextLeft = styled.span<{ size?: ButtonSize }>`
   padding-right: ${props => getIconPadding(props)};
-  line-height: normal;
+  line-height: inherit;
   flex: 0 0 auto;
 `;
 
 const SpanTextRight = styled.span<{ size?: ButtonSize }>`
   padding-left: ${props => getIconPadding(props)};
-  line-height: normal;
+  line-height: inherit;
   flex: 0 0 auto;
 `;
 
 const SpanTextBoth = styled.span<{ size?: ButtonSize }>`
   padding-right: ${props => getIconPadding(props)};
   padding-left: ${props => getIconPadding(props)};
-  line-height: normal;
+  line-height: inherit;
   flex: 0 0 auto;
 `;
 
@@ -168,6 +167,7 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
               </SpanTextLeft>
             )}
             {hasMultiIcons ? icon[0] : icon}
+            {/* {hasMultiIcons ? icon[0] : <span style={{alignSelf: 'center'}}>{icon}</span>} */}
             {iconPosition === HyperlinkIconPosition.left && (
               <SpanTextRight theme={theme} size={props.size}>
                 {children}

--- a/packages/react-magma-dom/src/components/Hyperlink/index.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/index.tsx
@@ -53,7 +53,6 @@ const linkStyles = props => css`
     : props.theme.colors.primary};
   text-decoration: ${props.hasUnderline ? 'underline' : 'none'};
   font-family: ${props.theme.bodyFont};
-  width: fit-content;
   display: inline-flex;
   align-items: center;
   &:not([disabled]) {

--- a/packages/react-magma-dom/src/components/Hyperlink/index.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/index.tsx
@@ -53,7 +53,7 @@ const linkStyles = props => css`
     : props.theme.colors.primary};
   text-decoration: ${props.hasUnderline ? 'underline' : 'none'};
   font-family: ${props.theme.bodyFont};
-  display: inline;
+  display: inline-flex;
   &:not([disabled]) {
     &:hover,
     &:focus {
@@ -87,23 +87,20 @@ function getIconPadding(props) {
   }
 }
 
-const SpanTextLeft = styled.span<{ size?: ButtonSize }>`
-  padding-right: ${props => getIconPadding(props)};
-  line-height: inherit;
-  flex: 0 0 auto;
-`;
-
-const SpanTextRight = styled.span<{ size?: ButtonSize }>`
-  padding-left: ${props => getIconPadding(props)};
-  line-height: inherit;
-  flex: 0 0 auto;
-`;
-
-const SpanTextBoth = styled.span<{ size?: ButtonSize }>`
-  padding-right: ${props => getIconPadding(props)};
-  padding-left: ${props => getIconPadding(props)};
-  line-height: inherit;
-  flex: 0 0 auto;
+const IconWrapper = styled.span<{
+  size?: ButtonSize;
+  position?: HyperlinkIconPosition;
+}>`
+  align-self: center;
+  display: inline-flex;
+  padding-left: ${props =>
+    (props.position === HyperlinkIconPosition.right ||
+      props.position === HyperlinkIconPosition.both) &&
+    getIconPadding(props)};
+  padding-right: ${props =>
+    (props.position === HyperlinkIconPosition.left ||
+      props.position === HyperlinkIconPosition.both) &&
+    getIconPadding(props)};
 `;
 
 export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
@@ -161,25 +158,34 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
             ref={ref}
             theme={theme}
           >
-            {iconPosition === HyperlinkIconPosition.right && (
-              <SpanTextLeft theme={theme} size={props.size}>
-                {children}
-              </SpanTextLeft>
-            )}
-            {hasMultiIcons ? icon[0] : icon}
-            {/* {hasMultiIcons ? icon[0] : <span style={{alignSelf: 'center'}}>{icon}</span>} */}
-            {iconPosition === HyperlinkIconPosition.left && (
-              <SpanTextRight theme={theme} size={props.size}>
-                {children}
-              </SpanTextRight>
-            )}
+            {iconPosition === HyperlinkIconPosition.right && <>{children}</>}
+            <IconWrapper
+              theme={theme}
+              size={props.size}
+              position={
+                iconPosition === HyperlinkIconPosition.both
+                  ? HyperlinkIconPosition.left
+                  : iconPosition
+              }
+            >
+              {hasMultiIcons ? icon[0] : icon}
+            </IconWrapper>
+            {iconPosition === HyperlinkIconPosition.left && <>{children}</>}
 
             {iconPosition === HyperlinkIconPosition.both && hasMultiIcons && (
               <>
-                <SpanTextBoth theme={theme} size={props.size}>
-                  {children}
-                </SpanTextBoth>
-                {icon[1]}
+                {children}
+                <IconWrapper
+                  theme={theme}
+                  size={props.size}
+                  position={
+                    iconPosition === HyperlinkIconPosition.both
+                      ? HyperlinkIconPosition.right
+                      : iconPosition
+                  }
+                >
+                  {icon[1]}
+                </IconWrapper>
               </>
             )}
           </HyperlinkComponent>

--- a/packages/react-magma-dom/src/components/Hyperlink/index.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/index.tsx
@@ -55,7 +55,7 @@ const linkStyles = props => css`
   font-family: ${props.theme.bodyFont};
   width: fit-content;
   display: inline-flex;
-  align-items: flex-start;
+  align-items: center;
   &:not([disabled]) {
     &:hover,
     &:focus {
@@ -108,10 +108,6 @@ const SpanTextBoth = styled.span`
   flex: 0 0 auto;
 `;
 
-const SpanFlex = styled.span`
-  flex: 0 0 auto;
-`;
-
 export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
   (props, ref) => {
     const {
@@ -154,45 +150,23 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
       const HyperlinkComponent =
         styledAs === 'Button' ? LinkStyledAsButton : StyledLink;
 
-      if (styledAs === 'Button') {
-        return (
-          <LinkStyledAsButton
-            {...other}
-            icon={icon}
-            iconPosition={iconPosition}
-            ref={ref}
-            data-testid={testId}
-            href={to}
-            isInverse={isInverse}
-            theme={theme}
-          >
-            {iconPosition === HyperlinkIconPosition.right && (
-              <SpanTextLeft theme={theme}>{children}</SpanTextLeft>
-            )}
-            {icon}
-            {iconPosition !== HyperlinkIconPosition.right && (
-              <SpanTextRight theme={theme}>{children}</SpanTextRight>
-            )}
-          </LinkStyledAsButton>
-        );
-      }
-
       if (icon && iconPosition !== null) {
         return (
           <HyperlinkComponent
             {...other}
-            ref={ref}
             data-testid={testId}
+            hasUnderline={hasUnderline}
+            icon={icon}
+            iconPosition={iconPosition}
             href={to}
             isInverse={isInverse}
+            ref={ref}
             theme={theme}
           >
             {iconPosition === HyperlinkIconPosition.right && (
               <SpanTextLeft theme={theme}>{children}</SpanTextLeft>
             )}
-
-            <SpanFlex>{hasMultiIcons ? icon[0] : icon}</SpanFlex>
-
+            {hasMultiIcons ? icon[0] : icon}
             {iconPosition === HyperlinkIconPosition.left && (
               <SpanTextRight theme={theme}>{children}</SpanTextRight>
             )}
@@ -200,7 +174,7 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
             {iconPosition === HyperlinkIconPosition.both && hasMultiIcons && (
               <>
                 <SpanTextBoth theme={theme}>{children}</SpanTextBoth>
-                <SpanFlex>{icon[1]}</SpanFlex>
+                {icon[1]}
               </>
             )}
           </HyperlinkComponent>
@@ -209,10 +183,11 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
         return (
           <HyperlinkComponent
             {...other}
-            ref={ref}
             data-testid={testId}
+            hasUnderline={hasUnderline}
             href={to}
             isInverse={isInverse}
+            ref={ref}
             theme={theme}
           >
             {children}

--- a/packages/react-magma-dom/src/components/Hyperlink/index.tsx
+++ b/packages/react-magma-dom/src/components/Hyperlink/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ButtonStyles } from '../Button';
+import { ButtonSize, ButtonStyles } from '../Button';
 import styled from '@emotion/styled';
 import { css, ClassNames } from '@emotion/core';
 import { omit, Omit } from '../../utils';
@@ -89,19 +89,19 @@ function getIconPadding(props) {
   }
 }
 
-const SpanTextLeft = styled.span`
+const SpanTextLeft = styled.span<{ size?: ButtonSize }>`
   padding-right: ${props => getIconPadding(props)};
   line-height: normal;
   flex: 0 0 auto;
 `;
 
-const SpanTextRight = styled.span`
+const SpanTextRight = styled.span<{ size?: ButtonSize }>`
   padding-left: ${props => getIconPadding(props)};
   line-height: normal;
   flex: 0 0 auto;
 `;
 
-const SpanTextBoth = styled.span`
+const SpanTextBoth = styled.span<{ size?: ButtonSize }>`
   padding-right: ${props => getIconPadding(props)};
   padding-left: ${props => getIconPadding(props)};
   line-height: normal;
@@ -164,16 +164,22 @@ export const Hyperlink = React.forwardRef<HTMLAnchorElement, HyperlinkProps>(
             theme={theme}
           >
             {iconPosition === HyperlinkIconPosition.right && (
-              <SpanTextLeft theme={theme}>{children}</SpanTextLeft>
+              <SpanTextLeft theme={theme} size={props.size}>
+                {children}
+              </SpanTextLeft>
             )}
             {hasMultiIcons ? icon[0] : icon}
             {iconPosition === HyperlinkIconPosition.left && (
-              <SpanTextRight theme={theme}>{children}</SpanTextRight>
+              <SpanTextRight theme={theme} size={props.size}>
+                {children}
+              </SpanTextRight>
             )}
 
             {iconPosition === HyperlinkIconPosition.both && hasMultiIcons && (
               <>
-                <SpanTextBoth theme={theme}>{children}</SpanTextBoth>
+                <SpanTextBoth theme={theme} size={props.size}>
+                  {children}
+                </SpanTextBoth>
                 {icon[1]}
               </>
             )}

--- a/packages/react-magma-dom/src/index.ts
+++ b/packages/react-magma-dom/src/index.ts
@@ -113,7 +113,7 @@ export {
   HideAtBreakpointDisplayType,
   HideAtBreakpointProps,
 } from './components/HideAtBreakpoint';
-export { Hyperlink, HyperlinkProps } from './components/Hyperlink';
+export { Hyperlink, HyperlinkIconPosition, HyperlinkProps } from './components/Hyperlink';
 export {
   IconButton,
   ButtonIconPosition,

--- a/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
+++ b/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
@@ -53,7 +53,7 @@ function getStyles(theme, isInverse: boolean) {
 
       &:hover,
       &:focus {
-        color: ${isInverse ? theme.colors.primary100 : theme.colors.primary400};
+        color: ${isInverse ? theme.colors.primary100 : theme.colors.primary700};
       }
       &:focus {
         outline: 2px solid

--- a/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
+++ b/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
@@ -53,7 +53,7 @@ function getStyles(theme, isInverse: boolean) {
 
       &:hover,
       &:focus {
-        color: ${isInverse ? theme.colors.primary100 : theme.colors.primary700};
+        color: ${isInverse ? theme.colors.neutral100 : theme.colors.primary700};
       }
       &:focus {
         outline: 2px solid

--- a/website/react-magma-docs/src/pages/api/hyperlink.mdx
+++ b/website/react-magma-docs/src/pages/api/hyperlink.mdx
@@ -105,6 +105,220 @@ export function Example() {
 }
 ```
 
+## Icon
+
+```tsx
+import React from 'react';
+import {
+  Hyperlink,
+  HyperlinkIconPosition,
+  Spacer,
+  SpacerAxis,
+  ButtonTextTransform,
+  Flex,
+  FlexBehavior,
+  FlexJustify,
+} from 'react-magma-dom';
+import {
+  KeyboardArrowLeftIcon,
+  KeyboardArrowRightIcon,
+  CalendarTodayIcon,
+  OpenInNewIcon
+} from 'react-magma-icons';
+
+export function Example() {
+  return (
+    <>
+      <Flex
+        behavior={FlexBehavior.container}
+        justify={FlexJustify.spaceBetween}
+      >
+        <span style={{ flex: '0 0 auto' }}>
+          <Hyperlink
+            target="_blank"
+            to="./"
+            hasUnderline={false}
+            icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.left}
+          >
+            Back
+          </Hyperlink>
+        </span>
+        <span style={{ flex: '0 0 auto' }}>
+          <Hyperlink
+            target="_blank"
+            to="./"
+            hasUnderline={false}
+            icon={<KeyboardArrowRightIcon aria-hidden={true} />}
+            iconPosition={HyperlinkIconPosition.right}
+          >
+            Next
+          </Hyperlink>
+        </span>
+      </Flex>
+      <Spacer size={'8px'} axis={SpacerAxis.both} />
+      <Hyperlink
+        styledAs="Button"
+        target="_blank"
+        to="./"
+        icon={<KeyboardArrowLeftIcon aria-hidden={true} />}
+        iconPosition={HyperlinkIconPosition.left}
+      >
+        Back
+      </Hyperlink>
+      <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
+      <Hyperlink
+        styledAs="Button"
+        target="_blank"
+        to="./"
+        icon={[
+          <KeyboardArrowLeftIcon aria-hidden={true} key={0} />,
+          <KeyboardArrowRightIcon aria-hidden={true} key={1} />,
+        ]}
+        iconPosition={HyperlinkIconPosition.both}
+      >
+        Guess
+      </Hyperlink>
+      <Spacer size={'8px'} axis={SpacerAxis.horizontal} />
+      <Hyperlink
+        styledAs="Button"
+        target="_blank"
+        to="./"
+        icon={<KeyboardArrowRightIcon aria-hidden={true} />}
+        iconPosition={HyperlinkIconPosition.right}
+      >
+        Next
+      </Hyperlink>
+      <Spacer size={'8px'} axis={SpacerAxis.both} />
+      <Paragraph visualStyle={TypographyVisualStyle.headingSmall}>
+        <Hyperlink
+          target="_blank"
+          to="https://www.google.com"
+          hasUnderline={false}
+          icon={[
+            <CalendarTodayIcon
+              key={0}
+              size={magma.iconSizes.xLarge}
+              style={{ marginRight: magma.spaceScale.spacing03 }}
+              aria-hidden={true}
+            />,
+            <OpenInNewIcon
+              key={1}
+              size={magma.iconSizes.xLarge}
+              style={{ marginLeft: magma.spaceScale.spacing03 }}
+              aria-hidden={true}
+            />,
+          ]}
+          iconPosition={HyperlinkIconPosition.both}
+        >
+          Schedule an appointment
+        </Hyperlink>
+      </Paragraph>
+      <Paragraph visualStyle={TypographyVisualStyle.bodyLarge}>
+        <Hyperlink
+          target="_blank"
+          to="https://www.google.com"
+          hasUnderline={false}
+          icon={[
+            <CalendarTodayIcon
+              key={0}
+              size={magma.iconSizes.large}
+              aria-hidden={true}
+            />,
+            <OpenInNewIcon
+              key={1}
+              size={magma.iconSizes.large}
+              aria-hidden={true}
+            />,
+          ]}
+          iconPosition={HyperlinkIconPosition.both}
+        >
+          Schedule an appointment
+        </Hyperlink>
+      </Paragraph>
+      <Paragraph visualStyle={TypographyVisualStyle.bodySmall}>
+        <Hyperlink
+          target="_blank"
+          to="https://www.google.com"
+          hasUnderline={false}
+          icon={[
+            <CalendarTodayIcon
+              key={0}
+              size={magma.iconSizes.small}
+              aria-hidden={true}
+            />,
+            <OpenInNewIcon
+              key={1}
+              size={magma.iconSizes.small}
+              aria-hidden={true}
+            />,
+          ]}
+          iconPosition={HyperlinkIconPosition.both}
+        >
+          Schedule an appointment
+        </Hyperlink>
+      </Paragraph>
+      <Paragraph visualStyle={TypographyVisualStyle.bodyXSmall}>
+        <Hyperlink
+          target="_blank"
+          to="https://www.google.com"
+          hasUnderline={false}
+          icon={[
+            <CalendarTodayIcon
+              key={0}
+              size={magma.iconSizes.xSmall}
+              aria-hidden={true}
+            />,
+            <OpenInNewIcon
+              key={1}
+              size={magma.iconSizes.xSmall}
+              aria-hidden={true}
+            />,
+          ]}
+          iconPosition={HyperlinkIconPosition.both}
+        >
+          Schedule an appointment
+        </Hyperlink>
+      </Paragraph>
+    </>
+  );
+}
+```
+
+## hasUnderline
+
+The underline text decoration can be turned off. When a hyperlink is used within other elements like paragraphs, the underline is still mandatory.
+
+```tsx
+import React from 'react';
+import { Hyperlink, Spacer, SpacerAxis, magma, HyperlinkIconPosition } from 'react-magma-dom';
+import { CakeIcon } from 'react-magma-icons';
+
+export function Example() {
+  return (
+    <>
+    <Hyperlink target="_blank" to="https://www.google.com" hasUnderline={false}>
+      Google
+    </Hyperlink>
+    <Spacer size={'8px'} axis={SpacerAxis.both} />
+      Cupcake ipsum dolor sit amet wafer biscuit toffee. Chocolate bar
+      brownie lemon drops tootsie roll pudding muffin powder pudding.{' '}
+      <Hyperlink
+        target="_blank"
+        to="https://sallysbakingaddiction.com/triple-chocolate-layer-cake/"
+        icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
+        iconPosition={HyperlinkIconPosition.left}
+      >
+        I love chocolate cake
+      </Hyperlink>{' '}
+      Pastry dragée cheesecake chocolate bar donut jujubes candy canes sugar
+      plum bonbon. Toffee pie macaroon apple pie gummi bears gummi bears
+      shortbread.
+    </>
+  );
+}
+```
+
 ## Render Props Usage
 
 Use this when you want to render something that is from another library. For example, the `Link` component from `react-router`.

--- a/website/react-magma-docs/src/pages/api/hyperlink.mdx
+++ b/website/react-magma-docs/src/pages/api/hyperlink.mdx
@@ -292,7 +292,7 @@ The underline text decoration can be turned off. When a hyperlink is used within
 ```tsx
 import React from 'react';
 import { Hyperlink, Spacer, SpacerAxis, magma, HyperlinkIconPosition } from 'react-magma-dom';
-import { CakeIcon } from 'react-magma-icons';
+import { OpenInNewIcon } from 'react-magma-icons';
 
 export function Example() {
   return (
@@ -306,8 +306,8 @@ export function Example() {
       <Hyperlink
         target="_blank"
         to="https://sallysbakingaddiction.com/triple-chocolate-layer-cake/"
-        icon={<CakeIcon size={magma.iconSizes.small} aria-hidden={true} />}
-        iconPosition={HyperlinkIconPosition.left}
+        icon={<OpenInNewIcon size={magma.iconSizes.small} aria-hidden={true} />}
+        iconPosition={HyperlinkIconPosition.right}
       >
         I love chocolate cake
       </Hyperlink>{' '}


### PR DESCRIPTION
Issue: #1120

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Added support for an icon on the left, right, or both sides of a Hyperlink
- Added `hasUnderline` prop that defaults to true
- Updated Hyperlink and native anchors hover color

## Screenshots:
<!-- Include screenshot of your change -->
![image](https://github.com/cengage/react-magma/assets/91160746/44be3b7e-e779-4807-84e7-ac78caffd5fe)
![image](https://github.com/cengage/react-magma/assets/91160746/803147f0-796a-430d-98c8-718a2fdc698f)


## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm all use cases for hyperlinks are working. Consider:
- styled as button or link
- inverse on/off
- hasUnderline on/off
- passing 1 icon
- passing 2 icons
- icon positions: left, right or both
- using it inside `<Paragraph>`, `<p>`, and other text wrappers