### PR TITLE
docs(TreeView): Update example with duplicate IDs

### DIFF
--- a/.changeset/treeview-docs.md
+++ b/.changeset/treeview-docs.md
@@ -1,0 +1,5 @@
+---
+"react-magma-docs": patch
+---
+
+docs(TreeView): Update example with duplicate IDs

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -74,6 +74,8 @@ export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
    */
   itemDepth?: number;
   /**
+   * TODO: improve functionality (issue #1305)
+   * @internal 
    * If true, element is disabled
    * @default false
    */
@@ -146,7 +148,7 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     (child: React.ReactElement<any>) => child.type === TreeItem
   );
 
-  // TODO fix for disabled items
+  // TODO fix for disabled items (issue #1305)
   // const numberOfTreeItemChildren = getEnabledTreeItemChildrenLength(treeItemChildren);
   const numberOfTreeItemChildren = treeItemChildren.length;
   const hasOwnTreeItems = numberOfTreeItemChildren > 0;

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -33,7 +33,7 @@ export function Example() {
         >
           <TreeItem
             label={<>Art History in the 21st Century</>}
-            itemId="I-intro"
+            itemId="I-21st-century"
           >
             <TreeItem
               label={<>The Questions Art Historians Ask</>}


### PR DESCRIPTION
Issue: #180 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Update docs example where we were repeating an itemId (and itemIds need to be unique for proper behavior)
- In addition, hiding the `isDisabled` prop for now because it's not fully implemented. Added a ticket number to the TODOs.

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm that for the Basic Usage example in the docs site, the itemIds are all unique. Also confirm that when tabbing into the tree, if you press tab one more time, it navigates out of the tree.