### PR TITLE
fix(modal): Update aria labels

### DIFF
--- a/.changeset/modal-aria.md
+++ b/.changeset/modal-aria.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix(Modal): Remove unnecessary `aria-describedBy=“modal”`. Add `ariaLabel` prop so that Modals without headers can customize the `aria-label` instead of defaulting to `aria-label="modal"` which is not correct for a11y standards.

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { axe } from '../../../axe-helper';
 import { Drawer } from '.';
-import { Transition } from '../Transition';
 import { render, fireEvent } from '@testing-library/react';
 
 const TEXT = 'Test Text';
@@ -88,7 +87,7 @@ describe('Drawer', () => {
   });
 
   it('Does not violate accessibility standards', async () => {
-    const { baseElement } = render(<Drawer isOpen>{TEXT}</Drawer>);
+    const { baseElement } = render(<Drawer isOpen ariaLabel="drawer">{TEXT}</Drawer>);
     const results = await axe(baseElement);
 
     return expect(results).toHaveNoViolations();

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -246,6 +246,7 @@ export const NoHeaderOrFocusableContent = () => {
   return (
     <>
       <Modal
+        ariaLabel="modalNoHeader"
         size={ModalSize.small}
         isCloseButtonHidden
         onClose={onModalNoFocusClose}
@@ -259,6 +260,7 @@ export const NoHeaderOrFocusableContent = () => {
           this. A modal should have something actionable inside it.
         </Paragraph>
       </Modal>
+      
       <Button onClick={onModalNoFocusShow} ref={buttonRef}>
         Show Modal with nothing focusable
       </Button>

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { axe } from '../../../axe-helper';
 import { Modal } from '.';
 import { act, render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -7,6 +8,29 @@ import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
 
 describe('Modal', () => {
+  describe('a11y', () => {
+    it('With header, does not violate accessibility standards', async () => {
+      const { baseElement } = render(
+        <Modal testId={'test-id'} isOpen header={'Modal'}>
+          Modal Text
+        </Modal>
+      );
+      const results = await axe(baseElement);
+
+      return expect(results).toHaveNoViolations();
+    });
+    it('Without header, does not violate accessibility standards', async () => {
+      const { baseElement } = render(
+        <Modal testId={'test-id'} isOpen ariaLabel="modal">
+          Modal Text
+        </Modal>
+      );
+      const results = await axe(baseElement);
+
+      return expect(results).toHaveNoViolations();
+    });
+  });
+
   it('should find element by testId', () => {
     const testId = 'test-id';
     const { getByTestId } = render(

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -28,6 +28,10 @@ export enum ModalSize {
  */
 export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
+   * Custom aria label ONLY for modals that do not have a header
+   */
+  ariaLabel?: string;
+  /**
    * The text read by screen readers for the close button
    * @default "Close dialog"
    */
@@ -324,6 +328,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     }
 
     const {
+      ariaLabel,
       children,
       closeAriaLabel,
       closeButtonSize,
@@ -367,8 +372,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
             />
             <ModalContainer
               aria-labelledby={header ? headingId : null}
-              aria-label="modal"
-              aria-describedby="modal"
+              aria-label={!header ? ariaLabel : null}
               aria-modal={true}
               data-testid={testId}
               id={id}

--- a/website/react-magma-docs/src/pages/api/drawer.mdx
+++ b/website/react-magma-docs/src/pages/api/drawer.mdx
@@ -61,6 +61,7 @@ export function Example() {
   return (
     <>
       <Drawer
+        ariaLabel="drawer"
         onClose={() => setShowDrawer(false)}
         isOpen={showDrawer}
         position={DrawerPosition.right}

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -144,8 +144,11 @@ export function Example() {
 ## Modal Header
 
 The modal header prop is optional. It can accept a node or a string, and will be rendered inside an H1.
+
 If there is a header passed in, the focus will be placed on the header when the modal opens. If not, the focus will be placed on
 the first actionable element.
+
+If the modal does not use the `header` prop, you must use the `ariaLabel` prop to ensure the correct aria properties are in place.
 
 ```tsx
 import React from 'react';
@@ -167,6 +170,7 @@ export function Example() {
   return (
     <>
       <Modal
+        ariaLabel="customAriaLabel"
         size={ModalSize.small}
         onClose={() => {
           setShowModal(false);


### PR DESCRIPTION
Issue: #1315 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Removed unnecessary `aria-describedBy=“modal”`
- Added `ariaLabel` prop so that Modals without headers can customize the `aria-label` instead of defaulting to `aria-label="modal"` which is not correct for a11y standards.
- Updated unit tests for Modal and Drawer

## Screenshots:
<!-- Include screenshot of your change -->
![image](https://github.com/cengage/react-magma/assets/91160746/da212796-bc8d-4546-825b-ecfd0fcbc7c7)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Test the following in storybook examples and docs: 

Modals AND Drawers with headers: 
1. should not have aria-describedBy
2. should have aria-labeledBy
3. should not have aria-label

Modals AND Drawers without headers: 
1. should not have aria-describedBy
2. should not have aria-labeledBy
3. should have aria-label

