### PR TITLE
react-magma-landing: Remove extra card with version 15

### DIFF
--- a/.changeset/landing-version.md
+++ b/.changeset/landing-version.md
@@ -1,0 +1,5 @@
+---
+"react-magma-landing": patch
+---
+
+fix: Remove card with version `^15.0.0`

--- a/website/react-magma-landing/scripts/build.js
+++ b/website/react-magma-landing/scripts/build.js
@@ -33,10 +33,12 @@ const versionsByReactDependency = ({ versions, time, tags }) => {
 
   var versionsByReactDep = new Map();
   allVersions.forEach(versionObj => {
-    if (!versionsByReactDep.has(versionObj?.reactDependency)) {
-      versionsByReactDep.set(versionObj?.reactDependency, []);
+    if (!versionObj?.reactDependency.includes('^15.0.0')) {
+      if (!versionsByReactDep.has(versionObj?.reactDependency)) {
+        versionsByReactDep.set(versionObj?.reactDependency, []);
+      }
+      versionsByReactDep.get(versionObj?.reactDependency).push(versionObj);
     }
-    versionsByReactDep.get(versionObj?.reactDependency).push(versionObj);
   });
 
   const latestVersions = [];


### PR DESCRIPTION
Issue: -

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
During the last release, we removed support for React 15, which caused an extra card to appear in the landing page. This PR removes that

## Screenshots:
![image](https://github.com/cengage/react-magma/assets/91160746/a83d4cf6-2b54-4578-8222-c35b3bd78a07)

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [-] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
