### PR TITLE
storybook(TimePicker): Update clear time example

### DIFF
--- a/.changeset/timepicker-example.md
+++ b/.changeset/timepicker-example.md
@@ -1,0 +1,5 @@
+---
+"react-magma-docs": patch
+---
+
+storybook(TimePicker): Update clear time example

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.stories.tsx
@@ -76,11 +76,7 @@ export const Events = () => {
       </Paragraph>
       <Paragraph>onChange called {onChangeCalledTimes} times</Paragraph>
 
-      <TimePicker
-        labelText="Time Due"
-        onChange={handleOnChange}
-        value={timeValue}
-      />
+      <TimePicker labelText="Time Due" onChange={handleOnChange} />
       <br />
       <Button onClick={() => setTimeValue(undefined)}>Clear Time</Button>
     </>

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.stories.tsx
@@ -82,7 +82,7 @@ export const Events = () => {
         value={timeValue}
       />
       <br />
-      <Button onClick={() => handleOnChange(undefined)}>Clear Time</Button>
+      <Button onClick={() => setTimeValue(undefined)}>Clear Time</Button>
     </>
   );
 };


### PR DESCRIPTION
Issue: #1270 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Updated TimePicker Events Storybook example so that `onChange` only gets called once when the clear time button is clicked.

## Screenshots:
<!-- Include screenshot of your change -->
![chrome-capture-2024-5-20](https://github.com/cengage/react-magma/assets/91160746/a6e7c167-5e5c-43e6-9ff0-c714c733d364)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm that onChange is only called once.