### PR TITLE
fix(NativeSelect): Update arrow placement and color

### DIFF
--- a/.changeset/nativeSelect-arrow.md
+++ b/.changeset/nativeSelect-arrow.md
@@ -2,4 +2,4 @@
 "react-magma-dom": patch
 ---
 
-fix(NativeSelect): Update arrow placement and color
+fix(NativeSelect): Update arrow placement, arrow color and border color when disabled

--- a/.changeset/nativeSelect-arrow.md
+++ b/.changeset/nativeSelect-arrow.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": patch
+---
+
+fix(NativeSelect): Update arrow placement and color

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.stories.tsx
@@ -14,6 +14,7 @@ const Template: Story<NativeSelectProps> = args => (
     <option>Red</option>
     <option>Green</option>
     <option>Blue</option>
+    <option>Purple mountain majesty</option>
   </NativeSelect>
 );
 

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.stories.tsx
@@ -43,6 +43,11 @@ export default {
         type: 'number',
       },
     },
+    errorMessage: {
+      control: {
+        type: 'text',
+      },
+    },
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -48,8 +48,10 @@ const StyledNativeSelectWrapper = styled.div<{
         ? transparentize(0.6, props.theme.colors.neutral100)
         : props.disabled
         ? transparentize(0.4, props.theme.colors.neutral500)
-        : 'inherit'};
-    margin: 0 0 0 -${props => props.theme.spaceScale.spacing06};
+        : props.isInverse
+        ? props.theme.colors.neutral100
+        : props.theme.colors.neutral700};
+    margin: 0 ${props => props.theme.spaceScale.spacing03} 0 -${props => props.theme.spaceScale.spacing08};
     pointer-events: none;
     z-index: 1;
   }
@@ -75,6 +77,7 @@ const StyledNativeSelect = styled.select<{
 }>`
   ${inputBaseStyles};
   height: 38px;
+  padding-right: ${props => props.theme.spaceScale.spacing08};
   // Required for Windows && Chrome support
   background: inherit;
   > option {

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -62,10 +62,16 @@ function borderColors(props) {
     if (props.hasError) {
       return props.theme.colors.danger200;
     }
+    if (props.disabled) {
+      return transparentize(0.85, props.theme.colors.neutral100);
+    }
     return transparentize(0.5, props.theme.colors.neutral100);
   }
   if (props.hasError) {
     return props.theme.colors.danger;
+  }
+  if (props.disabled) {
+    return props.theme.colors.neutral300;
   }
   return props.theme.colors.neutral500;
 }

--- a/packages/react-magma-dom/src/components/Select/Select.stories.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.stories.tsx
@@ -43,6 +43,7 @@ Default.args = {
     { label: 'Red', value: 'red' },
     { label: 'Blue', value: 'blue' },
     { label: 'Green', value: 'green' },
+    { label: 'Purple mountain majesty', value: 'purple' },
   ],
   errorMessage: '',
   helperMessage: '',

--- a/packages/react-magma-dom/src/components/Select/Select.stories.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.stories.tsx
@@ -122,6 +122,7 @@ Inverse.args = {
   ...Default.args,
   isMulti: false,
   isInverse: true,
+  disabled: false,
 };
 Inverse.decorators = [
   Story => (


### PR DESCRIPTION
Issue: #1164 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Updated arrow color for both inverse and not
- Updated spacing for arrow
- Added extra space so that, if the content is long, the arrow has a background to cover the long text

## Screenshots:
Before:
![image](https://github.com/cengage/react-magma/assets/91160746/88afc406-8a39-4cf6-8c1d-7b53cbc0c0d6)
![image](https://github.com/cengage/react-magma/assets/91160746/fcf35cb1-938d-42b7-b47d-d395b3708696)


After:
<!-- Include screenshot of your change -->
![image](https://github.com/cengage/react-magma/assets/91160746/81171c0b-7f2c-405a-a269-adfcee7b2182)
![image](https://github.com/cengage/react-magma/assets/91160746/cf8abf0a-9752-4b24-bc98-776624cf6507)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Test the spacing and color of NativeSelects in both inverse and regular, with short and long content.
