### PR TITLE
feat(Stepper): Additions to the Stepper component for accessibility compliance. The 'aria-current' attribute now reads 'step' when active, the DOM structure has been changed to a UL LI layout, and when labels are hidden, the screenreader sees the step state for each step label.

### DIFF
--- a/.changeset/feat-stepper-a11y.md
+++ b/.changeset/feat-stepper-a11y.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Stepper): Additions to the Stepper component for accessibility compliance. The 'aria-current' attribute now reads 'step' when active, the DOM structure has been changed to a UL LI layout, and when labels are hidden, the screenreader sees the step state for each step label.

--- a/packages/react-magma-dom/src/components/Stepper/Step.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Step.tsx
@@ -20,6 +20,10 @@ export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
    */
   areLabelsHidden?: boolean;
   /**
+   * @internal
+   */
+  hasLabels?: boolean;
+  /**
    * Label beneath each step.
    */
   label?: string;
@@ -34,7 +38,19 @@ export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
   /**
    * @internal
    */
+  index?: number;
+  /**
+   * @internal
+   */
+  isSummaryView?: boolean;
+  /**
+   * @internal
+   */
   isInverse?: boolean;
+  /**
+   * @internal
+   */
+  stepLabel?: string;
   /**
    * @internal
    */
@@ -203,8 +219,12 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
   const {
     hasError,
     areLabelsHidden,
+    hasLabels,
+    index,
     label,
+    isSummaryView,
     secondaryLabel,
+    stepLabel,
     testId,
     isInverse: isInverseProp,
     stepStatus,
@@ -230,6 +250,13 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
       <StyledStepTextWrapper>
         {!areLabelsHidden ? (
           <>
+            {hasLabels && (
+              <HiddenLabelText
+                data-testid={testId && `${testId}-labels-hiddenlabeltext`}
+              >
+                {`${stepLabel} ${index + 1}, `}
+              </HiddenLabelText>
+            )}
             {label && (
               <StyledLabel
                 label={label}
@@ -250,13 +277,31 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
                 {secondaryLabel}
               </StyledSecondaryLabel>
             )}
+            {hasLabels && (
+              <HiddenLabelText
+                data-testid={testId && `${testId}-labels-hiddenlabeltext`}
+              >
+                {`, ${stepLabel} ${stepStatus}`}
+              </HiddenLabelText>
+            )}
           </>
         ) : (
-          <HiddenLabelText>
-            {label && secondaryLabel
-              ? `${label} ${secondaryLabel}, ${stepStatus}`
-              : label || secondaryLabel}
-          </HiddenLabelText>
+          !isSummaryView && (
+            <HiddenLabelText
+              data-testid={testId && `${testId}-nolabels-hiddenlabeltext`}
+            >
+              {label && secondaryLabel
+                ? `${stepLabel} ${
+                    index + 1
+                  }, ${label} ${secondaryLabel}, ${stepStatus}`
+                : `${stepLabel} ${
+                    index + 1
+                  }, ${label}, ${stepLabel} ${stepStatus}` ||
+                  `${stepLabel} ${
+                    index + 1
+                  }, ${secondaryLabel}, ${stepLabel} ${stepStatus}`}
+            </HiddenLabelText>
+          )
         )}
       </StyledStepTextWrapper>
     </StyledStep>

--- a/packages/react-magma-dom/src/components/Stepper/Step.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Step.tsx
@@ -9,7 +9,7 @@ import { useIsInverse } from '../../inverse';
 import { transparentize } from 'polished';
 import { HiddenStyles } from '../../utils/UtilityStyles';
 
-export interface StepProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
   /**
    * Error state for each step.
    * @default false
@@ -124,7 +124,7 @@ export const HiddenLabelText = typedStyled.span`
   ${HiddenStyles};
 `;
 
-const StyledStep = typedStyled.div`
+const StyledStep = typedStyled.li`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -199,68 +199,66 @@ const StyledSecondaryLabel = typedStyled.span<{
   margin: 2px 12px 0 12px;
 `;
 
-export const Step = React.forwardRef<HTMLDivElement, StepProps>(
-  (props, ref) => {
-    const {
-      hasError,
-      areLabelsHidden,
-      label,
-      secondaryLabel,
-      testId,
-      isInverse: isInverseProp,
-      stepStatus,
-      ...rest
-    } = props;
-    const theme = React.useContext(ThemeContext);
-    const isInverse = useIsInverse(isInverseProp);
+export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
+  const {
+    hasError,
+    areLabelsHidden,
+    label,
+    secondaryLabel,
+    testId,
+    isInverse: isInverseProp,
+    stepStatus,
+    ...rest
+  } = props;
+  const theme = React.useContext(ThemeContext);
+  const isInverse = useIsInverse(isInverseProp);
 
-    return (
-      <StyledStep {...rest} ref={ref} data-testid={testId}>
-        <StyledStepIndicator
-          hasError={hasError}
-          isInverse={isInverse}
-          stepStatus={stepStatus}
-          theme={theme}
-        >
-          {stepStatus === StepStatus.complete && !hasError && (
-            <CheckIcon aria-hidden="true" />
-          )}
-          {hasError && <CrossIcon aria-hidden="true" />}
-        </StyledStepIndicator>
+  return (
+    <StyledStep {...rest} ref={ref} data-testid={testId}>
+      <StyledStepIndicator
+        hasError={hasError}
+        isInverse={isInverse}
+        stepStatus={stepStatus}
+        theme={theme}
+      >
+        {stepStatus === StepStatus.complete && !hasError && (
+          <CheckIcon aria-hidden="true" />
+        )}
+        {hasError && <CrossIcon aria-hidden="true" />}
+      </StyledStepIndicator>
 
-        <StyledStepTextWrapper>
-          {!areLabelsHidden ? (
-            <>
-              {label && (
-                <StyledLabel
-                  label={label}
-                  isInverse={isInverse}
-                  data-testid={testId && `${testId}-label`}
-                  theme={theme}
-                >
-                  {label}
-                </StyledLabel>
-              )}
-              {secondaryLabel && (
-                <StyledSecondaryLabel
-                  secondaryLabel={secondaryLabel}
-                  isInverse={isInverse}
-                  data-testid={testId && `${testId}-secondaryLabel`}
-                  theme={theme}
-                >
-                  {secondaryLabel}
-                </StyledSecondaryLabel>
-              )}
-            </>
-          ) : (
-            <HiddenLabelText>
-              {label && secondaryLabel
-                ? `${label} ${secondaryLabel}`
-                : label || secondaryLabel}
-            </HiddenLabelText>
-          )}
-        </StyledStepTextWrapper>
-      </StyledStep>
-    );
-  }
-);
+      <StyledStepTextWrapper>
+        {!areLabelsHidden ? (
+          <>
+            {label && (
+              <StyledLabel
+                label={label}
+                isInverse={isInverse}
+                data-testid={testId && `${testId}-label`}
+                theme={theme}
+              >
+                {label}
+              </StyledLabel>
+            )}
+            {secondaryLabel && (
+              <StyledSecondaryLabel
+                secondaryLabel={secondaryLabel}
+                isInverse={isInverse}
+                data-testid={testId && `${testId}-secondaryLabel`}
+                theme={theme}
+              >
+                {secondaryLabel}
+              </StyledSecondaryLabel>
+            )}
+          </>
+        ) : (
+          <HiddenLabelText data-testid="hello again">
+            {label && secondaryLabel
+              ? `${label} ${secondaryLabel}, ${stepStatus}`
+              : label || secondaryLabel}
+          </HiddenLabelText>
+        )}
+      </StyledStepTextWrapper>
+    </StyledStep>
+  );
+});

--- a/packages/react-magma-dom/src/components/Stepper/Step.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Step.tsx
@@ -19,10 +19,6 @@ export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
   /**
    * @internal
    */
-  areLabelsHidden?: boolean;
-  /**
-   * @internal
-   */
   layout?: StepperLayout;
   /**
    * Label beneath each step.
@@ -60,7 +56,7 @@ export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
 
 export enum StepStatus {
   active = 'active',
-  complete = 'complete',
+  completed = 'completed',
   incomplete = 'incomplete',
 }
 
@@ -87,13 +83,13 @@ function buildStepCircleOutlineColors(props) {
 function buildStepCircleBackgroundColors(props) {
   const { isInverse, stepStatus, hasError, theme } = props;
   if (isInverse) {
-    if (stepStatus === StepStatus.complete && !hasError) {
+    if (stepStatus === StepStatus.completed && !hasError) {
       return theme.colors.tertiary500;
     } else if (hasError) {
       return theme.colors.danger500;
     }
   } else {
-    if (stepStatus === StepStatus.complete && !hasError) {
+    if (stepStatus === StepStatus.completed && !hasError) {
       return theme.colors.primary500;
     } else if (hasError) {
       return theme.colors.danger500;
@@ -215,7 +211,6 @@ const StyledSecondaryLabel = typedStyled.span<{
 export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
   const {
     hasError,
-    areLabelsHidden,
     index,
     label,
     layout,
@@ -237,14 +232,15 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
         stepStatus={stepStatus}
         theme={theme}
       >
-        {stepStatus === StepStatus.complete && !hasError && (
+        {stepStatus === StepStatus.completed && !hasError && (
           <CheckIcon aria-hidden="true" />
         )}
         {hasError && <CrossIcon aria-hidden="true" />}
       </StyledStepIndicator>
 
       <StyledStepTextWrapper>
-        {!areLabelsHidden ? (
+        {layout !== StepperLayout.hideLabels &&
+        layout !== StepperLayout.summaryView ? (
           <>
             {layout === StepperLayout.showLabels && (
               <HiddenLabelText>{`${stepLabel} ${index + 1}, `}</HiddenLabelText>
@@ -271,7 +267,7 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
             )}
             {layout === StepperLayout.showLabels && (
               <HiddenLabelText>
-                {stepStatus === StepStatus.complete
+                {stepStatus === StepStatus.completed
                   ? `, ${stepLabel} ${stepStatus}`
                   : ''}
               </HiddenLabelText>
@@ -279,13 +275,11 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
           </>
         ) : (
           layout !== StepperLayout.summaryView && (
-            <HiddenLabelText
-              data-testid={testId && `${testId}-hiddenlabeltext`}
-            >
+            <HiddenLabelText>
               {`${stepLabel} ${index + 1}, ${label || ''}${
                 secondaryLabel ? ' ' : ''
               }${secondaryLabel || ''}${
-                stepStatus === StepStatus.complete
+                stepStatus === StepStatus.completed
                   ? `, ${stepLabel} ${stepStatus}`
                   : ''
               }`}

--- a/packages/react-magma-dom/src/components/Stepper/Step.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Step.tsx
@@ -8,6 +8,7 @@ import { ThemeInterface } from '../../theme/magma';
 import { useIsInverse } from '../../inverse';
 import { transparentize } from 'polished';
 import { HiddenStyles } from '../../utils/UtilityStyles';
+import { StepperLayout } from './Stepper';
 
 export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
   /**
@@ -22,7 +23,7 @@ export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
   /**
    * @internal
    */
-  hasLabels?: boolean;
+  layout?: StepperLayout;
   /**
    * Label beneath each step.
    */
@@ -39,10 +40,6 @@ export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
    * @internal
    */
   index?: number;
-  /**
-   * @internal
-   */
-  isSummaryView?: boolean;
   /**
    * @internal
    */
@@ -219,10 +216,9 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
   const {
     hasError,
     areLabelsHidden,
-    hasLabels,
     index,
     label,
-    isSummaryView,
+    layout,
     secondaryLabel,
     stepLabel,
     testId,
@@ -250,12 +246,8 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
       <StyledStepTextWrapper>
         {!areLabelsHidden ? (
           <>
-            {hasLabels && (
-              <HiddenLabelText
-                data-testid={testId && `${testId}-labels-hiddenlabeltext`}
-              >
-                {`${stepLabel} ${index + 1}, `}
-              </HiddenLabelText>
+            {layout === StepperLayout.showLabels && (
+              <HiddenLabelText>{`${stepLabel} ${index + 1}, `}</HiddenLabelText>
             )}
             {label && (
               <StyledLabel
@@ -277,29 +269,26 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
                 {secondaryLabel}
               </StyledSecondaryLabel>
             )}
-            {hasLabels && (
-              <HiddenLabelText
-                data-testid={testId && `${testId}-labels-hiddenlabeltext`}
-              >
-                {`, ${stepLabel} ${stepStatus}`}
+            {layout === StepperLayout.showLabels && (
+              <HiddenLabelText>
+                {stepStatus === StepStatus.complete
+                  ? `, ${stepLabel} ${stepStatus}`
+                  : ''}
               </HiddenLabelText>
             )}
           </>
         ) : (
-          !isSummaryView && (
+          layout !== StepperLayout.summaryView && (
             <HiddenLabelText
-              data-testid={testId && `${testId}-nolabels-hiddenlabeltext`}
+              data-testid={testId && `${testId}-hiddenlabeltext`}
             >
-              {label && secondaryLabel
-                ? `${stepLabel} ${
-                    index + 1
-                  }, ${label} ${secondaryLabel}, ${stepStatus}`
-                : `${stepLabel} ${
-                    index + 1
-                  }, ${label}, ${stepLabel} ${stepStatus}` ||
-                  `${stepLabel} ${
-                    index + 1
-                  }, ${secondaryLabel}, ${stepLabel} ${stepStatus}`}
+              {`${stepLabel} ${index + 1}, ${label || ''}${
+                secondaryLabel ? ' ' : ''
+              }${secondaryLabel || ''}${
+                stepStatus === StepStatus.complete
+                  ? `, ${stepLabel} ${stepStatus}`
+                  : ''
+              }`}
             </HiddenLabelText>
           )
         )}

--- a/packages/react-magma-dom/src/components/Stepper/Step.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Step.tsx
@@ -133,14 +133,13 @@ export const HiddenLabelText = typedStyled.span`
   ${HiddenStyles};
 `;
 
-const StyledStep = typedStyled.li`
+const StyledStep = typedStyled.span`
   display: flex;
   flex-direction: column;
   justify-content: center;
   text-align: center;
   align-self: self-start;
   align-items: center;
-
 `;
 
 const StyledStepIndicator = typedStyled.span<{

--- a/packages/react-magma-dom/src/components/Stepper/Step.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Step.tsx
@@ -10,7 +10,7 @@ import { transparentize } from 'polished';
 import { HiddenStyles } from '../../utils/UtilityStyles';
 import { StepperLayout } from './Stepper';
 
-export interface StepProps extends React.HTMLAttributes<HTMLLIElement> {
+export interface StepProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Error state for each step.
    * @default false
@@ -133,7 +133,7 @@ export const HiddenLabelText = typedStyled.span`
   ${HiddenStyles};
 `;
 
-const StyledStep = typedStyled.span`
+const StyledStep = typedStyled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -168,7 +168,7 @@ const StyledStepIndicator = typedStyled.span<{
   }
 `;
 
-const StyledStepTextWrapper = typedStyled.div`
+const StyledStepTextWrapper = typedStyled.span`
   flex: 1;
   display: flex;
   align-self: center;
@@ -207,84 +207,86 @@ const StyledSecondaryLabel = typedStyled.span<{
   margin: 2px 12px 0 12px;
 `;
 
-export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
-  const {
-    hasError,
-    index,
-    label,
-    layout,
-    secondaryLabel,
-    stepLabel,
-    testId,
-    isInverse: isInverseProp,
-    stepStatus,
-    ...rest
-  } = props;
-  const theme = React.useContext(ThemeContext);
-  const isInverse = useIsInverse(isInverseProp);
+export const Step = React.forwardRef<HTMLDivElement, StepProps>(
+  (props, ref) => {
+    const {
+      hasError,
+      index,
+      label,
+      layout,
+      secondaryLabel,
+      stepLabel,
+      testId,
+      isInverse: isInverseProp,
+      stepStatus,
+      ...rest
+    } = props;
+    const theme = React.useContext(ThemeContext);
+    const isInverse = useIsInverse(isInverseProp);
 
-  return (
-    <StyledStep {...rest} ref={ref} data-testid={testId}>
-      <StyledStepIndicator
-        hasError={hasError}
-        isInverse={isInverse}
-        stepStatus={stepStatus}
-        theme={theme}
-      >
-        {stepStatus === StepStatus.completed && !hasError && (
-          <CheckIcon aria-hidden="true" />
-        )}
-        {hasError && <CrossIcon aria-hidden="true" />}
-      </StyledStepIndicator>
+    return (
+      <StyledStep {...rest} ref={ref} data-testid={testId}>
+        <StyledStepIndicator
+          hasError={hasError}
+          isInverse={isInverse}
+          stepStatus={stepStatus}
+          theme={theme}
+        >
+          {stepStatus === StepStatus.completed && !hasError && (
+            <CheckIcon aria-hidden="true" />
+          )}
+          {hasError && <CrossIcon aria-hidden="true" />}
+        </StyledStepIndicator>
 
-      <StyledStepTextWrapper>
-        {layout !== StepperLayout.hideLabels &&
-        layout !== StepperLayout.summaryView ? (
-          <>
-            {layout === StepperLayout.showLabels && (
+        <StyledStepTextWrapper>
+          {layout !== StepperLayout.hideLabels &&
+          layout !== StepperLayout.summaryView ? (
+            <>
+              {layout === StepperLayout.showLabels && (
+                <HiddenLabelText>
+                  {`${
+                    stepStatus === StepStatus.completed
+                      ? `${stepLabel} ${stepStatus}, `
+                      : ''
+                  }`}
+                </HiddenLabelText>
+              )}
+              {label && (
+                <StyledLabel
+                  label={label}
+                  isInverse={isInverse}
+                  data-testid={testId && `${testId}-label`}
+                  theme={theme}
+                >
+                  {label}
+                </StyledLabel>
+              )}
+              {secondaryLabel && (
+                <StyledSecondaryLabel
+                  secondaryLabel={secondaryLabel}
+                  isInverse={isInverse}
+                  data-testid={testId && `${testId}-secondaryLabel`}
+                  theme={theme}
+                >
+                  {secondaryLabel}
+                </StyledSecondaryLabel>
+              )}
+            </>
+          ) : (
+            layout !== StepperLayout.summaryView && (
               <HiddenLabelText>
                 {`${
                   stepStatus === StepStatus.completed
                     ? `${stepLabel} ${stepStatus}, `
                     : ''
+                }${label || ''}${secondaryLabel ? ' ' : ''}${
+                  secondaryLabel || ''
                 }`}
               </HiddenLabelText>
-            )}
-            {label && (
-              <StyledLabel
-                label={label}
-                isInverse={isInverse}
-                data-testid={testId && `${testId}-label`}
-                theme={theme}
-              >
-                {label}
-              </StyledLabel>
-            )}
-            {secondaryLabel && (
-              <StyledSecondaryLabel
-                secondaryLabel={secondaryLabel}
-                isInverse={isInverse}
-                data-testid={testId && `${testId}-secondaryLabel`}
-                theme={theme}
-              >
-                {secondaryLabel}
-              </StyledSecondaryLabel>
-            )}
-          </>
-        ) : (
-          layout !== StepperLayout.summaryView && (
-            <HiddenLabelText>
-              {`${
-                stepStatus === StepStatus.completed
-                  ? `${stepLabel} ${stepStatus}, `
-                  : ''
-              }${label || ''}${secondaryLabel ? ' ' : ''}${
-                secondaryLabel || ''
-              }`}
-            </HiddenLabelText>
-          )
-        )}
-      </StyledStepTextWrapper>
-    </StyledStep>
-  );
-});
+            )
+          )}
+        </StyledStepTextWrapper>
+      </StyledStep>
+    );
+  }
+);

--- a/packages/react-magma-dom/src/components/Stepper/Step.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Step.tsx
@@ -243,7 +243,13 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
         layout !== StepperLayout.summaryView ? (
           <>
             {layout === StepperLayout.showLabels && (
-              <HiddenLabelText>{`${stepLabel} ${index + 1}, `}</HiddenLabelText>
+              <HiddenLabelText>
+                {`${
+                  stepStatus === StepStatus.completed
+                    ? `${stepLabel} ${stepStatus}, `
+                    : ''
+                }`}
+              </HiddenLabelText>
             )}
             {label && (
               <StyledLabel
@@ -265,23 +271,16 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
                 {secondaryLabel}
               </StyledSecondaryLabel>
             )}
-            {layout === StepperLayout.showLabels && (
-              <HiddenLabelText>
-                {stepStatus === StepStatus.completed
-                  ? `, ${stepLabel} ${stepStatus}`
-                  : ''}
-              </HiddenLabelText>
-            )}
           </>
         ) : (
           layout !== StepperLayout.summaryView && (
             <HiddenLabelText>
-              {`${stepLabel} ${index + 1}, ${label || ''}${
-                secondaryLabel ? ' ' : ''
-              }${secondaryLabel || ''}${
+              {`${
                 stepStatus === StepStatus.completed
-                  ? `, ${stepLabel} ${stepStatus}`
+                  ? `${stepLabel} ${stepStatus}, `
                   : ''
+              }${label || ''}${secondaryLabel ? ' ' : ''}${
+                secondaryLabel || ''
               }`}
             </HiddenLabelText>
           )

--- a/packages/react-magma-dom/src/components/Stepper/Step.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Step.tsx
@@ -252,7 +252,7 @@ export const Step = React.forwardRef<HTMLLIElement, StepProps>((props, ref) => {
             )}
           </>
         ) : (
-          <HiddenLabelText data-testid="hello again">
+          <HiddenLabelText>
             {label && secondaryLabel
               ? `${label} ${secondaryLabel}, ${stepStatus}`
               : label || secondaryLabel}

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.stories.tsx
@@ -24,14 +24,18 @@ export default {
       control: 'number',
     },
     breakpointLayout: {
-      control: 'select',
-      options: StepperLayout,
-      defaultValue: StepperLayout.hideLabels,
+      control: {
+        type: 'select',
+        options: StepperLayout,
+        defaultValue: StepperLayout.hideLabels,
+      },
     },
     layout: {
-      control: 'select',
-      options: StepperLayout,
-      defaultValue: StepperLayout.showLabels,
+      control: {
+        type: 'select',
+        options: StepperLayout,
+        defaultValue: StepperLayout.showLabels,
+      },
     },
     completionLabel: {
       control: 'text',
@@ -174,20 +178,28 @@ const RealisticLabels: Story<StepperProps> = args => {
     <>
       <Stepper currentStep={currentStep} {...args}>
         <Step
+          key={0}
           label="Fenway seating"
           secondaryLabel="Select an area in the ball park"
+          testId="fenway0"
         />
         <Step
+          key={1}
           label="Guest information"
           secondaryLabel="Please fill out the registration form for your party"
+          testId="fenway1"
         />
         <Step
+          key={2}
           label="Yankees fans?"
           secondaryLabel="An additional surcharge may be applicable"
+          testId="fenway2"
         />
         <Step
+          key={3}
           label="MBTA and parking information"
           secondaryLabel="Suggested methods of transportation"
+          testId="fenway3"
         />
       </Stepper>
 
@@ -224,16 +236,21 @@ const ErrorTemplate: Story<StepperProps> = args => {
   return (
     <>
       <Stepper currentStep={2} {...args}>
-        <Step label="First Item" secondaryLabel="Description One">
+        <Step key={0} label="First Item" secondaryLabel="Description One">
           Item Content One
         </Step>
-        <Step label="Second Item" secondaryLabel="Description Two">
+        <Step key={1} label="Second Item" secondaryLabel="Description Two">
           Item Content Two
         </Step>
-        <Step label="Third Item" hasError secondaryLabel="Description Three">
+        <Step
+          key={2}
+          label="Third Item"
+          hasError
+          secondaryLabel="Description Three"
+        >
           Item Content Three
         </Step>
-        <Step label="Fourth Item" secondaryLabel="Description Four">
+        <Step key={3} label="Fourth Item" secondaryLabel="Description Four">
           Item Content Four
         </Step>
       </Stepper>

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.stories.tsx
@@ -163,6 +163,79 @@ const Template: Story<StepperProps> = args => {
   );
 };
 
+const RealisticLabels: Story<StepperProps> = args => {
+  const [currentStep, setCurrentStep] = React.useState(0);
+
+  const handleOnNext = () => {
+    if (currentStep !== 4) {
+      setCurrentStep(currentStep + 1);
+    }
+  };
+  const handleOnPrevious = () => {
+    if (currentStep !== 0) {
+      setCurrentStep(currentStep - 1);
+    }
+  };
+  const handleFinish = () => {
+    if (currentStep >= 4) {
+      setCurrentStep(0);
+    }
+  };
+
+  return (
+    <>
+      <Stepper
+        ariaLabel="progress"
+        currentStep={currentStep}
+        stepLabel="Module"
+      >
+        <Step
+          label="Fenway seating"
+          secondaryLabel="Select an area in the ball park"
+        />
+        <Step
+          label="Guest information"
+          secondaryLabel="Please fill out the registration form for your party"
+        />
+        <Step
+          label="Yankees fans?"
+          secondaryLabel="An additional surcharge may be applicable"
+        />
+        <Step
+          label="MBTA and parking information"
+          secondaryLabel="Suggested methods of transportation"
+        />
+      </Stepper>
+
+      <Container
+        style={{
+          background: '#F5F5F5',
+          borderRadius: '6px',
+          margin: '20px 0 0',
+          padding: '20px',
+        }}
+      >
+        {currentStep === 0 && <div>Step Content One</div>}
+        {currentStep === 1 && <div>Step Content Two</div>}
+        {currentStep === 2 && <div>Step Content Three</div>}
+        {currentStep === 3 && <div>Step Content Four</div>}
+        {currentStep === 4 && <div>Steps completed</div>}
+      </Container>
+
+      <Container style={{ padding: '20px 0' }}>
+        <ButtonGroup>
+          <Button disabled={currentStep === 0} onClick={handleOnPrevious}>
+            Previous
+          </Button>
+          <Button onClick={currentStep >= 4 ? handleFinish : handleOnNext}>
+            {currentStep >= 4 ? 'Finish' : 'Next'}
+          </Button>
+        </ButtonGroup>
+      </Container>
+    </>
+  );
+};
+
 const ErrorTemplate: Story<StepperProps> = args => {
   return (
     <>
@@ -203,6 +276,11 @@ const ErrorTemplate: Story<StepperProps> = args => {
 
 export const Default = Template.bind({});
 Default.args = {
+  ariaLabel: 'progress',
+};
+
+export const RealWorldExample = RealisticLabels.bind({});
+RealisticLabels.args = {
   ariaLabel: 'progress',
 };
 

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.stories.tsx
@@ -99,8 +99,8 @@ const Template: Story<StepperProps> = args => {
     return (
       <Step
         key={i}
-        testId={`Step ${i}`}
-        label={`Step ${i}`}
+        testId={`Item ${i}`}
+        label={`Item ${i}`}
         secondaryLabel={`Description area in secondaryLabel component ${i}`}
       />
     );
@@ -122,8 +122,8 @@ const Template: Story<StepperProps> = args => {
       >
         <div>
           {currentStep < numberOfSteps
-            ? `Step Content ${currentStep + 1}`
-            : `Steps Completed`}
+            ? `Item Content ${currentStep + 1}`
+            : `Items Completed`}
         </div>
       </Container>
 
@@ -167,17 +167,17 @@ const ErrorTemplate: Story<StepperProps> = args => {
   return (
     <>
       <Stepper ariaLabel="progress" currentStep={2} {...args}>
-        <Step label="First Step" secondaryLabel="Description One">
-          Step Content One
+        <Step label="First Item" secondaryLabel="Description One">
+          Item Content One
         </Step>
-        <Step label="Second Step" secondaryLabel="Description Two">
-          Step Content Two
+        <Step label="Second Item" secondaryLabel="Description Two">
+          Item Content Two
         </Step>
-        <Step label="Third Step" hasError secondaryLabel="Description Three">
-          Step Content Three
+        <Step label="Third Item" hasError secondaryLabel="Description Three">
+          Item Content Three
         </Step>
-        <Step label="Fourth Step" secondaryLabel="Description Four">
-          Step Content Four
+        <Step label="Fourth Item" secondaryLabel="Description Four">
+          Item Content Four
         </Step>
       </Stepper>
       <Container
@@ -188,7 +188,7 @@ const ErrorTemplate: Story<StepperProps> = args => {
           padding: '20px',
         }}
       >
-        <div>Step Content Three</div>
+        <div>Item Content Three</div>
       </Container>
 
       <Container style={{ padding: '20px 0' }}>

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.stories.tsx
@@ -21,46 +21,34 @@ export default {
   ],
   argTypes: {
     breakpoint: {
-      control: {
-        type: 'number',
-      },
+      control: 'number',
     },
     breakpointLayout: {
-      control: {
-        type: 'select',
-        options: StepperLayout,
-      },
+      control: 'select',
+      options: StepperLayout,
+      defaultValue: StepperLayout.hideLabels,
     },
     layout: {
-      control: {
-        type: 'select',
-        options: StepperLayout,
-      },
+      control: 'select',
+      options: StepperLayout,
+      defaultValue: StepperLayout.showLabels,
     },
     completionLabel: {
-      control: {
-        type: 'text',
-      },
+      control: 'text',
     },
     stepLabel: {
-      control: {
-        type: 'text',
-      },
+      control: 'text',
     },
     isInverse: {
-      control: {
-        type: 'boolean',
-      },
+      control: 'boolean',
+      defaultValue: false,
     },
     testId: {
-      control: {
-        type: 'text',
-      },
+      control: 'text',
     },
     ariaLabel: {
-      control: {
-        type: 'text',
-      },
+      control: 'text',
+      defaultValue: 'progress',
     },
   },
 } as Meta;
@@ -108,7 +96,7 @@ const Template: Story<StepperProps> = args => {
 
   return (
     <>
-      <Stepper ariaLabel="progress" currentStep={currentStep} {...args}>
+      <Stepper currentStep={currentStep} {...args}>
         {step}
       </Stepper>
 
@@ -184,11 +172,7 @@ const RealisticLabels: Story<StepperProps> = args => {
 
   return (
     <>
-      <Stepper
-        ariaLabel="progress"
-        currentStep={currentStep}
-        stepLabel="Module"
-      >
+      <Stepper currentStep={currentStep} {...args}>
         <Step
           label="Fenway seating"
           secondaryLabel="Select an area in the ball park"
@@ -215,10 +199,10 @@ const RealisticLabels: Story<StepperProps> = args => {
           padding: '20px',
         }}
       >
-        {currentStep === 0 && <div>Step Content One</div>}
-        {currentStep === 1 && <div>Step Content Two</div>}
-        {currentStep === 2 && <div>Step Content Three</div>}
-        {currentStep === 3 && <div>Step Content Four</div>}
+        {currentStep === 0 && <div>Fenway seating Content</div>}
+        {currentStep === 1 && <div>Guest information Content</div>}
+        {currentStep === 2 && <div>Yankees fans? Content</div>}
+        {currentStep === 3 && <div>MBTA and parking information Content</div>}
         {currentStep === 4 && <div>Steps completed</div>}
       </Container>
 
@@ -239,7 +223,7 @@ const RealisticLabels: Story<StepperProps> = args => {
 const ErrorTemplate: Story<StepperProps> = args => {
   return (
     <>
-      <Stepper ariaLabel="progress" currentStep={2} {...args}>
+      <Stepper currentStep={2} {...args}>
         <Step label="First Item" secondaryLabel="Description One">
           Item Content One
         </Step>
@@ -275,13 +259,11 @@ const ErrorTemplate: Story<StepperProps> = args => {
 };
 
 export const Default = Template.bind({});
-Default.args = {
-  ariaLabel: 'progress',
-};
+Default.args = {};
 
 export const RealWorldExample = RealisticLabels.bind({});
 RealisticLabels.args = {
-  ariaLabel: 'progress',
+  stepLabel: 'Module',
 };
 
 export const WithError = ErrorTemplate.bind({});

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
@@ -57,13 +57,13 @@ describe('Stepper', () => {
       );
 
       expect(getByTestId(`${testId}-1`)).toHaveTextContent(
-        `Step 1, ${TEXT}-1, Step completed`
+        `Step completed, ${TEXT}-1`
       );
       expect(getByTestId(`${testId}-1`)).toHaveAttribute(
         'aria-current',
         'false'
       );
-      expect(getByTestId(`${testId}-2`)).toHaveTextContent(`Step 2, ${TEXT}-2`);
+      expect(getByTestId(`${testId}-2`)).toHaveTextContent(`${TEXT}-2`);
       expect(getByTestId(`${testId}-2`)).toHaveAttribute(
         'aria-current',
         'step'
@@ -83,13 +83,13 @@ describe('Stepper', () => {
       );
 
       expect(getByTestId(`${testId}-1`)).toHaveTextContent(
-        `Step 1, ${TEXT}-1, Step completed`
+        `Step completed, ${TEXT}-1`
       );
       expect(getByTestId(`${testId}-1`)).toHaveAttribute(
         'aria-current',
         'false'
       );
-      expect(getByTestId(`${testId}-2`)).toHaveTextContent(`Step 2, ${TEXT}-2`);
+      expect(getByTestId(`${testId}-2`)).toHaveTextContent(`${TEXT}-2`);
       expect(getByTestId(`${testId}-2`)).toHaveAttribute(
         'aria-current',
         'step'
@@ -468,8 +468,8 @@ describe('Stepper', () => {
           </Stepper>
         );
 
-        const label1 = getByText(`Step 1, ${TEXT}-1, Step completed`);
-        const label2 = getByText(`Step 2, ${TEXT}-2`);
+        const label1 = getByText(`Step completed, ${TEXT}-1`);
+        const label2 = getByText(`${TEXT}-2`);
 
         expect(label1).toHaveStyleRule('height', '1px');
         expect(label1).toHaveStyleRule('position', 'absolute');
@@ -503,7 +503,7 @@ describe('Stepper', () => {
         expect(getByTestId(testId)).toHaveTextContent('Step 1 of 2');
       });
 
-      it('should show labels when layout is set to showLabels', () => {
+      it('should show labels when layout is set to "showLabels"', () => {
         const { getByText } = render(
           <Stepper
             ariaLabel="progress"
@@ -543,7 +543,7 @@ describe('Stepper', () => {
           global.innerWidth = 1400;
           global.dispatchEvent(new Event('resize'));
         });
-        const label1 = getByText(`Step 1,`);
+        const label1 = getByText(`Step completed,`);
 
         expect(label1).toHaveStyleRule('height', '1px');
         expect(label1).toHaveStyleRule('position', 'absolute');

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
@@ -13,35 +13,97 @@ const testId = 'test-id';
 
 describe('Stepper', () => {
   it('should find element by testId', () => {
-    const { getByTestId } = render(<Stepper ariaLabel="progress"  testId={testId}></Stepper>);
+    const { getByTestId } = render(
+      <Stepper ariaLabel="progress" testId={testId}></Stepper>
+    );
 
     expect(getByTestId(testId)).toBeInTheDocument();
   });
 
-  it('Does not violate accessibility standards', () => {
-    const { container } = render(<Stepper ariaLabel="progress" role="form"></Stepper>);
+  describe('Accessibility', () => {
+    it('Does not violate accessibility standards', () => {
+      const { container } = render(
+        <Stepper ariaLabel="progress" role="form"></Stepper>
+      );
 
-    return axe(container.innerHTML).then(result => {
-      return expect(result).toHaveNoViolations();
+      return axe(container.innerHTML).then(result => {
+        return expect(result).toHaveNoViolations();
+      });
     });
-  });
 
-  it('should use the custom aria-label', () => {
-    const { getByLabelText } = render(
-      <Stepper ariaLabel="custom" testId={testId}  currentStep={0}>
-        <Step />
-        <Step />
-      </Stepper>
-    );
+    it('should use the custom aria-label', () => {
+      const { getByLabelText } = render(
+        <Stepper ariaLabel="custom" testId={testId} currentStep={0}>
+          <Step />
+          <Step />
+        </Stepper>
+      );
 
-    const customAriaLabel = getByLabelText('custom', {selector: 'div'});
+      const customAriaLabel = getByLabelText('custom', { selector: 'div' });
 
-    expect(customAriaLabel).toBeInTheDocument();
+      expect(customAriaLabel).toBeInTheDocument();
+    });
+
+    it('should have hidden labels for screen readers when layout is set to "showLabels"', () => {
+      const { getByTestId } = render(
+        <Stepper
+          ariaLabel="progress"
+          layout={StepperLayout.showLabels}
+          currentStep={0}
+        >
+          <Step
+            testId={`${testId}-1-nolabels-hiddenlabeltext`}
+            label={`${TEXT}-1`}
+          />
+          <Step
+            testId={`${testId}-2-nolabels-hiddenlabeltext`}
+            label={`${TEXT}-2`}
+          />
+        </Stepper>
+      );
+
+      expect(
+        getByTestId(`${testId}-1-nolabels-hiddenlabeltext`)
+      ).toHaveTextContent(`Step 1, ${TEXT}-1, Step active`);
+      expect(
+        getByTestId(`${testId}-2-nolabels-hiddenlabeltext`)
+      ).toHaveTextContent(`Step 2, ${TEXT}-2, Step incomplete`);
+    });
+
+    it('should have hidden labels for screen readers when layout is set to "hideLabels"', () => {
+      const { getByTestId } = render(
+        <Stepper
+          ariaLabel="progress"
+          layout={StepperLayout.hideLabels}
+          currentStep={1}
+        >
+          <Step
+            testId={`${testId}-1-nolabels-hiddenlabeltext`}
+            label={`${TEXT}-1`}
+          />
+          <Step
+            testId={`${testId}-2-nolabels-hiddenlabeltext`}
+            label={`${TEXT}-2`}
+          />
+        </Stepper>
+      );
+
+      expect(
+        getByTestId(`${testId}-1-nolabels-hiddenlabeltext`)
+      ).toHaveTextContent(`Step 1, ${TEXT}-1, Step complete`);
+      expect(
+        getByTestId(`${testId}-2-nolabels-hiddenlabeltext`)
+      ).toHaveTextContent(`Step 2, ${TEXT}-2, Step active`);
+    });
   });
 
   it('should use the default completion label', () => {
     const { getByText } = render(
-      <Stepper ariaLabel="progress"  currentStep={2} layout={StepperLayout.summaryView}>
+      <Stepper
+        ariaLabel="progress"
+        currentStep={2}
+        layout={StepperLayout.summaryView}
+      >
         <Step />
         <Step />
       </Stepper>
@@ -52,7 +114,11 @@ describe('Stepper', () => {
 
   it('should use the default step label', () => {
     const { getByText } = render(
-      <Stepper ariaLabel="progress"  currentStep={0} layout={StepperLayout.summaryView}>
+      <Stepper
+        ariaLabel="progress"
+        currentStep={0}
+        layout={StepperLayout.summaryView}
+      >
         <Step />
         <Step />
       </Stepper>
@@ -63,7 +129,8 @@ describe('Stepper', () => {
 
   it('should use the custom completion label', () => {
     const { getByText } = render(
-      <Stepper ariaLabel="progress" 
+      <Stepper
+        ariaLabel="progress"
         completionLabel="You're victorious"
         currentStep={2}
         layout={StepperLayout.summaryView}
@@ -78,7 +145,8 @@ describe('Stepper', () => {
 
   it('should use the custom step label', () => {
     const { getByText } = render(
-      <Stepper ariaLabel="progress" 
+      <Stepper
+        ariaLabel="progress"
         stepLabel="Party On"
         currentStep={0}
         layout={StepperLayout.summaryView}
@@ -103,7 +171,11 @@ describe('Stepper', () => {
             },
           }}
         >
-          <Stepper ariaLabel="progress"  currentStep={2} layout={StepperLayout.summaryView}>
+          <Stepper
+            ariaLabel="progress"
+            currentStep={2}
+            layout={StepperLayout.summaryView}
+          >
             <Step />
             <Step />
           </Stepper>
@@ -126,7 +198,11 @@ describe('Stepper', () => {
             },
           }}
         >
-          <Stepper ariaLabel="progress"  currentStep={0} layout={StepperLayout.summaryView}>
+          <Stepper
+            ariaLabel="progress"
+            currentStep={0}
+            layout={StepperLayout.summaryView}
+          >
             <Step />
             <Step />
           </Stepper>
@@ -140,7 +216,7 @@ describe('Stepper', () => {
   describe('Styling', () => {
     it('should have an active styled circle', () => {
       const { getByTestId } = render(
-        <Stepper ariaLabel="progress"  currentStep={0}>
+        <Stepper ariaLabel="progress" currentStep={0}>
           <Step testId={testId} />
           <Step />
         </Stepper>
@@ -156,7 +232,7 @@ describe('Stepper', () => {
 
     it('should have an incomplete styled circle', () => {
       const { getByTestId } = render(
-        <Stepper ariaLabel="progress"  currentStep={0}>
+        <Stepper ariaLabel="progress" currentStep={0}>
           <Step />
           <Step testId={testId} />
         </Stepper>
@@ -172,7 +248,7 @@ describe('Stepper', () => {
 
     it('should have a completed styled circle', () => {
       const { getByTestId } = render(
-        <Stepper ariaLabel="progress"  currentStep={1}>
+        <Stepper ariaLabel="progress" currentStep={1}>
           <Step testId={testId} />
           <Step />
         </Stepper>
@@ -185,7 +261,7 @@ describe('Stepper', () => {
 
     it('should have a error styled circle', () => {
       const { getByTestId } = render(
-        <Stepper ariaLabel="progress"  currentStep={1}>
+        <Stepper ariaLabel="progress" currentStep={1}>
           <Step testId={testId} hasError />
           <Step />
         </Stepper>
@@ -198,7 +274,7 @@ describe('Stepper', () => {
 
     it('should have a primary label', () => {
       const { getByText } = render(
-        <Stepper ariaLabel="progress"  currentStep={1}>
+        <Stepper ariaLabel="progress" currentStep={1}>
           <Step label={TEXT} />
           <Step />
         </Stepper>
@@ -213,7 +289,7 @@ describe('Stepper', () => {
 
     it('should have a secondary label', () => {
       const { getByText } = render(
-        <Stepper ariaLabel="progress"  currentStep={1}>
+        <Stepper ariaLabel="progress" currentStep={1}>
           <Step secondaryLabel={TEXT} hasError />
           <Step />
         </Stepper>
@@ -227,7 +303,7 @@ describe('Stepper', () => {
 
     it('should have an incomplete styled separator', () => {
       const { getByTestId } = render(
-        <Stepper ariaLabel="progress"  currentStep={0}>
+        <Stepper ariaLabel="progress" currentStep={0}>
           <Step testId={testId} />
           <Step />
         </Stepper>
@@ -241,7 +317,7 @@ describe('Stepper', () => {
 
     it('should have a completed styled separator', () => {
       const { getByTestId } = render(
-        <Stepper ariaLabel="progress"  currentStep={1}>
+        <Stepper ariaLabel="progress" currentStep={1}>
           <Step testId={testId} />
           <Step />
         </Stepper>
@@ -256,7 +332,12 @@ describe('Stepper', () => {
     describe('Inverse', () => {
       it('should have an inverse active styled circle', () => {
         const { getByTestId } = render(
-          <Stepper ariaLabel="progress"  testId={testId} isInverse currentStep={0}>
+          <Stepper
+            ariaLabel="progress"
+            testId={testId}
+            isInverse
+            currentStep={0}
+          >
             <Step />
             <Step />
           </Stepper>
@@ -272,7 +353,7 @@ describe('Stepper', () => {
 
       it('should have an inverse incomplete styled circle', () => {
         const { getByTestId } = render(
-          <Stepper ariaLabel="progress"  isInverse currentStep={0}>
+          <Stepper ariaLabel="progress" isInverse currentStep={0}>
             <Step />
             <Step testId={testId} />
           </Stepper>
@@ -288,7 +369,7 @@ describe('Stepper', () => {
 
       it('should have an inverse completed styled circle', () => {
         const { getByTestId } = render(
-          <Stepper ariaLabel="progress"  isInverse currentStep={1}>
+          <Stepper ariaLabel="progress" isInverse currentStep={1}>
             <Step testId={testId} />
             <Step />
           </Stepper>
@@ -301,7 +382,7 @@ describe('Stepper', () => {
 
       it('should have an inverse error styled circle', () => {
         const { getByTestId } = render(
-          <Stepper ariaLabel="progress"  isInverse currentStep={1}>
+          <Stepper ariaLabel="progress" isInverse currentStep={1}>
             <Step testId={testId} hasError />
             <Step />
           </Stepper>
@@ -314,7 +395,7 @@ describe('Stepper', () => {
 
       it('should have an inverse primary label', () => {
         const { getByText } = render(
-          <Stepper ariaLabel="progress"  isInverse currentStep={1}>
+          <Stepper ariaLabel="progress" isInverse currentStep={1}>
             <Step label={TEXT} hasError />
             <Step />
           </Stepper>
@@ -327,7 +408,7 @@ describe('Stepper', () => {
 
       it('should have an inverse secondary label', () => {
         const { getByText } = render(
-          <Stepper ariaLabel="progress"  isInverse currentStep={1}>
+          <Stepper ariaLabel="progress" isInverse currentStep={1}>
             <Step secondaryLabel={TEXT} hasError />
             <Step />
           </Stepper>
@@ -343,7 +424,7 @@ describe('Stepper', () => {
 
       it('should have an inverse incomplete styled separator', () => {
         const { getByTestId } = render(
-          <Stepper ariaLabel="progress"  isInverse currentStep={0}>
+          <Stepper ariaLabel="progress" isInverse currentStep={0}>
             <Step testId={testId} />
             <Step />
           </Stepper>
@@ -359,7 +440,7 @@ describe('Stepper', () => {
 
       it('should have an inverse completed styled separator', () => {
         const { getByTestId } = render(
-          <Stepper ariaLabel="progress"  isInverse currentStep={1}>
+          <Stepper ariaLabel="progress" isInverse currentStep={1}>
             <Step testId={testId} />
             <Step />
           </Stepper>
@@ -377,14 +458,18 @@ describe('Stepper', () => {
     describe('States', () => {
       it('should hide labels when layout is set to "hideLabels"', () => {
         const { getByText } = render(
-          <Stepper ariaLabel="progress"  layout={StepperLayout.hideLabels} currentStep={1}>
+          <Stepper
+            ariaLabel="progress"
+            layout={StepperLayout.hideLabels}
+            currentStep={1}
+          >
             <Step label={`${TEXT}-1`} />
             <Step label={`${TEXT}-2`} />
           </Stepper>
         );
 
-        const label1 = getByText(`${TEXT}-1`);
-        const label2 = getByText(`${TEXT}-2`);
+        const label1 = getByText(`Step 1, ${TEXT}-1, Step complete`);
+        const label2 = getByText(`Step 2, ${TEXT}-2, Step active`);
 
         expect(label1).toHaveStyleRule('height', '1px');
         expect(label1).toHaveStyleRule('position', 'absolute');
@@ -403,7 +488,8 @@ describe('Stepper', () => {
 
       it('should only show one step label and description at a time along with a counter when layout is set to summaryView', () => {
         const { getByTestId } = render(
-          <Stepper ariaLabel="progress" 
+          <Stepper
+            ariaLabel="progress"
             testId={testId}
             layout={StepperLayout.summaryView}
             currentStep={0}
@@ -419,7 +505,11 @@ describe('Stepper', () => {
 
       it('should show labels when layout is set to showLabels', () => {
         const { getByText } = render(
-          <Stepper ariaLabel="progress"  layout={StepperLayout.showLabels} currentStep={0}>
+          <Stepper
+            ariaLabel="progress"
+            layout={StepperLayout.showLabels}
+            currentStep={0}
+          >
             <Step label={`${TEXT}-1`} />
             <Step label={`${TEXT}-2`} />
           </Stepper>
@@ -439,7 +529,8 @@ describe('Stepper', () => {
 
       it('should hide labels when breakpointLayout is set to "hideLabels" if viewport is smaller than set breakpoint prop', () => {
         const { getByText } = render(
-          <Stepper ariaLabel="progress" 
+          <Stepper
+            ariaLabel="progress"
             breakpoint={1500}
             breakpointLayout={StepperLayout.hideLabels}
             currentStep={0}
@@ -452,7 +543,7 @@ describe('Stepper', () => {
           global.innerWidth = 1400;
           global.dispatchEvent(new Event('resize'));
         });
-        const label1 = getByText(`${TEXT}-1`);
+        const label1 = getByText(`Step 1, ${TEXT}-1, Step active`);
 
         expect(label1).toHaveStyleRule('height', '1px');
         expect(label1).toHaveStyleRule('position', 'absolute');
@@ -464,7 +555,8 @@ describe('Stepper', () => {
 
       it('should show labels when breakpointLayout is set to "showLabels" if viewport is smaller than set breakpoint prop', () => {
         const { getByText } = render(
-          <Stepper ariaLabel="progress" 
+          <Stepper
+            ariaLabel="progress"
             breakpoint={1500}
             breakpointLayout={StepperLayout.showLabels}
             currentStep={0}
@@ -492,7 +584,8 @@ describe('Stepper', () => {
 
       it('should show summaryView when breakpointStyle is set to "summaryView" if viewport is smaller than set breakpoint prop', () => {
         const { getByTestId } = render(
-          <Stepper ariaLabel="progress" 
+          <Stepper
+            ariaLabel="progress"
             testId={testId}
             breakpoint={1500}
             breakpointLayout={StepperLayout.summaryView}

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
@@ -3,7 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
 import { Stepper, Step, StepperLayout } from '.';
-import { getByTestId, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { transparentize } from 'polished';
 import { I18nContext } from '../../i18n';
 import { defaultI18n } from '../../i18n/default';
@@ -14,7 +14,9 @@ const testId = 'test-id';
 describe('Stepper', () => {
   it('should find element by testId', () => {
     const { getByTestId } = render(
-      <Stepper ariaLabel="progress" testId={testId}></Stepper>
+      <Stepper ariaLabel="progress" testId={testId}>
+        <Step testId="step" label="step" />
+      </Stepper>
     );
 
     expect(getByTestId(testId)).toBeInTheDocument();
@@ -24,7 +26,8 @@ describe('Stepper', () => {
     it('Does not violate accessibility standards', () => {
       const { container } = render(
         <Stepper ariaLabel="progress">
-          {/* <Step testId="step1" label="step1" /> */}
+          <Step testId="step1" label="step1" />
+          <Step testId="step2" label="step2" />
         </Stepper>
       );
 
@@ -61,12 +64,12 @@ describe('Stepper', () => {
       expect(getByTestId(`${testId}-1`)).toHaveTextContent(
         `Step completed, ${TEXT}-1`
       );
-      expect(getByTestId(`${testId}-1`)).toHaveAttribute(
+      expect(getByTestId(`${testId}-1`).closest('li')).toHaveAttribute(
         'aria-current',
         'false'
       );
       expect(getByTestId(`${testId}-2`)).toHaveTextContent(`${TEXT}-2`);
-      expect(getByTestId(`${testId}-2`)).toHaveAttribute(
+      expect(getByTestId(`${testId}-2`).closest('li')).toHaveAttribute(
         'aria-current',
         'step'
       );
@@ -87,12 +90,12 @@ describe('Stepper', () => {
       expect(getByTestId(`${testId}-1`)).toHaveTextContent(
         `Step completed, ${TEXT}-1`
       );
-      expect(getByTestId(`${testId}-1`)).toHaveAttribute(
+      expect(getByTestId(`${testId}-1`).closest('li')).toHaveAttribute(
         'aria-current',
         'false'
       );
       expect(getByTestId(`${testId}-2`)).toHaveTextContent(`${TEXT}-2`);
-      expect(getByTestId(`${testId}-2`)).toHaveAttribute(
+      expect(getByTestId(`${testId}-2`).closest('li')).toHaveAttribute(
         'aria-current',
         'step'
       );
@@ -347,7 +350,7 @@ describe('Stepper', () => {
 
         const step = getByTestId(testId).querySelector('span');
 
-        expect(step).toHaveStyleRule(
+        expect(step.firstChild).toHaveStyleRule(
           'box-shadow',
           `inset 0 0 0 2px ${magma.colors.tertiary500}`
         );

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
@@ -51,22 +51,20 @@ describe('Stepper', () => {
           layout={StepperLayout.showLabels}
           currentStep={1}
         >
-          <Step testId={`${testId}-1-hiddenlabeltext`} label={`${TEXT}-1`} />
-          <Step testId={`${testId}-2-hiddenlabeltext`} label={`${TEXT}-2`} />
+          <Step testId={`${testId}-1`} label={`${TEXT}-1`} />
+          <Step testId={`${testId}-2`} label={`${TEXT}-2`} />
         </Stepper>
       );
 
-      expect(getByTestId(`${testId}-1-hiddenlabeltext`)).toHaveTextContent(
-        `Step 1, ${TEXT}-1, Step complete`
+      expect(getByTestId(`${testId}-1`)).toHaveTextContent(
+        `Step 1, ${TEXT}-1, Step completed`
       );
-      expect(getByTestId(`${testId}-1-hiddenlabeltext`)).toHaveAttribute(
+      expect(getByTestId(`${testId}-1`)).toHaveAttribute(
         'aria-current',
         'false'
       );
-      expect(getByTestId(`${testId}-2-hiddenlabeltext`)).toHaveTextContent(
-        `Step 2, ${TEXT}-2`
-      );
-      expect(getByTestId(`${testId}-2-hiddenlabeltext`)).toHaveAttribute(
+      expect(getByTestId(`${testId}-2`)).toHaveTextContent(`Step 2, ${TEXT}-2`);
+      expect(getByTestId(`${testId}-2`)).toHaveAttribute(
         'aria-current',
         'step'
       );
@@ -79,22 +77,20 @@ describe('Stepper', () => {
           layout={StepperLayout.hideLabels}
           currentStep={1}
         >
-          <Step testId={`${testId}-1-hiddenlabeltext`} label={`${TEXT}-1`} />
-          <Step testId={`${testId}-2-hiddenlabeltext`} label={`${TEXT}-2`} />
+          <Step testId={`${testId}-1`} label={`${TEXT}-1`} />
+          <Step testId={`${testId}-2`} label={`${TEXT}-2`} />
         </Stepper>
       );
 
-      expect(getByTestId(`${testId}-1-hiddenlabeltext`)).toHaveTextContent(
-        `Step 1, ${TEXT}-1, Step complete`
+      expect(getByTestId(`${testId}-1`)).toHaveTextContent(
+        `Step 1, ${TEXT}-1, Step completed`
       );
-      expect(getByTestId(`${testId}-1-hiddenlabeltext`)).toHaveAttribute(
+      expect(getByTestId(`${testId}-1`)).toHaveAttribute(
         'aria-current',
         'false'
       );
-      expect(getByTestId(`${testId}-2-hiddenlabeltext`)).toHaveTextContent(
-        `Step 2, ${TEXT}-2`
-      );
-      expect(getByTestId(`${testId}-2-hiddenlabeltext`)).toHaveAttribute(
+      expect(getByTestId(`${testId}-2`)).toHaveTextContent(`Step 2, ${TEXT}-2`);
+      expect(getByTestId(`${testId}-2`)).toHaveAttribute(
         'aria-current',
         'step'
       );
@@ -472,7 +468,7 @@ describe('Stepper', () => {
           </Stepper>
         );
 
-        const label1 = getByText(`Step 1, ${TEXT}-1, Step complete`);
+        const label1 = getByText(`Step 1, ${TEXT}-1, Step completed`);
         const label2 = getByText(`Step 2, ${TEXT}-2`);
 
         expect(label1).toHaveStyleRule('height', '1px');
@@ -537,7 +533,7 @@ describe('Stepper', () => {
             ariaLabel="progress"
             breakpoint={1500}
             breakpointLayout={StepperLayout.hideLabels}
-            currentStep={0}
+            currentStep={1}
           >
             <Step label={`${TEXT}-1`} />
             <Step label={`${TEXT}-2`} />
@@ -547,7 +543,7 @@ describe('Stepper', () => {
           global.innerWidth = 1400;
           global.dispatchEvent(new Event('resize'));
         });
-        const label1 = getByText(`Step 1, ${TEXT}-1`);
+        const label1 = getByText(`Step 1,`);
 
         expect(label1).toHaveStyleRule('height', '1px');
         expect(label1).toHaveStyleRule('position', 'absolute');

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
@@ -23,7 +23,9 @@ describe('Stepper', () => {
   describe('Accessibility', () => {
     it('Does not violate accessibility standards', () => {
       const { container } = render(
-        <Stepper ariaLabel="progress" role="form"></Stepper>
+        <Stepper ariaLabel="progress">
+          {/* <Step testId="step1" label="step1" /> */}
+        </Stepper>
       );
 
       return axe(container.innerHTML).then(result => {
@@ -39,7 +41,7 @@ describe('Stepper', () => {
         </Stepper>
       );
 
-      const customAriaLabel = getByLabelText('custom', { selector: 'div' });
+      const customAriaLabel = getByLabelText('custom', { selector: 'ol' });
 
       expect(customAriaLabel).toBeInTheDocument();
     });

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
@@ -337,20 +337,15 @@ describe('Stepper', () => {
     describe('Inverse', () => {
       it('should have an inverse active styled circle', () => {
         const { getByTestId } = render(
-          <Stepper
-            ariaLabel="progress"
-            testId={testId}
-            isInverse
-            currentStep={0}
-          >
-            <Step />
+          <Stepper ariaLabel="progress" isInverse currentStep={0}>
+            <Step testId={testId} />
             <Step />
           </Stepper>
         );
 
         const step = getByTestId(testId).querySelector('span');
 
-        expect(step.firstChild).toHaveStyleRule(
+        expect(step).toHaveStyleRule(
           'box-shadow',
           `inset 0 0 0 2px ${magma.colors.tertiary500}`
         );

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
@@ -49,25 +49,27 @@ describe('Stepper', () => {
         <Stepper
           ariaLabel="progress"
           layout={StepperLayout.showLabels}
-          currentStep={0}
+          currentStep={1}
         >
-          <Step
-            testId={`${testId}-1-nolabels-hiddenlabeltext`}
-            label={`${TEXT}-1`}
-          />
-          <Step
-            testId={`${testId}-2-nolabels-hiddenlabeltext`}
-            label={`${TEXT}-2`}
-          />
+          <Step testId={`${testId}-1-hiddenlabeltext`} label={`${TEXT}-1`} />
+          <Step testId={`${testId}-2-hiddenlabeltext`} label={`${TEXT}-2`} />
         </Stepper>
       );
 
-      expect(
-        getByTestId(`${testId}-1-nolabels-hiddenlabeltext`)
-      ).toHaveTextContent(`Step 1, ${TEXT}-1, Step active`);
-      expect(
-        getByTestId(`${testId}-2-nolabels-hiddenlabeltext`)
-      ).toHaveTextContent(`Step 2, ${TEXT}-2, Step incomplete`);
+      expect(getByTestId(`${testId}-1-hiddenlabeltext`)).toHaveTextContent(
+        `Step 1, ${TEXT}-1, Step complete`
+      );
+      expect(getByTestId(`${testId}-1-hiddenlabeltext`)).toHaveAttribute(
+        'aria-current',
+        'false'
+      );
+      expect(getByTestId(`${testId}-2-hiddenlabeltext`)).toHaveTextContent(
+        `Step 2, ${TEXT}-2`
+      );
+      expect(getByTestId(`${testId}-2-hiddenlabeltext`)).toHaveAttribute(
+        'aria-current',
+        'step'
+      );
     });
 
     it('should have hidden labels for screen readers when layout is set to "hideLabels"', () => {
@@ -77,23 +79,25 @@ describe('Stepper', () => {
           layout={StepperLayout.hideLabels}
           currentStep={1}
         >
-          <Step
-            testId={`${testId}-1-nolabels-hiddenlabeltext`}
-            label={`${TEXT}-1`}
-          />
-          <Step
-            testId={`${testId}-2-nolabels-hiddenlabeltext`}
-            label={`${TEXT}-2`}
-          />
+          <Step testId={`${testId}-1-hiddenlabeltext`} label={`${TEXT}-1`} />
+          <Step testId={`${testId}-2-hiddenlabeltext`} label={`${TEXT}-2`} />
         </Stepper>
       );
 
-      expect(
-        getByTestId(`${testId}-1-nolabels-hiddenlabeltext`)
-      ).toHaveTextContent(`Step 1, ${TEXT}-1, Step complete`);
-      expect(
-        getByTestId(`${testId}-2-nolabels-hiddenlabeltext`)
-      ).toHaveTextContent(`Step 2, ${TEXT}-2, Step active`);
+      expect(getByTestId(`${testId}-1-hiddenlabeltext`)).toHaveTextContent(
+        `Step 1, ${TEXT}-1, Step complete`
+      );
+      expect(getByTestId(`${testId}-1-hiddenlabeltext`)).toHaveAttribute(
+        'aria-current',
+        'false'
+      );
+      expect(getByTestId(`${testId}-2-hiddenlabeltext`)).toHaveTextContent(
+        `Step 2, ${TEXT}-2`
+      );
+      expect(getByTestId(`${testId}-2-hiddenlabeltext`)).toHaveAttribute(
+        'aria-current',
+        'step'
+      );
     });
   });
 
@@ -469,7 +473,7 @@ describe('Stepper', () => {
         );
 
         const label1 = getByText(`Step 1, ${TEXT}-1, Step complete`);
-        const label2 = getByText(`Step 2, ${TEXT}-2, Step active`);
+        const label2 = getByText(`Step 2, ${TEXT}-2`);
 
         expect(label1).toHaveStyleRule('height', '1px');
         expect(label1).toHaveStyleRule('position', 'absolute');
@@ -543,7 +547,7 @@ describe('Stepper', () => {
           global.innerWidth = 1400;
           global.dispatchEvent(new Event('resize'));
         });
-        const label1 = getByText(`Step 1, ${TEXT}-1, Step active`);
+        const label1 = getByText(`Step 1, ${TEXT}-1`);
 
         expect(label1).toHaveStyleRule('height', '1px');
         expect(label1).toHaveStyleRule('position', 'absolute');

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.test.js
@@ -455,7 +455,7 @@ describe('Stepper', () => {
       });
     });
 
-    describe('States', () => {
+    describe('Layout', () => {
       it('should hide labels when layout is set to "hideLabels"', () => {
         const { getByText } = render(
           <Stepper
@@ -533,6 +533,7 @@ describe('Stepper', () => {
             ariaLabel="progress"
             breakpoint={1500}
             breakpointLayout={StepperLayout.hideLabels}
+            layout={StepperLayout.showLabels}
             currentStep={1}
           >
             <Step label={`${TEXT}-1`} />
@@ -543,7 +544,7 @@ describe('Stepper', () => {
           global.innerWidth = 1400;
           global.dispatchEvent(new Event('resize'));
         });
-        const label1 = getByText(`Step completed,`);
+        const label1 = getByText(`Step completed, ${TEXT}-1`);
 
         expect(label1).toHaveStyleRule('height', '1px');
         expect(label1).toHaveStyleRule('position', 'absolute');
@@ -559,6 +560,7 @@ describe('Stepper', () => {
             ariaLabel="progress"
             breakpoint={1500}
             breakpointLayout={StepperLayout.showLabels}
+            layout={StepperLayout.hideLabels}
             currentStep={0}
           >
             <Step label={`${TEXT}-1`} />
@@ -589,6 +591,7 @@ describe('Stepper', () => {
             testId={testId}
             breakpoint={1500}
             breakpointLayout={StepperLayout.summaryView}
+            layout={StepperLayout.showLabels}
             currentStep={0}
           >
             <Step label={`${TEXT}-1`} />

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
@@ -84,20 +84,18 @@ const StyledStepper = typedStyled.div`
   flex-direction: column;
 `;
 
-const StyledStepContent = typedStyled.ul<{
+const StyledStepContent = typedStyled.ol<{
   showLabelsLayout?: boolean;
   theme?: ThemeInterface;
 }>`
   display: flex;
   margin:0;
   padding:0;
-  
 `;
 
 const StyledWrapper = typedStyled.div`
-list-style-type:none;
-    position:relative;
-    flex:1;
+  position: relative;
+  flex: 1;
 `;
 
 const StyledSeparator = typedStyled.div<{
@@ -152,7 +150,7 @@ const StyledSummary = typedStyled.div<{
     display: flex;
     text-align: left;
   }
-  svg{
+  svg {
     height:0;
   }
   li > span{
@@ -164,7 +162,7 @@ const StyledSummary = typedStyled.div<{
       margin:0
     }
   }
-  li div span:last-child{
+  li div span:last-child {
     margin: 4px 0 0 0;
   } 
 `;
@@ -330,14 +328,12 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
       props.completionLabel || i18n.stepper.completionLabel;
 
     return (
-      <StyledStepper
-        {...rest}
-        aria-label={ariaLabel}
-        data-testid={testId}
-        role="form"
-        ref={ref}
-      >
-        <StyledStepContent showLabelsLayout={showLabelsLayout} theme={theme}>
+      <StyledStepper {...rest} data-testid={testId} ref={ref}>
+        <StyledStepContent
+          aria-label={ariaLabel}
+          showLabelsLayout={showLabelsLayout}
+          theme={theme}
+        >
           {stepContent}
         </StyledStepContent>
         {summaryViewLayout && (

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
@@ -84,15 +84,18 @@ const StyledStepper = typedStyled.div`
   flex-direction: column;
 `;
 
-const StyledStepContent = typedStyled.div<{
+const StyledStepContent = typedStyled.ul<{
   showLabelsLayout?: boolean;
   theme?: ThemeInterface;
 }>`
   display: flex;
+  margin:0;
+  padding:0;
   
 `;
 
-const StyledWrapper = typedStyled.div`
+const StyledWrapper = typedStyled.li`
+list-style-type:none;
     position:relative;
     flex:1;
 `;
@@ -152,16 +155,16 @@ const StyledSummary = typedStyled.div<{
   svg{
     height:0;
   }
-  div > span{
+  li > span{
     height: auto;
   }
-  div div {
+  li div {
     margin:3px 0;
     span{
       margin:0
     }
   }
-  div div span:last-child{
+  li div span:last-child{
     margin: 4px 0 0 0;
   } 
 `;
@@ -269,7 +272,8 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
               : StepStatus.incomplete;
 
           const item = React.cloneElement(child, {
-            'aria-current': !showLabelsLayout ? currentStep === index : null,
+            'aria-current':
+              !showLabelsLayout && currentStep === index ? 'step' : 'false',
             key: index,
             isInverse: isInverse,
             areLabelsHidden: hideLabelsLayout || summaryViewLayout,
@@ -299,7 +303,10 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
             (allStepsHaveLabels || allStepsHaveSecondaryLabels)
           ) {
             return (
-              <StyledWrapper aria-current={currentStep === index} theme={theme}>
+              <StyledWrapper
+                aria-current={currentStep === index ? 'step' : 'false'}
+                theme={theme}
+              >
                 {stepAndSeparator()}
               </StyledWrapper>
             );

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
@@ -272,15 +272,13 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
               : StepStatus.incomplete;
 
           const item = React.cloneElement(child, {
-            'aria-current':
-              !showLabelsLayout && currentStep === index ? 'step' : 'false',
+            'aria-current': currentStep === index ? 'step' : 'false',
             key: index,
             isInverse: isInverse,
             index: index,
-            hasLabels: showLabelsLayout,
+            layout: layout,
             areLabelsHidden: hideLabelsLayout || summaryViewLayout,
-            isSummaryView: summaryViewLayout,
-            stepLabel: stepLabel ? stepLabel : i18n.stepper.stepLabel,
+            stepLabel: stepLabel || i18n.stepper.stepLabel,
             stepStatus: stepStatusStyles,
           });
 

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
@@ -91,7 +91,7 @@ const StyledStepContent = typedStyled.ol`
   padding: 0;
 `;
 
-const StyledWrapper = typedStyled.li<{ hasLabels?: boolean }>`
+const StyledLiWrapper = typedStyled.li<{ hasLabels?: boolean }>`
   list-style-type: none;
   ${props =>
     props.hasLabels
@@ -161,6 +161,7 @@ const StyledSummary = typedStyled.div<{
   }
   div > span:first-child {
     height: auto;
+    margin: 0;
   }
   div span {
     margin: 3px 0;
@@ -275,9 +276,13 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
               : StepStatus.incomplete;
 
           const item = React.cloneElement(child, {
-            isInverse: isInverse,
-            index: index,
-            layout: layout,
+            isInverse,
+            index,
+            layout: summaryViewLayout
+              ? StepperLayout.summaryView
+              : hideLabelsLayout
+              ? StepperLayout.hideLabels
+              : StepperLayout.showLabels,
             stepLabel: stepLabel || i18n.stepper.stepLabel,
             stepStatus: stepStatusStyles,
           });
@@ -301,7 +306,7 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
           };
 
           return (
-            <StyledWrapper
+            <StyledLiWrapper
               aria-current={currentStep === index ? 'step' : false}
               hasLabels={
                 showLabelsLayout &&
@@ -309,7 +314,7 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
               }
             >
               {stepAndSeparator()}
-            </StyledWrapper>
+            </StyledLiWrapper>
           );
         }
       }

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
@@ -159,18 +159,18 @@ const StyledSummary = typedStyled.div<{
   svg {
     height: 0;
   }
-  span > span {
+  div > span:first-child {
     height: auto;
   }
-  span div {
+  div span {
     margin: 3px 0;
-    span{
+    span:first-child {
       margin: 0
     }
+    span:last-child {
+      margin: 4px 0 0 0;
+    } 
   }
-  span div span:last-child {
-    margin: 4px 0 0 0;
-  } 
 `;
 
 // Stepper!
@@ -333,10 +333,7 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
 
     return (
       <StyledStepper {...rest} data-testid={testId} ref={ref}>
-        <StyledStepContent
-          aria-label={ariaLabel}
-          theme={theme}
-        >
+        <StyledStepContent aria-label={ariaLabel} theme={theme}>
           {stepContent}
         </StyledStepContent>
         {summaryViewLayout && (

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
@@ -94,7 +94,7 @@ const StyledStepContent = typedStyled.ul<{
   
 `;
 
-const StyledWrapper = typedStyled.li`
+const StyledWrapper = typedStyled.div`
 list-style-type:none;
     position:relative;
     flex:1;
@@ -303,12 +303,7 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
             (allStepsHaveLabels || allStepsHaveSecondaryLabels)
           ) {
             return (
-              <StyledWrapper
-                aria-current={currentStep === index ? 'step' : 'false'}
-                theme={theme}
-              >
-                {stepAndSeparator()}
-              </StyledWrapper>
+              <StyledWrapper theme={theme}>{stepAndSeparator()}</StyledWrapper>
             );
           } else {
             return <>{stepAndSeparator()}</>;

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
@@ -276,7 +276,11 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
               !showLabelsLayout && currentStep === index ? 'step' : 'false',
             key: index,
             isInverse: isInverse,
+            index: index,
+            hasLabels: showLabelsLayout,
             areLabelsHidden: hideLabelsLayout || summaryViewLayout,
+            isSummaryView: summaryViewLayout,
+            stepLabel: stepLabel ? stepLabel : i18n.stepper.stepLabel,
             stepStatus: stepStatusStyles,
           });
 

--- a/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
+++ b/packages/react-magma-dom/src/components/Stepper/Stepper.tsx
@@ -64,12 +64,12 @@ export enum StepperLayout {
 function buildSeparatorBackgroundColors(props) {
   const { isInverse, theme, stepStatus } = props;
   if (isInverse) {
-    if (stepStatus === StepStatus.complete) {
+    if (stepStatus === StepStatus.completed) {
       return theme.colors.tertiary500;
     }
     return theme.colors.primary400;
   } else {
-    if (stepStatus === StepStatus.complete) {
+    if (stepStatus === StepStatus.completed) {
       return theme.colors.primary500;
     }
     return theme.colors.neutral300;
@@ -266,18 +266,16 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
         if (child.type === Step) {
           const stepStatusStyles =
             currentStep >= index + 1
-              ? StepStatus.complete
+              ? StepStatus.completed
               : currentStep >= index
               ? StepStatus.active
               : StepStatus.incomplete;
 
           const item = React.cloneElement(child, {
             'aria-current': currentStep === index ? 'step' : 'false',
-            key: index,
             isInverse: isInverse,
             index: index,
             layout: layout,
-            areLabelsHidden: hideLabelsLayout || summaryViewLayout,
             stepLabel: stepLabel || i18n.stepper.stepLabel,
             stepStatus: stepStatusStyles,
           });
@@ -336,6 +334,7 @@ export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
         {...rest}
         aria-label={ariaLabel}
         data-testid={testId}
+        role="form"
         ref={ref}
       >
         <StyledStepContent showLabelsLayout={showLabelsLayout} theme={theme}>

--- a/website/react-magma-docs/src/pages/api/stepper.mdx
+++ b/website/react-magma-docs/src/pages/api/stepper.mdx
@@ -55,7 +55,7 @@ export function Example() {
       <Heading level={4} style={{ textAlign: 'center' }}>
         Course Selector
       </Heading>
-      <Stepper  ariaLabel="progress" currentStep={currentStep}>
+      <Stepper ariaLabel="progress" currentStep={currentStep}>
         <Step label="Choose materials" />
         <Step label="Additional details" />
         <Step label="Confirm" />
@@ -122,7 +122,7 @@ export function Example() {
   return (
     <>
       <Stepper
-       ariaLabel="progress" 
+        ariaLabel="progress"
         layout={StepperLayout.summaryView}
         currentStep={currentStep}
         stepLabel="Module"
@@ -190,7 +190,7 @@ export function Example() {
   return (
     <>
       <Stepper
-       ariaLabel="progress" 
+        ariaLabel="progress"
         completedStepDescription="Steps Complete!"
         layout={StepperLayout.summaryView}
         currentStep={currentStep}
@@ -260,7 +260,7 @@ export function Example() {
 
   return (
     <>
-      <Stepper  ariaLabel="progress" currentStep={currentStep}>
+      <Stepper ariaLabel="progress" currentStep={currentStep}>
         <Step label="First Step" secondaryLabel="Description One" />
         <Step label="Second Step" secondaryLabel="Description Two" />
         <Step label="Third Step" secondaryLabel="Description Three" />
@@ -335,7 +335,11 @@ export function Example() {
 
   return (
     <>
-      <Stepper  ariaLabel="progress" layout={StepperLayout.hideLabels} currentStep={currentStep}>
+      <Stepper
+        ariaLabel="progress"
+        layout={StepperLayout.hideLabels}
+        currentStep={currentStep}
+      >
         <Step label="First Step" secondaryLabel="Description One" />
         <Step label="Second Step" secondaryLabel="Description Two" />
         <Step label="Third Step" secondaryLabel="Description Three" />
@@ -406,7 +410,11 @@ export function Example() {
 
   return (
     <>
-      <Stepper  ariaLabel="progress" layout={StepperLayout.showLabels} currentStep={currentStep}>
+      <Stepper
+        ariaLabel="progress"
+        layout={StepperLayout.showLabels}
+        currentStep={currentStep}
+      >
         <Step label="First Step" secondaryLabel="Description One" />
         <Step label="Second Step" secondaryLabel="Description Two" />
         <Step label="Third Step" secondaryLabel="Description Three" />
@@ -477,7 +485,11 @@ export function Example() {
 
   return (
     <>
-      <Stepper  ariaLabel="progress" layout={StepperLayout.summaryView} currentStep={currentStep}>
+      <Stepper
+        ariaLabel="progress"
+        layout={StepperLayout.summaryView}
+        currentStep={currentStep}
+      >
         <Step label="First Step" secondaryLabel="Description One" />
         <Step label="Second Step" secondaryLabel="Description Two" />
         <Step label="Third Step" secondaryLabel="Description Three" />
@@ -553,7 +565,7 @@ export function Example() {
   return (
     <>
       <Stepper
-       ariaLabel="progress" 
+        ariaLabel="progress"
         layout={StepperLayout.hideLabels}
         breakpoint={1500}
         breakpointLayout={StepperLayout.showLabels}
@@ -630,7 +642,7 @@ export function Example() {
   return (
     <>
       <Stepper
-       ariaLabel="progress" 
+        ariaLabel="progress"
         breakpoint={1500}
         breakpointLayout={StepperLayout.hideLabels}
         currentStep={currentStep}
@@ -706,7 +718,7 @@ export function Example() {
   return (
     <>
       <Stepper
-       ariaLabel="progress" 
+        ariaLabel="progress"
         breakpoint={1500}
         breakpointLayout={StepperLayout.summaryView}
         currentStep={currentStep}
@@ -760,7 +772,7 @@ export function Example() {
 
   return (
     <>
-      <Stepper  ariaLabel="progress" currentStep={2}>
+      <Stepper ariaLabel="progress" currentStep={2}>
         <Step label="First Step" secondaryLabel="Description One" />
         <Step label="Second Step" secondaryLabel="Description Two" />
         <Step label="Third Step" hasError secondaryLabel="Description Three" />
@@ -816,7 +828,7 @@ export function Example() {
 
   return (
     <Container isInverse style={{ padding: '20px' }}>
-      <Stepper  ariaLabel="progress" currentStep={currentStep} isInverse>
+      <Stepper ariaLabel="progress" currentStep={currentStep} isInverse>
         <Step label="First Step" secondaryLabel="Description One" />
         <Step label="Second Step" secondaryLabel="Description Two" />
         <Step label="Third Step" secondaryLabel="Description Three" />
@@ -853,13 +865,13 @@ export function Example() {
 }
 ```
 
-# Step Props
+## Step Props
 
 **Any other props supplied will be provided to the wrapping `div` element.**
 
 <StepProps />
 
-# Stepper Props
+## Stepper Props
 
 **Any other props supplied will be provided to the wrapping `div` element.**
 


### PR DESCRIPTION
Issue: # [1143](https://github.com/cengage/react-magma/issues/1143)

## What I did
- Changed aria-current to read "step" when active.
- Converted to UL LI structure for the component layout.
- Added the state for each step when labels are hidden.

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
- Make sure aria-current reads "step".
- Verify in DOM that the UL LI structure looks sufficient.
- Ensure screen reader can read the step state after the label when labels are hidden.
