### PR TITLE
fix(Modal): Nested modal bg overlay

### DIFF
--- a/.changeset/nested-modal-bg-overlay.md
+++ b/.changeset/nested-modal-bg-overlay.md
@@ -1,0 +1,6 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal): Background overlay issue on nested modals
+

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -370,70 +370,6 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                 }
               `}
             />
-            <ModalContainer
-              aria-labelledby={header ? headingId : null}
-              aria-label={!header ? ariaLabel : null}
-              aria-modal={true}
-              data-testid={testId}
-              id={id}
-              onClick={isBackgroundClickDisabled ? null : handleModalClick}
-              onMouseDown={
-                isBackgroundClickDisabled ? null : handleModalOnMouseDown
-              }
-              role="dialog"
-              style={containerStyle}
-              theme={theme}
-              isOpen={isModalOpen}
-              {...containerTransition}
-              unmountOnExit={unmountOnExit}
-            >
-              <ModalContent
-                {...other}
-                data-testid="modal-content"
-                id={contentId}
-                isExiting={isExiting}
-                ref={ref}
-                theme={theme}
-              >
-                {header && (
-                  <ModalHeader theme={theme}>
-                    {header && (
-                      <H1
-                        id={headingId}
-                        isInverse={isInverse}
-                        level={1}
-                        ref={headingRef}
-                        visualStyle={TypographyVisualStyle.headingSmall}
-                        tabIndex={-1}
-                        theme={theme}
-                      >
-                        {header}
-                      </H1>
-                    )}
-                  </ModalHeader>
-                )}
-                <ModalWrapper ref={bodyRef} theme={theme}>
-                  {children}
-                </ModalWrapper>
-                {!isCloseButtonHidden && (
-                  <CloseBtn theme={theme}>
-                    <IconButton
-                      aria-label={
-                        closeAriaLabel
-                          ? closeAriaLabel
-                          : i18n.modal.closeAriaLabel
-                      }
-                      color={ButtonColor.primary}
-                      icon={CloseIconButton}
-                      isInverse={isInverse}
-                      onClick={handleClose}
-                      testId="modal-closebtn"
-                      variant={ButtonVariant.link}
-                    />
-                  </CloseBtn>
-                )}
-              </ModalContent>
-            </ModalContainer>
             <ModalBackdrop
               data-testid="modal-backdrop"
               isExiting={isExiting}
@@ -446,7 +382,72 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
               isOpen={isModalOpen}
               unmountOnExit
               theme={theme}
-            />
+            >
+              <ModalContainer
+                aria-labelledby={header ? headingId : null}
+                aria-label={!header ? ariaLabel : null}
+                aria-modal={true}
+                data-testid={testId}
+                id={id}
+                onClick={isBackgroundClickDisabled ? null : handleModalClick}
+                onMouseDown={
+                  isBackgroundClickDisabled ? null : handleModalOnMouseDown
+                }
+                role="dialog"
+                style={containerStyle}
+                theme={theme}
+                isOpen={isModalOpen}
+                {...containerTransition}
+                unmountOnExit={unmountOnExit}
+              >
+                <ModalContent
+                  {...other}
+                  data-testid="modal-content"
+                  id={contentId}
+                  isExiting={isExiting}
+                  ref={ref}
+                  theme={theme}
+                >
+                  {header && (
+                    <ModalHeader theme={theme}>
+                      {header && (
+                        <H1
+                          id={headingId}
+                          isInverse={isInverse}
+                          level={1}
+                          ref={headingRef}
+                          visualStyle={TypographyVisualStyle.headingSmall}
+                          tabIndex={-1}
+                          theme={theme}
+                        >
+                          {header}
+                        </H1>
+                      )}
+                    </ModalHeader>
+                  )}
+                  <ModalWrapper ref={bodyRef} theme={theme}>
+                    {children}
+                  </ModalWrapper>
+                  {!isCloseButtonHidden && (
+                    <CloseBtn theme={theme}>
+                      <IconButton
+                        aria-label={
+                          closeAriaLabel
+                            ? closeAriaLabel
+                            : i18n.modal.closeAriaLabel
+                        }
+                        color={ButtonColor.primary}
+                        icon={CloseIconButton}
+                        isInverse={isInverse}
+                        onClick={handleClose}
+                        testId="modal-closebtn"
+                        variant={ButtonVariant.link}
+                      />
+                    </CloseBtn>
+                  )}
+                </ModalContent>
+              </ModalContainer>
+            </ModalBackdrop>
           </div>,
           document.getElementsByTagName('body')[0]
         )


### PR DESCRIPTION
Issue: #1200

## What I did
Fixed background overlay for nested modal

## Screenshots:
![image](https://github.com/user-attachments/assets/da3b12f8-e97e-43fb-a0c1-40612324462a)
## Checklist 
- [x] changeset has been added
- [ ] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
1. Open storybook with nested modals
https://storybook-preview-dev--upbeat-sinoussi-f675aa.netlify.app/?path=/story/modal--modal-in-a-modal
https://storybook-preview-dev--upbeat-sinoussi-f675aa.netlify.app/?path=/story/modal--close-modal-with-confirmation
2.Open nested modal
3.Background overlay of nested modal should be placed over first modal
