### PR TITLE
fix(Dropzone): Open file browse on button click

### DIFF
--- a/.changeset/dropzone-files-browse.md
+++ b/.changeset/dropzone-files-browse.md
@@ -1,0 +1,5 @@
+---
+"@react-magma/dropzone": patch
+---
+
+fix(Dropzone): Open file browse on button click

--- a/packages/dropzone/src/components/dropzone/Dropzone.test.js
+++ b/packages/dropzone/src/components/dropzone/Dropzone.test.js
@@ -58,6 +58,22 @@ describe('File Uploader', () => {
     expect(getByTestId(testId)).toBeInTheDocument();
   });
 
+  it('browse file should open on button click', async () => {
+    const { getByRole, getByTestId } = render(<Dropzone testId="testId" />);
+
+    const fileInputClickFn = jest.fn();
+
+    const fileInput = getByTestId('file-input');
+
+    fileInput.click = fileInputClickFn;
+
+    userEvent.click(getByRole('button'));
+
+    await waitFor(() => {
+      expect(fileInputClickFn).toHaveBeenCalled();
+    });
+  });
+
   it('Does not violate accessibility standards', () => {
     jest.useRealTimers();
 

--- a/packages/dropzone/src/components/dropzone/Dropzone.tsx
+++ b/packages/dropzone/src/components/dropzone/Dropzone.tsx
@@ -439,6 +439,7 @@ export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
               onClick={inputProps.onClick}
               style={inputProps.style}
               tabIndex={inputProps.tabIndex}
+              data-testid="file-input"
             />
             {noDrag ? (
               <Flex xs behavior={FlexBehavior.item}>

--- a/packages/dropzone/src/components/dropzone/Dropzone.tsx
+++ b/packages/dropzone/src/components/dropzone/Dropzone.tsx
@@ -5,7 +5,7 @@
  * `{...file}` WILL NOT COPY ALL OF THE FILE PROPERTIES
  */
 
-import React from 'react';
+import React, { useImperativeHandle } from 'react';
 import {
   useDropzone,
   DropzoneOptions,
@@ -28,7 +28,7 @@ import {
   ThemeInterface,
   useGenerateId,
   useIsInverse,
-  styled
+  styled,
 } from 'react-magma-dom';
 
 import { CloudUploadIcon } from 'react-magma-icons';
@@ -253,6 +253,7 @@ export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
       isDragActive,
       isDragReject,
       open,
+      inputRef,
     } = useDropzone({
       noClick: true,
       disabled,
@@ -263,6 +264,11 @@ export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
       onDrop,
       noDrag,
     });
+
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => inputRef.current
+    );
 
     const inputProps = getInputProps({ id });
 
@@ -423,7 +429,7 @@ export const Dropzone = React.forwardRef<HTMLInputElement, DropzoneProps>(
             tabIndex={-1}
           >
             <input
-              ref={ref}
+              ref={inputRef}
               type={inputProps.type}
               accept={inputProps.accept}
               autoComplete={inputProps.autoComplete}


### PR DESCRIPTION
Issue: #1146 

## What I did
Fix the 'Open File' menu to open on button click.

## Checklist 
- [x] changeset has been added
- [ ] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
1.Go to dropzone in storybook
2.Try to open file by click `Browse Files`
