### PR TITLE
feat(Modal): New prop headerRef exposes the heading element for use in custom headers.

### DIFF
--- a/.changeset/feat-modal-headerref.md
+++ b/.changeset/feat-modal-headerref.md
@@ -2,4 +2,4 @@
 'react-magma-dom': minor
 ---
 
-feat(Modal): New `headerRef` prop that returns a reference to the header element`
+feat(Modal): New `headerRef` prop that returns a reference to the header element

--- a/.changeset/feat-modal-headerref.md
+++ b/.changeset/feat-modal-headerref.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Modal): New prop headerRef exposes the heading element for use in custom headers.

--- a/.changeset/feat-modal-headerref.md
+++ b/.changeset/feat-modal-headerref.md
@@ -2,4 +2,4 @@
 'react-magma-dom': minor
 ---
 
-feat(Modal): New prop headerRef exposes the heading element for use in custom headers.
+feat(Modal): New `headerRef` prop that returns a reference to the header element`

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -476,6 +476,100 @@ export const CloseModalWithConfirmation = () => {
   );
 };
 
+export const HeaderReference = () => {
+  const [showModal, setShowModal] = React.useState(false);
+  const [showDefaultModal, setShowDefaultModal] = React.useState(false);
+  const [customHeadingRef, setCustomHeadingRef] = React.useState(
+    React.useRef<any>()
+  );
+
+  const handleGetHeaderRef = ref => {
+    setCustomHeadingRef(ref);
+  };
+
+  const onModalShow = () => {
+    setShowModal(true);
+  };
+
+  const onModalClose = () => {
+    setShowModal(false);
+  };
+
+  const onModalShowDefault = () => {
+    setShowDefaultModal(true);
+  };
+
+  const onModalCloseDefault = () => {
+    setShowDefaultModal(false);
+  };
+
+  const onHeadingFocus = () => {
+    customHeadingRef?.current?.focus();
+  };
+
+  return (
+    <>
+      {/* Custom Heading */}
+      <Modal
+        onClose={onModalClose}
+        isOpen={showModal}
+        headerRef={handleGetHeaderRef}
+      >
+        <h3 ref={customHeadingRef} tabIndex={-1}>
+          Custom header using h3
+        </h3>
+        <Paragraph>
+          Wicked pissah dolor sit amet, consectetur adipisicing elit. Blandit
+          sagittae Suspendisse mus fah daze, candle pin Market Basket P-town. Id
+          labore, TD Gahden consectetur morbi consectetur sketchy ad. Adipiscing
+          postea kid kid. Dis dolor scriptorem frickin auctor eros Bunker Hill
+          parturient. Suspendisse penatibus roast beef Bunker Hill.
+          Orange Line, blandit consectetur nam cu no eget ne, clicker. Mauris
+          vestibulum, augue Downtown Crossing, lectus half moon lorem.
+          Scelerisque sketchy wicked smaht carriage down Cape no.
+        </Paragraph>
+        <ButtonGroup>
+          <Button onClick={onHeadingFocus} color={ButtonColor.subtle}>
+            Focus Heading
+          </Button>
+          <Button onClick={onModalClose}>Close</Button>
+        </ButtonGroup>
+      </Modal>
+
+      {/* Default Heading */}
+      <Modal
+        onClose={onModalCloseDefault}
+        isOpen={showDefaultModal}
+        headerRef={handleGetHeaderRef}
+        header="I am a default magma header"
+      >
+        <Paragraph>
+          Wicked pissah dolor sit amet, consectetur adipisicing elit. Pike,
+          sketchy sagittae, parturient est Fenway Park venenatis quo graeci
+          stet. Habeo vehicula vis cum sed lectus pretium. Packie, Freedom
+          Trail, Vivamus phaedrum pahk cah Green Monstah Southie Newbury Street.
+          Gravida dis placerat sketchy carriage. Eum splendide Big Dig, Boston
+          Tea Party Charles sagittae wicked pissah packie. Ipsum id scrod,
+          sagittae I-90 chowdah frickin. Est ipsum rutrum, vis erat, ridens.
+        </Paragraph>
+        <ButtonGroup>
+          <Button onClick={onHeadingFocus} color={ButtonColor.subtle}>
+            Focus Heading
+          </Button>
+          <Button onClick={onModalCloseDefault}>Close</Button>
+        </ButtonGroup>
+      </Modal>
+
+      <ButtonGroup>
+        <Button onClick={onModalShow}>Show Custom Heading Modal</Button>
+        <Button onClick={onModalShowDefault}>
+          Show Modal with Default Heading
+        </Button>
+      </ButtonGroup>
+    </>
+  );
+};
+
 export const Inverse = () => {
   const [showModal, setShowModal] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>();

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { I18nContext } from '../../i18n';
 import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
+import { Button } from '../Button';
 
 describe('Modal', () => {
   describe('a11y', () => {
@@ -994,6 +995,31 @@ describe('Modal', () => {
       userEvent.tab();
 
       expect(getByTestId('closeButton')).toHaveFocus();
+    });
+
+    it('headerRef prop allows a custom header to be focused on load, then should loses focus after other Modal elements are looped through', async () => {
+      const headerRef = React.createRef();
+
+      const handleFocus = () => {
+        headerRef?.current?.focus();
+      };
+
+      const { getByText } = render(
+        <Modal headerRef={handleFocus} isOpen={true}>
+          <h3 ref={headerRef} tabIndex={-1}>
+            Custom header using h3
+          </h3>
+          <Button>Focusable element</Button>
+        </Modal>
+      );
+
+      expect(getByText('Custom header using h3')).toHaveFocus();
+
+      userEvent.tab();
+
+      userEvent.tab();
+
+      expect(getByText('Custom header using h3')).not.toHaveFocus();
     });
 
     it('should not attempt to loop through the modal if there are no tabbable elements', () => {

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -997,7 +997,7 @@ describe('Modal', () => {
       expect(getByTestId('closeButton')).toHaveFocus();
     });
 
-    it('headerRef prop allows a custom header to be focused on load, then should loses focus after other Modal elements are looped through', async () => {
+    it('headerRef prop allows a custom header to be focused on load, then should lose focus after other Modal elements are looped through', async () => {
       const headerRef = React.createRef();
 
       const handleFocus = () => {

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -49,6 +49,10 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   header?: React.ReactNode;
   /**
+   * Function that returns reference for the header
+   */
+  headerRef?: (headerRef: React.Ref<any>) => void;
+  /**
    * If true, closing the modal handled on the consumer side
    * @default false
    */
@@ -223,11 +227,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     const [currentTarget, setCurrentTarget] = React.useState(null);
     const [modalCount, setModalCount] = React.useState<number>(0);
 
-    const focusTrapElement = useFocusLock(
-      isModalOpen,
-      props.header ? headingRef : null,
-      bodyRef
-    );
+    const focusTrapElement = useFocusLock(isModalOpen, headingRef, bodyRef);
 
     const prevOpen = usePrevious(props.isOpen);
 
@@ -241,6 +241,9 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         setIsModalOpen(false);
       } else if (!prevOpen && props.isOpen) {
         setIsModalOpen(true);
+        if (props.headerRef && typeof props.headerRef === 'function') {
+          props.headerRef(headingRef);
+        }
       } else if (prevOpen && !props.isOpen && isModalOpen) {
         handleClose();
       }

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -212,6 +212,110 @@ export function Example() {
 }
 ```
 
+## Modal Header Ref
+
+The modal headerRef prop allows access to a header element within the Modal. This is helpful for when a custom header is needed as it provides the ability to focus on load.
+
+```tsx
+import React from 'react';
+import {
+  Button,
+  ButtonColor,
+  IconButton,
+  Flex,
+  FlexBehavior,
+  FlexDirection,
+  FlexJustify,
+  FlexAlignItems,
+  magma,
+  Modal,
+  ModalSize,
+  Paragraph,
+  VisuallyHidden,
+  ButtonGroup,
+  ButtonGroupAlignment,
+} from 'react-magma-dom';
+import { CheckIcon } from 'react-magma-icons';
+
+export function Example() {
+  const [showModal, setShowModal] = React.useState(false);
+  const [showDefaultModal, setShowDefaultModal] = React.useState(false);
+  const [customHeadingRef, setCustomHeadingRef] = React.useState(
+    React.useRef<any>()
+  );
+
+  const handleGetHeaderRef = ref => {
+    setCustomHeadingRef(ref);
+  };
+
+  const onModalShow = () => {
+    setShowModal(true);
+  };
+
+  const onModalClose = () => {
+    setShowModal(false);
+  };
+
+  const onModalShowDefault = () => {
+    setShowDefaultModal(true);
+  };
+
+  const onModalCloseDefault = () => {
+    setShowDefaultModal(false);
+  };
+
+  const onHeadingFocus = () => {
+    customHeadingRef.current.focus();
+  };
+
+  return (
+    <>
+      <Modal
+        onClose={onModalClose}
+        isOpen={showModal}
+        headerRef={handleGetHeaderRef}
+        style={{ padding: '20px' }}
+      >
+        <Flex
+          behavior={FlexBehavior.container}
+          direction={FlexDirection.column}
+          alignItems={FlexAlignItems.center}
+          justify={FlexJustify.center}
+          spacing={2}
+          wrap={FlexWrap.nowrap}
+        >
+          <IconButton
+            style={{ background: magma.colors.success }}
+            icon={<CheckIcon />}
+          />
+          <h2 ref={customHeadingRef} tabIndex={-1}>
+            Add Links to Cengage Content
+          </h2>
+          <Paragraph>
+            Your LMS course is now integrated with Cengage. Select specific
+            Cengage activities to provide students with direct links. Or, add
+            just one link to your entire course. You can return to select more
+            content later.
+          </Paragraph>
+          <ButtonGroup>
+            <Button onClick={onHeadingFocus} color={ButtonColor.subtle}>
+              Focus Heading
+            </Button>
+            <Button onClick={onModalClose} color={ButtonColor.subtle}>
+              Close
+            </Button>
+          </ButtonGroup>
+        </Flex>
+      </Modal>
+
+      <ButtonGroup>
+        <Button onClick={onModalShow}>Show Custom Heading Modal</Button>
+      </ButtonGroup>
+    </>
+  );
+}
+```
+
 ## Hide Close Button
 
 The close button can be hidden by using the `isCloseButtonHidden` prop. If this prop is used, it is mandatory to provide another way to close the modal.

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -179,18 +179,6 @@ export function Example() {
     setCustomHeadingRef(ref);
   };
 
-  const onModalShow = () => {
-    setShowModal(true);
-  };
-
-  const onModalClose = () => {
-    setShowModal(false);
-  };
-
-  const onHeadingFocus = () => {
-    customHeadingRef.current.focus();
-  };
-
   return (
     <>
       <Modal
@@ -250,15 +238,18 @@ export function Example() {
             }}
           />
           <h2 ref={customHeadingRef} tabIndex={-1}>
-            Add Links to Your Content
+            Confirmation header
           </h2>
           <Paragraph>
-            Your course is now integrated. Select specific activities to provide
-            students with direct links. Or, add just one link to your entire
-            course. You can return to select more content later.
+            With watermelon ostriches. Gourds utters at welding equipment a oink
+            oink haybine. Goose hammers cattle rats in crows. Blue berries
+            pigeons buzz and bean prairie dogs nails at est.
           </Paragraph>
           <ButtonGroup>
-            <Button onClick={onHeadingFocus} color={ButtonColor.subtle}>
+            <Button
+              onClick={() => customHeadingRef.current.focus()}
+              color={ButtonColor.subtle}
+            >
               Focus Heading
             </Button>
             <Button

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -150,6 +150,8 @@ the first actionable element.
 
 If the modal does not use the `header` prop, you must use the `ariaLabel` prop to ensure the correct aria properties are in place.
 
+When a reference to the header is needed, use the `headerRef` prop.
+
 ```tsx
 import React from 'react';
 import {
@@ -164,82 +166,10 @@ import {
 export function Example() {
   const [showModal, setShowModal] = React.useState(false);
   const [showModalHeader, setShowModalHeader] = React.useState(false);
+  const [showModalHeaderRef, setShowModalHeaderRef] = React.useState(false);
   const buttonRef = React.useRef();
   const headerButtonRef = React.useRef();
 
-  return (
-    <>
-      <Modal
-        ariaLabel="customAriaLabel"
-        size={ModalSize.small}
-        onClose={() => {
-          setShowModal(false);
-          buttonRef.current.focus();
-        }}
-        isOpen={showModal}
-      >
-        <Paragraph noTopMargin>This modal has no header.</Paragraph>
-        <ButtonGroup alignment={ButtonGroupAlignment.center}>
-          <Button onClick={() => setShowModal(false)}>OK</Button>
-        </ButtonGroup>
-      </Modal>
-      <Modal
-        header="This modal has a header"
-        size={ModalSize.small}
-        onClose={() => {
-          setShowModalHeader(false);
-          headerButtonRef.current.focus();
-        }}
-        isOpen={showModalHeader}
-      >
-        <Paragraph noTopMargin>This modal has no header.</Paragraph>
-        <ButtonGroup alignment={ButtonGroupAlignment.center}>
-          <Button onClick={() => setShowModalHeader(false)}>OK</Button>
-        </ButtonGroup>
-      </Modal>
-      <ButtonGroup>
-        <Button onClick={() => setShowModal(true)} ref={buttonRef}>
-          Show Modal with no header
-          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
-        </Button>
-        <Button onClick={() => setShowModalHeader(true)} ref={headerButtonRef}>
-          Show Modal with header
-          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
-        </Button>
-      </ButtonGroup>
-    </>
-  );
-}
-```
-
-## Modal Header Ref
-
-The modal headerRef prop allows access to a header element within the Modal. This is helpful for when a custom header is needed as it provides the ability to focus on load.
-
-```tsx
-import React from 'react';
-import {
-  Button,
-  ButtonColor,
-  IconButton,
-  Flex,
-  FlexBehavior,
-  FlexDirection,
-  FlexJustify,
-  FlexAlignItems,
-  magma,
-  Modal,
-  ModalSize,
-  Paragraph,
-  VisuallyHidden,
-  ButtonGroup,
-  ButtonGroupAlignment,
-} from 'react-magma-dom';
-import { CheckIcon } from 'react-magma-icons';
-
-export function Example() {
-  const [showModal, setShowModal] = React.useState(false);
-  const [showDefaultModal, setShowDefaultModal] = React.useState(false);
   const [customHeadingRef, setCustomHeadingRef] = React.useState(
     React.useRef<any>()
   );
@@ -271,8 +201,37 @@ export function Example() {
   return (
     <>
       <Modal
-        onClose={onModalClose}
+        ariaLabel="customAriaLabel"
+        size={ModalSize.small}
+        onClose={() => {
+          setShowModal(false);
+          buttonRef.current.focus();
+        }}
         isOpen={showModal}
+      >
+        <Paragraph noTopMargin>This modal has no header.</Paragraph>
+        <ButtonGroup alignment={ButtonGroupAlignment.center}>
+          <Button onClick={() => setShowModal(false)}>OK</Button>
+        </ButtonGroup>
+      </Modal>
+      <Modal
+        header="This modal has a header"
+        size={ModalSize.small}
+        onClose={() => {
+          setShowModalHeader(false);
+          headerButtonRef.current.focus();
+        }}
+        isOpen={showModalHeader}
+      >
+        <Paragraph noTopMargin>This modal has no header.</Paragraph>
+        <ButtonGroup alignment={ButtonGroupAlignment.center}>
+          <Button onClick={() => setShowModalHeader(false)}>OK</Button>
+        </ButtonGroup>
+      </Modal>
+
+      <Modal
+        onClose={() => setShowModalHeaderRef(false)}
+        isOpen={showModalHeaderRef}
         headerRef={handleGetHeaderRef}
         style={{ padding: '20px' }}
       >
@@ -284,9 +243,15 @@ export function Example() {
           spacing={2}
           wrap={FlexWrap.nowrap}
         >
-          <IconButton
-            style={{ background: magma.colors.success }}
-            icon={<CheckIcon />}
+          <CheckIcon
+            style={{
+              background: magma.colors.success,
+              color: magma.colors.neutral100,
+              width: '36px',
+              height: '36px',
+              padding: '8px',
+              borderRadius: '50%',
+            }}
           />
           <h2 ref={customHeadingRef} tabIndex={-1}>
             Add Links to Cengage Content
@@ -301,7 +266,10 @@ export function Example() {
             <Button onClick={onHeadingFocus} color={ButtonColor.subtle}>
               Focus Heading
             </Button>
-            <Button onClick={onModalClose} color={ButtonColor.subtle}>
+            <Button
+              onClick={() => setShowModalHeaderRef(false)}
+              color={ButtonColor.subtle}
+            >
               Close
             </Button>
           </ButtonGroup>
@@ -309,7 +277,20 @@ export function Example() {
       </Modal>
 
       <ButtonGroup>
-        <Button onClick={onModalShow}>Show Custom Heading Modal</Button>
+        <Button onClick={() => setShowModal(true)} ref={buttonRef}>
+          Show Modal with no header
+          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+        </Button>
+        <Button onClick={() => setShowModalHeader(true)} ref={headerButtonRef}>
+          Show Modal with header
+          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+        </Button>
+        <Button
+          style={{ marginLeft: '0' }}
+          onClick={() => setShowModalHeaderRef(true)}
+        >
+          Show Modal with headerRef
+        </Button>
       </ButtonGroup>
     </>
   );

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -169,6 +169,7 @@ export function Example() {
   const [showModalHeaderRef, setShowModalHeaderRef] = React.useState(false);
   const buttonRef = React.useRef();
   const headerButtonRef = React.useRef();
+  const headerRefButtonRef = React.useRef();
 
   const [customHeadingRef, setCustomHeadingRef] = React.useState(
     React.useRef<any>()
@@ -184,14 +185,6 @@ export function Example() {
 
   const onModalClose = () => {
     setShowModal(false);
-  };
-
-  const onModalShowDefault = () => {
-    setShowDefaultModal(true);
-  };
-
-  const onModalCloseDefault = () => {
-    setShowDefaultModal(false);
   };
 
   const onHeadingFocus = () => {
@@ -230,7 +223,10 @@ export function Example() {
       </Modal>
 
       <Modal
-        onClose={() => setShowModalHeaderRef(false)}
+        onClose={() => {
+          setShowModalHeaderRef(false);
+          headerRefButtonRef.current.focus();
+        }}
         isOpen={showModalHeaderRef}
         headerRef={handleGetHeaderRef}
         style={{ padding: '20px' }}
@@ -254,13 +250,12 @@ export function Example() {
             }}
           />
           <h2 ref={customHeadingRef} tabIndex={-1}>
-            Add Links to Cengage Content
+            Add Links to Your Content
           </h2>
           <Paragraph>
-            Your LMS course is now integrated with Cengage. Select specific
-            Cengage activities to provide students with direct links. Or, add
-            just one link to your entire course. You can return to select more
-            content later.
+            Your course is now integrated. Select specific activities to provide
+            students with direct links. Or, add just one link to your entire
+            course. You can return to select more content later.
           </Paragraph>
           <ButtonGroup>
             <Button onClick={onHeadingFocus} color={ButtonColor.subtle}>
@@ -288,6 +283,7 @@ export function Example() {
         <Button
           style={{ marginLeft: '0' }}
           onClick={() => setShowModalHeaderRef(true)}
+          ref={headerRefButtonRef}
         >
           Show Modal with headerRef
         </Button>


### PR DESCRIPTION
Issue: # [1308](https://github.com/cengage/react-magma/issues/1308)

## What I did
- Addition of `headerRef` prop to access Modal header.

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
- Open docs or storybook
- Go to modal header ref examples
- Ensure focus is initially on title
- Tab through the Modal and confirm the focus remains within it and doesn't go behind the Modal
- Confirm title _**doesn't**_ get focused again when tabbing
