### PR TITLE
fix(Docs): Drawer on small screens is broken

### DIFF
--- a/.changeset/drawer-docs.md
+++ b/.changeset/drawer-docs.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Drawer): Fixed drawer appearing open at lower screen resolutions for the doc site navigation.

--- a/website/react-magma-docs/src/components/MainContainer/index.js
+++ b/website/react-magma-docs/src/components/MainContainer/index.js
@@ -16,9 +16,6 @@ const StyledContainer = styled.div`
       'masthead masthead'
       'nav content';
   }
-  @media (max-width: 1024px) {
-    display: hidden;
-  }
 `;
 
 const StyledSkipLink = styled(SkipLink)`


### PR DESCRIPTION
Issue: # [1370](https://github.com/cengage/react-magma/issues/1370)

## What I did
-Fixed nav overlap when screen breaks at 1025px

## Screenshots:
<img width="1008" alt="Screeny" src="https://github.com/user-attachments/assets/0e652fba-6712-4934-a1d3-3b5ddbc38cc3">

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
- Open Docs
- Size screen to 1024px
- Verify nav no longer overlays and instead hides at this resolution
