### PR TITLE
fix(Breadcrumbs): Fixed alignment issue between elements.

### DIFF
--- a/.changeset/breadcrumbs-alignment.md
+++ b/.changeset/breadcrumbs-alignment.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Breadcrumbs): Fixed alignment issue between elements.

--- a/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -20,7 +20,6 @@ export interface BreadcrumbItemProps
   to?: string;
 }
 
-
 const StyledItem = styled.li`
   list-style: none;
   margin: 0;
@@ -29,6 +28,8 @@ const StyledItem = styled.li`
 `;
 
 const StyledSpan = styled.span<{ isInverse?: boolean }>`
+  align-items: center;
+  display: flex;
   color: ${props =>
     props.isInverse
       ? props.theme.colors.neutral100


### PR DESCRIPTION
Issue: # [1380](https://github.com/cengage/react-magma/issues/1380)

## What I did
-Fixed alignment appearing off between elements in the `Breadcrumbs` component

## Screenshots:
😭:
![sad](https://github.com/user-attachments/assets/18f0f753-3278-4a54-9539-59615d8c335a)

🤩:
![happy](https://github.com/user-attachments/assets/9b778176-df5b-4c4a-b576-488f80650b39)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
- Open Breadcrumbs in Storybook or Docs
- Verify all elements properly display inline and have no bottom offset
