### PR TITLE
fix(Button): Improved accessibility for `isLoading` button state

### DIFF
--- a/.changeset/a11y-loadingBtn.md
+++ b/.changeset/a11y-loadingBtn.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Button): Improved accessibility for `isLoading` state

--- a/packages/react-magma-dom/src/components/Button/Button.stories.tsx
+++ b/packages/react-magma-dom/src/components/Button/Button.stories.tsx
@@ -40,11 +40,7 @@ const Template: Story<ButtonProps> = args => (
       >
         Secondary
       </Button>
-      <Button
-        variant={ButtonVariant.link}
-        {...args}
-        color={ButtonColor.subtle}
-      >
+      <Button variant={ButtonVariant.link} {...args} color={ButtonColor.subtle}>
         Subtle
       </Button>
       <Button variant={ButtonVariant.link} {...args} color={ButtonColor.danger}>
@@ -268,6 +264,29 @@ export const All = () => {
           </ButtonGroup>
         </CardBody>
       </Card>
+    </>
+  );
+};
+
+export const LoadingButton = args => {
+  const [isLoading, setIsLoading] = React.useState(args.isLoading);
+  React.useEffect(() => {
+    if (isLoading) {
+      setTimeout(() => {
+        setIsLoading(false);
+      }, 4000);
+    }
+  }, [isLoading]);
+
+  return (
+    <>
+      <p>Click the button below to show the loading state</p>
+      <div role="status">Status: {isLoading ? 'Loading...' : 'Ready'}</div>
+      <ButtonGroup>
+        <Button {...args} isLoading={isLoading} onClick={() => setIsLoading(true)}>
+          Save
+        </Button>
+      </ButtonGroup>
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/Button/Button.stories.tsx
+++ b/packages/react-magma-dom/src/components/Button/Button.stories.tsx
@@ -13,6 +13,7 @@ import { Card, CardBody } from '../Card';
 import { magma } from '../../theme/magma';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { ButtonGroup } from '../ButtonGroup';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 const Template: Story<ButtonProps> = args => (
   <>
@@ -281,9 +282,15 @@ export const LoadingButton = args => {
   return (
     <>
       <p>Click the button below to show the loading state</p>
-      <div role="status">Status: {isLoading ? 'Loading...' : 'Ready'}</div>
+      <VisuallyHidden>
+        <span role="status">{isLoading ? 'Loading...' : 'Ready'}</span>
+      </VisuallyHidden>
       <ButtonGroup>
-        <Button {...args} isLoading={isLoading} onClick={() => setIsLoading(true)}>
+        <Button
+          {...args}
+          isLoading={isLoading}
+          onClick={() => setIsLoading(true)}
+        >
           Save
         </Button>
       </ButtonGroup>

--- a/packages/react-magma-dom/src/components/Button/Button.test.js
+++ b/packages/react-magma-dom/src/components/Button/Button.test.js
@@ -1,4 +1,3 @@
-// <reference types="jest-dom/extend-expect"/>
 import React from 'react';
 import { axe } from '../../../axe-helper';
 import {

--- a/packages/react-magma-dom/src/components/Spinner/index.tsx
+++ b/packages/react-magma-dom/src/components/Spinner/index.tsx
@@ -13,6 +13,11 @@ export interface SpinnerProps extends React.HTMLAttributes<HTMLSpanElement> {
   color?: string;
   isInverse?: boolean;
   /**
+   * Use when Spinner does not need the "img" role (ex: button loading state)
+   * @internal
+   */
+  noRole?: boolean;
+  /**
    * The height and width of the spinner.  Can be a string or number; if number is provided, the size is in px.
    * @default 16
    */
@@ -45,7 +50,14 @@ const StyledSpinner = styled.span<SpinnerProps>`
 
 export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
   (props, ref) => {
-    const { 'aria-label': ariaLabel, color, size, testId, ...other } = props;
+    const {
+      'aria-label': ariaLabel,
+      color,
+      noRole,
+      size,
+      testId,
+      ...other
+    } = props;
 
     const theme = React.useContext(ThemeContext);
     const i18n = React.useContext(I18nContext);
@@ -70,7 +82,7 @@ export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
         }
         data-testid={testId}
         ref={ref}
-        role="img"
+        role={noRole ? null : 'img'}
         size={sizeString}
       />
     );

--- a/packages/react-magma-dom/src/components/Spinner/index.tsx
+++ b/packages/react-magma-dom/src/components/Spinner/index.tsx
@@ -82,7 +82,8 @@ export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
         }
         data-testid={testId}
         ref={ref}
-        role={noRole ? null : 'img'}
+        role={!noRole && 'img'}
+        aria-hidden={noRole}
         size={sizeString}
       />
     );

--- a/packages/react-magma-dom/src/components/StyledButton/index.tsx
+++ b/packages/react-magma-dom/src/components/StyledButton/index.tsx
@@ -21,6 +21,7 @@ import { ThemeContext } from '../../theme/ThemeContext';
 import { ButtonType, ButtonProps, ButtonSize, ButtonVariant } from '../Button';
 import { Spinner } from '../Spinner';
 import { I18nContext } from '../../i18n';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 export interface StyledButtonProps extends ButtonProps {
   href?: string;
@@ -128,9 +129,6 @@ export const BaseStyledButton = styled.button`
 const SpinnerWrapper = styled.span`
   position: absolute;
   display: flex;
-  > span:last-child {
-    display: none;
-  }
 `;
 
 const ChildrenWrapper = styled.span<{ isLoading: boolean; testId?: string }>`
@@ -184,7 +182,7 @@ export const StyledButton = React.forwardRef<
             size={spinnerSize}
             noRole
           />
-          <span>{i18n.spinner.ariaLabel}</span>
+          <VisuallyHidden>{i18n.spinner.ariaLabel}</VisuallyHidden>
         </SpinnerWrapper>
       )}
       <ChildrenWrapper isLoading={isLoading} testId={`${testId}-children`}>

--- a/packages/react-magma-dom/src/components/StyledButton/index.tsx
+++ b/packages/react-magma-dom/src/components/StyledButton/index.tsx
@@ -20,6 +20,7 @@ import {
 import { ThemeContext } from '../../theme/ThemeContext';
 import { ButtonType, ButtonProps, ButtonSize, ButtonVariant } from '../Button';
 import { Spinner } from '../Spinner';
+import { I18nContext } from '../../i18n';
 
 export interface StyledButtonProps extends ButtonProps {
   href?: string;
@@ -127,6 +128,9 @@ export const BaseStyledButton = styled.button`
 const SpinnerWrapper = styled.span`
   position: absolute;
   display: flex;
+  > span:last-child {
+    display: none;
+  }
 `;
 
 const ChildrenWrapper = styled.span<{ isLoading: boolean; testId?: string }>`
@@ -149,6 +153,7 @@ export const StyledButton = React.forwardRef<
     isLoading,
   } = props;
   const theme = React.useContext(ThemeContext);
+  const i18n = React.useContext(I18nContext);
 
   const spinnerColor =
     isInverse && variant === ButtonVariant.link
@@ -177,7 +182,9 @@ export const StyledButton = React.forwardRef<
             testId={`${testId}-spinner`}
             color={spinnerColor}
             size={spinnerSize}
+            noRole
           />
+          <span>{i18n.spinner.ariaLabel}</span>
         </SpinnerWrapper>
       )}
       <ChildrenWrapper isLoading={isLoading} testId={`${testId}-children`}>

--- a/website/react-magma-docs/src/pages/api/button.mdx
+++ b/website/react-magma-docs/src/pages/api/button.mdx
@@ -136,7 +136,7 @@ When a button is in a loading state, the label can be replaced with a loading sp
 
 ```tsx
 import React from 'react';
-import { Button, ButtonGroup } from 'react-magma-dom';
+import { Button, ButtonGroup, VisuallyHidden } from 'react-magma-dom';
 
 export function Example() {
   const [isLoading, setIsLoading] = React.useState(false);
@@ -151,7 +151,9 @@ export function Example() {
   return (
     <>
       <p>Click the button below to show the loading state</p>
-      <div role="status">Status: {isLoading ? 'Loading...' : 'Ready'}</div>
+      <VisuallyHidden>
+        <span role="status">{isLoading ? 'Loading...' : 'Ready'}</span>
+      </VisuallyHidden>
       <ButtonGroup>
         <Button isLoading={isLoading} onClick={() => setIsLoading(true)}>
           Save

--- a/website/react-magma-docs/src/pages/api/button.mdx
+++ b/website/react-magma-docs/src/pages/api/button.mdx
@@ -139,11 +139,25 @@ import React from 'react';
 import { Button, ButtonGroup } from 'react-magma-dom';
 
 export function Example() {
+  const [isLoading, setIsLoading] = React.useState(false);
+  React.useEffect(() => {
+    if (isLoading) {
+      setTimeout(() => {
+        setIsLoading(false);
+      }, 4000);
+    }
+  }, [isLoading]);
+
   return (
-    <ButtonGroup>
-      <Button isLoading>Save</Button>
-      <Button isLoading={false}>Save</Button>
-    </ButtonGroup>
+    <>
+      <p>Click the button below to show the loading state</p>
+      <div role="status">Status: {isLoading ? 'Loading...' : 'Ready'}</div>
+      <ButtonGroup>
+        <Button isLoading={isLoading} onClick={() => setIsLoading(true)}>
+          Save
+        </Button>
+      </ButtonGroup>
+    </>
   );
 }
 ```


### PR DESCRIPTION
Issue: #1398 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Improved `isLoading` button example
- Removed Spinner role inside button when isLoading
- Added invisible span inside `isLoading` button that reads Loading

## Screenshots:
<!-- Include screenshot of your change -->
![image](https://github.com/user-attachments/assets/11fc7cdf-c9c7-44a9-8952-8281a772a71f)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm the isLoading state in all buttons (regular, icon)