### PR TITLE
fix(DataGrid): Improved accessibility by adding `aria-live="polite"` and fixing labelText

### DIFF
--- a/.changeset/a11y-datagrid.md
+++ b/.changeset/a11y-datagrid.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DataGrid): Improved accessibility by adding `aria-live="polite"` and fixing labelText for checkboxes when `isSelectable={true}`

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -23,6 +23,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 1',
   },
   {
     id: 2,
@@ -30,6 +31,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 2',
   },
   {
     id: 3,
@@ -37,6 +39,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 3',
   },
   {
     id: 4,
@@ -44,6 +47,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 4',
   },
   {
     id: 5,
@@ -51,6 +55,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 5',
   },
   {
     id: 6,
@@ -58,6 +63,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 6',
   },
   {
     id: 7,
@@ -65,6 +71,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 7',
   },
   {
     id: 8,
@@ -72,6 +79,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 8',
   },
   {
     id: 9,
@@ -79,6 +87,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 9',
   },
   {
     id: 10,
@@ -86,6 +95,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 10',
   },
   {
     id: 11,
@@ -93,6 +103,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 11',
   },
   {
     id: 12,
@@ -100,6 +111,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 12',
   },
   {
     id: 13,
@@ -107,6 +119,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 13',
   },
   {
     id: 14,
@@ -114,6 +127,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 14',
   },
   {
     id: 15,
@@ -121,6 +135,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 15',
   },
   {
     id: 16,
@@ -128,6 +143,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 16',
   },
   {
     id: 17,
@@ -135,6 +151,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 17',
   },
   {
     id: 18,
@@ -142,6 +159,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 18',
   },
   {
     id: 19,
@@ -149,6 +167,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 19',
   },
   {
     id: 20,
@@ -156,6 +175,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 20',
   },
   {
     id: 21,
@@ -163,6 +183,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 21',
   },
   {
     id: 22,
@@ -170,6 +191,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 22',
   },
   {
     id: 23,
@@ -177,6 +199,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 23',
   },
   {
     id: 24,
@@ -184,6 +207,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 24',
   },
   {
     id: 25,
@@ -191,6 +215,7 @@ const rowsForPagination = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row 25',
   },
 ];
 
@@ -275,6 +300,7 @@ const coloredRows = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row danger',
   },
   {
     id: 2,
@@ -283,6 +309,7 @@ const coloredRows = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row info',
   },
   {
     id: 3,
@@ -291,6 +318,7 @@ const coloredRows = [
     col2: 'Lorem ipsum dolor',
     col3: 'Lorem ipsum dolor',
     col4: 'Lorem ipsum',
+    rowName: 'Row success',
   },
 ];
 
@@ -354,7 +382,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
       setSelectedDirection(direction);
       setPriceDirection(TableSortDirection.none);
       setStockDirection(TableSortDirection.none);
-    } else if (key === 'price'){
+    } else if (key === 'price') {
       if (
         sortConfig?.key === key &&
         priceDirection === TableSortDirection.ascending
@@ -364,7 +392,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
       setPriceDirection(direction);
       setSelectedDirection(TableSortDirection.none);
       setStockDirection(TableSortDirection.none);
-    } else if (key === 'stock'){
+    } else if (key === 'stock') {
       if (
         sortConfig?.key === key &&
         stockDirection === TableSortDirection.ascending
@@ -402,12 +430,12 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
     },
   ];
   const products = [
-    { id: 1, name: 'Cheese', price: 5, stock: 20 },
-    { id: 2, name: 'Milk', price: 5, stock: 32 },
-    { id: 3, name: 'Yogurt', price: 3, stock: 12 },
-    { id: 4, name: 'Heavy Cream', price: 10, stock: 9 },
-    { id: 5, name: 'Butter', price: 2, stock: 99 },
-    { id: 6, name: 'Sour Cream ', price: 4, stock: 86 },
+    { id: 1, name: 'Cheese', price: 5, stock: 20, rowName: 'Cheese' },
+    { id: 2, name: 'Milk', price: 5, stock: 32, rowName: 'Milk' },
+    { id: 3, name: 'Yogurt', price: 3, stock: 12, rowName: 'Yogurt' },
+    { id: 4, name: 'Heavy Cream', price: 10, stock: 9, rowName: 'Heavy Cream' },
+    { id: 5, name: 'Butter', price: 2, stock: 99, rowName: 'Butter' },
+    { id: 6, name: 'Sour Cream', price: 4, stock: 86, rowName: 'Sour Cream' },
   ];
 
   const [selectedItems, setSelectedItems] = React.useState([]);
@@ -447,7 +475,8 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
       }
     } else {
       let sortableItems = [...products];
-      const direction = sortConfig.key === 'price' ? priceDirection : stockDirection;
+      const direction =
+        sortConfig.key === 'price' ? priceDirection : stockDirection;
       sortableItems.sort((a, b) => {
         if (a[sortConfig.key] < b[sortConfig.key]) {
           return direction === TableSortDirection.ascending ? -1 : 1;
@@ -496,9 +525,9 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
         onRowSelect={handleRowSelect}
         onHeaderSelect={handleHeaderSelect}
         sortDirection={selectedDirection}
-        />
-        <Announce>
-          <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
+      />
+      <Announce>
+        <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
       </Announce>
     </>
   );

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -278,7 +278,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
 
     return (
       <>
-        <Table {...other} ref={ref}>
+        <Table {...other} ref={ref} aria-live="polite">
           <TableHead>
             <TableRow
               headerRowStatus={headerRowStatus}
@@ -308,6 +308,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
                 }
                 isSelectableDisabled={isSelectableDisabled}
                 onTableRowSelect={event => handleRowSelect(id, event)}
+                {...other}
               >
                 {columns.map(({ field, isRowHeader }: DatagridColumn) => {
                   return isRowHeader ? (

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -175,6 +175,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           isInverse: isInverse,
           isSelectable,
           isSortableBySelected,
+          rowCount
         }}
       >
         <TableContainer

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -18,6 +18,7 @@ import {
 import { transparentize } from 'polished';
 import { NorthIcon, SortDoubleArrowIcon, SouthIcon } from 'react-magma-icons';
 import styled from '@emotion/styled';
+import { I18nContext } from '../../i18n';
 
 /**
  * @children required
@@ -43,6 +44,10 @@ export interface TableRowProps
   onHeaderRowSelect?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onTableRowSelect?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   rowIndex?: number;
+  /**
+   * Unique name to be used to identify row for screenreaders
+   */
+  rowName?: string;
   /**
    * @internal
    */
@@ -196,12 +201,14 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
       onHeaderRowSelect,
       onTableRowSelect,
       rowIndex,
+      rowName,
       onSort,
       testId,
       ...other
     } = props;
     const theme = React.useContext(ThemeContext);
     const tableContext = React.useContext(TableContext);
+    const i18n = React.useContext(I18nContext);
 
     let isHeaderRow = false;
 
@@ -294,7 +301,11 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
                 status={headerRowStatus}
                 isInverse={getIsCheckboxInverse()}
                 labelStyle={{ padding: 0 }}
-                labelText="Select all rows"
+                labelText={
+                  headerRowStatus === IndeterminateCheckboxStatus.unchecked
+                    ? i18n.table.selectable.selectAllRowsAriaLabel
+                    : i18n.table.selectable.deselectAllRowsAriaLabel
+                }
                 isTextVisuallyHidden
                 onChange={onHeaderRowSelect}
               />
@@ -308,7 +319,7 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
                   onMouseEnter={handleMouseEnter}
                   onMouseLeave={handleMouseLeave}
                   data-testid={`${testId || ''}-sort-button`}
-                  aria-label="Sort rows"
+                  aria-label={i18n.table.selectable.sortButtonAriaLabel}
                 >
                   <SortIconWrapper theme={theme}>{SortIcon}</SortIconWrapper>
                 </SortButton>
@@ -325,7 +336,11 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
               checked={isSelected}
               disabled={isSelectableDisabled}
               labelStyle={{ padding: 0 }}
-              labelText={`Select row ${rowIndex} of ${tableContext.rowCount}`}
+              labelText={
+                isSelected
+                  ? `${i18n.table.selectable.deselectRowAriaLabel} ${rowName || ''}`
+                  : `${i18n.table.selectable.selectRowAriaLabel} ${rowName || ''}`
+              }
               isTextVisuallyHidden
               isInverse={getIsCheckboxInverse()}
               onChange={onTableRowSelect}

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -288,6 +288,13 @@ export const defaultI18n: I18nInterface = {
       previousAriaLabel: 'Previous page',
       rowsPerPageLabel: 'Rows per page',
     },
+    selectable: {
+      sortButtonAriaLabel: 'Sort rows',
+      selectAllRowsAriaLabel: 'Select all rows',
+      selectRowAriaLabel: 'Select row',
+      deselectAllRowsAriaLabel: 'Deselect all rows',
+      deselectRowAriaLabel: 'Deselect row',
+    }
   },
   tabs: {
     horizontalTabsInstructions:

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -272,6 +272,13 @@ export interface I18nInterface {
       previousAriaLabel: string;
       rowsPerPageLabel: string;
     };
+    selectable: {
+      sortButtonAriaLabel: string;
+      selectAllRowsAriaLabel: string;
+      selectRowAriaLabel: string;
+      deselectAllRowsAriaLabel: string;
+      deselectRowAriaLabel: string;
+    };
   };
   tabs: {
     horizontalTabsInstructions: string;

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -242,6 +242,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row danger',
     },
     {
       id: 2,
@@ -250,6 +251,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row info',
     },
     {
       id: 3,
@@ -258,6 +260,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row success',
     },
   ];
 
@@ -266,6 +269,8 @@ export function Example() {
 ```
 
 ## Selectable
+
+Use `rowName` when using Selectable so that the aria labels on the checkboxes can be unique, otherwise the labels will default to "Select Row" or "Deselect Row."
 
 ```typescript
 import React from 'react';
@@ -286,6 +291,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 1'
     },
     {
       id: 2,
@@ -293,6 +299,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 2'
     },
     {
       id: 3,
@@ -300,6 +307,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 3'
     },
     {
       id: 4,
@@ -307,6 +315,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 4'
     },
     {
       id: 5,
@@ -314,6 +323,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 5'
     },
     {
       id: 6,
@@ -321,6 +331,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 6'
     },
     {
       id: 7,
@@ -328,6 +339,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 7'
     },
     {
       id: 8,
@@ -335,6 +347,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 8'
     },
     {
       id: 9,
@@ -342,6 +355,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 9'
     },
     {
       id: 10,
@@ -349,6 +363,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 10'
     },
     {
       id: 11,
@@ -356,6 +371,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 11',
     },
     {
       id: 12,
@@ -363,6 +379,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 12',
     },
     {
       id: 13,
@@ -370,6 +387,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 13',
     },
     {
       id: 14,
@@ -377,6 +395,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 14',
     },
     {
       id: 15,
@@ -384,6 +403,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 15',
     },
     {
       id: 16,
@@ -391,6 +411,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 16',
     },
     {
       id: 17,
@@ -398,6 +419,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 17',
     },
     {
       id: 18,
@@ -405,6 +427,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 18',
     },
     {
       id: 19,
@@ -412,6 +435,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 19',
     },
     {
       id: 20,
@@ -419,6 +443,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 20',
     },
     {
       id: 21,
@@ -426,6 +451,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 21',
     },
     {
       id: 22,
@@ -433,6 +459,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 22',
     },
     {
       id: 23,
@@ -440,6 +467,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 23',
     },
     {
       id: 24,
@@ -447,6 +475,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 24',
     },
     {
       id: 25,
@@ -454,6 +483,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 25',
     },
   ];
 
@@ -486,6 +516,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 1'
     },
     {
       id: 2,
@@ -493,6 +524,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 2'
     },
     {
       id: 3,
@@ -500,6 +532,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 3'
     },
     {
       id: 4,
@@ -508,6 +541,7 @@ export function Example() {
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
       isSelectableDisabled: true,
+      rowName: 'Row 4'
     },
     {
       id: 5,
@@ -515,6 +549,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 5'
     },
     {
       id: 6,
@@ -522,6 +557,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 6'
     },
     {
       id: 7,
@@ -529,6 +565,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 7'
     },
     {
       id: 8,
@@ -536,6 +573,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 8'
     },
     {
       id: 9,
@@ -543,6 +581,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 9'
     },
     {
       id: 10,
@@ -550,6 +589,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 10'
     },
     {
       id: 11,
@@ -557,6 +597,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 11',
     },
     {
       id: 12,
@@ -564,6 +605,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 12',
     },
     {
       id: 13,
@@ -571,6 +613,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 13',
     },
     {
       id: 14,
@@ -578,6 +621,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 14',
     },
     {
       id: 15,
@@ -585,6 +629,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 15',
     },
     {
       id: 16,
@@ -592,6 +637,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 16',
     },
     {
       id: 17,
@@ -599,6 +645,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 17',
     },
     {
       id: 18,
@@ -606,6 +653,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 18',
     },
     {
       id: 19,
@@ -613,6 +661,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 19',
     },
     {
       id: 20,
@@ -620,6 +669,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 20',
     },
     {
       id: 21,
@@ -627,6 +677,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 21',
     },
     {
       id: 22,
@@ -634,6 +685,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 22',
     },
     {
       id: 23,
@@ -641,6 +693,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 23',
     },
     {
       id: 24,
@@ -648,6 +701,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 24',
     },
     {
       id: 25,
@@ -655,6 +709,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 25',
     },
   ];
 
@@ -883,6 +938,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 1'
     },
     {
       id: 2,
@@ -890,6 +946,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 2'
     },
     {
       id: 3,
@@ -897,6 +954,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 3'
     },
     {
       id: 4,
@@ -904,6 +962,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 4'
     },
     {
       id: 5,
@@ -911,6 +970,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 5'
     },
     {
       id: 6,
@@ -918,6 +978,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 6'
     },
     {
       id: 7,
@@ -925,6 +986,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 7'
     },
     {
       id: 8,
@@ -932,6 +994,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 8'
     },
     {
       id: 9,
@@ -939,6 +1002,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 9'
     },
     {
       id: 10,
@@ -946,6 +1010,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 10'
     },
     {
       id: 11,
@@ -953,6 +1018,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 11',
     },
     {
       id: 12,
@@ -960,6 +1026,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 12',
     },
     {
       id: 13,
@@ -967,6 +1034,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 13',
     },
     {
       id: 14,
@@ -974,6 +1042,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 14',
     },
     {
       id: 15,
@@ -981,6 +1050,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 15',
     },
     {
       id: 16,
@@ -988,6 +1058,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 16',
     },
     {
       id: 17,
@@ -995,6 +1066,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 17',
     },
     {
       id: 18,
@@ -1002,6 +1074,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 18',
     },
     {
       id: 19,
@@ -1009,6 +1082,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 19',
     },
     {
       id: 20,
@@ -1016,6 +1090,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 20',
     },
     {
       id: 21,
@@ -1023,6 +1098,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 21',
     },
     {
       id: 22,
@@ -1030,6 +1106,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 22',
     },
     {
       id: 23,
@@ -1037,6 +1114,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 23',
     },
     {
       id: 24,
@@ -1044,6 +1122,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 24',
     },
     {
       id: 25,
@@ -1051,6 +1130,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
+      rowName: 'Row 25',
     },
   ];
 


### PR DESCRIPTION
Issue: #1384 #1383 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Added `aria-live="polite"`
- Updated selectable datagrid to have unique labels for each checkbox
- Updated checkbox labels to update accordingly from "Select Row" to "Deselect Row" (each individual row and also the indeterminate one)
- Table Aria labels are now part of the i18n interface so they can be customized
- Updated examples in storybook and docs

## Screenshots:
<!-- Include screenshot of your change -->
![image](https://github.com/user-attachments/assets/b1ddb159-295b-48df-814f-7ac10f0826ff)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
- Test all datagrid examples in the docs site
- Test that the table component has not been affected
- Confirm that the appropriate aria labels are in place
- Confirm that the information is communicated correctly for screen readers when the pagination updated, or when items are selected
