### PR TITLE
fix(NavTabs): Improved accessibility by adding `aria-current="page"` for active tabs.

### DIFF
--- a/.changeset/a11y-navTabs.md
+++ b/.changeset/a11y-navTabs.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(NavTabs): Improved accessibility by adding `aria-current="page"` for active tabs.

--- a/packages/react-magma-dom/src/components/NavTabs/NavTab.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTab.tsx
@@ -13,9 +13,6 @@ import { TabsOrientation } from '../Tabs/shared';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { omit, useForkedRef, XOR } from '../../utils';
 
-/**
- * @children required
- */
 export interface BaseNavTabProps
   extends React.HTMLAttributes<HTMLAnchorElement> {
   /**
@@ -52,7 +49,7 @@ export interface BaseNavTabProps
 }
 
 export interface NavTabChildrenProps extends BaseNavTabProps {
-  children: JSX.Element | string;
+  children?: JSX.Element | string;
   /**
    * The href value of the tab link
    */
@@ -189,6 +186,7 @@ export const NavTab = React.forwardRef<any, NavTabProps>(
         {component ? (
           <StyledCustomTab
             {...other}
+            aria-current={isActive ? 'page' : false}
             component={component}
             data-testid={testId}
             iconPosition={tabIconPosition}
@@ -209,6 +207,7 @@ export const NavTab = React.forwardRef<any, NavTabProps>(
         ) : (
           <StyledTab
             {...other}
+            aria-current={isActive ? 'page' : false}
             ref={ref}
             data-testid={testId}
             href={to}

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.stories.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.stories.tsx
@@ -4,6 +4,7 @@ import { NavTab } from './NavTab';
 import { Card } from '../Card';
 import { magma } from '../../theme/magma';
 import { Meta } from '@storybook/react/types-6-0';
+import { AndroidIcon, EmailIcon, NotificationsIcon } from 'react-magma-icons';
 
 export default {
   component: NavTabs,
@@ -17,6 +18,16 @@ export const Default = () => {
         Current Page
       </NavTab>
       <NavTab to="http://google.com">Link to Google</NavTab>
+    </NavTabs>
+  );
+};
+
+export const IconOnly = () => {
+  return (
+    <NavTabs aria-label="Icon Only Nav Tabs">
+      <NavTab aria-label="Email" icon={<EmailIcon />} to="#" isActive />
+      <NavTab aria-label="Android" icon={<AndroidIcon />} to="#" />
+      <NavTab aria-label="Notifications" icon={<NotificationsIcon />} to="#" />
     </NavTabs>
   );
 };
@@ -42,5 +53,20 @@ export const Inverse = () => {
         <NavTab to="http://apple.com">Link to Apple</NavTab>
       </NavTabs>
     </Card>
+  );
+};
+
+export const CustomTab = () => {
+  const Link = ({ to, children, ...rest }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  );
+  return (
+    <NavTabs aria-label="Sample Custom Component Navigation Tabs">
+      <NavTab component={<Link to="./">Main page</Link>} />
+      <NavTab isActive component={<Link to="./">FAQ</Link>} />
+      <NavTab component={<Link to="./">About us</Link>} />
+    </NavTabs>
   );
 };

--- a/website/react-magma-docs/src/pages/api/nav-tabs.mdx
+++ b/website/react-magma-docs/src/pages/api/nav-tabs.mdx
@@ -73,12 +73,16 @@ import React from 'react';
 import { NavTab, NavTabs } from 'react-magma-dom';
 export function Example() {
   // We support Link components from libraries such as react-router/reach-router/gatsby that use the `to` prop in place of `href`
-  const Link = ({ to, ...rest }) => <a href={to} {...rest} />;
+   const Link = ({ to, children, ...rest }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  );
   return (
     <NavTabs aria-label="Sample Custom Component Navigation Tabs">
       <NavTab component={<Link to="./">Main page</Link>} />
       <NavTab component={<Link to="./">FAQ</Link>} />
-      <NavTab component={<Link to="./">About us</Link>} />
+      <NavTab isActive component={<Link to="./">About us</Link>} />
     </NavTabs>
   );
 }
@@ -268,7 +272,7 @@ import { EmailIcon, AndroidIcon, NotificationsIcon } from 'react-magma-icons';
 export function Example() {
   return (
     <NavTabs aria-label="Icon Only Nav Tabs">
-      <NavTab aria-label="Email" icon={<EmailIcon isActive />} to="#" />
+      <NavTab aria-label="Email" icon={<EmailIcon />} to="#" isActive />
       <NavTab aria-label="Android" icon={<AndroidIcon />} to="#" />
       <NavTab aria-label="Notifications" icon={<NotificationsIcon />} to="#" />
     </NavTabs>


### PR DESCRIPTION
Issue: #1238 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Added `aria-current="page"` for active tabs
- Update `children` prop to not be required because they are not required for Icon only nav tabs, which we want to support
- Updated docs examples that were broken
- Added 2 more examples to storybook

Outstanding question: do we need aria-current for our regular tabs as well?

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [ ] changeset has been added
- [ ] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
- Confirm new aria-current property for all nav tabs (custom and default)
- Confirm that NavTabs docs site is working as expected