### PR TITLE
docs(Modal): Modal Heading example fixes

### DIFF
--- a/.changeset/feat-modal-headerref-docs.md
+++ b/.changeset/feat-modal-headerref-docs.md
@@ -1,5 +1,5 @@
 ---
-'react-magma-dom': minor
+'react-magma-docs': patch
 ---
 
-feat(Modal): Fixed codesandbox omissions in the doc example of Modal Header.
+docs(Modal): Modal Heading example fixes

--- a/.changeset/feat-modal-headerref-docs.md
+++ b/.changeset/feat-modal-headerref-docs.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Modal): Fixed codesandbox omissions in the doc example of Modal Header.

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -150,13 +150,22 @@ the first actionable element.
 
 If the modal does not use the `header` prop, you must use the `ariaLabel` prop to ensure the correct aria properties are in place.
 
-When a reference to the header is needed, use the `headerRef` prop.
+When a reference to the header is needed, use the headerRef prop. When using a custom header, you must also use `tabIndex={-1}` property.
 
 ```tsx
 import React from 'react';
 import {
   Button,
+  ButtonColor,
   Modal,
+  Flex,
+  FlexBehavior,
+  FlexDirection,
+  FlexAlignItems,
+  FlexJustify,
+  FlexWrap,
+  CheckIcon,
+  magma,
   ModalSize,
   Paragraph,
   VisuallyHidden,
@@ -204,7 +213,7 @@ export function Example() {
         }}
         isOpen={showModalHeader}
       >
-        <Paragraph noTopMargin>This modal has no header.</Paragraph>
+        <Paragraph noTopMargin>This modal has a header.</Paragraph>
         <ButtonGroup alignment={ButtonGroupAlignment.center}>
           <Button onClick={() => setShowModalHeader(false)}>OK</Button>
         </ButtonGroup>


### PR DESCRIPTION
Issue: # [1308](https://github.com/cengage/react-magma/issues/1308)

## What I did
- Documentation change (docs or storybook only)

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
- Go to docs
- Ensure Modal Header examples all work in Codesandbox
- Ensure Modal header sentence "When a reference to the header is needed, use the headerRef prop. When using a custom header, you must also use `tabIndex={-1}` property." is there
