### PR TITLE
Fix / Modal: Docs Modal Heading icon example fix

### DIFF
--- a/.changeset/fix-modal-headerref-docs.md
+++ b/.changeset/fix-modal-headerref-docs.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+docs(Modal): Modal Heading icon example fix

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -164,7 +164,6 @@ import {
   FlexAlignItems,
   FlexJustify,
   FlexWrap,
-  CheckIcon,
   magma,
   ModalSize,
   Paragraph,
@@ -172,6 +171,9 @@ import {
   ButtonGroup,
   ButtonGroupAlignment,
 } from 'react-magma-dom';
+
+import { CheckIcon } from 'react-magma-icons';
+
 export function Example() {
   const [showModal, setShowModal] = React.useState(false);
   const [showModalHeader, setShowModalHeader] = React.useState(false);


### PR DESCRIPTION
Issue: # [1308](https://github.com/cengage/react-magma/issues/1308)

## What I did
- Fixing import in Docs site example

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
- Ensure Modal Header doc site imports the `CheckIcon` properly in CodeSandbox
