### PR TITLE
fix(Modal): Modal disabled background click focus fix.

### DIFF
--- a/.changeset/fix-modal-background.md
+++ b/.changeset/fix-modal-background.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal): Modal disabled background click focus fix.

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -53,6 +53,35 @@ export const Default = () => {
   );
 };
 
+export const BackgroundCickDisabled = () => {
+  const [showModal, setShowModal] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
+
+  return (
+    <>
+      <Modal
+        header="Modal Title"
+        isBackgroundClickDisabled
+        onClose={() => {
+          setShowModal(false);
+          buttonRef.current.focus();
+        }}
+        isOpen={showModal}
+      >
+        <Paragraph noTopMargin>This is a modal, doing modal things.</Paragraph>
+        <ButtonGroup alignment={ButtonGroupAlignment.right}>
+          <Button color={ButtonColor.secondary}>Cancel</Button>
+          <Button>Save</Button>
+        </ButtonGroup>
+      </Modal>
+      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
+        Show Modal
+        <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+      </Button>
+    </>
+  );
+};
+
 export const LongContentWithScrolling = () => {
   const [showModal, setShowModal] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>();
@@ -257,7 +286,7 @@ export const NoHeaderOrFocusableContent = () => {
           this. A modal should have something actionable inside it.
         </Paragraph>
       </Modal>
-      
+
       <Button onClick={onModalNoFocusShow} ref={buttonRef}>
         Show Modal with nothing focusable
       </Button>
@@ -520,10 +549,10 @@ export const HeaderReference = () => {
           sagittae Suspendisse mus fah daze, candle pin Market Basket P-town. Id
           labore, TD Gahden consectetur morbi consectetur sketchy ad. Adipiscing
           postea kid kid. Dis dolor scriptorem frickin auctor eros Bunker Hill
-          parturient. Suspendisse penatibus roast beef Bunker Hill.
-          Orange Line, blandit consectetur nam cu no eget ne, clicker. Mauris
-          vestibulum, augue Downtown Crossing, lectus half moon lorem.
-          Scelerisque sketchy wicked smaht carriage down Cape no.
+          parturient. Suspendisse penatibus roast beef Bunker Hill. Orange Line,
+          blandit consectetur nam cu no eget ne, clicker. Mauris vestibulum,
+          augue Downtown Crossing, lectus half moon lorem. Scelerisque sketchy
+          wicked smaht carriage down Cape no.
         </Paragraph>
         <ButtonGroup>
           <Button onClick={onHeadingFocus} color={ButtonColor.subtle}>

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -363,20 +363,6 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       />
     );
 
-    const modalBackDrop = (
-      <ModalBackdrop
-        data-testid="modal-backdrop"
-        isExiting={isExiting}
-        onMouseDown={
-          isBackgroundClickDisabled ? event => event.preventDefault() : null
-        }
-        fade
-        isOpen={isModalOpen}
-        unmountOnExit
-        theme={theme}
-      />
-    );
-
     return isModalOpen
       ? ReactDOM.createPortal(
           <div ref={focusTrapElement}>
@@ -398,7 +384,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                 isBackgroundClickDisabled ? null : handleModalOnMouseDown
               }
               role="dialog"
-              style={containerStyle}
+              style={containerStyle || (modalCount >= 2 && { zIndex: '999' })}
               theme={theme}
               isOpen={isModalOpen}
               {...containerTransition}
@@ -450,9 +436,21 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                   </CloseBtn>
                 )}
               </ModalContent>
-              {modalCount >= 2 && modalBackDrop}
             </ModalContainer>
-            {modalCount <= 1 && modalBackDrop}
+            <ModalBackdrop
+              data-testid="modal-backdrop"
+              isExiting={isExiting}
+              onMouseDown={
+                isBackgroundClickDisabled
+                  ? event => event.preventDefault()
+                  : null
+              }
+              fade
+              isOpen={isModalOpen}
+              style={modalCount >= 2 && { zIndex: '998' }}
+              unmountOnExit
+              theme={theme}
+            />
           </div>,
           document.getElementsByTagName('body')[0]
         )

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -112,6 +112,7 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const ModalContainer = styled(Transition)<{
   theme: ThemeInterface;
+  modalCount?: number;
 }>`
   bottom: 0;
   left: 0;
@@ -119,7 +120,7 @@ const ModalContainer = styled(Transition)<{
   padding: ${props => props.theme.spaceScale.spacing03};
   right: 0;
   top: 0;
-  z-index: 998;
+  z-index: ${props => (props.modalCount >= 2 ? '999' : '998')};
 `;
 
 const ModalBackdrop = styled(Transition)<{
@@ -379,12 +380,13 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
               aria-modal={true}
               data-testid={testId}
               id={id}
+              modalCount={modalCount}
               onClick={isBackgroundClickDisabled ? null : handleModalClick}
               onMouseDown={
                 isBackgroundClickDisabled ? null : handleModalOnMouseDown
               }
               role="dialog"
-              style={containerStyle || (modalCount >= 2 && { zIndex: '999' })}
+              style={containerStyle}
               theme={theme}
               isOpen={isModalOpen}
               {...containerTransition}

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -363,6 +363,20 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       />
     );
 
+    const modalBackDrop = (
+      <ModalBackdrop
+        data-testid="modal-backdrop"
+        isExiting={isExiting}
+        onMouseDown={
+          isBackgroundClickDisabled ? event => event.preventDefault() : null
+        }
+        fade
+        isOpen={isModalOpen}
+        unmountOnExit
+        theme={theme}
+      />
+    );
+
     return isModalOpen
       ? ReactDOM.createPortal(
           <div ref={focusTrapElement}>
@@ -436,20 +450,9 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                   </CloseBtn>
                 )}
               </ModalContent>
-              <ModalBackdrop
-                data-testid="modal-backdrop"
-                isExiting={isExiting}
-                onMouseDown={
-                  isBackgroundClickDisabled
-                    ? event => event.preventDefault()
-                    : null
-                }
-                fade
-                isOpen={isModalOpen}
-                unmountOnExit
-                theme={theme}
-              />
+              {modalCount >= 2 && modalBackDrop}
             </ModalContainer>
+            {modalCount <= 1 && modalBackDrop}
           </div>,
           document.getElementsByTagName('body')[0]
         )

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -373,84 +373,83 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                 }
               `}
             />
-            <ModalBackdrop
-              data-testid="modal-backdrop"
-              isExiting={isExiting}
+            <ModalContainer
+              aria-labelledby={header ? headingId : null}
+              aria-label={!header ? ariaLabel : null}
+              aria-modal={true}
+              data-testid={testId}
+              id={id}
+              onClick={isBackgroundClickDisabled ? null : handleModalClick}
               onMouseDown={
-                isBackgroundClickDisabled
-                  ? event => event.preventDefault()
-                  : null
+                isBackgroundClickDisabled ? null : handleModalOnMouseDown
               }
-              fade
-              isOpen={isModalOpen}
-              unmountOnExit
+              role="dialog"
+              style={containerStyle}
               theme={theme}
+              isOpen={isModalOpen}
+              {...containerTransition}
+              unmountOnExit={unmountOnExit}
             >
-              <ModalContainer
-                aria-labelledby={header ? headingId : null}
-                aria-label={!header ? ariaLabel : null}
-                aria-modal={true}
-                data-testid={testId}
-                id={id}
-                onClick={isBackgroundClickDisabled ? null : handleModalClick}
-                onMouseDown={
-                  isBackgroundClickDisabled ? null : handleModalOnMouseDown
-                }
-                role="dialog"
-                style={containerStyle}
+              <ModalContent
+                {...other}
+                data-testid="modal-content"
+                id={contentId}
+                isExiting={isExiting}
+                ref={ref}
                 theme={theme}
-                isOpen={isModalOpen}
-                {...containerTransition}
-                unmountOnExit={unmountOnExit}
               >
-                <ModalContent
-                  {...other}
-                  data-testid="modal-content"
-                  id={contentId}
-                  isExiting={isExiting}
-                  ref={ref}
-                  theme={theme}
-                >
-                  {header && (
-                    <ModalHeader theme={theme}>
-                      {header && (
-                        <H1
-                          id={headingId}
-                          isInverse={isInverse}
-                          level={1}
-                          ref={headingRef}
-                          visualStyle={TypographyVisualStyle.headingSmall}
-                          tabIndex={-1}
-                          theme={theme}
-                        >
-                          {header}
-                        </H1>
-                      )}
-                    </ModalHeader>
-                  )}
-                  <ModalWrapper ref={bodyRef} theme={theme}>
-                    {children}
-                  </ModalWrapper>
-                  {!isCloseButtonHidden && (
-                    <CloseBtn theme={theme}>
-                      <IconButton
-                        aria-label={
-                          closeAriaLabel
-                            ? closeAriaLabel
-                            : i18n.modal.closeAriaLabel
-                        }
-                        color={ButtonColor.primary}
-                        icon={CloseIconButton}
+                {header && (
+                  <ModalHeader theme={theme}>
+                    {header && (
+                      <H1
+                        id={headingId}
                         isInverse={isInverse}
-                        onClick={handleClose}
-                        testId="modal-closebtn"
-                        variant={ButtonVariant.link}
-                      />
-                    </CloseBtn>
-                  )}
-                </ModalContent>
-              </ModalContainer>
-            </ModalBackdrop>
+                        level={1}
+                        ref={headingRef}
+                        visualStyle={TypographyVisualStyle.headingSmall}
+                        tabIndex={-1}
+                        theme={theme}
+                      >
+                        {header}
+                      </H1>
+                    )}
+                  </ModalHeader>
+                )}
+                <ModalWrapper ref={bodyRef} theme={theme}>
+                  {children}
+                </ModalWrapper>
+                {!isCloseButtonHidden && (
+                  <CloseBtn theme={theme}>
+                    <IconButton
+                      aria-label={
+                        closeAriaLabel
+                          ? closeAriaLabel
+                          : i18n.modal.closeAriaLabel
+                      }
+                      color={ButtonColor.primary}
+                      icon={CloseIconButton}
+                      isInverse={isInverse}
+                      onClick={handleClose}
+                      testId="modal-closebtn"
+                      variant={ButtonVariant.link}
+                    />
+                  </CloseBtn>
+                )}
+              </ModalContent>
+              <ModalBackdrop
+                data-testid="modal-backdrop"
+                isExiting={isExiting}
+                onMouseDown={
+                  isBackgroundClickDisabled
+                    ? event => event.preventDefault()
+                    : null
+                }
+                fade
+                isOpen={isModalOpen}
+                unmountOnExit
+                theme={theme}
+              />
+            </ModalContainer>
           </div>,
           document.getElementsByTagName('body')[0]
         )


### PR DESCRIPTION
Issue: # [1417](https://github.com/cengage/react-magma/issues/1417)

## What I did
- Restructured DOM order to help with focus issue while using `isBackgroundClickDisabled` prop.

## Screenshots:
![nested](https://github.com/user-attachments/assets/0177876b-a409-4289-bb65-5b961f392175)
![clickable](https://github.com/user-attachments/assets/20ebc701-25b1-4a5e-9ac0-796618ea5c20)

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
- Storybook
- Open Background Click Disabled story
- Verify you can now select text on the modal and click the buttons
- Open Modal In A Modal story
- Go into second modal and verify overlay is beneath it properly
