### PR TITLE
docs: Update changelog text to alert adopters about the emotion update.

### DIFF
--- a/.changeset/emotion-update.md
+++ b/.changeset/emotion-update.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+Update changelog text to alert adopters about the emotion update.

--- a/website/react-magma-docs/src/pages/api-intro/changelog.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/changelog.mdx
@@ -9,7 +9,7 @@ order: 4
 
 ### Minor Changes
 
-- ae668a3e5: chore: Updating emotion to v11
+- ae668a3e5: chore: Updating emotion to v11. **Note: adopters will need to upgrade** their packages to the following versions `"@emotion/react": "^11.13.0", "@emotion/styled": "^11.13.0"`. Notice that `@emotion/core` has been replaced with `@emotion/styled` and that's the only breaking change.
 - 9e38e9e7f: feat(Stepper): New Stepper component. Displays step based content for use in multi-step interfaces.
 
 ### Patch Changes


### PR DESCRIPTION
Issue: #1411

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
We upgraded emotion but did not make it clear that this would require our adopters to upgrade their emotion versions. Adding it to our changelog

## Screenshots:
![image](https://github.com/user-attachments/assets/7a03dbdf-dfe1-4bc1-8780-9c62c2af2b65)

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
Confirm the information about upgrading emotion is visible in /api-intro/changelog/