### PR TITLE
fix(accordion): fix screen scroll behavior during accordion navigation

### DIFF
--- a/.changeset/fix-accordion-navigation.md
+++ b/.changeset/fix-accordion-navigation.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Accordion): Fix screen scroll behavior during accordion navigation

--- a/packages/react-magma-dom/src/components/Accordion/useAccordionButton.ts
+++ b/packages/react-magma-dom/src/components/Accordion/useAccordionButton.ts
@@ -67,6 +67,10 @@ export function useAccordionButton(
   const handleKeyDown = (event: React.KeyboardEvent) => {
     const arrLength = buttonRefArray.current.length;
 
+    if (['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+      event.preventDefault();
+    }
+    
     switch (event.key) {
       case 'ArrowDown': {
         index === arrLength - 1 ? focusFirst() : focusNext();


### PR DESCRIPTION
Issue: #1385

## What I did
We prevent default keyboard scroll behavior if some accordion header button are focused
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
- Open storybook accordion section
- Click on the first accordion header button
- Press on the keyboard 'Down' key
- Make sure scrollbar position on the page is not changed 
