### PR TITLE
fix(BreadCrumb): replace span with link to fix focus

### DIFF
--- a/.changeset/a111y-breadCrumbs.md
+++ b/.changeset/a111y-breadCrumbs.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(BreadCrumb): replace span with link to fix focus

--- a/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -44,6 +44,14 @@ const StyledLink = styled.a<{ isInverse?: boolean }>`
         ? props.theme.colors.neutral100
         : props.theme.colors.neutral700};
   }
+  &:focus {
+    outline: 2px solid
+      ${props =>
+        props.isInverse
+          ? props.theme.colors.focusInverse
+          : props.theme.colors.focus};
+    outline-offset: 2px;
+  }
 `;
 
 const StyledSpan = styled.span<{ isInverse?: boolean }>`

--- a/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -1,9 +1,9 @@
+import styled from '@emotion/styled';
 import * as React from 'react';
+import { ChevronRightIcon } from 'react-magma-icons';
+import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { Hyperlink } from '../Hyperlink';
-import { useIsInverse } from '../../inverse';
-import { ChevronRightIcon } from 'react-magma-icons';
-import styled from '@emotion/styled';
 
 /**
  * @children required
@@ -15,7 +15,7 @@ export interface BreadcrumbItemProps
    */
   testId?: string;
   /**
-   * The href value of the link. If left blank, the breadcrumb item will render as a span with aria-current="page" on it.
+   * The URL for the link. If not provided, the breadcrumb item will display as a non-clickable element with aria-current="page".
    */
   to?: string;
 }
@@ -27,13 +27,28 @@ const StyledItem = styled.li`
   display: flex;
 `;
 
-const StyledSpan = styled.span<{ isInverse?: boolean }>`
+const StyledLink = styled.a<{ isInverse?: boolean }>`
   align-items: center;
   display: flex;
   color: ${props =>
     props.isInverse
       ? props.theme.colors.neutral100
       : props.theme.colors.neutral700};
+  text-decoration: none;
+  cursor: default;
+  
+  &:hover,
+  &:focus {
+    color: ${props =>
+      props.isInverse
+        ? props.theme.colors.neutral100
+        : props.theme.colors.neutral700};
+  }
+`;
+
+const StyledSpan = styled.span<{ isInverse?: boolean }>`
+  align-items: center;
+  display: flex;
 
   svg {
     margin: 0 ${props => props.theme.spaceScale.spacing02};
@@ -64,9 +79,17 @@ export const BreadcrumbItem = React.forwardRef<
           </StyledSpan>
         </>
       ) : (
-        <StyledSpan aria-current="page" isInverse={isInverse} theme={theme}>
-          {children}
-        </StyledSpan>
+        <>
+          <StyledLink
+            href=""
+            aria-current="page"
+            isInverse={isInverse}
+            theme={theme}
+            onClick={e => e.preventDefault()}
+          >
+            {children}
+          </StyledLink>
+        </>
       )}
     </StyledItem>
   );

--- a/website/react-magma-docs/src/pages/api/breadcrumb.mdx
+++ b/website/react-magma-docs/src/pages/api/breadcrumb.mdx
@@ -19,7 +19,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 The breadcrumb menu consists of two components: `Breadcrumb` and `BreadcrumbItem`. The `Breadcrumb` is the wrapper for the entire menu; the `BreadcrumbItem`
 should be used multiple times within it, and refers to each node in the menu. A `BreadcrumbItem` takes a `to` prop, which determines the href of that item. If that prop is left blank,
-the item will be rendered as a span and will have `aria-current="page"` on it. All items in a breadcrumb menu should have the `to` prop, except for the last one, which represents the current page.
+the item will be rendered as a non-clickable element with `aria-current="page"` on it. All items in a breadcrumb menu should have the `to` prop, except for the last one, which represents the current page.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
Issue: #1247

## What I did
- Bug fix replace span with link to fix focus

## Screenshots:
![image](https://github.com/user-attachments/assets/4a57abc3-41f7-48d2-8836-249dd617bf19)

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
1. Ensure each BreadcrumbItem is clickable when the to prop is provided.
2. Verify the last BreadcrumbItem is non-clickable, has aria-current="page", and can be focused.
3. Confirm the correct styles and focus behavior for both clickable and non-clickable items.