### PR TITLE
fix(DatePicker): Remove the shortcut to open the `HelperInformation` component.

### DIFF
--- a/.changeset/a11y-datePicker-shortcut.md
+++ b/.changeset/a11y-datePicker-shortcut.md
@@ -2,4 +2,4 @@
 'react-magma-dom': patch
 ---
 
-fix(DatePicker): Change shortcut to open `HelperInformation` from `?` to `Ctrl+Shift+?`
+fix(DatePicker): Remove shortcut to open `HelperInformation`.

--- a/.changeset/a11y-datePicker-shortcut.md
+++ b/.changeset/a11y-datePicker-shortcut.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(DatePicker): Change shortcut to open `HelperInformation` from `?` to `Ctrl+Shift+?`

--- a/.changeset/a11y-datePicker-shortcut.md
+++ b/.changeset/a11y-datePicker-shortcut.md
@@ -1,5 +1,5 @@
 ---
-'react-magma-docs': patch
+'react-magma-dom': patch
 ---
 
 fix(DatePicker): Change shortcut to open `HelperInformation` from `?` to `Ctrl+Shift+?`

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -195,8 +195,8 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
               </tbody>
             </Table>
             <Tooltip
-              content={'Keyboard instructions\nctrl+shift+?'}
-              tooltipStyle={{ position: 'fixed', whiteSpace: 'pre-line' }}
+              content={'Keyboard instructions'}
+              tooltipStyle={{ position: 'fixed' }}
             >
               <HelperButton theme={theme}>
                 <IconButton

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -21,7 +21,6 @@ interface CalendarMonthProps {
   setDateFocused?: (value: boolean) => void;
 }
 
-
 const CalendarContainer = styled.div<{ isInverse?: boolean }>`
   background: ${props =>
     props.isInverse
@@ -196,8 +195,8 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
               </tbody>
             </Table>
             <Tooltip
-              content={'Keyboard instructions'}
-              tooltipStyle={{ position: 'fixed' }}
+              content={'Keyboard instructions\nctrl+shift+?'}
+              tooltipStyle={{ position: 'fixed', whiteSpace: 'pre-line' }}
             >
               <HelperButton theme={theme}>
                 <IconButton

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -841,9 +841,7 @@ describe('Date Picker', () => {
       expect(document.activeElement).toBe(container.querySelector('button'));
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('?', async () => {
-      // TODO
+    it('?', async () => {
       const defaultDate = new Date();
       const labelText = 'Date picker label';
       const { getByText, baseElement } = render(
@@ -857,6 +855,16 @@ describe('Date Picker', () => {
       fireEvent.keyDown(baseElement.querySelector('table'), {
         key: '?',
       });
+
+      expect(() => getByText(/keyboard shortcuts/i)).toThrow();
+
+      fireEvent.keyDown(baseElement.querySelector('table'), {
+        key: '?',
+        ctrlKey: true,
+        shiftKey: true,
+      });
+
+      expect(getByText(/keyboard shortcuts/i)).toBeInTheDocument();
     });
 
     it('Escape without focus', () => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -841,32 +841,6 @@ describe('Date Picker', () => {
       expect(document.activeElement).toBe(container.querySelector('button'));
     });
 
-    it('Ctrl + Shift + ?', async () => {
-      const defaultDate = new Date();
-      const labelText = 'Date picker label';
-      const { getByText, baseElement } = render(
-        <DatePicker defaultDate={defaultDate} labelText={labelText} />
-      );
-
-      fireEvent.focus(baseElement.querySelector('table'));
-
-      getByText(defaultDate.getDate().toString()).focus();
-
-      fireEvent.keyDown(baseElement.querySelector('table'), {
-        key: '?',
-      });
-
-      expect(() => getByText(/keyboard shortcuts/i)).toThrow();
-
-      fireEvent.keyDown(baseElement.querySelector('table'), {
-        key: '?',
-        ctrlKey: true,
-        shiftKey: true,
-      });
-
-      expect(getByText(/keyboard shortcuts/i)).toBeInTheDocument();
-    });
-
     it('Escape without focus', () => {
       const defaultDate = new Date();
       const labelText = 'Date picker label';

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -841,7 +841,7 @@ describe('Date Picker', () => {
       expect(document.activeElement).toBe(container.querySelector('button'));
     });
 
-    it('?', async () => {
+    it('Ctrl + Shift + ?', async () => {
       const defaultDate = new Date();
       const labelText = 'Date picker label';
       const { getByText, baseElement } = render(

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
@@ -32,7 +32,7 @@ const Item = styled.li`
   line-height: ${props => props.theme.typeScale.size02.lineHeight};
   align-items: center;
   span {
-    flex: 0 0 100px;
+    flex: 0 0 130px;
     overflow: hidden;
     line-height: 28px;
     min-height: 36px;
@@ -220,13 +220,13 @@ export const HelperInformation: React.FunctionComponent<
             <KeyboardShortcutButtonWrapper
               role="img"
               theme={theme}
-              aria-label={i18n.datePicker.helpModal.questionMark.ariaLabel}
+              aria-label={i18n.datePicker.helpModal.ctrlShiftAndQuestionMark.ariaLabel}
               isInverse={isInverse}
             >
-              ?
+              {i18n.datePicker.helpModal.ctrlShiftAndQuestionMark.displayValue}
             </KeyboardShortcutButtonWrapper>
             <StyledDescription theme={theme}>
-              {i18n.datePicker.helpModal.questionMark.explanation}
+              {i18n.datePicker.helpModal.ctrlShiftAndQuestionMark.explanation}
             </StyledDescription>
           </Item>
         </List>

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
@@ -220,13 +220,13 @@ export const HelperInformation: React.FunctionComponent<
             <KeyboardShortcutButtonWrapper
               role="img"
               theme={theme}
-              aria-label={i18n.datePicker.helpModal.ctrlShiftAndQuestionMark.ariaLabel}
+              aria-label={i18n.datePicker.helpModal.questionMark.ariaLabel}
               isInverse={isInverse}
             >
-              {i18n.datePicker.helpModal.ctrlShiftAndQuestionMark.displayValue}
+              {i18n.datePicker.helpModal.questionMark.displayValue}
             </KeyboardShortcutButtonWrapper>
             <StyledDescription theme={theme}>
-              {i18n.datePicker.helpModal.ctrlShiftAndQuestionMark.explanation}
+              {i18n.datePicker.helpModal.questionMark.explanation}
             </StyledDescription>
           </Item>
         </List>

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
@@ -32,7 +32,7 @@ const Item = styled.li`
   line-height: ${props => props.theme.typeScale.size02.lineHeight};
   align-items: center;
   span {
-    flex: 0 0 130px;
+    flex: 0 0 100px;
     overflow: hidden;
     line-height: 28px;
     min-height: 36px;
@@ -214,19 +214,6 @@ export const HelperInformation: React.FunctionComponent<
             </KeyboardShortcutButtonWrapper>
             <StyledDescription theme={theme}>
               {i18n.datePicker.helpModal.escape.explanation}
-            </StyledDescription>
-          </Item>
-          <Item theme={theme}>
-            <KeyboardShortcutButtonWrapper
-              role="img"
-              theme={theme}
-              aria-label={i18n.datePicker.helpModal.questionMark.ariaLabel}
-              isInverse={isInverse}
-            >
-              {i18n.datePicker.helpModal.questionMark.displayValue}
-            </KeyboardShortcutButtonWrapper>
-            <StyledDescription theme={theme}>
-              {i18n.datePicker.helpModal.questionMark.explanation}
             </StyledDescription>
           </Item>
         </List>

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -325,10 +325,6 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
         if (newChosenDate) {
           setFocusedDate(newChosenDate);
         }
-      } else {
-        if (event.ctrlKey && event.shiftKey && event.key === '?') {
-          showHelperInformation();
-        }
       }
     }
 

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -326,7 +326,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
           setFocusedDate(newChosenDate);
         }
       } else {
-        if (event.key === '?') {
+        if (event.ctrlKey && event.shiftKey && event.key === '?') {
           showHelperInformation();
         }
       }

--- a/packages/react-magma-dom/src/components/DatePicker/utils.ts
+++ b/packages/react-magma-dom/src/components/DatePicker/utils.ts
@@ -88,13 +88,6 @@ export function handleKeyPress(
       iconRef.current.focus();
       break;
 
-    case '?':
-      e.preventDefault();
-      if (e.ctrlKey && e.shiftKey) {
-        showHelperInformation();
-      }
-      break;
-
     default:
       break;
   }

--- a/packages/react-magma-dom/src/components/DatePicker/utils.ts
+++ b/packages/react-magma-dom/src/components/DatePicker/utils.ts
@@ -90,7 +90,9 @@ export function handleKeyPress(
 
     case '?':
       e.preventDefault();
-      showHelperInformation();
+      if (e.ctrlKey && e.shiftKey) {
+        showHelperInformation();
+      }
       break;
 
     default:

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -144,7 +144,7 @@ export const defaultI18n: I18nInterface = {
         displayValue: 'ESC',
         explanation: 'Return to the date input field.',
       },
-      ctrlShiftAndQuestionMark: {
+      questionMark: {
         ariaLabel: 'Ctrl + Shift + Question Mark',
         displayValue: 'CTRL+SHIFT+?',
         explanation: 'Open this panel.',

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -144,8 +144,9 @@ export const defaultI18n: I18nInterface = {
         displayValue: 'ESC',
         explanation: 'Return to the date input field.',
       },
-      questionMark: {
-        ariaLabel: 'Question Mark',
+      ctrlShiftAndQuestionMark: {
+        ariaLabel: 'Ctrl + Shift + Question Mark',
+        displayValue: 'CTRL+SHIFT+?',
         explanation: 'Open this panel.',
       },
     },
@@ -294,7 +295,7 @@ export const defaultI18n: I18nInterface = {
       selectRowAriaLabel: 'Select row',
       deselectAllRowsAriaLabel: 'Deselect all rows',
       deselectRowAriaLabel: 'Deselect row',
-    }
+    },
   },
   tabs: {
     horizontalTabsInstructions:

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -144,11 +144,6 @@ export const defaultI18n: I18nInterface = {
         displayValue: 'ESC',
         explanation: 'Return to the date input field.',
       },
-      questionMark: {
-        ariaLabel: 'Ctrl + Shift + Question Mark',
-        displayValue: 'CTRL+SHIFT+?',
-        explanation: 'Open this panel.',
-      },
     },
   },
   dropdown: {

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -151,11 +151,6 @@ export interface I18nInterface {
         displayValue: string;
         explanation: string;
       };
-      questionMark: {
-        ariaLabel: string;
-        displayValue: string,
-        explanation: string;
-      };
     };
   };
   dropdown: {

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -151,8 +151,9 @@ export interface I18nInterface {
         displayValue: string;
         explanation: string;
       };
-      questionMark: {
+      ctrlShiftAndQuestionMark: {
         ariaLabel: string;
+        displayValue: string,
         explanation: string;
       };
     };

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -151,7 +151,7 @@ export interface I18nInterface {
         displayValue: string;
         explanation: string;
       };
-      ctrlShiftAndQuestionMark: {
+      questionMark: {
         ariaLabel: string;
         displayValue: string,
         explanation: string;

--- a/website/react-magma-docs/src/pages/api/internationalization.mdx
+++ b/website/react-magma-docs/src/pages/api/internationalization.mdx
@@ -114,8 +114,9 @@ export function Example() {
               displayValue: 'ESCAPAR',
               explanation: 'Regresar al campo de entrada de fecha.',
             },
-            questionMark: {
-              ariaLabel: 'Signo de interrogación',
+            ctrlShiftAndQuestionMark: {
+              ariaLabel: 'Ctrl + Shift + Signo de interrogación',
+              displayValue: 'CTRL+SHIFT+?',
               explanation: 'Abre este panel.',
             },
           },

--- a/website/react-magma-docs/src/pages/api/internationalization.mdx
+++ b/website/react-magma-docs/src/pages/api/internationalization.mdx
@@ -114,7 +114,7 @@ export function Example() {
               displayValue: 'ESCAPAR',
               explanation: 'Regresar al campo de entrada de fecha.',
             },
-            ctrlShiftAndQuestionMark: {
+            questionMark: {
               ariaLabel: 'Ctrl + Shift + Signo de interrogación',
               displayValue: 'CTRL+SHIFT+?',
               explanation: 'Abre este panel.',

--- a/website/react-magma-docs/src/pages/api/internationalization.mdx
+++ b/website/react-magma-docs/src/pages/api/internationalization.mdx
@@ -114,11 +114,6 @@ export function Example() {
               displayValue: 'ESCAPAR',
               explanation: 'Regresar al campo de entrada de fecha.',
             },
-            questionMark: {
-              ariaLabel: 'Ctrl + Shift + Signo de interrogación',
-              displayValue: 'CTRL+SHIFT+?',
-              explanation: 'Abre este panel.',
-            },
           },
         },
         locale: es,


### PR DESCRIPTION
Issue: #1396

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Change the shortcut on the DatePicker to open `HelperInformation` from `?` to `Ctrl+Shift+?`. Add a tooltip for it. Write test. Change localization.

## Screenshots:
<!-- Include screenshot of your change -->
![image](https://github.com/user-attachments/assets/1165526f-1e03-4216-8213-f4713eb8343b)
![image](https://github.com/user-attachments/assets/d39a8078-e017-49e8-af03-801fc5ad8534)


## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->