### PR TITLE
fix(Modal): refactor useFocusLock to fix bug with dynamic content ins…

### DIFF
--- a/.changeset/fix-modal-focuslock.md
+++ b/.changeset/fix-modal-focuslock.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal): Fix modal losing focus order with dynamic content.

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -179,6 +179,11 @@ export const ModalContentUpdate = () => {
   const [showHidden, setShowHidden] = React.useState(false);
   const [goToNextPageEnabled, setGoToNextPageEnabled] = React.useState(true);
   const buttonRef = React.useRef<HTMLButtonElement>();
+  const [mainHeaderRef, setmainHeaderRef] = React.useState(React.useRef<any>());
+
+  const handleGetHeaderRef = ref => {
+    setmainHeaderRef(ref);
+  };
 
   const onModalShow = () => {
     setShowModal(true);
@@ -190,10 +195,12 @@ export const ModalContentUpdate = () => {
   };
 
   const goToPage1 = () => {
+    mainHeaderRef?.current?.focus();
     setPage(1);
   };
 
   const goToPage2 = () => {
+    mainHeaderRef?.current?.focus();
     setPage(2);
   };
 
@@ -207,7 +214,7 @@ export const ModalContentUpdate = () => {
 
   return (
     <>
-      <Modal header="Modal Title" onClose={onModalClose} isOpen={showModal}>
+      <Modal header="Modal Title" onClose={onModalClose} isOpen={showModal} headerRef={handleGetHeaderRef}>
         <div id="attachToMe">
           {page === 1 && (
             <>

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -296,7 +296,18 @@ export const NoHeaderOrFocusableContent = () => {
 export const ModalInAModal = () => {
   const [showModal, setShowModal] = React.useState(false);
   const [showModal2, setShowModal2] = React.useState(false);
+  const [mainHeaderRef, setmainHeaderRef] = React.useState(React.useRef<any>());
+
   const buttonRef = React.useRef<HTMLButtonElement>();
+
+  const handleGetHeaderRef = ref => {
+    setmainHeaderRef(ref);
+  };
+
+  const closeModal2 = () => {
+    mainHeaderRef?.current?.focus();
+    setShowModal2(false);
+  };
 
   return (
     <>
@@ -307,6 +318,7 @@ export const ModalInAModal = () => {
           buttonRef.current.focus();
         }}
         isOpen={showModal}
+        headerRef={handleGetHeaderRef}
       >
         <Paragraph noTopMargin>This is a modal, doing modal things.</Paragraph>
         <Paragraph>
@@ -353,7 +365,7 @@ export const ModalInAModal = () => {
       <Modal
         size={ModalSize.small}
         header="Modal 2 Title"
-        onClose={() => setShowModal2(false)}
+        onClose={() => closeModal2()}
         isOpen={showModal2}
       >
         <Paragraph noTopMargin>This is modal 2</Paragraph>

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -1,22 +1,21 @@
 import React from 'react';
+import { Modal, ModalSize, NativeSelect, Toggle, VisuallyHidden } from '../..';
 import { Button, ButtonColor } from '../Button';
 import { ButtonGroup, ButtonGroupAlignment } from '../ButtonGroup';
 import { Combobox } from '../Combobox';
 import { Container } from '../Container';
 import { DatePicker } from '../DatePicker';
-import { Modal, ModalSize, NativeSelect, Toggle, VisuallyHidden } from '../..';
-import { Paragraph } from '../Paragraph';
-import { Radio } from '../Radio';
-import { RadioGroup } from '../RadioGroup';
-import { Spacer } from '../Spacer';
 import {
   Dropdown,
   DropdownButton,
   DropdownContent,
   DropdownMenuItem,
 } from '../Dropdown';
+import { Paragraph } from '../Paragraph';
+import { Radio } from '../Radio';
+import { RadioGroup } from '../RadioGroup';
 import { Select } from '../Select';
-import { useFocusLock } from '../..';
+import { Spacer } from '../Spacer';
 
 const info = {
   component: Modal,
@@ -440,19 +439,27 @@ export const CloseModalWithConfirmation = () => {
   const [showModal, setShowModal] = React.useState(false);
   const [showConfirmationModal, setShowConfirmationModal] =
     React.useState(false);
-  const buttonRef = React.useRef<HTMLButtonElement>();
-  const focusTrapElement = useFocusLock(!showConfirmationModal && showModal);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const mainModalRef = React.useRef<HTMLDivElement>(null);
+  const confirmationModalRef = React.useRef<HTMLDivElement>(null);
+  const [mainHeaderRef, setmainHeaderRef] = React.useState(React.useRef<any>());
+
+  const handleGetHeaderRef = ref => {
+    setmainHeaderRef(ref);
+  };
 
   const closeTheModal = () => {
     setShowConfirmationModal(true);
+    confirmationModalRef.current?.focus();
   };
 
   const closeTheConfirmationModal = () => {
+    mainHeaderRef?.current?.focus();
     setShowConfirmationModal(false);
   };
 
   const closeBothModals = () => {
-    buttonRef.current.focus();
+    buttonRef.current?.focus();
     setShowConfirmationModal(false);
     setShowModal(false);
   };
@@ -467,7 +474,8 @@ export const CloseModalWithConfirmation = () => {
         isModalClosingControlledManually
         onClose={closeTheModal}
         isOpen={showModal}
-        ref={focusTrapElement}
+        ref={mainModalRef}
+        headerRef={handleGetHeaderRef}
       >
         <Paragraph noTopMargin>This is a modal, doing modal things.</Paragraph>
         <Paragraph>
@@ -491,6 +499,7 @@ export const CloseModalWithConfirmation = () => {
         isModalClosingControlledManually
         onClose={closeTheConfirmationModal}
         isOpen={showConfirmationModal}
+        ref={confirmationModalRef}
       >
         <Paragraph noTopMargin>Close the modal?</Paragraph>
         <ButtonGroup>

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -13,14 +13,24 @@ export function useFocusLock(
   const focusableItems = React.useRef<Array<HTMLElement>>([]);
 
   const updateFocusableItems = () => {
-    focusableItems.current = rootNode.current?.querySelectorAll(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), video'
-    ) as unknown as Array<HTMLElement>;
+    focusableItems.current = Array.from(
+      rootNode.current?.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), video'
+      ) || []
+    );
   };
 
   React.useEffect(() => {
     if (active) {
       updateFocusableItems();
+
+      const observer: MutationObserver = new MutationObserver(() => {
+        updateFocusableItems();
+      });
+
+      if (rootNode.current) {
+        observer.observe(rootNode.current, { childList: true, subtree: true });
+      }
 
       if (header && header.current) {
         header.current.focus();
@@ -32,22 +42,11 @@ export function useFocusLock(
         (body.current.firstChild as HTMLElement).setAttribute('tabIndex', '-1');
         (body.current.firstChild as HTMLElement).focus();
       }
+      return () => {
+        observer.disconnect();
+      };
     }
-  }, [active]);
-
-  React.useEffect(() => {
-    const observer: MutationObserver = new MutationObserver(() => {
-      updateFocusableItems();
-    });
-
-    updateFocusableItems();
-
-    rootNode.current &&
-      observer.observe(rootNode.current, { childList: true, subtree: true });
-    return () => {
-      observer.disconnect();
-    };
-  }, [rootNode]);
+  }, [active, header, body]);
 
   React.useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
@@ -102,7 +101,7 @@ export function useFocusLock(
     return () => {
       window.removeEventListener('keydown', handleKeyPress);
     };
-  }, [active, focusableItems]);
+  }, [active, focusableItems, header]);
 
   return rootNode;
 }

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -435,26 +435,33 @@ import {
   Combobox,
   Modal,
   ModalSize,
-  Paragraph,
-  useFocusLock,
+  Paragraph
 } from 'react-magma-dom';
 export function Example() {
   const [showModal, setShowModal] = React.useState(false);
   const [showConfirmationModal, setShowConfirmationModal] =
     React.useState(false);
-  const buttonRef = React.useRef<HTMLButtonElement>();
-  const focusTrapElement = useFocusLock(!showConfirmationModal && showModal);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const mainModalRef = React.useRef<HTMLDivElement>(null);
+  const confirmationModalRef = React.useRef<HTMLDivElement>(null);
+  const [mainHeaderRef, setmainHeaderRef] = React.useState(React.useRef<any>());
+
+  const handleGetHeaderRef = ref => {
+    setmainHeaderRef(ref);
+  };
 
   const closeTheModal = () => {
     setShowConfirmationModal(true);
+    confirmationModalRef.current && confirmationModalRef.current.focus();
   };
 
   const closeTheConfirmationModal = () => {
+    mainHeaderRef.current && mainHeaderRef.current.focus();
     setShowConfirmationModal(false);
   };
 
   const closeBothModals = () => {
-    buttonRef.current.focus();
+    buttonRef.current && buttonRef.current.focus();
     setShowConfirmationModal(false);
     setShowModal(false);
   };
@@ -469,7 +476,8 @@ export function Example() {
         isModalClosingControlledManually
         onClose={closeTheModal}
         isOpen={showModal}
-        ref={focusTrapElement}
+        ref={mainModalRef}
+        headerRef={handleGetHeaderRef}
       >
         <Paragraph noTopMargin>This is a modal, doing modal things.</Paragraph>
         <Paragraph>
@@ -493,6 +501,7 @@ export function Example() {
         isModalClosingControlledManually
         onClose={closeTheConfirmationModal}
         isOpen={showConfirmationModal}
+        ref={confirmationModalRef}
       >
         <Paragraph noTopMargin>Close the modal?</Paragraph>
         <ButtonGroup>

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -399,7 +399,7 @@ export function Example() {
   };
 
   const closeModal2 = () => {
-    mainHeaderRef?.current?.focus();
+    mainHeaderRef.current.focus();
     setShowModal2(false);
   };
 

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -392,6 +392,16 @@ import {
 export function Example() {
   const [showModal, setShowModal] = React.useState(false);
   const [showModal2, setShowModal2] = React.useState(false);
+  const [mainHeaderRef, setmainHeaderRef] = React.useState(React.useRef<any>());
+
+  const handleGetHeaderRef = ref => {
+    setmainHeaderRef(ref);
+  };
+
+  const closeModal2 = () => {
+    mainHeaderRef?.current?.focus();
+    setShowModal2(false);
+  };
 
   return (
     <>
@@ -413,7 +423,7 @@ export function Example() {
       <Modal
         size={ModalSize.small}
         header="Modal 2 Title"
-        onClose={() => setShowModal2(false)}
+        onClose={() => closeModal2()}
         isOpen={showModal2}
       >
         <Paragraph noMargins>This is modal 2</Paragraph>


### PR DESCRIPTION
Issue: #1302 

## What I did
- Bug fix modal lock bug with dynamic content

## Screenshots:
https://codesandbox.io/p/sandbox/react-magma-example-forked-mhp2vh

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
open below example
open one of the modal examples
check tab order
change content
check tab order again and verify that the focus lock is still working

https://codesandbox.io/p/sandbox/react-magma-example-forked-mhp2vh
