### PR TITLE
feat(treeview): add ability to change items selection outside

### DIFF
--- a/.changeset/treeViewSelectItemsOutside.md
+++ b/.changeset/treeViewSelectItemsOutside.md
@@ -1,0 +1,6 @@
+---
+'react-magma-dom': minor
+'react-magma-docs': minor
+---
+
+feat(TreeView): Add ability to change items selection outside

--- a/.changeset/treeViewSelectItemsOutside.md
+++ b/.changeset/treeViewSelectItemsOutside.md
@@ -1,6 +1,5 @@
 ---
 'react-magma-dom': minor
-'react-magma-docs': minor
 ---
 
 feat(TreeView): Add ability to change items selection outside

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { axe } from '../../../axe-helper';
-import { TreeItem } from '.';
+import { TreeItem, TreeView } from '.';
 import { render, getByTestId } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { magma } from '../../theme/magma';
@@ -91,13 +91,15 @@ describe('TreeItem', () => {
 
     it('the ability to expand the item is disabled', () => {
       const { getByTestId } = render(
-        <TreeItem label={labelText} itemId="parent" testId={testId} isDisabled>
-          <TreeItem
-            label={`${labelText}-child`}
-            testId={`${testId}-child`}
-            itemId="child"
-          />
-        </TreeItem>
+        <TreeView>
+          <TreeItem label={labelText} itemId="parent" testId={testId} isDisabled>
+            <TreeItem
+              label={`${labelText}-child`}
+              testId={`${testId}-child`}
+              itemId="child"
+            />
+          </TreeItem>
+        </TreeView>
       );
 
       expect(getByTestId(`${testId}-expand`)).toHaveAttribute(

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -10,7 +10,7 @@ import {
   useTreeItem,
   checkedStatusToBoolean,
 } from './useTreeItem';
-import { TreeViewSelectable } from './useTreeView';
+import { TreeViewSelectable } from './types';
 import {
   FolderIcon,
   ArticleIcon,
@@ -190,10 +190,8 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
       isDisabled,
       label,
       labelStyle,
-      parentCheckedStatus,
       style,
       testId,
-      updateParentCheckStatus,
       topLevel,
       ...rest
     } = props;
@@ -219,7 +217,6 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
       ref,
       selectedItems,
       setExpanded,
-      updateCheckedStatusFromChild,
     } = contextValue;
 
     const nodeType = hasOwnTreeItems ? TreeNodeType.branch : TreeNodeType.leaf;
@@ -387,8 +384,6 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
                         key: index,
                         itemDepth,
                         parentDepth,
-                        parentCheckedStatus: checkedStatus,
-                        updateParentCheckStatus: updateCheckedStatusFromChild,
                       })}
                     </ul>
                   </Transition>

--- a/packages/react-magma-dom/src/components/TreeView/TreeItemContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItemContext.ts
@@ -7,12 +7,7 @@ interface TreeItemContextInterface {
   setExpanded: React.Dispatch<React.SetStateAction<boolean>>;
   checkedStatus: IndeterminateCheckboxStatus;
   checkboxChangeHandler: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  numberOfTreeItemChildren: number;
   hasOwnTreeItems: boolean;
-  updateCheckedStatusFromChild: (
-    index: number,
-    status: IndeterminateCheckboxStatus
-  ) => void;
   parentDepth: number;
 }
 
@@ -22,7 +17,5 @@ export const TreeItemContext = React.createContext<TreeItemContextInterface>({
   checkedStatus: IndeterminateCheckboxStatus.unchecked,
   checkboxChangeHandler: () => {},
   hasOwnTreeItems: false,
-  updateCheckedStatusFromChild: () => {},
-  numberOfTreeItemChildren: 0,
   parentDepth: 0,
 });

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -101,7 +101,7 @@ function createControlledTags(items = [], api?: TreeViewApi) {
   const selected = items
     ?.filter(i => i.checkedStatus === IndeterminateCheckboxStatus.checked)
     .map((i, key) => (
-      <Tag key={key} size={TagSize.small} color={TagColor.primary} onClick={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+      <Tag key={key} size={TagSize.small} color={TagColor.primary} onDelete={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
         {i.itemId}
       </Tag>
     ));
@@ -109,7 +109,7 @@ function createControlledTags(items = [], api?: TreeViewApi) {
   const indeterminate = items
     ?.filter(i => i.checkedStatus === IndeterminateCheckboxStatus.indeterminate)
     .map((i, key) => (
-      <Tag key={key} size={TagSize.small} color={TagColor.default} onClick={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+      <Tag key={key} size={TagSize.small} color={TagColor.default} onDelete={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
         {i.itemId}
       </Tag>
     ));
@@ -420,6 +420,8 @@ Complex.args = {
     { itemId: 'pt2ch5.2', checkedStatus: IndeterminateCheckboxStatus.checked },
     { itemId: 'pt2ch5.3', checkedStatus: IndeterminateCheckboxStatus.checked },
   ],
+  checkParents: true,
+  checkChildren: true,
   testId: 'complex-example',
 };
 

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TreeView, TreeItem, TreeViewSelectable } from '.';
+import { TreeView, TreeItem, TreeViewSelectable, TreeViewApi } from '.';
 import { magma } from '../../theme/magma';
 
 import {
@@ -19,6 +19,8 @@ import {
   Flex,
   FlexBehavior,
   IndeterminateCheckboxStatus,
+  ButtonVariant,
+  ButtonGroup,
 } from '../..';
 import { ButtonSize } from '../Button';
 import { FlexAlignContent, FlexAlignItems } from '../Flex';
@@ -94,6 +96,30 @@ function createTags(items) {
   };
 }
 
+
+function createControlledTags(items = [], api?: TreeViewApi) {
+  const selected = items
+    ?.filter(i => i.checkedStatus === IndeterminateCheckboxStatus.checked)
+    .map((i, key) => (
+      <Tag key={key} size={TagSize.small} color={TagColor.primary} onClick={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+        {i.itemId}
+      </Tag>
+    ));
+
+  const indeterminate = items
+    ?.filter(i => i.checkedStatus === IndeterminateCheckboxStatus.indeterminate)
+    .map((i, key) => (
+      <Tag key={key} size={TagSize.small} color={TagColor.default} onClick={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+        {i.itemId}
+      </Tag>
+    ));
+
+  return {
+    selected,
+    indeterminate,
+  };
+}
+
 export const Simple = args => {
   const [selectedItems, setSelectedItems] = React.useState(null);
   const [indeterminateItems, setIndeterminateItems] = React.useState(null);
@@ -145,22 +171,16 @@ Simple.parameters = { controls: { exclude: ['isInverse'] } };
 
 export const Complex = args => {
   const [selectedItems, setSelectedItems] = React.useState(null);
-  const [indeterminateItems, setIndeterminateItems] = React.useState(null);
-  const [total, setTotal] = React.useState(selectedItems?.length || 0);
 
-  function onSelection(items) {
-    const selected = createTags(items).selected;
-    const indet = createTags(items).indeterminate;
+  const apiRef = React.useRef<TreeViewApi>(null);
 
-    setSelectedItems(selected);
-    setIndeterminateItems(indet);
-    setTotal(items.length);
-  }
+  const { selected, indeterminate } = createControlledTags(selectedItems, apiRef.current);
+  const total = selectedItems?.length || 0;
 
   return (
     <>
       <Card isInverse={args.isInverse}>
-        <TreeView {...args} onSelectedItemChange={onSelection}>
+        <TreeView {...args} apiRef={apiRef} onSelectedItemChange={setSelectedItems}>
           <TreeItem label={<>Part 1: Introduction</>} itemId="pt1" testId="pt1">
             <TreeItem
               icon={<FolderIcon aria-hidden={true} />}
@@ -371,12 +391,16 @@ export const Complex = args => {
       {args.selectable !== TreeViewSelectable.off && (
         <>
           <p>{total} total</p>
-          <p>Selected: {selectedItems}</p>
+          <p>Selected: {selected}</p>
           {args.selectable === TreeViewSelectable.multi && (
-            <p>Indeterminate: {indeterminateItems}</p>
+            <p>Indeterminate: {indeterminate}</p>
           )}
         </>
       )}
+      <ButtonGroup size={ButtonSize.small} variant={ButtonVariant.solid}>
+        <Button onClick={() => apiRef.current?.selectAll()}>Select all</Button>
+        <Button onClick={() => apiRef.current?.clearAll()}>Clear all</Button>
+      </ButtonGroup>
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -92,6 +92,71 @@ const getTreeItemsWithDisabled = props => (
   </TreeView>
 );
 
+
+const TreeItemsMultiLevelControlledOutside = props => {
+  const apiRef = React.useRef(null);
+  const [items, setItems] = React.useState([]);
+  
+  const onSelectedItemChange = items => {
+    setItems(items);
+    props.onSelectedItemChange(items)
+  }
+
+  return (
+    <>
+      <button data-testid="select-all" onClick={() => apiRef.current.selectAll()}>Select all</button>
+      <button data-testid="clear-all" onClick={() => apiRef.current.clearAll()} />
+      {items.map(({ itemId }) => (
+        <button key={itemId} data-testid={`${itemId}-tag`} onClick={() => apiRef.current.selectItem({ itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked  })} />
+      ))}
+      <TreeView
+        testId={testId}
+        apiRef={apiRef}
+        selectable={TreeViewSelectable.multi}
+        {...props}
+        onSelectedItemChange={onSelectedItemChange}
+      >
+        <TreeItem label="Node 0" itemId="item0" testId="item0" />
+        <TreeItem label="Node 1" itemId="item1" testId="item1">
+          <TreeItem label="Child 1" itemId="item-child1" testId="item-child1" />
+        </TreeItem>
+        <TreeItem label="Node 2" itemId="item2" testId="item2">
+          <TreeItem
+            label="Child 2"
+            itemId="item-child2.1"
+            testId="item-child2.1"
+          >
+            <TreeItem
+              label="Grandchild 2"
+              itemId="item-gchild2"
+              testId="item-gchild2"
+            >
+              <TreeItem
+                label="Great-grandchild 1"
+                itemId="item-ggchild1"
+                testId="item-ggchild1"
+              />
+              <TreeItem
+                label="Great-grandchild 2"
+                itemId="item-ggchild2"
+                testId="item-ggchild2"
+              />
+              <TreeItem
+                label="Great-grandchild 3"
+                itemId="item-ggchild3"
+                testId="item-ggchild3"
+              />
+            </TreeItem>
+          </TreeItem>
+        </TreeItem>
+        <TreeItem label="Node 3" itemId="item3" testId="item3">
+          <TreeItem label="Child 3" itemId="item-child3" testId="item-child3" />
+        </TreeItem>
+      </TreeView>
+    </>
+  );
+};
+
 describe('TreeView', () => {
   it('should find element by testId', () => {
     const { getByTestId } = render(
@@ -547,23 +612,23 @@ describe('TreeView', () => {
 
         expect(onSelectedItemChange).toHaveBeenCalledWith([
           {
-            itemId: 'item-child2.1',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
-            itemId: 'item-child2.2',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
             itemId: 'item1',
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
+          },
+          {
+            itemId: 'item-child1',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
           },
           {
             itemId: 'item2',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
           {
-            itemId: 'item-child1',
+            itemId: 'item-child2.1',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
+          },
+          {
+            itemId: 'item-child2.2',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
         ]);
@@ -737,11 +802,11 @@ describe('TreeView', () => {
 
         expect(onSelectedItemChange).toHaveBeenCalledWith([
           {
-            itemId: 'item-child1',
+            itemId: 'item1',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
           {
-            itemId: 'item1',
+            itemId: 'item-child1',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
         ]);
@@ -777,6 +842,10 @@ describe('TreeView', () => {
         userEvent.click(getByTestId('item2-checkbox'));
         expect(onSelectedItemChange).toHaveBeenCalledWith([
           {
+            itemId: 'item2',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
+          },
+          {
             itemId: 'item-child2.1',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
@@ -796,10 +865,6 @@ describe('TreeView', () => {
             itemId: 'item-ggchild3',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
-          {
-            itemId: 'item2',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
         ]);
         userEvent.click(getByTestId('item2-expand'));
         userEvent.click(getByTestId('item-child2.1-expand'));
@@ -808,15 +873,7 @@ describe('TreeView', () => {
         userEvent.click(getByTestId('item-ggchild2-checkbox'));
         expect(onSelectedItemChange).toHaveBeenCalledWith([
           {
-            itemId: 'item-ggchild3',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
-            itemId: 'item-ggchild1',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
-            itemId: 'item-gchild2',
+            itemId: 'item2',
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
           },
           {
@@ -824,8 +881,16 @@ describe('TreeView', () => {
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
           },
           {
-            itemId: 'item2',
+            itemId: 'item-gchild2',
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
+          },
+          {
+            itemId: 'item-ggchild1',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
+          },
+          {
+            itemId: 'item-ggchild3',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
           },
         ]);
 
@@ -844,6 +909,10 @@ describe('TreeView', () => {
         userEvent.click(getByTestId('item2-checkbox'));
         expect(onSelectedItemChange).toHaveBeenCalledWith([
           {
+            itemId: 'item2',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
+          },
+          {
             itemId: 'item-child2.1',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
@@ -861,10 +930,6 @@ describe('TreeView', () => {
           },
           {
             itemId: 'item-ggchild3',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
-            itemId: 'item2',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
         ]);
@@ -875,15 +940,7 @@ describe('TreeView', () => {
         userEvent.click(getByTestId('item-ggchild2-checkbox'));
         expect(onSelectedItemChange).toHaveBeenCalledWith([
           {
-            itemId: 'item-ggchild3',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
-            itemId: 'item-ggchild1',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
-            itemId: 'item-gchild2',
+            itemId: 'item2',
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
           },
           {
@@ -891,19 +948,23 @@ describe('TreeView', () => {
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
           },
           {
-            itemId: 'item2',
+            itemId: 'item-gchild2',
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
+          },
+          {
+            itemId: 'item-ggchild1',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
+          },
+          {
+            itemId: 'item-ggchild3',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
           },
         ]);
 
         userEvent.click(getByTestId('item-ggchild3-checkbox'));
         expect(onSelectedItemChange).toHaveBeenCalledWith([
           {
-            itemId: 'item-ggchild1',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
-            itemId: 'item-gchild2',
+            itemId: 'item2',
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
           },
           {
@@ -911,8 +972,12 @@ describe('TreeView', () => {
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
           },
           {
-            itemId: 'item2',
+            itemId: 'item-gchild2',
             checkedStatus: IndeterminateCheckboxStatus.indeterminate,
+          },
+          {
+            itemId: 'item-ggchild1',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
           },
         ]);
 
@@ -921,6 +986,10 @@ describe('TreeView', () => {
 
         userEvent.click(getByTestId('item2-checkbox'));
         expect(onSelectedItemChange).toHaveBeenCalledWith([
+          {
+            itemId: 'item2',
+            checkedStatus: IndeterminateCheckboxStatus.checked,
+          },
           {
             itemId: 'item-child2.1',
             checkedStatus: IndeterminateCheckboxStatus.checked,
@@ -939,10 +1008,6 @@ describe('TreeView', () => {
           },
           {
             itemId: 'item-ggchild3',
-            checkedStatus: IndeterminateCheckboxStatus.checked,
-          },
-          {
-            itemId: 'item2',
             checkedStatus: IndeterminateCheckboxStatus.checked,
           },
         ]);
@@ -1001,11 +1066,7 @@ describe('TreeView', () => {
       userEvent.click(grandChildCheckbox);
       expect(onSelectedItemChange).toHaveBeenCalledWith([
         {
-          itemId: 'item-ggchild1',
-          checkedStatus: IndeterminateCheckboxStatus.checked
-        },
-        {
-          itemId: 'item-gchild2',
+          itemId: 'item2',
           checkedStatus: IndeterminateCheckboxStatus.indeterminate
         },
         {
@@ -1013,9 +1074,13 @@ describe('TreeView', () => {
           checkedStatus: IndeterminateCheckboxStatus.indeterminate
         },
         {
-          itemId: 'item2',
+          itemId: 'item-gchild2',
           checkedStatus: IndeterminateCheckboxStatus.indeterminate
-        }
+        },
+        {
+          itemId: 'item-ggchild1',
+          checkedStatus: IndeterminateCheckboxStatus.checked
+        },
       ]);
     });
   });
@@ -1675,11 +1740,11 @@ describe('TreeView', () => {
           expect(item3).toHaveAttribute('aria-checked', 'true');
           expect(onSelectedItemChange).toHaveBeenCalledWith([
             {
-              itemId: 'item-child3',
+              itemId: 'item3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
             {
-              itemId: 'item3',
+              itemId: 'item-child3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
           ]);
@@ -1716,11 +1781,11 @@ describe('TreeView', () => {
           expect(item3).toHaveAttribute('aria-checked', 'true');
           expect(onSelectedItemChange).toHaveBeenCalledWith([
             {
-              itemId: 'item-child3',
+              itemId: 'item3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
             {
-              itemId: 'item3',
+              itemId: 'item-child3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
           ]);
@@ -1755,11 +1820,11 @@ describe('TreeView', () => {
           expect(itemChild3).toHaveAttribute('aria-checked', 'true');
           expect(onSelectedItemChange).toHaveBeenCalledWith([
             {
-              itemId: 'item-child3',
+              itemId: 'item3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
             {
-              itemId: 'item3',
+              itemId: 'item-child3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
           ]);
@@ -1792,11 +1857,11 @@ describe('TreeView', () => {
           expect(itemChild3).toHaveAttribute('aria-checked', 'true');
           expect(onSelectedItemChange).toHaveBeenCalledWith([
             {
-              itemId: 'item-child3',
+              itemId: 'item3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
             {
-              itemId: 'item3',
+              itemId: 'item-child3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
           ]);
@@ -1826,11 +1891,11 @@ describe('TreeView', () => {
           expect(item3).toHaveAttribute('aria-checked', 'true');
           expect(onSelectedItemChange).toHaveBeenCalledWith([
             {
-              itemId: 'item-child3',
+              itemId: 'item3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
             {
-              itemId: 'item3',
+              itemId: 'item-child3',
               checkedStatus: IndeterminateCheckboxStatus.checked,
             },
           ]);
@@ -1843,6 +1908,125 @@ describe('TreeView', () => {
           );
         });
       });
+    });
+  });
+
+  describe('when controlled outside', () => {
+    it('should be able to select all and clear all outside of TreeView', () => {
+      const onSelectedItemChange = jest.fn();
+      const { getByTestId, debug } = render(
+        <TreeItemsMultiLevelControlledOutside onSelectedItemChange={onSelectedItemChange} />
+      );
+
+      expect(onSelectedItemChange).not.toHaveBeenCalled();
+
+      userEvent.click(getByTestId('select-all'));
+
+      expect(onSelectedItemChange).toHaveBeenCalledWith([
+        {
+          itemId: "item0",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item1",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-child1",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item2",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-child2.1",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-gchild2",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-ggchild1",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-ggchild2",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-ggchild3",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item3",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-child3",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+      ]);
+      
+      userEvent.click(getByTestId('clear-all'));
+
+      expect(onSelectedItemChange).toHaveBeenCalledWith([]);
+    });
+    
+    it('should be able to unselect item outside of TreeView', () => {
+      const onSelectedItemChange = jest.fn();
+      const { getByTestId, debug } = render(
+        <TreeItemsMultiLevelControlledOutside onSelectedItemChange={onSelectedItemChange} />
+      );
+
+      expect(onSelectedItemChange).not.toHaveBeenCalled();
+
+      userEvent.click(getByTestId('select-all'));
+      userEvent.click(getByTestId('item-ggchild2-tag'));
+
+      expect(onSelectedItemChange).toHaveBeenCalledWith([
+        {
+          itemId: "item0",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item1",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-child1",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item2",
+          checkedStatus: IndeterminateCheckboxStatus.indeterminate,
+        },
+        {
+          itemId: "item-child2.1",
+          checkedStatus: IndeterminateCheckboxStatus.indeterminate,
+        },
+        {
+          itemId: "item-gchild2",
+          checkedStatus: IndeterminateCheckboxStatus.indeterminate,
+        },
+        {
+          itemId: "item-ggchild1",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-ggchild3",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item3",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+        {
+          itemId: "item-child3",
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+      ]);
     });
   });
 });

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import {
   UseTreeViewProps,
   useTreeView,
-  TreeViewSelectable,
 } from './useTreeView';
+import { TreeViewSelectable } from './types';
 import { TreeItem } from './TreeItem';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { InverseContext, useIsInverse } from '../../inverse';
@@ -42,6 +42,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       onSelectedItemChange,
       selectable,
       testId,
+      apiRef,
       ...rest
     } = props;
     const theme = React.useContext(ThemeContext);
@@ -49,10 +50,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
 
     const { contextValue } = useTreeView(props);
 
-    const { contextValue: treeItemContextValue } = useTreeItem(
-      { label: ariaLabel, itemId: '' },
-      ref
-    );
+    useTreeItem({ label: ariaLabel, itemId: '' }, ref);
 
     let treeItemIndex = 0;
 
@@ -78,10 +76,6 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
                   parentDepth: 0,
                   itemDepth: 0,
                   topLevel: true,
-                  parentCheckedStatus:
-                    treeItemContextValue.checkedStatus || null,
-                  updateParentCheckStatus:
-                    treeItemContextValue.updateCheckedStatusFromChild,
                 });
                 treeItemIndex++;
                 return item;

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
@@ -1,10 +1,18 @@
 import * as React from 'react';
-import { TreeViewSelectable } from './useTreeView';
+import { TreeViewSelectable } from './types';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
 
 export interface TreeItemSelectedInterface {
   itemId?: string;
   checkedStatus: IndeterminateCheckboxStatus;
+}
+
+export interface TreeViewItemInterface {
+  itemId?: string;
+  parentId?: string | null;
+  icon?: React.ReactNode;
+  checkedStatus: IndeterminateCheckboxStatus;
+  hasOwnTreeItems: boolean
 }
 
 export interface TreeViewContextInterface {
@@ -16,39 +24,31 @@ export interface TreeViewContextInterface {
   onSelectedItemChange?: (
     selectedItems: Array<TreeItemSelectedInterface>
   ) => void;
-  preselectedItemsNeedUpdate: boolean;
   registerTreeItem: (
     itemRefArray: React.MutableRefObject<React.MutableRefObject<Element>[]>,
     itemRef: React.MutableRefObject<Element>
   ) => void;
   selectable: TreeViewSelectable;
   selectedItems: Array<TreeItemSelectedInterface>;
-  selectedItemsChanged: boolean;
-  setHasIcons: React.Dispatch<React.SetStateAction<boolean>>;
   setInitialExpandedItemsNeedUpdate: React.Dispatch<React.SetStateAction<any>>;
-  setPreselectedItemsNeedUpdate: React.Dispatch<React.SetStateAction<any>>;
-  setSelectedItems: React.Dispatch<React.SetStateAction<any>>;
-  setSelectedItemsChanged: React.Dispatch<React.SetStateAction<any>>;
   treeItemRefArray?: React.MutableRefObject<React.MutableRefObject<Element>[]>;
   itemToFocus?: string;
   checkParents: boolean;
   checkChildren: boolean;
+  items: TreeViewItemInterface[];
+  selectItem: (data: Pick<TreeViewItemInterface, 'itemId' | 'checkedStatus'>) => void
 }
 
 export const TreeViewContext = React.createContext<TreeViewContextInterface>({
   hasIcons: false,
   initialExpandedItems: [],
   initialExpandedItemsNeedUpdate: false,
-  preselectedItemsNeedUpdate: false,
   registerTreeItem: (elements, element) => {},
   selectable: TreeViewSelectable.single,
   selectedItems: [],
-  selectedItemsChanged: false,
-  setHasIcons: () => {},
   setInitialExpandedItemsNeedUpdate: () => {},
-  setPreselectedItemsNeedUpdate: () => {},
-  setSelectedItems: () => {},
-  setSelectedItemsChanged: () => {},
   checkParents: true,
   checkChildren: true,
+  items: [],
+  selectItem: () => undefined
 });

--- a/packages/react-magma-dom/src/components/TreeView/index.ts
+++ b/packages/react-magma-dom/src/components/TreeView/index.ts
@@ -3,3 +3,4 @@ export * from './TreeItem';
 export * from './useTreeItem';
 export * from './useTreeView';
 export * from './utils';
+export * from './types';

--- a/packages/react-magma-dom/src/components/TreeView/types.ts
+++ b/packages/react-magma-dom/src/components/TreeView/types.ts
@@ -1,0 +1,5 @@
+export enum TreeViewSelectable {
+  single = 'single',
+  multi = 'multi',
+  off = 'off',
+}

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -3,28 +3,10 @@ import { IconProps } from 'react-magma-icons';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
 import { TreeItem } from './TreeItem';
 import { TreeViewContext } from './TreeViewContext';
-import { TreeViewSelectable } from './useTreeView';
+import { TreeViewSelectable } from './types';
 import { useForceUpdate } from '../../hooks/useForceUpdate';
 import { useGenerateId, useForkedRef } from '../../utils';
-import {
-  // getEnabledTreeItemChildrenLength,
-  areArraysEqual,
-  arrayIncludesId,
-  filterNullEntries,
-  filterSelectedItems,
-  findChildByItemId,
-  findCommonItems,
-  getAllChildrenEnabled,
-  getAllParentIds,
-  getCheckedStatus,
-  getChildrenCheckedStatus,
-  getChildrenItemIds,
-  getChildrenItemIdsFlat,
-  getChildrenItemIdsInTree,
-  getMissingChildrenIds,
-  getUniqueSelectedItemsArray,
-  getUpdatedSelectedItems,
-} from './utils';
+import { filterNullEntries, getChildrenItemIdsFlat } from './utils';
 
 export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
   /**
@@ -53,18 +35,8 @@ export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
    */
   icon?: React.ReactElement<IconProps>;
   /**
-   * Indeterminate Checkbox status
    * @internal
    */
-  parentCheckedStatus?: IndeterminateCheckboxStatus;
-  /**
-   * @internal
-   */
-  updateParentCheckStatus?: (
-    index: number,
-    status: IndeterminateCheckboxStatus,
-    isInitialRender?: boolean
-  ) => void;
   /**
    * @internal
    */
@@ -90,13 +62,6 @@ export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
   topLevel?: boolean;
 }
 
-const enum StatusUpdatedByOptions {
-  checkboxChange = 'checkboxChange',
-  parent = 'parent',
-  children = 'children',
-  default = 'default',
-}
-
 export const checkedStatusToBoolean = (
   status: IndeterminateCheckboxStatus
 ): boolean => status === IndeterminateCheckboxStatus.checked;
@@ -104,16 +69,12 @@ export const checkedStatusToBoolean = (
 export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   const {
     children,
-    icon,
-    index,
     isDisabled = false,
     itemDepth,
     itemId,
     onClick,
-    parentCheckedStatus,
     parentDepth,
     topLevel,
-    updateParentCheckStatus,
   } = props;
 
   const {
@@ -121,44 +82,28 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     registerTreeItem,
     selectable,
     selectedItems,
-    setHasIcons,
-    setSelectedItems,
     treeItemRefArray,
-    preselectedItemsNeedUpdate,
-    setPreselectedItemsNeedUpdate,
     initialExpandedItemsNeedUpdate,
-    setSelectedItemsChanged,
-    selectedItemsChanged,
-    checkParents,
-    checkChildren,
+    items,
+    selectItem,
   } = React.useContext(TreeViewContext);
+  
+  const treeViewItemData = React.useMemo(() => {
+    return items.find((item) => item.itemId === itemId)
+  }, [itemId, items])
+  
+  const checkedStatus = React.useMemo(() => {
+    return treeViewItemData?.checkedStatus ?? IndeterminateCheckboxStatus.unchecked
+  }, [treeViewItemData])
 
-  // Needs to skip sending an "onSelection" event during the initial render of items
-  const [isSkipSelectedItemsUpdate, setIsSkipSelectedItemsUpdate] =
-    React.useState(false);
+  const hasOwnTreeItems = React.useMemo(() => {
+    return treeViewItemData?.hasOwnTreeItems
+  }, [treeViewItemData])
 
   const [expanded, setExpanded] = React.useState(false);
-  const [checkedStatus, setCheckedStatus] =
-    React.useState<IndeterminateCheckboxStatus>(
-      IndeterminateCheckboxStatus.unchecked
-    );
-  const [statusUpdatedBy, setStatusUpdatedBy] = React.useState<
-    StatusUpdatedByOptions | undefined
-  >(undefined);
 
   const treeItemChildren = React.Children.toArray(children).filter(
     (child: React.ReactElement<any>) => child.type === TreeItem
-  );
-
-  // TODO fix for disabled items (issue #1305)
-  // const numberOfTreeItemChildren = getEnabledTreeItemChildrenLength(treeItemChildren);
-  const numberOfTreeItemChildren = treeItemChildren.length;
-  const hasOwnTreeItems = numberOfTreeItemChildren > 0;
-
-  const [childrenCheckedStatus, setChildrenCheckedStatus] = React.useState<
-    IndeterminateCheckboxStatus[]
-  >(
-    Array(numberOfTreeItemChildren).fill(IndeterminateCheckboxStatus.unchecked)
   );
 
   const ownRef = React.useRef<HTMLDivElement>();
@@ -168,52 +113,6 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   const generatedId = useGenerateId();
 
   React.useEffect(() => {
-    setTreeViewIconVisibility();
-
-    selectedItems.map(item => {
-      if (item?.itemId === itemId) {
-        const newStatus = item?.checkedStatus;
-
-        if (checkedStatus !== newStatus) {
-          const childrenOfItemId = getChildrenItemIds(
-            treeItemChildren,
-            IndeterminateCheckboxStatus.checked
-          );
-
-          const itemIdChildrenInTree =
-            getChildrenItemIdsInTree(treeItemChildren);
-          const parentIds =
-            itemId && itemIdChildrenInTree.length > 0
-              ? getAllParentIds(itemIdChildrenInTree, itemId)
-              : [];
-
-          let additionalItems = [];
-          if (newStatus === IndeterminateCheckboxStatus.checked) {
-            if (parentIds && checkParents) additionalItems.push(...parentIds);
-            if (hasOwnTreeItems && checkChildren)
-              additionalItems.push(...childrenOfItemId);
-          }
-
-          setStatusUpdatedBy(StatusUpdatedByOptions.checkboxChange);
-          setCheckedStatus(item?.checkedStatus);
-
-          if (selectable === TreeViewSelectable.multi) {
-            // Pass "true" as isInitialRender value to skip sending an "onSelection" event
-            // Required since this useEffect handles initial rendering of the item
-            updateParentCheckStatus(index, newStatus, true);
-          }
-          setSelectedItems(prev => {
-            return getUniqueSelectedItemsArray(
-              [{ itemId: itemId, checkedStatus: newStatus }],
-              prev,
-              additionalItems
-            );
-          });
-        }
-        return;
-      }
-    });
-
     if (!isDisabled && ownRef.current !== null) {
       registerTreeItem(treeItemRefArray, ownRef);
     }
@@ -221,111 +120,11 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     forceUpdate();
   }, []);
 
-  function setTreeViewIconVisibility() {
-    if (treeItemChildren.length === 0 && icon) {
-      setHasIcons(true);
-      return;
-    }
-
-    treeItemChildren.forEach((child: React.ReactElement<any>) => {
-      if (child?.props.icon) {
-        setHasIcons(true);
-        return;
-      }
-    });
-  }
-
-  function updateSelectedItemsChanged() {
-    if (topLevel && !selectedItemsChanged) {
-      setSelectedItemsChanged(true);
-    }
-  }
-
-  React.useEffect(() => {
-    if (preselectedItemsNeedUpdate) {
-      updateInitialSelected();
-    }
-  }, [preselectedItemsNeedUpdate]);
-
   React.useEffect(() => {
     if (initialExpandedItemsNeedUpdate) {
       updateInitialExpanded();
     }
   }, [initialExpandedItemsNeedUpdate]);
-
-  const updateCheckedStatusFromChild = (
-    index: number,
-    status: IndeterminateCheckboxStatus,
-    isInitialRender?: boolean
-  ) => {
-    if (checkParents) {
-      // Set isSkipSelectedItemsUpdate as true if this update caused by the initial render of children during expanding
-      setIsSkipSelectedItemsUpdate(Boolean(isInitialRender));
-      setStatusUpdatedBy(StatusUpdatedByOptions.children);
-      setChildrenCheckedStatus(prev => {
-        const newChildrenCheckedStatus = [...prev];
-        newChildrenCheckedStatus[index] = status;
-        return newChildrenCheckedStatus;
-      });
-    }
-  };
-
-  const updateStatusForItem = (
-    childrenItemIds,
-    preselectedChildrenItems,
-    itemId,
-    itemIdChildren
-  ) => {
-    const item = preselectedChildrenItems.find(
-      child => child.itemId === itemId
-    );
-
-    const itemStatus =
-      item?.checkedStatus ||
-      areArraysEqual(preselectedChildrenItems, childrenItemIds)
-        ? IndeterminateCheckboxStatus.checked
-        : IndeterminateCheckboxStatus.indeterminate;
-
-    setStatusUpdatedBy(StatusUpdatedByOptions.checkboxChange);
-    setCheckedStatus(itemStatus);
-    updateParentCheckStatus(index, itemStatus);
-
-    if (!item) {
-      setSelectedItems(prev => {
-        return getUniqueSelectedItemsArray(
-          [{ itemId: itemId, checkedStatus: itemStatus }],
-          preselectedChildrenItems,
-          prev
-        );
-      });
-
-      setSelectedItemsChanged(true);
-      return;
-    }
-
-    const thisItem = itemIdChildren.find(child => child.itemId === itemId);
-
-    if (
-      thisItem?.children.length > 0 &&
-      item?.checkedStatus === IndeterminateCheckboxStatus.checked
-    ) {
-      const itemNode = findChildByItemId(treeItemChildren, thisItem?.itemId);
-      const newChildren = getChildrenItemIds(
-        itemNode?.props.children,
-        checkedStatus
-      );
-
-      setSelectedItems(prev => {
-        return getUniqueSelectedItemsArray(
-          [{ itemId: itemId, checkedStatus: itemStatus }],
-          newChildren,
-          prev
-        );
-      });
-
-      setSelectedItemsChanged(true);
-    }
-  };
 
   const updateInitialExpanded = () => {
     if (initialExpandedItems?.length !== 0 && !isDisabled) {
@@ -341,316 +140,15 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     }
   };
 
-  const updateInitialSelected = () => {
-    if (selectable === TreeViewSelectable.single && selectedItems) {
-      const firstItemId = selectedItems?.[0]?.itemId;
-      if (firstItemId && !isDisabled) {
-        setSelectedItems(prev => {
-          if (!arrayIncludesId(prev, firstItemId)) {
-            return [
-              {
-                itemId: firstItemId,
-                checkedStatus: IndeterminateCheckboxStatus.checked,
-              },
-            ];
-          }
-        });
-        setSelectedItemsChanged(true);
-      }
-    } else if (selectable === TreeViewSelectable.multi && selectedItems) {
-      const item = selectedItems.find(obj => obj.itemId === itemId);
-      const status = item?.checkedStatus;
-      const childrenItemIds = getChildrenItemIds(
-        treeItemChildren,
-        status || IndeterminateCheckboxStatus.checked
-      );
-      // Items from selectedItems that are children
-      const preselectedChildrenItems = findCommonItems(
-        childrenItemIds,
-        selectedItems
-      );
-
-      if (
-        !isDisabled &&
-        (arrayIncludesId(selectedItems, itemId) ||
-          childrenItemIds?.includes(itemId))
-      ) {
-        setStatusUpdatedBy(StatusUpdatedByOptions.checkboxChange);
-        setCheckedStatus(status);
-        updateParentCheckStatus(index, status);
-
-        if (
-          childrenItemIds.length > 0 &&
-          status === IndeterminateCheckboxStatus.checked
-        ) {
-          const newChildrenCheckedStatus = getChildrenCheckedStatus(
-            childrenItemIds,
-            checkChildren && status
-          );
-          setChildrenCheckedStatus(newChildrenCheckedStatus);
-        }
-        setSelectedItems(prev => {
-          const allItems = getUniqueSelectedItemsArray(
-            childrenItemIds,
-            selectedItems,
-            prev
-          );
-          return allItems;
-        });
-        updateSelectedItemsChanged();
-      } else if (
-        !isDisabled &&
-        preselectedChildrenItems.length > 0 &&
-        checkParents
-      ) {
-        // Case for selectedItems that are inside a collapsed item
-        const itemIdChildren = getChildrenItemIdsInTree(treeItemChildren);
-        for (const i of preselectedChildrenItems) {
-          const itemIdNode = findChildByItemId(treeItemChildren, i.itemId);
-          const childrenOfItemId = getChildrenItemIds(
-            itemIdNode?.props?.children,
-            IndeterminateCheckboxStatus.checked
-          );
-
-          const parentIds = getAllParentIds(itemIdChildren, i.itemId);
-
-          for (const p of parentIds) {
-            updateStatusForItem(
-              childrenOfItemId,
-              preselectedChildrenItems,
-              p,
-              itemIdChildren
-            );
-          }
-        }
-        updateStatusForItem(
-          childrenItemIds,
-          preselectedChildrenItems,
-          itemId,
-          itemIdChildren
-        );
-      }
-    }
-
-    setPreselectedItemsNeedUpdate(false);
-  };
-
-  React.useEffect(() => {
-    if (statusUpdatedBy && updateParentCheckStatus && !topLevel) {
-      updateParentCheckStatus(index, checkedStatus);
-    }
-    setStatusUpdatedBy(undefined);
-  }, [checkedStatus]);
-
-  React.useEffect(() => {
-    if (
-      parentCheckedStatus &&
-      checkChildren &&
-      checkedStatus !== parentCheckedStatus &&
-      parentCheckedStatus !== IndeterminateCheckboxStatus.indeterminate &&
-      !topLevel &&
-      !isDisabled
-    ) {
-      setStatusUpdatedBy(StatusUpdatedByOptions.parent);
-      setCheckedStatus(parentCheckedStatus);
-      if (hasOwnTreeItems) {
-        if (getAllChildrenEnabled(treeItemChildren)) {
-          setChildrenCheckedStatus(
-            Array(numberOfTreeItemChildren).fill(parentCheckedStatus)
-          );
-        } else {
-          const childrenIds = getChildrenItemIds(treeItemChildren);
-
-          const newChildrenCheckedStatus = getChildrenCheckedStatus(
-            childrenIds,
-            parentCheckedStatus
-          );
-          setChildrenCheckedStatus(newChildrenCheckedStatus);
-        }
-      }
-    }
-  }, [parentCheckedStatus]);
-
-  React.useEffect(() => {
-    if (statusUpdatedBy && childrenCheckedStatus?.[0] !== undefined) {
-      const statusFromChildren = childrenCheckedStatus.every(
-        status => status === childrenCheckedStatus[0]
-      )
-        ? childrenCheckedStatus[0]
-        : IndeterminateCheckboxStatus.indeterminate;
-      const updateItemStatus = getUpdatedSelectedItems(
-        selectedItems,
-        itemId,
-        statusFromChildren
-      );
-
-      if (
-        checkedStatus !== statusFromChildren &&
-        statusUpdatedBy !== StatusUpdatedByOptions.parent
-      ) {
-        setStatusUpdatedBy(StatusUpdatedByOptions.children);
-        setCheckedStatus(statusFromChildren);
-        if (
-          statusFromChildren === IndeterminateCheckboxStatus.checked ||
-          statusFromChildren === IndeterminateCheckboxStatus.indeterminate
-        ) {
-          if (itemId && !arrayIncludesId(selectedItems, itemId)) {
-            setSelectedItems([
-              ...selectedItems,
-              { itemId, checkedStatus: statusFromChildren },
-            ]);
-            updateSelectedItemsChanged();
-          } else {
-            setSelectedItems(updateItemStatus);
-            updateSelectedItemsChanged();
-          }
-        } else if (
-          statusFromChildren === IndeterminateCheckboxStatus.unchecked
-        ) {
-          setSelectedItems(selectedItems.filter(obj => obj.itemId !== itemId));
-          updateSelectedItemsChanged();
-        }
-      } else if (
-        checkedStatus === statusFromChildren &&
-        statusUpdatedBy !== StatusUpdatedByOptions.parent &&
-        statusFromChildren === IndeterminateCheckboxStatus.indeterminate &&
-        expanded
-      ) {
-        if (!arrayIncludesId(selectedItems, itemId)) {
-          setSelectedItems([
-            ...selectedItems,
-            { itemId, checkedStatus: statusFromChildren },
-          ]);
-          updateSelectedItemsChanged();
-        } else {
-          const itemStatus = getCheckedStatus(itemId, selectedItems);
-
-          if (itemStatus === parentCheckedStatus) {
-            // Skip updating items if instructed to do so
-            if (isSkipSelectedItemsUpdate) return;
-
-            if (!selectedItemsChanged) {
-              if (!topLevel && updateParentCheckStatus) {
-                setSelectedItemsChanged(true);
-              } else {
-                updateSelectedItemsChanged();
-              }
-            }
-          } else {
-            updateSelectedItemsChanged();
-          }
-        }
-      } else {
-        setSelectedItems(updateItemStatus);
-        if (!expanded) {
-          updateSelectedItemsChanged();
-        }
-      }
-    }
-  }, [childrenCheckedStatus]);
-
   const checkboxChangeHandler = (
     event: React.ChangeEvent<HTMLInputElement>
   ): void => {
-    const status = event.target.checked
-      ? IndeterminateCheckboxStatus.checked
-      : IndeterminateCheckboxStatus.unchecked;
-    if (checkedStatus !== status) {
-      setCheckedStatus(status);
-      setStatusUpdatedBy(StatusUpdatedByOptions.checkboxChange);
-      updateParentCheckStatus(index, status);
-
-      if (hasOwnTreeItems && checkChildren) {
-        if (getAllChildrenEnabled(treeItemChildren)) {
-          setChildrenCheckedStatus(
-            Array(numberOfTreeItemChildren).fill(status)
-          );
-        } else {
-          const childrenIds = getChildrenItemIds(treeItemChildren);
-
-          const newChildrenCheckedStatus = getChildrenCheckedStatus(
-            childrenIds,
-            status
-          );
-          setChildrenCheckedStatus(newChildrenCheckedStatus);
-        }
-      }
-    }
     handleClick(event, itemId);
-  };
-
-  const singleSelectChangeHandler = (
-    event: React.ChangeEvent<HTMLInputElement>,
-    itemId: any
-  ): void => {
-    if (!arrayIncludesId(selectedItems, itemId)) {
-      setSelectedItems([
-        { itemId, checkedStatus: IndeterminateCheckboxStatus.checked },
-      ]);
-      setSelectedItemsChanged(true);
-    }
-  };
-
-  const multiSelectChangeHandler = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ): void => {
-    if (!checkParents) {
-      setSelectedItemsChanged(true);
-    }
-    if (hasOwnTreeItems && checkChildren) {
-      const childrenIds = getChildrenItemIds(
-        treeItemChildren,
-        IndeterminateCheckboxStatus.checked
-      );
-      if (event.target.checked) {
-        updateParentCheckStatus(index, IndeterminateCheckboxStatus.checked);
-        if (!arrayIncludesId(selectedItems, itemId)) {
-          setSelectedItems([
-            ...selectedItems,
-            ...childrenIds,
-            { itemId, checkedStatus: IndeterminateCheckboxStatus.checked },
-          ]);
-          updateSelectedItemsChanged();
-        } else {
-          const missingChildren = getMissingChildrenIds(
-            selectedItems,
-            childrenIds
-          );
-          setSelectedItems([...selectedItems, ...missingChildren]);
-          updateSelectedItemsChanged();
-        }
-      } else if (!event.target.checked) {
-        const newSelectedItems = filterSelectedItems(
-          selectedItems,
-          childrenIds,
-          { itemId, checkedStatus }
-        );
-        setSelectedItems(newSelectedItems);
-        updateSelectedItemsChanged();
-      }
-    } else {
-      if (event.target.checked) {
-        if (!arrayIncludesId(selectedItems, itemId)) {
-          setSelectedItems([
-            ...selectedItems,
-            { itemId, checkedStatus: IndeterminateCheckboxStatus.checked },
-          ]);
-          updateSelectedItemsChanged();
-        }
-      } else if (!event.target.checked) {
-        setSelectedItems(selectedItems.filter(obj => obj.itemId !== itemId));
-        updateSelectedItemsChanged();
-      }
-    }
   };
 
   const handleClick = (event, itemId) => {
     if (selectable !== TreeViewSelectable.off) {
-      if (selectable === TreeViewSelectable.single) {
-        singleSelectChangeHandler(event, itemId);
-      } else if (selectable === TreeViewSelectable.multi) {
-        multiSelectChangeHandler(event);
-      }
+      selectItem({ itemId, checkedStatus: checkedStatus === IndeterminateCheckboxStatus.checked ? IndeterminateCheckboxStatus.unchecked : IndeterminateCheckboxStatus.checked })
       onClick && typeof onClick === 'function' && onClick();
     }
   };
@@ -770,50 +268,14 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     }
   };
 
-  const toggleMultiSelectItems = () => {
-    const status = arrayIncludesId(selectedItems, itemId)
-      ? IndeterminateCheckboxStatus.unchecked
-      : IndeterminateCheckboxStatus.checked;
-    setStatusUpdatedBy(StatusUpdatedByOptions.checkboxChange);
-    setCheckedStatus(status);
-    updateParentCheckStatus(index, status);
-
-    if (hasOwnTreeItems && checkChildren) {
-      const childrenIds = getChildrenItemIds(
-        treeItemChildren,
-        IndeterminateCheckboxStatus.checked
-      );
-      if (!arrayIncludesId(selectedItems, itemId)) {
-        setSelectedItems([
-          ...selectedItems,
-          ...childrenIds,
-          { itemId, checkedStatus: status },
-        ]);
-      } else {
-        const newSelectedItems = filterSelectedItems(
-          selectedItems,
-          childrenIds,
-          { itemId, checkedStatus }
-        );
-        setSelectedItems(newSelectedItems);
-      }
-    } else {
-      if (!arrayIncludesId(selectedItems, itemId)) {
-        setSelectedItems([
-          ...selectedItems,
-          { itemId, checkedStatus: IndeterminateCheckboxStatus.checked },
-        ]);
-      } else {
-        setSelectedItems(selectedItems.filter(obj => obj.itemId !== itemId));
-      }
-    }
-    updateSelectedItemsChanged();
-  };
-
   const handleKeyDown = (event: React.KeyboardEvent) => {
     const filteredRefArray = filterNullEntries(treeItemRefArray);
     const curr = filteredRefArray['current'];
     const arrLength = curr.length;
+
+    if (['ArrowDown', 'ArrowUp', 'Home', 'End', ' '].includes(event.key)) {
+      event.preventDefault();
+    }
 
     switch (event.key) {
       case 'ArrowDown': {
@@ -852,13 +314,10 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
           setExpanded(!expanded);
         } else if (selectable === TreeViewSelectable.single) {
           // In single-select it selects the focused node.
-          setSelectedItems([
-            { itemId, checkedStatus: IndeterminateCheckboxStatus.checked },
-          ]);
-          setSelectedItemsChanged(true);
+          selectItem({ itemId, checkedStatus: IndeterminateCheckboxStatus.checked })
         } else if (selectable === TreeViewSelectable.multi) {
           // In multi-select, it toggles the selection state of the focused node.
-          toggleMultiSelectItems();
+          selectItem({ itemId, checkedStatus: checkedStatus === IndeterminateCheckboxStatus.checked ? IndeterminateCheckboxStatus.unchecked : IndeterminateCheckboxStatus.checked })
         }
         break;
       }
@@ -870,13 +329,10 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
           if (hasOwnTreeItems) {
             setExpanded(!expanded);
           } else {
-            setSelectedItems([
-              { itemId, checkedStatus: IndeterminateCheckboxStatus.checked },
-            ]);
-            setSelectedItemsChanged(true);
+            selectItem({ itemId, checkedStatus: IndeterminateCheckboxStatus.checked });
           }
         } else if (selectable === TreeViewSelectable.multi) {
-          toggleMultiSelectItems();
+          selectItem({ itemId, checkedStatus: checkedStatus === IndeterminateCheckboxStatus.checked ? IndeterminateCheckboxStatus.unchecked : IndeterminateCheckboxStatus.checked });
         }
         break;
       }
@@ -892,17 +348,12 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     hasOwnTreeItems,
     itemDepth: parentDepth === 0 && topLevel ? 0 : itemDepth + 1,
     itemId: itemId || generatedId,
-    numberOfTreeItemChildren,
-    parentCheckedStatus,
     parentDepth,
     ref,
     selectedItems,
     setExpanded,
-    updateCheckedStatusFromChild,
     treeItemChildren,
   };
 
   return { contextValue, handleClick, handleKeyDown };
 }
-
-export type UseTreeItemReturn = ReturnType<typeof useTreeItem>;

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -73,7 +73,7 @@ export interface UseTreeViewProps {
   children?: React.ReactNode[];
   /**
    * The ref object that allows TreeView manipulation.
-   * Available the next actions:
+   * Actions available:
    * selectItem({ itemId, checkedStatus }: Pick<TreeViewItemInterface, 'itemId' | 'checkedStatus'>): void - action that allows to change item selection, 
    * selectAll(): void - action that allows to select all items, 
    * clearAll(): void - action that allows to unselect all items.
@@ -110,21 +110,21 @@ export function useTreeView(props: UseTreeViewProps) {
   }, [items]); 
 
   const itemToFocus = React.useMemo(() => {
+    const [firstItem] = items;
+
+    if (selectable === TreeViewSelectable.off) {
+      const firstExpandableItem = items.find((item) => item.hasOwnTreeItems)
+
+      return firstExpandableItem ? firstExpandableItem.itemId : firstItem?.itemId;
+    }
+
     const firstNonUncheckedItem = items.find((item) => item.checkedStatus && item.checkedStatus !== IndeterminateCheckboxStatus.unchecked)
-    
+
     if (firstNonUncheckedItem) {
       return firstNonUncheckedItem.itemId;
     }
-    
-    const [firstItem] = items;
 
-    if (selectable !== TreeViewSelectable.off) {
-      return firstItem?.itemId;
-    }
-    
-    const firstExpandableItem = items.find((item) => item.hasOwnTreeItems)
-
-    return firstExpandableItem ? firstExpandableItem.itemId : firstItem?.itemId;
+    return firstItem?.itemId;
   }, [items]);
   
   const initializationRef = React.useRef(true);

--- a/packages/react-magma-dom/src/components/TreeView/utils.ts
+++ b/packages/react-magma-dom/src/components/TreeView/utils.ts
@@ -165,57 +165,6 @@ export function getChildrenItemIdsInTree(children) {
   return itemIds;
 }
 
-// Return first child that is a branch
-export function findFirstBranchNode(children) {
-  for (const item of children) {
-    if (item.props?.children && item.props?.children) {
-      return item;
-    }
-    if (item.props?.children && item.props?.children.length === 0) {
-      const childResult = findFirstBranchNode(item.props?.children);
-      if (childResult) {
-        return childResult;
-      }
-    }
-  }
-  return null;
-}
-
-// Returns the first item in the tree from the array of selected items
-export function getFirstItemInTree(arr, children) {
-  // If there's only 1 item, return that one first
-  if (arr.length === 1) {
-    return arr[0]?.itemId;
-  }
-  
-  let allFoundItems = [];
-  
-  for (const item of arr) {
-    const foundItem = Array.isArray(children)
-      ? children.find(child => child.props?.itemId === item.itemId)
-      : children.props?.itemId === item.itemId;
-
-    if (foundItem) {
-      allFoundItems.push(foundItem.props?.itemId);
-    } else if (children.props?.children) {
-      const result = getFirstItemInTree(arr, children.props.children);
-      if (result) {
-        allFoundItems.push(result);
-      }
-    }
-  }
-
-  // After finding all the items, return the one that comes first on the tree (top to bottom)
-  if (allFoundItems.length === 1) {
-    return allFoundItems[0];
-  } else if (allFoundItems.length > 1) {
-    for (const ch of children) {
-      return allFoundItems.find(i => i === ch.props?.itemId);
-    }
-  }
-  return null;
-}
-
 // Return a treeItemRefArray object with no null children
 export function filterNullEntries(obj) {
   if (Array.isArray(obj.current)) {
@@ -292,7 +241,7 @@ export const getInitialItems = ({ children, preselectedItems: rawPreselectedItem
     return preselectedItem ? { ...treeViewDataItem, checkedStatus: preselectedItem.checkedStatus } : treeViewDataItem
   }) : treeViewData
 
-  return checkParents && preselectedItems ? processInitialParentStatuses({ items: enhancedWithPreselectedItems }) : enhancedWithPreselectedItems
+  return selectable === TreeViewSelectable.multi && checkParents && preselectedItems ? processInitialParentStatuses({ items: enhancedWithPreselectedItems }) : enhancedWithPreselectedItems
 }
 
 export const selectSingle = ({items, itemId, checkedStatus}: { items: TreeViewItemInterface[]; itemId: TreeViewItemInterface['itemId']; checkedStatus: TreeViewItemInterface['checkedStatus'] }) => {

--- a/packages/react-magma-dom/src/components/TreeView/utils.ts
+++ b/packages/react-magma-dom/src/components/TreeView/utils.ts
@@ -201,10 +201,10 @@ const getChildrenIds = ({ items, itemId }: { items: TreeViewItemInterface[]; ite
 
 const getChildrenUniqueStatuses = ({ items, itemId }: { items: TreeViewItemInterface[]; itemId: TreeViewItemInterface['itemId']; }) => {
   const childrenAndItemIds = getChildrenIds({ items, itemId });
-  const leafs = items.filter((item) => {
+  const leaves = items.filter((item) => {
     return !item.hasOwnTreeItems && childrenAndItemIds.includes(item.itemId);
   })
-  const uniqueStatuses = Array.from(new Set(leafs.map(item => item.checkedStatus ?? IndeterminateCheckboxStatus.unchecked)));
+  const uniqueStatuses = Array.from(new Set(leaves.map(item => item.checkedStatus ?? IndeterminateCheckboxStatus.unchecked)));
 
   return uniqueStatuses.filter(checkedStatus => checkedStatus && checkedStatus !== IndeterminateCheckboxStatus.indeterminate)
 }

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -508,6 +508,143 @@ export function Example() {
 }
 ```
 
+## Update Selected Items From Outside
+
+Use the `apiRef` prop to change items selection from outside. It exposes these functions: `selectItem`, `selectAll`, `clearAll`
+
+```typescript
+import React from 'react';
+import {
+ TreeView,
+ TreeItem,
+ Tag,
+ IndeterminateCheckboxStatus,
+ TreeViewSelectable,
+ ButtonGroup,
+ Button,
+ ButtonSize,
+ ButtonVariant,
+ TagSize,
+ TagColor,
+ TreeViewApi,
+ magma
+} from 'react-magma-dom';
+import { FolderIcon, ArticleIcon } from 'react-magma-icons';
+
+function createControlledTags(items = [], api?: TreeViewApi) {
+  const selected = items && items
+    .filter(i => i.checkedStatus === IndeterminateCheckboxStatus.checked)
+    .map((i, key) => (
+      <Tag key={key} size={TagSize.small} color={TagColor.primary} onDelete={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+        {i.itemId}
+      </Tag>
+    ));
+
+  const indeterminate = items && items
+    .filter(i => i.checkedStatus === IndeterminateCheckboxStatus.indeterminate)
+    .map((i, key) => (
+      <Tag key={key} size={TagSize.small} color={TagColor.default} onDelete={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+        {i.itemId}
+      </Tag>
+    ));
+
+  return {
+    selected: selected || [],
+    indeterminate: indeterminate || [],
+  };
+}
+
+export function Example() {
+    const [selectedItems, setSelectedItems] = React.useState(null);
+  
+    const apiRef = React.useRef<TreeViewApi>(null);
+    
+    const { selected, indeterminate } = createControlledTags(selectedItems, apiRef.current);
+    
+    return (
+      <>
+        <Heading level={3} id="ah-textbook">
+          Gardner's Art through the ages
+        </Heading>
+        <TreeView ariaLabelledBy={'ah-textbook'} selectable={TreeViewSelectable.multi} apiRef={apiRef} onSelectedItemChange={setSelectedItems}>
+          <TreeItem
+            label={<>I. INTRODUCTION: WHAT IS ART HISTORY?</>}
+            itemId="I-intro"
+          >
+            <TreeItem
+              label={<>Art History in the 21st Century</>}
+              itemId="I-21st-century"
+            >
+              <TreeItem
+                label={<>The Questions Art Historians Ask</>}
+                itemId="I-questions"
+              />
+              <TreeItem
+                label={<>The Words Art Historians Use</>}
+                itemId="I-words"
+              >
+                <TreeItem label={<>Vocabulary</>} itemId="I-vocab" />
+              </TreeItem>
+              <TreeItem
+                label={<>Art History and Other Disciplines</>}
+                itemId="I-other"
+              />
+            </TreeItem>
+            <TreeItem
+              label={<>Different Ways of Seeing</>}
+              itemId="I-different-ways"
+            />
+          </TreeItem>
+          <TreeItem label={<>1. ART IN THE STONE AGE</>} itemId="1-stone-age">
+            <TreeItem label={<>Paleolithic Art</>} itemId="1-paleolithic">
+              <TreeItem label={<>Africa</>} itemId="1-africa" />
+              <TreeItem label={<>Europe</>} itemId="1-europe" />
+            </TreeItem>
+            <TreeItem label={<>Neolithic Art</>} itemId="1-neolithic">
+              <TreeItem
+                label={<>Anatolia and Mesopotamia</>}
+                itemId="1-anatolia"
+              />
+              <TreeItem
+                label={<>Europe</>}
+                itemId="1-neolithic-europe"
+                isDisabled
+              />
+            </TreeItem>
+          </TreeItem>
+          <TreeItem
+            label={<>2. ANCIENT MESOPOTAMIA AND PERSIA</>}
+            itemId="2-ancient"
+          >
+            <TreeItem label={<>Mesopotamia</>} itemId="2-mesopotamia">
+              <TreeItem label={<>Sumer</>} itemId="2-sumer" />
+              <TreeItem label={<>Akkad</>} itemId="2-akkad" />
+              <TreeItem label={<>Third Dynasty of Ur</>} itemId="2-ur" />
+              <TreeItem label={<>Babylon</>} itemId="2-babylon" />
+              <TreeItem label={<>Elam</>} itemId="2-elam" />
+              <TreeItem label={<>Assyria</>} itemId="2-assyria" />
+              <TreeItem label={<>Neo-Babylonia</>} itemId="2-neo" />
+            </TreeItem>
+            <TreeItem label={<>Persia</>} itemId="2-persia">
+              <TreeItem label={<>Achaemenid Empire</>} itemId="2-achaemenid" />
+              <TreeItem label={<>Sasanian Empire</>} itemId="2-sasanian" />
+            </TreeItem>
+          </TreeItem>
+        </TreeView>
+        <br />
+        <>
+        <p>Selected: {selected}</p>
+        <p>Indeterminate: {indeterminate}</p>
+      </>
+        <ButtonGroup size={ButtonSize.small} variant={ButtonVariant.solid}>
+          <Button onClick={() => apiRef.current.selectAll()}>Select all</Button>
+          <Button onClick={() => apiRef.current.clearAll()}>Clear all</Button>
+        </ButtonGroup>
+      </>
+    );
+}
+```
+
 ## Change Events
 
 The following events are available: `onSelectedItemChange` and `onExpandedChange`.
@@ -672,269 +809,6 @@ export function Example() {
       </TreeView>
     </>
   );
-}
-```
-
-
-## Update Selected Items From Outside
-
-Use the `apiRef` prop to change items selection from outside. It exposes these functions: `selectItem`, `selectAll`, `clearAll`
-
-```typescript
-import React from 'react';
-import { TreeView, TreeItem, Tag, TreeViewApi, IndeterminateCheckboxStatus, TreeViewSelectable, magma } from 'react-magma-dom';
-
-function createControlledTags(items = [], api?: TreeViewApi) {
-  const selected = items && items
-    .filter(i => i.checkedStatus === IndeterminateCheckboxStatus.checked)
-    .map((i, key) => (
-      <Tag key={key} size={TagSize.small} color={TagColor.primary} onDelete={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
-        {i.itemId}
-      </Tag>
-    ));
-
-  const indeterminate = items && items
-    .filter(i => i.checkedStatus === IndeterminateCheckboxStatus.indeterminate)
-    .map((i, key) => (
-      <Tag key={key} size={TagSize.small} color={TagColor.default} onDelete={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
-        {i.itemId}
-      </Tag>
-    ));
-
-  return {
-    selected: selected || [],
-    indeterminate: indeterminate || [],
-  };
-}
-
-export function Example() {
-    const [selectedItems, setSelectedItems] = React.useState(null);
-  
-    const apiRef = React.useRef<TreeViewApi>(null);
-    
-    const { selected, indeterminate } = createControlledTags(selectedItems, apiRef.current);
-    
-    return (
-      <>
-        <Card>
-          <TreeView selectable={TreeViewSelectable.multi} apiRef={apiRef} onSelectedItemChange={setSelectedItems}>
-            <TreeItem label={<>Part 1: Introduction</>} itemId="pt1" testId="pt1">
-              <TreeItem
-                icon={<FolderIcon aria-hidden={true} />}
-                label={<>Chapter 1: I love tiramisu jelly beans soufflé</>}
-                itemId="pt1ch1"
-                testId="pt1ch1"
-              >
-                <TreeItem
-                  icon={<ArticleIcon aria-hidden={true} />}
-                  label={<>Section 1.1: Cake donut lemon drops gingerbread</>}
-                  itemId="pt1ch1.1"
-                />
-              </TreeItem>
-              <TreeItem
-                label={
-                  <>
-                    Chapter 2: Chocolate bar ice cream cake liquorice icing tart
-                  </>
-                }
-                itemId="pt1ch2"
-              />
-              <TreeItem
-                icon={<FolderIcon aria-hidden={true} />}
-                label={
-                  <>Chapter 3: Pudding jujubes icing fruitcake bonbon icing</>
-                }
-                itemId="pt1ch3"
-              >
-                <TreeItem
-                  icon={<ArticleIcon aria-hidden={true} />}
-                  label={
-                    <>
-                      Section 3.1: Topping pudding marshmallow caramels I love pie
-                    </>
-                  }
-                  itemId="pt1ch3.1"
-                />
-                <TreeItem
-                  icon={<ArticleIcon aria-hidden={true} />}
-                  label={
-                    <>
-                      Section 3.2: Tart sweet roll caramels candy canes sweet roll
-                    </>
-                  }
-                  itemId="pt1ch3.2"
-                />
-                <TreeItem
-                  icon={<ArticleIcon aria-hidden={true} />}
-                  label={
-                    <>
-                      Section 3.3: Tart sweet roll caramels candy canes sweet roll
-                    </>
-                  }
-                  itemId="pt1ch3.3"
-                />
-              </TreeItem>
-            </TreeItem>
-            <TreeItem
-              icon={<FolderIcon aria-hidden={true} />}
-              label={
-                <>
-                  Part 2: Candy powder carrot cake cotton candy marshmallow
-                  caramels croissant I love
-                </>
-              }
-              itemId="pt2"
-            >
-              <TreeItem
-                icon={<ArticleIcon aria-hidden={true} />}
-                label={
-                  <>
-                    Chapter 4: I love carrot cake sweet roll I love liquorice
-                    sweet
-                  </>
-                }
-                itemId="pt2ch4"
-              />
-              <TreeItem
-                icon={<FolderIcon aria-hidden={true} />}
-                label={
-                  <>
-                    Chapter 5: Wafer I love I love sesame snaps I love muffin
-                    dragée halvah
-                  </>
-                }
-                itemId="pt2ch5"
-              >
-                <TreeItem
-                  icon={<ArticleIcon aria-hidden={true} />}
-                  label={
-                    <>
-                      Section 5.1: Apple pie apple pie tart macaroon topping
-                      chocolate cake
-                    </>
-                  }
-                  itemId="pt2ch5.1"
-                >
-                  <TreeItem
-                    icon={<ArticleIcon aria-hidden={true} />}
-                    label={
-                      <>
-                        Section 5.1.1: Apple pie apple pie tart macaroon topping
-                        chocolate cake
-                      </>
-                    }
-                    itemId="pt2ch5.1.1"
-                  />
-                  <TreeItem
-                    icon={<ArticleIcon aria-hidden={true} />}
-                    label={
-                      <>
-                        Section 5.1.2: Apple pie apple pie tart macaroon topping
-                        chocolate cake
-                      </>
-                    }
-                    itemId="pt2ch5.1.2"
-                  />
-                </TreeItem>
-                <TreeItem
-                  icon={<ArticleIcon aria-hidden={true} />}
-                  label={
-                    <>
-                      Section 5.2: Jelly lollipop tart gummies pie croissant
-                      sesame snaps sesame snaps
-                    </>
-                  }
-                  itemId="pt2ch5.2"
-                />
-                <TreeItem
-                  icon={<ArticleIcon aria-hidden={true} />}
-                  label={
-                    <>
-                      Section 5.3: Bonbon chocolate bar lollipop lollipop I love
-                      chocolate cake cupcake soufflé pie
-                    </>
-                  }
-                  itemId="pt2ch5.3"
-                />
-              </TreeItem>
-              <TreeItem
-                icon={<ArticleIcon aria-hidden={true} />}
-                label={<>Chapter 6: Cupcake dragée I love cookie I love</>}
-                itemId="pt2ch6"
-              />
-            </TreeItem>
-            <TreeItem
-              icon={<FolderIcon aria-hidden={true} />}
-              label={
-                <>
-                  Part 3: Sugar plum halvah shortbread apple pie I love brownie
-                  gummi bears
-                </>
-              }
-              itemId="pt3"
-            >
-              <TreeItem
-                icon={<ArticleIcon aria-hidden={true} />}
-                label={
-                  <>
-                    Chapter 7: Cheesecake lollipop tootsie roll candy canes
-                    cupcake I love dessert liquorice
-                  </>
-                }
-                itemId="pt3ch7"
-              />
-              <TreeItem
-                icon={<ArticleIcon aria-hidden={true} />}
-                label={
-                  <>
-                    Chapter 8: Jelly pastry jelly-o topping cookie carrot cake
-                    shortbread
-                  </>
-                }
-                itemId="pt3ch8"
-              />
-              <TreeItem
-                icon={<ArticleIcon aria-hidden={true} />}
-                label={
-                  <>Chapter 9: Jelly beans sweet candy canes croissant bonbon.</>
-                }
-                itemId="pt3ch9"
-              />
-              <TreeItem
-                icon={<ArticleIcon aria-hidden={true} />}
-                label={
-                  <>
-                    Chapter 10: Wafer carrot cake powder candy canes sweet roll
-                    bear claw croissant cheesecake tart
-                  </>
-                }
-                itemId="pt3ch10"
-              />
-              <TreeItem
-                icon={<ArticleIcon aria-hidden={true} />}
-                label={
-                  <>
-                    Chapter 11: Apple pie chocolate cake tiramisu bonbon I love
-                    croissant. I love chupa chups croissant tiramisu toffee cake
-                    tart
-                  </>
-                }
-                itemId="pt3ch11"
-              />
-            </TreeItem>
-          </TreeView>
-        </Card>
-        <br />
-        <>
-        <p>Selected: {selected}</p>
-        <p>Indeterminate: {indeterminate}</p>
-      </>
-        <ButtonGroup size={ButtonSize.small} variant={ButtonVariant.solid}>
-          <Button onClick={() => apiRef.current.selectAll()}>Select all</Button>
-          <Button onClick={() => apiRef.current.clearAll()}>Clear all</Button>
-        </ButtonGroup>
-      </>
-    );
 }
 ```
 

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -527,6 +527,7 @@ import {
  TagSize,
  TagColor,
  TreeViewApi,
+ Heading,
  magma
 } from 'react-magma-dom';
 import { FolderIcon, ArticleIcon } from 'react-magma-icons';

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -678,7 +678,7 @@ export function Example() {
 
 ## Update Selected Items From Outside
 
-Use the `apiRef` prop to change items selection from outside.
+Use the `apiRef` prop to change items selection from outside. It exposes these functions: `selectItem`, `selectAll`, `clearAll`
 
 ```typescript
 import React from 'react';
@@ -688,7 +688,7 @@ function createControlledTags(items = [], api?: TreeViewApi) {
   const selected = items && items
     .filter(i => i.checkedStatus === IndeterminateCheckboxStatus.checked)
     .map((i, key) => (
-      <Tag key={key} size={TagSize.small} color={TagColor.primary} onClick={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+      <Tag key={key} size={TagSize.small} color={TagColor.primary} onDelete={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
         {i.itemId}
       </Tag>
     ));
@@ -696,7 +696,7 @@ function createControlledTags(items = [], api?: TreeViewApi) {
   const indeterminate = items && items
     .filter(i => i.checkedStatus === IndeterminateCheckboxStatus.indeterminate)
     .map((i, key) => (
-      <Tag key={key} size={TagSize.small} color={TagColor.default} onClick={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+      <Tag key={key} size={TagSize.small} color={TagColor.default} onDelete={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
         {i.itemId}
       </Tag>
     ));

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -675,6 +675,269 @@ export function Example() {
 }
 ```
 
+
+## Update Selected Items From Outside
+
+Use the `apiRef` prop to change items selection from outside.
+
+```typescript
+import React from 'react';
+import { TreeView, TreeItem, Tag, TreeViewApi, IndeterminateCheckboxStatus, TreeViewSelectable, magma } from 'react-magma-dom';
+
+function createControlledTags(items = [], api?: TreeViewApi) {
+  const selected = items && items
+    .filter(i => i.checkedStatus === IndeterminateCheckboxStatus.checked)
+    .map((i, key) => (
+      <Tag key={key} size={TagSize.small} color={TagColor.primary} onClick={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+        {i.itemId}
+      </Tag>
+    ));
+
+  const indeterminate = items && items
+    .filter(i => i.checkedStatus === IndeterminateCheckboxStatus.indeterminate)
+    .map((i, key) => (
+      <Tag key={key} size={TagSize.small} color={TagColor.default} onClick={() => api.selectItem({ itemId: i.itemId, checkedStatus: IndeterminateCheckboxStatus.unchecked })}>
+        {i.itemId}
+      </Tag>
+    ));
+
+  return {
+    selected: selected || [],
+    indeterminate: indeterminate || [],
+  };
+}
+
+export function Example() {
+    const [selectedItems, setSelectedItems] = React.useState(null);
+  
+    const apiRef = React.useRef<TreeViewApi>(null);
+    
+    const { selected, indeterminate } = createControlledTags(selectedItems, apiRef.current);
+    
+    return (
+      <>
+        <Card>
+          <TreeView selectable={TreeViewSelectable.multi} apiRef={apiRef} onSelectedItemChange={setSelectedItems}>
+            <TreeItem label={<>Part 1: Introduction</>} itemId="pt1" testId="pt1">
+              <TreeItem
+                icon={<FolderIcon aria-hidden={true} />}
+                label={<>Chapter 1: I love tiramisu jelly beans soufflé</>}
+                itemId="pt1ch1"
+                testId="pt1ch1"
+              >
+                <TreeItem
+                  icon={<ArticleIcon aria-hidden={true} />}
+                  label={<>Section 1.1: Cake donut lemon drops gingerbread</>}
+                  itemId="pt1ch1.1"
+                />
+              </TreeItem>
+              <TreeItem
+                label={
+                  <>
+                    Chapter 2: Chocolate bar ice cream cake liquorice icing tart
+                  </>
+                }
+                itemId="pt1ch2"
+              />
+              <TreeItem
+                icon={<FolderIcon aria-hidden={true} />}
+                label={
+                  <>Chapter 3: Pudding jujubes icing fruitcake bonbon icing</>
+                }
+                itemId="pt1ch3"
+              >
+                <TreeItem
+                  icon={<ArticleIcon aria-hidden={true} />}
+                  label={
+                    <>
+                      Section 3.1: Topping pudding marshmallow caramels I love pie
+                    </>
+                  }
+                  itemId="pt1ch3.1"
+                />
+                <TreeItem
+                  icon={<ArticleIcon aria-hidden={true} />}
+                  label={
+                    <>
+                      Section 3.2: Tart sweet roll caramels candy canes sweet roll
+                    </>
+                  }
+                  itemId="pt1ch3.2"
+                />
+                <TreeItem
+                  icon={<ArticleIcon aria-hidden={true} />}
+                  label={
+                    <>
+                      Section 3.3: Tart sweet roll caramels candy canes sweet roll
+                    </>
+                  }
+                  itemId="pt1ch3.3"
+                />
+              </TreeItem>
+            </TreeItem>
+            <TreeItem
+              icon={<FolderIcon aria-hidden={true} />}
+              label={
+                <>
+                  Part 2: Candy powder carrot cake cotton candy marshmallow
+                  caramels croissant I love
+                </>
+              }
+              itemId="pt2"
+            >
+              <TreeItem
+                icon={<ArticleIcon aria-hidden={true} />}
+                label={
+                  <>
+                    Chapter 4: I love carrot cake sweet roll I love liquorice
+                    sweet
+                  </>
+                }
+                itemId="pt2ch4"
+              />
+              <TreeItem
+                icon={<FolderIcon aria-hidden={true} />}
+                label={
+                  <>
+                    Chapter 5: Wafer I love I love sesame snaps I love muffin
+                    dragée halvah
+                  </>
+                }
+                itemId="pt2ch5"
+              >
+                <TreeItem
+                  icon={<ArticleIcon aria-hidden={true} />}
+                  label={
+                    <>
+                      Section 5.1: Apple pie apple pie tart macaroon topping
+                      chocolate cake
+                    </>
+                  }
+                  itemId="pt2ch5.1"
+                >
+                  <TreeItem
+                    icon={<ArticleIcon aria-hidden={true} />}
+                    label={
+                      <>
+                        Section 5.1.1: Apple pie apple pie tart macaroon topping
+                        chocolate cake
+                      </>
+                    }
+                    itemId="pt2ch5.1.1"
+                  />
+                  <TreeItem
+                    icon={<ArticleIcon aria-hidden={true} />}
+                    label={
+                      <>
+                        Section 5.1.2: Apple pie apple pie tart macaroon topping
+                        chocolate cake
+                      </>
+                    }
+                    itemId="pt2ch5.1.2"
+                  />
+                </TreeItem>
+                <TreeItem
+                  icon={<ArticleIcon aria-hidden={true} />}
+                  label={
+                    <>
+                      Section 5.2: Jelly lollipop tart gummies pie croissant
+                      sesame snaps sesame snaps
+                    </>
+                  }
+                  itemId="pt2ch5.2"
+                />
+                <TreeItem
+                  icon={<ArticleIcon aria-hidden={true} />}
+                  label={
+                    <>
+                      Section 5.3: Bonbon chocolate bar lollipop lollipop I love
+                      chocolate cake cupcake soufflé pie
+                    </>
+                  }
+                  itemId="pt2ch5.3"
+                />
+              </TreeItem>
+              <TreeItem
+                icon={<ArticleIcon aria-hidden={true} />}
+                label={<>Chapter 6: Cupcake dragée I love cookie I love</>}
+                itemId="pt2ch6"
+              />
+            </TreeItem>
+            <TreeItem
+              icon={<FolderIcon aria-hidden={true} />}
+              label={
+                <>
+                  Part 3: Sugar plum halvah shortbread apple pie I love brownie
+                  gummi bears
+                </>
+              }
+              itemId="pt3"
+            >
+              <TreeItem
+                icon={<ArticleIcon aria-hidden={true} />}
+                label={
+                  <>
+                    Chapter 7: Cheesecake lollipop tootsie roll candy canes
+                    cupcake I love dessert liquorice
+                  </>
+                }
+                itemId="pt3ch7"
+              />
+              <TreeItem
+                icon={<ArticleIcon aria-hidden={true} />}
+                label={
+                  <>
+                    Chapter 8: Jelly pastry jelly-o topping cookie carrot cake
+                    shortbread
+                  </>
+                }
+                itemId="pt3ch8"
+              />
+              <TreeItem
+                icon={<ArticleIcon aria-hidden={true} />}
+                label={
+                  <>Chapter 9: Jelly beans sweet candy canes croissant bonbon.</>
+                }
+                itemId="pt3ch9"
+              />
+              <TreeItem
+                icon={<ArticleIcon aria-hidden={true} />}
+                label={
+                  <>
+                    Chapter 10: Wafer carrot cake powder candy canes sweet roll
+                    bear claw croissant cheesecake tart
+                  </>
+                }
+                itemId="pt3ch10"
+              />
+              <TreeItem
+                icon={<ArticleIcon aria-hidden={true} />}
+                label={
+                  <>
+                    Chapter 11: Apple pie chocolate cake tiramisu bonbon I love
+                    croissant. I love chupa chups croissant tiramisu toffee cake
+                    tart
+                  </>
+                }
+                itemId="pt3ch11"
+              />
+            </TreeItem>
+          </TreeView>
+        </Card>
+        <br />
+        <>
+        <p>Selected: {selected}</p>
+        <p>Indeterminate: {indeterminate}</p>
+      </>
+        <ButtonGroup size={ButtonSize.small} variant={ButtonVariant.solid}>
+          <Button onClick={() => apiRef.current.selectAll()}>Select all</Button>
+          <Button onClick={() => apiRef.current.clearAll()}>Clear all</Button>
+        </ButtonGroup>
+      </>
+    );
+}
+```
+
 ## TreeView Props
 
 **Any other props supplied will be provided to the wrapping `ul` element.**


### PR DESCRIPTION
Now it's possible to control TreeView state outside of this component by using `apiRef` prop. Available actions: selectItem, selectAll, clearAll.

feat #1286

Issue: #1286

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
Storybook -> TreeView -> Complex
Click on 'Select all' button - all items should be selected
Click on 'Clear all' button - all items should be unselected
I some item was selected then at the bottom appears corresponding tag. If remove this tag - item will be unselected
