### PR TITLE
fix(Input): Remove flex-shrink to allow inputs to shrink as needed

### DIFF
--- a/.changeset/inputwrapperstyles.md
+++ b/.changeset/inputwrapperstyles.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Input): Remove flex-shrink to allow inputs to shrink as needed.

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -161,7 +161,6 @@ export const inputWrapperStyles = (props: InputWrapperStylesProps) => css`
   flex: 1 1 auto;
   align-items: center;
   display: flex;
-  // flex-shrink: 0;
   position: relative;
   width: ${props.width || 'auto'};
   background-color: ${props.isInverse

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -161,7 +161,7 @@ export const inputWrapperStyles = (props: InputWrapperStylesProps) => css`
   flex: 1 1 auto;
   align-items: center;
   display: flex;
-  flex-shrink: 0;
+  // flex-shrink: 0;
   position: relative;
   width: ${props.width || 'auto'};
   background-color: ${props.isInverse


### PR DESCRIPTION
Issue: none

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Removed flex-shrink. We noticed that DatePicker had a min-width of 320px because of this, and it isn't needed.

This would affect:
- Input
- NativeSelect
- Select
- Textarea
- TimePicker
- DatePicker
- PasswordInput
- Search
- Combobox

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [-] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm that all of the components above continue to work as expected in all screen sizes and browsers.