### PR TITLE
fix(dropdown): Fix the dropdown closing on the second button click in…

### DIFF
--- a/.changeset/dropdown-safari.md
+++ b/.changeset/dropdown-safari.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(dropdown): Fix the dropdown closing on the second button click in `Safari`

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -392,7 +392,7 @@ describe('Dropdown', () => {
 
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'block');
 
-    userEvent.click(document.body);
+    fireEvent.blur(getByText('Toggle me'));
 
     act(jest.runAllTimers);
 
@@ -827,7 +827,7 @@ describe('Dropdown', () => {
         'block'
       );
 
-      userEvent.click(document.body);
+      fireEvent.blur(getByText('Toggle me'));
       act(jest.runAllTimers);
 
       expect(onClose).toHaveBeenCalled();

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
@@ -122,6 +122,11 @@ export const DropdownButton = React.forwardRef<
     }
   }
 
+  // For the correct functionality of opening and closing in Safari
+  function handleMouseDown(event: React.MouseEvent) {
+    event.preventDefault();
+  }
+
   const iconPositionToUse = props.icon
     ? iconPosition
       ? iconPosition
@@ -140,6 +145,7 @@ export const DropdownButton = React.forwardRef<
       id={context.dropdownButtonId.current}
       isInverse={context.isInverse}
       onClick={handleClick}
+      onMouseDown={handleMouseDown}
       ref={ref}
       theme={theme}
     >

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
@@ -122,6 +122,7 @@ export const DropdownButton = React.forwardRef<
     }
   }
 
+  // Necessary for the proper opening and closing of the menu in Safari
   function handleMouseDown(event: React.MouseEvent) {
     event.preventDefault();
   }

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -77,10 +77,18 @@ export const DropdownSplitButton = React.forwardRef<
     }
   }
 
+  // Necessary for the proper opening and closing of the menu in Safari
+  function handleMouseDown(event: React.MouseEvent) {
+    event.preventDefault();
+  }
+
   const i18n = React.useContext(I18nContext);
 
   function buildIconButtonStyles(props) {
-    if (props.color === ButtonColor.secondary || props.color === ButtonColor.subtle) {
+    if (
+      props.color === ButtonColor.secondary ||
+      props.color === ButtonColor.subtle
+    ) {
       return '0';
     }
     return theme.spaceScale.spacing01;
@@ -107,6 +115,7 @@ export const DropdownSplitButton = React.forwardRef<
         icon={buttonIcon}
         isInverse={resolvedContext.isInverse}
         onClick={handleClick}
+        onMouseDown={handleMouseDown}
         shape={ButtonShape.rightCap}
         style={{
           marginLeft: buildIconButtonStyles(resolvedProps),


### PR DESCRIPTION
… Safari

Issue: #1142

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

Changes were made to the default behavior of the onMouseDown handler because it was causing the dropdown to "flash" instead of closing on the second click in Safari. Additionally, updates were made to the tests to properly simulate the blur event on the dropdown button.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->

1. In Safari, go to the doc site.
2. Go to Dropdown.
3. Click on any Dropdown button to open a Dropdown, then click again to close.
