### PR TITLE
fix(drawer): Fix trapped focus in the drawer

### DIFF
--- a/.changeset/a11y-drawer-navigation-focus
+++ b/.changeset/a11y-drawer-navigation-focus
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(drawer): Fixed trapped focus in the drawer

--- a/.changeset/a11y-drawer-navigation-focus
+++ b/.changeset/a11y-drawer-navigation-focus
@@ -1,5 +1,0 @@
----
-'react-magma-dom': patch
----
-
-fix(drawer): Fixed trapped focus in the drawer

--- a/.changeset/a11y-drawer-navigation-focus.md
+++ b/.changeset/a11y-drawer-navigation-focus.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(drawer): Fix trapped focus in the drawer

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -17,7 +17,14 @@ export function useFocusLock(
       rootNode.current?.querySelectorAll(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), video'
       ) || []
-    );
+    ).filter((element): element is HTMLElement => {
+      const style = window.getComputedStyle(element);
+      return (
+        element instanceof HTMLElement &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden'
+      );
+    });
   };
 
   React.useEffect(() => {

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -12,6 +12,7 @@ export function useFocusLock(
   const rootNode = React.useRef<HTMLElement>(null);
   const focusableItems = React.useRef<Array<HTMLElement>>([]);
 
+  // The filter is necessary for the proper functioning of focus in drawer-navigation or similar cases
   const updateFocusableItems = () => {
     focusableItems.current = Array.from(
       rootNode.current?.querySelectorAll(


### PR DESCRIPTION
Issue: #1241

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->


A filtering function was added to the `useFocusLock` hook, which filters out invisible elements that were being included in the `focusableItems.current` array and preventing the focus from being properly locked on the modal window.


## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->

1) Go to our documentation site.
2) Navigate to Components > Drawer
3) Click "Show Drawer" under "Navigation Example"
4) Tab through the opened Drawer
