### PR TITLE
fix gatsby empty image alts

### DIFF
--- a/.changeset/a11y-docs-img-empty-alts.md
+++ b/.changeset/a11y-docs-img-empty-alts.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Docs): add "GATSBY_EMPTY_ALT" as alt text for empty alts.

--- a/website/react-magma-docs/src/pages/api-intro/page-templates.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/page-templates.mdx
@@ -16,7 +16,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 This template is ideal for applications that need as much of the screen as possible.
 
 <figure>
-  <img src="../../images/layout/template-full-width.png" alt="" />
+  <img src="../../images/layout/template-full-width.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ```tsx
@@ -141,7 +141,7 @@ export function Example() {
 This template is great for pages that focus more on reading content like marketing materials, articles, etc.
 
 <figure>
-  <img src="../../images/layout/template-restricted-width.png" alt="" />
+  <img src="../../images/layout/template-restricted-width.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ```tsx
@@ -246,7 +246,7 @@ export function Example() {
 This template includes a screen region for a left sidebar and includes all of the necessary responsive behavior.
 
 <figure>
-  <img src="../../images/layout/template-sidebar-app-header.png" alt="" />
+  <img src="../../images/layout/template-sidebar-app-header.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ```tsx
@@ -342,7 +342,7 @@ export function Example() {
 This template also includes the sidebar screen region, but the header extends all the way across the top of the page.
 
 <figure>
-  <img src="../../images/layout/template-sidebar-global-header.png" alt="" />
+  <img src="../../images/layout/template-sidebar-global-header.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ```tsx

--- a/website/react-magma-docs/src/pages/design-intro/layout.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/layout.mdx
@@ -28,7 +28,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 Every layout is made up of columns, gutters, and margins that respond accordingly to the size of the viewport.
 
 <figure>
-  <img src="../../images/layout/columns-gutters-margins.png" alt="" />
+  <img src="../../images/layout/columns-gutters-margins.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 1. Columns
@@ -40,7 +40,7 @@ Every layout is made up of columns, gutters, and margins that respond accordingl
 The columns indicate where the content of the page goes. The widths of the columns are fluid, allowing content to scale and resize depending on the width of the device. The number of columns is determined by pre-defined breakpoint ranges.
 
 <figure>
-  <img src="../../images/layout/columns-12.png" alt="" />
+  <img src="../../images/layout/columns-12.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     When the viewport is greater than 768px wide, the layout has 12 columns.
   </figcaption>
@@ -49,7 +49,7 @@ The columns indicate where the content of the page goes. The widths of the colum
 <span class="horizontal-spacer"></span>
 
 <figure>
-  <img src="../../images/layout/columns-6.png" alt="" />
+  <img src="../../images/layout/columns-6.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     When the viewport is 768px wide or smaller, the layout has 6 columns.
   </figcaption>
@@ -58,7 +58,7 @@ The columns indicate where the content of the page goes. The widths of the colum
 <span class="horizontal-spacer"></span>
 
 <figure>
-  <img src="../../images/layout/columns-4.png" alt="" />
+  <img src="../../images/layout/columns-4.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     When the viewport is 375px wide and smaller, the layout changes to 4
     columns.
@@ -72,7 +72,7 @@ Gutters are the spaces in between columns. This space is used to separate conten
 The width of gutters on standard Cengage page layouts should be set to 24px. On smaller screens the gutters change to 16px.
 
 <figure>
-  <img src="../../images/layout/gutters-24.png" alt="" />
+  <img src="../../images/layout/gutters-24.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     When the viewport is greater than 600px wide, gutters are 24px wide.
   </figcaption>
@@ -81,7 +81,7 @@ The width of gutters on standard Cengage page layouts should be set to 24px. On 
 <span class="horizontal-spacer"></span>
 
 <figure>
-  <img src="../../images/layout/gutters-16.png" alt="" />
+  <img src="../../images/layout/gutters-16.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     When the viewport is 600px wide and smaller, gutters are 16px wide.
   </figcaption>
@@ -98,7 +98,7 @@ Margins are a fixed value, typically consistent with the gutter widths. The widt
 The width of margins on standard Cengage full-width page layouts should be set to 24px. On smaller screens the margins change to 16px.
 
 <figure>
-  <img src="../../images/layout/layout-full-width.png" alt="" />
+  <img src="../../images/layout/layout-full-width.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 #### Restricted-width Layout
@@ -106,7 +106,7 @@ The width of margins on standard Cengage full-width page layouts should be set t
 Larger margins based on percentages can be used to restrict the maximum width of the content area. Commonly used for text-heavy pages displaying sales materials, articles, etc.
 
 <figure>
-  <img src="../../images/layout/layout-restricted-width.png" alt="" />
+  <img src="../../images/layout/layout-restricted-width.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -165,7 +165,7 @@ _\* Even for full-width layouts, we are only allowing the content area to size u
 Some Cengage web applications have a global sidebar on the left side of the page. This sidebar necessitates that the main content changes from 12 columns to 6 at 1024px wide and below. This is much earlier than the other layouts detailed above.
 
 <figure>
-  <img src="../../images/layout/layout-with-sidebar.png" alt="" />
+  <img src="../../images/layout/layout-with-sidebar.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     When using the global sidebar, the main content area still has 12 columns
     when the viewport is wider than 1024px
@@ -175,7 +175,7 @@ Some Cengage web applications have a global sidebar on the left side of the page
 <span class="horizontal-spacer"></span>
 
 <figure>
-  <img src="../../images/layout/layout-with-sidebar-1024.png" alt="" />
+  <img src="../../images/layout/layout-with-sidebar-1024.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     When using the global sidebar, the main content area changes to 6 columns
     when the viewport is 1024px wide and below.

--- a/website/react-magma-docs/src/pages/design-intro/spacing.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/spacing.mdx
@@ -155,7 +155,7 @@ The spacing scale helps us determine how much space to put between or inside of 
 <span class="horizontal-spacer"></span>
 
 <figure>
-  <img src="../../images/spacing/icon-text-balance-correct.png" alt="" />
+  <img src="../../images/spacing/icon-text-balance-correct.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     Example of using spacing properties to add padding inside a card, as well as
     the margins between the content within the card.
@@ -165,7 +165,7 @@ The spacing scale helps us determine how much space to put between or inside of 
 <span class="horizontal-spacer"></span>
 
 <figure>
-  <img src="../../images/spacing/spacing-example.png" alt="" />
+  <img src="../../images/spacing/spacing-example.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     Example of using spacing properties to create the space between cards in a
     grid.

--- a/website/react-magma-docs/src/pages/design-intro/typography.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/typography.mdx
@@ -809,7 +809,7 @@ The headings presets above are assigned by default to H1 through H6 in the <Link
 One example of this is in the <Link to="/api/modal/">Modal component</Link>. For optimal accessibility the title of the modal needs to be an H1, but we definitely don't want it to be styled with text that large. So we use an H1, but apply the Productive Heading Small style to it. This flexibility allows consumers of Magma to design using the styles that work best for the UI, but still have a clear informational hierarchy for assistive technologies.
 
 <figure>
-  <img src="../../images/typography/modal-title-style.png" alt="" />
+  <img src="../../images/typography/modal-title-style.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 #### Consistency is Key
@@ -821,7 +821,7 @@ Continuing from above, there isn't just one way an H1 or and H3 should be styled
 Another advantage to using the presets above is that Responsive behavior is already built into each style so you don't have to figure out and include it yourself. This means a number of the larger sizes will automatically reduce in size at 600px wide. This ensures we have appropriate text sizes on smaller devices. The breakpoint can be overridden if you want this change to happen earlier or later.
 
 <figure>
-  <img src="../../images/typography/responsive-example.png" alt="" />
+  <img src="../../images/typography/responsive-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -839,7 +839,7 @@ Our primary typface is Work Sans. It’s clear and approachable and is great for
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/typography/work-sans-characters.png" alt="" />
+        <img src="../../images/typography/work-sans-characters.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -867,7 +867,7 @@ Noto Serif is a beautiful serif font. It's easy to read, provides a nice contras
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/typography/noto-serif-characters.png" alt="" />
+        <img src="../../images/typography/noto-serif-characters.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -901,7 +901,7 @@ Line-heights are also defined at this level to adhere to an 8px spacing system, 
 If you have a need to use a font size outside of the pre-made sets above, you may only choose from this list.
 
 <figure>
-  <img src="../../images/typography/type-scale.png" alt="" />
+  <img src="../../images/typography/type-scale.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -916,7 +916,7 @@ Font weight is an important typographic variable that can add emphasis and diffe
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/typography/font-weights.png" alt="" />
+        <img src="../../images/typography/font-weights.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -931,7 +931,7 @@ Each weight has an italic style, which should only be used when you need to emph
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/typography/font-italic.png" alt="" />
+        <img src="../../images/typography/font-italic.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -946,7 +946,7 @@ Type color should be carefully considered, with legibility and accessibility as 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/typography/text-color-neutral-1.png" alt="" />
+        <img src="../../images/typography/text-color-neutral-1.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -958,7 +958,7 @@ Type color should be carefully considered, with legibility and accessibility as 
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/typography/text-color-neutral-2.png" alt="" />
+        <img src="../../images/typography/text-color-neutral-2.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>On dark backgrounds, neutral text appears as white.</p>
@@ -969,7 +969,7 @@ Type color should be carefully considered, with legibility and accessibility as 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/typography/text-color-decoration.png" alt="" />
+        <img src="../../images/typography/text-color-decoration.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>Don't use color as decoration.</p>
@@ -978,7 +978,7 @@ Type color should be carefully considered, with legibility and accessibility as 
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/typography/text-color-contrast.png" alt="" />
+        <img src="../../images/typography/text-color-contrast.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -992,7 +992,7 @@ Type color should be carefully considered, with legibility and accessibility as 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/typography/text-color-meaning.png" alt="" />
+        <img src="../../images/typography/text-color-meaning.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -1005,7 +1005,7 @@ Type color should be carefully considered, with legibility and accessibility as 
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/typography/text-color-meaning-2.png" alt="" />
+        <img src="../../images/typography/text-color-meaning-2.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -1026,12 +1026,12 @@ It is common to lighten certain pieces of text in order to create more contrast.
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/typography/subdued-example-1.png" alt="" />
+        <img src="../../images/typography/subdued-example-1.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/typography/subdued-example-2.png" alt="" />
+        <img src="../../images/typography/subdued-example-2.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -1044,7 +1044,7 @@ It is common to lighten certain pieces of text in order to create more contrast.
 Headings and paragraphs have margins built into them by default. These margins provide the desired rhythm created by spacing when they are used together in a traditional narrative context. These margins can be easily modified using the spacing scale or completely removed when using headings or paragraphs in other contexts.
 
 <figure>
-  <img src="../../images/typography/margins-illustration.png" alt="" />
+  <img src="../../images/typography/margins-illustration.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 </PageContent>

--- a/website/react-magma-docs/src/pages/design/accordion.mdx
+++ b/website/react-magma-docs/src/pages/design/accordion.mdx
@@ -44,7 +44,7 @@ In some scenarios, the accordion can be modified to place the chevron icon in fr
 
 <div class="image-grid">
   <figure>
-    <img src="../../images/accordion/accordion-good-alignment.png" alt="" />
+    <img src="../../images/accordion/accordion-good-alignment.png" alt="GATSBY_EMPTY_ALT" />
     <figcaption>
       <p class="title title-correct">Correct</p>
       <p>
@@ -54,7 +54,7 @@ In some scenarios, the accordion can be modified to place the chevron icon in fr
     </figcaption>
   </figure>
   <figure>
-    <img src="../../images/accordion/accordion-bad-alignment.png" alt="" />
+    <img src="../../images/accordion/accordion-bad-alignment.png" alt="GATSBY_EMPTY_ALT" />
     <figcaption>
       <p class="title title-caution">Caution</p>
       <p>
@@ -72,7 +72,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
   <figure>
     <img
       src="../../images/accordion/accordion-incorrect-icon-orientation.png"
-      alt=""
+      alt="GATSBY_EMPTY_ALT"
     />
     <figcaption>
       <p class="title title-incorrect">Incorrect</p>
@@ -83,7 +83,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
     </figcaption>
   </figure>
   <figure>
-    <img src="../../images/accordion/accordion-incorrect-icons.png" alt="" />
+    <img src="../../images/accordion/accordion-incorrect-icons.png" alt="GATSBY_EMPTY_ALT" />
     <figcaption>
       <p class="title title-incorrect">Incorrect</p>
       <p>
@@ -95,7 +95,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
 </div>
 
 <figure>
-  <img src="../../images/accordion/accordion-crowded-icons.png" alt="" />
+  <img src="../../images/accordion/accordion-crowded-icons.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p class="title title-incorrect">Incorrect</p>
     <p>
@@ -111,13 +111,13 @@ Accordions can be placed within main page content or placed inside of a containe
 
 <div class="image-grid">
   <figure>
-    <img src="../../images/accordion/accordion-in-page.png" alt="" />
+    <img src="../../images/accordion/accordion-in-page.png" alt="GATSBY_EMPTY_ALT" />
   </figure>
   <figure>
-    <img src="../../images/accordion/accordion-sidebar.png" alt="" />
+    <img src="../../images/accordion/accordion-sidebar.png" alt="GATSBY_EMPTY_ALT" />
   </figure>
   <figure>
-    <img src="../../images/accordion/accordion-drawer.png" alt="" />
+    <img src="../../images/accordion/accordion-drawer.png" alt="GATSBY_EMPTY_ALT" />
   </figure>
 </div>
 

--- a/website/react-magma-docs/src/pages/design/alert.mdx
+++ b/website/react-magma-docs/src/pages/design/alert.mdx
@@ -21,7 +21,7 @@ This page focuses primarily on the commonalities between the different alert typ
 Use alerts to inform users of updates, changes to system status, or as feedback to an action they have taken. Proactively communicating with users and providing immediate feedback is important for building trust and maintaining a constant awareness of the system status. While alerts are an effective method of communicating with users, they have the potential to be disruptive and should be used with care.
 
 <figure>
-  <img src="../../images/alerts/alert-intro-image.png" alt="" />
+  <img src="../../images/alerts/alert-intro-image.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -47,7 +47,7 @@ Alerts are interruptive, but their level of interruption should match the inform
 The basic anatomy of the alert is the same across all three types (banner, inline, toast).
 
 <figure>
-  <img src="../../images/alerts/alert-anatomy.png" alt="" />
+  <img src="../../images/alerts/alert-anatomy.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 1. Container
@@ -103,13 +103,13 @@ Alerts have an inverse option where we have defined colors that are optimized fo
 Inline alerts are embedded within the content of a page. They can provide the user with helpful information regarding a specific process or part of the interface. They can also be triggered by an action the user took, like submitting a form before filling out all the required fields.
 
 <figure>
-  <img src="../../images/alerts/inline-alert-example.png" alt="" />
+  <img src="../../images/alerts/inline-alert-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 If an inline alert is being used to communicate some general information to the user, then you can choose to allow them to dismiss the alert to get it out of their way. However, error messages are typically not dismissible by the user and persist until the issue is fixed either by the user or the system.
 
 <figure>
-  <img src="../../images/alerts/inline-alert-example-2.png" alt="" />
+  <img src="../../images/alerts/inline-alert-example-2.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -119,7 +119,7 @@ If an inline alert is being used to communicate some general information to the 
 When the viewport is 600px wide and smaller, we automatically reduce the icon and font size to optimize the amount of space given to the message and optional links or buttons in the alert.
 
 <figure>
-  <img src="../../images/alerts/mobile-inline-alert-example.png" alt="" />
+  <img src="../../images/alerts/mobile-inline-alert-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <span class="horizontal-spacer"></span>
 

--- a/website/react-magma-docs/src/pages/design/badge.mdx
+++ b/website/react-magma-docs/src/pages/design/badge.mdx
@@ -20,7 +20,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 Badges are used as a form of inline feedback and labeling. They are typically used to provide additional context to components already on the page.
 
 <figure>
-  <img src="../../images/badges/Badges.png" alt="" />
+  <img src="../../images/badges/Badges.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -28,7 +28,7 @@ Badges are used as a form of inline feedback and labeling. They are typically us
 ## Text Badges
 
 <figure>
-  <img src="../../images/badges/label-example.png" alt="" />
+  <img src="../../images/badges/label-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 Text badges provide a way to provide feedback or label pieces of data.
@@ -42,7 +42,7 @@ Unless the context is clear, consider including additional context with a visual
 ## Counters
 
 <figure>
-  <img src="../../images/badges/counter-example.png" alt="" />
+  <img src="../../images/badges/counter-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 Counters can be used as part of links or buttons, or simply in a context that conveys the count of something to the user. When space is limited, and if the exact count isn't important, you may consider limiting the count to "99+".
@@ -52,7 +52,7 @@ Counters can be used as part of links or buttons, or simply in a context that co
 ## Color
 
 <figure>
-  <img src="../../images/badges/label-colors.png" alt="" />
+  <img src="../../images/badges/label-colors.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 There are multiple colors available for badges, but they should be used with purpose. The colors that should be used most commonly are primary, secondary/high contrast, and light/low contrast. The best color to use will most likely be determined by which one gives the appropriate level of emphasis with the surrounding content.

--- a/website/react-magma-docs/src/pages/design/banner.mdx
+++ b/website/react-magma-docs/src/pages/design/banner.mdx
@@ -15,7 +15,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 </LeadParagraph>
 
 <figure>
-  <img src="../../images/alerts/banner-alert-example.png" alt="" />
+  <img src="../../images/alerts/banner-alert-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ## Usage
@@ -29,7 +29,7 @@ Banner alerts typically appear at the very top of the browser viewport and exten
 When the viewport is 600px wide and smaller, we automatically reduce the icon and font size to optimize the amount of space given to the message and optional links or buttons in the alert.
 
 <figure>
-  <img src="../../images/alerts/mobile-banner-alert-example.png" alt="" />
+  <img src="../../images/alerts/mobile-banner-alert-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <span class="horizontal-spacer"></span>
 

--- a/website/react-magma-docs/src/pages/design/breadcrumb.mdx
+++ b/website/react-magma-docs/src/pages/design/breadcrumb.mdx
@@ -20,7 +20,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 The default breadcrumb component is styled for use on backgrounds **neutral100** or **neutral200**. For dark backgrounds you can use the inverse version.
 
 <figure>
-  <img src="../../images/breadcrumbs/example-breadcrumbs.png" alt="" />
+  <img src="../../images/breadcrumbs/example-breadcrumbs.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -33,7 +33,7 @@ As the viewport gets smaller, the breadcrumb component will simply wrap to as ma
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/breadcrumbs/breadcrumbs-wrap.png" alt="" />
+        <img src="../../images/breadcrumbs/breadcrumbs-wrap.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>

--- a/website/react-magma-docs/src/pages/design/button.mdx
+++ b/website/react-magma-docs/src/pages/design/button.mdx
@@ -68,7 +68,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_1.png" alt="" />
+        <img src="../../images/buttons/ex_4_1.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>Keep labels short</p>
@@ -77,7 +77,7 @@ Text labels should always be short and have clear purpose. If a button requires 
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_2.png" alt="" />
+        <img src="../../images/buttons/ex_4_2.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -91,7 +91,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_3.png" alt="" />
+        <img src="../../images/buttons/ex_4_3.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -107,7 +107,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_4.png" alt="" />
+        <img src="../../images/buttons/ex_4_4.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -119,7 +119,7 @@ Text labels should always be short and have clear purpose. If a button requires 
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_5.png" alt="" />
+        <img src="../../images/buttons/ex_4_5.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-caution">Caution</p>
           <p>
@@ -141,7 +141,7 @@ You can place icons next to text labels to both clarify an action and call atten
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_6.png" alt="" />
+        <img src="../../images/buttons/ex_4_6.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>Use icons that clearly communicate their meaning.</p>
@@ -150,7 +150,7 @@ You can place icons next to text labels to both clarify an action and call atten
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_7.png" alt="" />
+        <img src="../../images/buttons/ex_4_7.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -164,7 +164,7 @@ You can place icons next to text labels to both clarify an action and call atten
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_8.png" alt="" />
+        <img src="../../images/buttons/ex_4_8.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -176,7 +176,7 @@ You can place icons next to text labels to both clarify an action and call atten
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_9.png" alt="" />
+        <img src="../../images/buttons/ex_4_9.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>Don’t use two icons in the same button.</p>
@@ -216,7 +216,7 @@ When you are pairing together primary and secondary actions such as "Save" and "
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_6_1.png" alt="" />
+        <img src="../../images/buttons/ex_6_1.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -233,12 +233,12 @@ An additional benefit of the subtle button's very neutral appearance is to help 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/subtle_button_example_1.png" alt="" />
+        <img src="../../images/buttons/subtle_button_example_1.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/buttons/subtle_button_example_2.png" alt="" />
+        <img src="../../images/buttons/subtle_button_example_2.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -252,7 +252,7 @@ For actions that delete things, you can emphasize this action with the **danger*
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_6_3.png" alt="" />
+        <img src="../../images/buttons/ex_6_3.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -273,7 +273,7 @@ If your button is going on a dark background, all of the buttons have an inverse
   <div class="row">
     <div class="col">
       <figure>
-        <img src="../../images/buttons/ex_6_4.png" alt="" />
+        <img src="../../images/buttons/ex_6_4.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -289,7 +289,7 @@ Buttons have clear states to provide feedback to the user.
   <div class="row">
     <div class="col">
       <figure>
-        <img src="../../images/buttons/ex_7_1.png" alt="" />
+        <img src="../../images/buttons/ex_7_1.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -305,7 +305,7 @@ The solid outline is 2px thick with at least a 2px offset, and the color is info
   <div class="row">
     <div class="col">
       <figure>
-        <img src="../../images/buttons/ex_7_2.png" alt="" />
+        <img src="../../images/buttons/ex_7_2.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -333,7 +333,7 @@ Multiple button types can be used to express different emphasis levels. When usi
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_8_1.png" alt="" />
+        <img src="../../images/buttons/ex_8_1.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -345,7 +345,7 @@ Multiple button types can be used to express different emphasis levels. When usi
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_8_2.png" alt="" />
+        <img src="../../images/buttons/ex_8_2.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -360,7 +360,7 @@ Multiple button types can be used to express different emphasis levels. When usi
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_8_3.png" alt="" />
+        <img src="../../images/buttons/ex_8_3.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -384,7 +384,7 @@ Button sizes and placements will sometimes need to change because of the size of
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_9_1.png" alt="" />
+        <img src="../../images/buttons/ex_9_1.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -397,7 +397,7 @@ Button sizes and placements will sometimes need to change because of the size of
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_9_2.png" alt="" />
+        <img src="../../images/buttons/ex_9_2.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>

--- a/website/react-magma-docs/src/pages/design/buttongroup.mdx
+++ b/website/react-magma-docs/src/pages/design/buttongroup.mdx
@@ -28,7 +28,7 @@ ButtonGroup can be either horizontal or vertical in its orientation. By default,
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/button-group/orientation.png" alt="" />
+        <img src="../../images/button-group/orientation.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -43,7 +43,7 @@ ButtonGroup comes in three different sizes: small, medium, and large. The medium
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/button-group/size.png" alt="" />
+        <img src="../../images/button-group/size.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -58,7 +58,7 @@ You can easily remove the space between buttons to create a single unit. When yo
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/button-group/no-space.png" alt="" />
+        <img src="../../images/button-group/no-space.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -77,12 +77,12 @@ The most critical action within a ButtonGroup should be a primary, marketing, or
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/button-group/good-groupings.png" alt="" />
+        <img src="../../images/button-group/good-groupings.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/button-group/bad-groupings.png" alt="" />
+        <img src="../../images/button-group/bad-groupings.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -96,7 +96,7 @@ ButtonGroups are aligned contextually. In general, ButtonGroups are left-aligned
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/button-group/alignment.png" alt="" />
+        <img src="../../images/button-group/alignment.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -111,12 +111,12 @@ The order of button priority should match the alignment of surrounding text. Whe
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/button-group/button-order-good.png" alt="" />
+        <img src="../../images/button-group/button-order-good.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/button-group/button-order-bad.png" alt="" />
+        <img src="../../images/button-group/button-order-bad.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -130,12 +130,12 @@ Not all buttons in a group require an icon, but buttons with icons should always
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/button-group/icons-good.png" alt="" />
+        <img src="../../images/button-group/icons-good.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/button-group/icons-bad.png" alt="" />
+        <img src="../../images/button-group/icons-bad.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -149,7 +149,7 @@ Use ButtonGroup to show any additional actions related to the most critical acti
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/button-group/additional-actions.png" alt="" />
+        <img src="../../images/button-group/additional-actions.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>

--- a/website/react-magma-docs/src/pages/design/card.mdx
+++ b/website/react-magma-docs/src/pages/design/card.mdx
@@ -24,12 +24,12 @@ Cards are one of the core building blocks in React Magma. They can be used to cr
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/cards/cards-layout.png" alt="" />
+        <img src="../../images/cards/cards-layout.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/cards/cards-related-pieces.png" alt="" />
+        <img src="../../images/cards/cards-related-pieces.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -41,7 +41,7 @@ Cards are one of the core building blocks in React Magma. They can be used to cr
 The only part of a card that is required is the container itself. All other content is optional and completely depends on the purpose of the card.
 
 <figure>
-  <img src="../../images/cards/card-anatomy.png" alt="" />
+  <img src="../../images/cards/card-anatomy.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 1. Container
@@ -59,7 +59,7 @@ Inset dividers do not extend to the edges of the card. Inset dividers are used t
 Use full-width dividers that extend to the edges of a card to separate more distinct pieces of content or isolate actions that have more to do with the card than any specific piece of content within it.
 
 <figure>
-  <img src="../../images/cards/card-dividers.png" alt="" />
+  <img src="../../images/cards/card-dividers.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <span class="horizontal-spacer"></span>
 
@@ -78,7 +78,7 @@ The card component is by default displayed as flat. This implies the card itself
 If a card can move, such as in a carousel or a drag and drop scenario, you should use the property that adds a dropshadow to the container to help communicate the dynamic nature of that component.
 
 <figure>
-  <img src="../../images/cards/card-depth.png" alt="" />
+  <img src="../../images/cards/card-depth.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <span class="horizontal-spacer"></span>
 
@@ -94,7 +94,7 @@ To avoid these issues, you should instead provide links within the card to view 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/cards/card-truncate-correct.png" alt="" />
+        <img src="../../images/cards/card-truncate-correct.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -107,7 +107,7 @@ To avoid these issues, you should instead provide links within the card to view 
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/cards/card-scrolling-incorrect.png" alt="" />
+        <img src="../../images/cards/card-scrolling-incorrect.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -129,7 +129,7 @@ To avoid these issues, you should instead provide links within the card to view 
 Depending how the card is being used, the card could contain any number of action buttons. Like with everything else, make sure the primary action is clear compared to any secondary actions. For small cards, avoid cluttering the card with too many actions by creating an overflow menu within a dropdown.
 
 <figure>
-  <img src="../../images/cards/card-overflow.png" alt="" />
+  <img src="../../images/cards/card-overflow.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### UI Controls
@@ -137,7 +137,7 @@ Depending how the card is being used, the card could contain any number of actio
 Cards can contain many kinds of UI controls, including buttons, tabs, toggle switches, etc. These allow the user to interact with the content of the card.
 
 <figure>
-  <img src="../../images/cards/card-ui-controls.png" alt="" />
+  <img src="../../images/cards/card-ui-controls.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <span class="horizontal-spacer"></span>
 
@@ -150,7 +150,7 @@ Various colors from the global color palette may be used as the background of a 
 **Important:** Conveying meaning with color does not translate to assistive technologies. If the communication of this meaning is important, make sure it is also obvious in the content that is visible, or is possibly delivered through alternative methods such as visibly hidden text that is read by screen readers.
 
 <figure>
-  <img src="../../images/cards/card-colors.png" alt="" />
+  <img src="../../images/cards/card-colors.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <span class="horizontal-spacer"></span>
 
@@ -163,7 +163,7 @@ Callout cards add a band of color to the left edge of the container. This can be
 **Important:** Conveying meaning with color does not translate to assistive technologies. If the communication of this meaning is important, make sure it is also obvious in the content that is visible, or is possibly delivered through alternative methods such as visibly hidden text that is read by screen readers.
 
 <figure>
-  <img src="../../images/cards/card-callout.png" alt="" />
+  <img src="../../images/cards/card-callout.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <span class="horizontal-spacer"></span>
 
@@ -178,7 +178,7 @@ When cards are grouped together, it's because they are working together for a co
 In general, cards change size depending on the amount of content within them. But you can emphasize certain cards creating a layout that implies a hierarchy on the page with different sized columns. Just be mindful the card is large enough to support the content of the card, and that the content responds appropriately on smaller screens.
 
 <figure>
-  <img src="../../images/cards/card-general-layout.png" alt="" />
+  <img src="../../images/cards/card-general-layout.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Scannable
@@ -186,7 +186,7 @@ In general, cards change size depending on the amount of content within them. Bu
 If you want a group of cards to be easy to scan, use a clean and consistent pattern for the layout.
 
 <figure>
-  <img src="../../images/cards/card-scannable.png" alt="" />
+  <img src="../../images/cards/card-scannable.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <span class="horizontal-spacer"></span>
 

--- a/website/react-magma-docs/src/pages/design/character-counter.mdx
+++ b/website/react-magma-docs/src/pages/design/character-counter.mdx
@@ -44,7 +44,7 @@ The character counter initially tells the user the maximum number of characters 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/character-counter/behavior-1.png" alt="" />
+        <img src="../../images/character-counter/behavior-1.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -57,7 +57,7 @@ As the user types, the character counter updates in real-time and informs the us
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/character-counter/behavior-2.png" alt="" />
+        <img src="../../images/character-counter/behavior-2.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -70,7 +70,7 @@ When the user exceeds the maximum number of characters allowed, the character co
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/character-counter/behavior-3.png" alt="" />
+        <img src="../../images/character-counter/behavior-3.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>

--- a/website/react-magma-docs/src/pages/design/checkboxes.mdx
+++ b/website/react-magma-docs/src/pages/design/checkboxes.mdx
@@ -24,7 +24,7 @@ Use checkboxes to:
 
 <figure>
   <div class="image-container">
-    <img src="../../images/selection-controls/Checkbox-example.png" alt="" />
+    <img src="../../images/selection-controls/Checkbox-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
   <figcaption>
     <p>Checkboxes</p>
@@ -43,7 +43,7 @@ Checkboxes can have a parent-child relationship with other checkboxes.
   <div class="image-container">
     <img
       src="../../images/selection-controls/Checkbox-parent-child-example.png"
-      alt=""
+      alt="GATSBY_EMPTY_ALT"
     />
   </div>
   <figcaption>
@@ -57,7 +57,7 @@ Checkboxes can be selected, unselected, or indeterminate. Checkboxes have enable
 
 <figure>
   <div class="image-container">
-    <img src="../../images/selection-controls/Checkbox-states.png" alt="" />
+    <img src="../../images/selection-controls/Checkbox-states.png" alt="GATSBY_EMPTY_ALT" />
   </div>
   <figcaption>
     <p>Checkbox states</p>
@@ -72,7 +72,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
   <div class="image-container">
     <img
       src="../../images/selection-controls/Checkbox-alternate-colors.png"
-      alt=""
+      alt="GATSBY_EMPTY_ALT"
     />
   </div>
   <figcaption>
@@ -86,7 +86,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
       <figure>
         <img
           src="../../images/selection-controls/Checkbox-incorrect-multi-color.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
@@ -101,7 +101,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
       <figure>
         <img
           src="../../images/selection-controls/Checkbox-incorrect-neutral.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
@@ -121,7 +121,7 @@ Use the inverse version when using the checkboxes on a dark background.
 
 <figure>
   <div class="image-container">
-    <img src="../../images/selection-controls/Checkbox-inverse.png" alt="" />
+    <img src="../../images/selection-controls/Checkbox-inverse.png" alt="GATSBY_EMPTY_ALT" />
   </div>
   <figcaption>
     <p>Inverse colors</p>

--- a/website/react-magma-docs/src/pages/design/date-picker.mdx
+++ b/website/react-magma-docs/src/pages/design/date-picker.mdx
@@ -17,7 +17,7 @@ import { Link } from 'gatsby';
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/date-input-example.png" alt="" />
+    <img src="../../images/inputs/date-input-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -51,7 +51,7 @@ The field label tells the user what information they need to input. Using placeh
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/wrong-truncate-label.png" alt="" />
+        <img src="../../images/inputs/wrong-truncate-label.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>Do not truncate field labels.</p>
@@ -60,7 +60,7 @@ The field label tells the user what information they need to input. Using placeh
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/inputs/caution-wrap-label.png" alt="" />
+        <img src="../../images/inputs/caution-wrap-label.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-caution">Caution</p>
           <p>
@@ -82,7 +82,7 @@ Placeholder text provides hints or examples of what to enter. Placeholder text d
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-text.png" alt="" />
+        <img src="../../images/inputs/input-text.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             This example shows how the placeholder text provides a hint to the
@@ -103,7 +103,7 @@ Helper text is pertinent information that assists the user in completing a field
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-helper-text.png" alt="" />
+        <img src="../../images/inputs/input-helper-text.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Example of input helper text</p>
         </figcaption>
@@ -121,7 +121,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/single-required-field.png" alt="" />
+        <img src="../../images/inputs/single-required-field.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -134,7 +134,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/inputs/multiple-required-fields.png" alt="" />
+        <img src="../../images/inputs/multiple-required-fields.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -148,7 +148,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/wrong-optional-field.png" alt="" />
+        <img src="../../images/inputs/wrong-optional-field.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -178,7 +178,7 @@ Inputs have a 5px border radius to be consistent with buttons, which often accom
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-container.png" alt="" />
+        <img src="../../images/inputs/input-container.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Examples of text fields on light and dark backgrounds.</p>
         </figcaption>
@@ -198,7 +198,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-leading-icon.png" alt="" />
+        <img src="../../images/inputs/input-leading-icon.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             Example of input with leading icon. The Visa icon helps identify the
@@ -209,7 +209,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/inputs/input-trailing-icon.png" alt="" />
+        <img src="../../images/inputs/input-trailing-icon.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             Example of input with trailing icon. The calendar icon is a button
@@ -231,7 +231,7 @@ The icon can be configured to simply display a message within a tooltip or also 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-what-is-this.png" alt="" />
+        <img src="../../images/inputs/input-what-is-this.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Example of input with Help icon</p>
         </figcaption>
@@ -249,7 +249,7 @@ The icon can be configured to simply display a message within a tooltip or also 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-states.png" alt="" />
+        <img src="../../images/inputs/input-states.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             Inputs can display the following states: active, disabled, focused,
@@ -277,7 +277,7 @@ When the input provided is invalid, an error message should be used to provide i
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-error-message.png" alt="" />
+        <img src="../../images/inputs/input-error-message.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Example of input with error message</p>
         </figcaption>

--- a/website/react-magma-docs/src/pages/design/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/design/dropdown.mdx
@@ -18,7 +18,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 ## Usage
 
 <figure>
-  <img src="../../images/dropdowns/dropdown-intro-example.png" alt="" />
+  <img src="../../images/dropdowns/dropdown-intro-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -33,7 +33,7 @@ Dropdown menus typically contain a list of text-only menu items.
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/anatomy-text-list.png" alt="" />
+        <img src="../../images/dropdowns/anatomy-text-list.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             There is 8px of space above the first item in the dropdown, and
@@ -61,7 +61,7 @@ Dropdown menu items may also use an icon on the left side to help clarify the me
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/anatomy-icon-and-text.png" alt="" />
+        <img src="../../images/dropdowns/anatomy-icon-and-text.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -85,7 +85,7 @@ Dropdown menus may use a selection state by placing a checkmark next to the curr
       <figure>
         <img
           src="../../images/dropdowns/anatomy-selection-state-list.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
       </figure>
     </div>
@@ -107,7 +107,7 @@ Some dropdowns benefit from organizing the choices or options into groups, and t
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/dropdown-groups.png" alt="" />
+        <img src="../../images/dropdowns/dropdown-groups.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -124,7 +124,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/menu-too-wide.png" alt="" />
+        <img src="../../images/dropdowns/menu-too-wide.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -136,7 +136,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/dropdowns/menu-item-wrapped.png" alt="" />
+        <img src="../../images/dropdowns/menu-item-wrapped.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -150,7 +150,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/menu-adjust-placement.png" alt="" />
+        <img src="../../images/dropdowns/menu-adjust-placement.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -172,7 +172,7 @@ Dropdowns have a default max-height of 250px and will scroll if necessary. This 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/menu-max-height.png" alt="" />
+        <img src="../../images/dropdowns/menu-max-height.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -184,7 +184,7 @@ Dropdowns have a default max-height of 250px and will scroll if necessary. This 
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/dropdowns/menu-too-long.png" alt="" />
+        <img src="../../images/dropdowns/menu-too-long.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-caution">Caution</p>
           <p>
@@ -209,7 +209,7 @@ The standard dropdown button is the most common element used to trigger a dropdo
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/simple-dropdown-button.png" alt="" />
+        <img src="../../images/dropdowns/simple-dropdown-button.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Example of single dropdown button.</p>
         </figcaption>
@@ -227,7 +227,7 @@ Split buttons combine a single action button with a menu of related choices into
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/split-dropdown-button.png" alt="" />
+        <img src="../../images/dropdowns/split-dropdown-button.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Example of split-dropdown button.</p>
         </figcaption>
@@ -247,7 +247,7 @@ Other button variants may be used as a trigger for a dropdown menu. Caution shou
       <figure>
         <img
           src="../../images/dropdowns/custom-dropdown-button-1.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
         <figcaption>
           <p>
@@ -261,7 +261,7 @@ Other button variants may be used as a trigger for a dropdown menu. Caution shou
       <figure>
         <img
           src="../../images/dropdowns/custom-dropdown-button-2.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
         <figcaption>
           <p>Example of a "more options" dropdown menu.</p>
@@ -280,14 +280,14 @@ Dropdowns are positioned relative to the trigger element that is clicked on to o
 A dropdown is typically displayed below the trigger element, and the left edge of the dropdown is aligned with the left edge of the trigger element. To make sure dropdowns don’t become obscured by running off the edge of the browser, you may position the dropdown to the left, right, or above the trigger element. You may also change the alignment to the right, top, or bottom edges.
 
 <figure>
-  <img src="../../images/dropdowns/dropdown-alignment-1.png" alt="" />
+  <img src="../../images/dropdowns/dropdown-alignment-1.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>Dropdowns can be left or right aligned.</p>
   </figcaption>
 </figure>
 <span class="horizontal-spacer"></span>
 <figure>
-  <img src="../../images/dropdowns/dropdown-alignment-2.png" alt="" />
+  <img src="../../images/dropdowns/dropdown-alignment-2.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       Dropdowns can be positioned above the trigger element. If using a button,
@@ -297,7 +297,7 @@ A dropdown is typically displayed below the trigger element, and the left edge o
 </figure>
 <span class="horizontal-spacer"></span>
 <figure>
-  <img src="../../images/dropdowns/dropdown-alignment-3.png" alt="" />
+  <img src="../../images/dropdowns/dropdown-alignment-3.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       Dropdowns can be positioned to the left or right of the trigger element.
@@ -315,7 +315,7 @@ Dropdowns are capable of displaying any kind of content, but great care should b
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/dropdowns/dropdown-signin-form.png" alt="" />
+        <img src="../../images/dropdowns/dropdown-signin-form.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             Small forms can be shown inside a dropdown instead of going to a new
@@ -326,7 +326,7 @@ Dropdowns are capable of displaying any kind of content, but great care should b
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/dropdowns/dropdown-custom-content.png" alt="" />
+        <img src="../../images/dropdowns/dropdown-custom-content.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Menu items can be combined with custom content.</p>
         </figcaption>

--- a/website/react-magma-docs/src/pages/design/header.mdx
+++ b/website/react-magma-docs/src/pages/design/header.mdx
@@ -33,13 +33,13 @@ The header component is designed to be extremely flexible allowing designers to 
 
 <figure>
   <div class="background">
-    <img src="../../images/header/anatomy-standard-responsive.png" alt="" />
+    <img src="../../images/header/anatomy-standard-responsive.png" alt="GATSBY_EMPTY_ALT" />
   </div>
   <figcaption>Header on small/mobile screen</figcaption>
 </figure>
 
 <figure class="with-background">
-  <img src="../../images/header/anatomy-standard.png" alt="" />
+  <img src="../../images/header/anatomy-standard.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>Header on large/desktop screen</figcaption>
 </figure>
 
@@ -48,17 +48,17 @@ The header component is designed to be extremely flexible allowing designers to 
 Horizontal specifications are consistent across all “flavors” of the header (standard, compact, and responsive.)
 
 <figure>
-  <img src="../../images/header/h-specs-standard-responsive.png" alt="" />
+  <img src="../../images/header/h-specs-standard-responsive.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>Header on small/mobile screen</figcaption>
 </figure>
 
 <figure>
-  <img src="../../images/header/h-specs-standard.png" alt="" />
+  <img src="../../images/header/h-specs-standard.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>Header on large/desktop screen</figcaption>
 </figure>
 
 <figure>
-  <img src="../../images/header/h-specs-standard-with-sidebar.png" alt="" />
+  <img src="../../images/header/h-specs-standard-with-sidebar.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>Header with sidebar menu icon</figcaption>
 </figure>
 
@@ -67,7 +67,7 @@ Horizontal specifications are consistent across all “flavors” of the header 
 In certain circumstances, designers may need to left-justify header features. The component allows for this and uses the same basic rules of horizontal and vertical spacing.
 
 <figure>
-  <img src="../../images/header/left-justification.png" alt="" />
+  <img src="../../images/header/left-justification.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>Header with left justification</figcaption>
 </figure>
 
@@ -76,7 +76,7 @@ In certain circumstances, designers may need to left-justify header features. Th
 The header should span the full width of the screen. On extra wide displays, the content may include expanded margins on each side, but the header logo should remain left-justfied to the edge of the screen, and (in most cases) the icons, features and inputs should remain right-justfied to the edge of the screen.
 
 <figure>
-  <img src="../../images/header/span-width.png" alt="" />
+  <img src="../../images/header/span-width.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ## Vertical Specifications
@@ -84,12 +84,12 @@ The header should span the full width of the screen. On extra wide displays, the
 Vertical specifications vary between the standard and compact views.
 
 <figure>
-  <img src="../../images/header/v-specs-compact.png" alt="" />
+  <img src="../../images/header/v-specs-compact.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>Compact header</figcaption>
 </figure>
 
 <figure>
-  <img src="../../images/header/v-specs-standard.png" alt="" />
+  <img src="../../images/header/v-specs-standard.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>Standard header</figcaption>
 </figure>
 
@@ -124,7 +124,7 @@ Here are several examples of strategies that designers should avoid:
 ### Don't use too many icons
 
 <figure>
-  <img src="../../images/header/too-many-icons.png" alt="" />
+  <img src="../../images/header/too-many-icons.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p class="title title-incorrect">Incorrect</p>
     <p>Incorrect: Too many icons create inbalance and clutter</p>
@@ -136,7 +136,7 @@ Here are several examples of strategies that designers should avoid:
 Don't duplicate items that already exist in the sidebar or elsewhere on the UI.
 
 <figure>
-  <img src="../../images/header/duplicate-sidebar.png" alt="" />
+  <img src="../../images/header/duplicate-sidebar.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p class="title title-incorrect">Incorrect</p>
     <p>These already exist in the sidebar or are better suited there</p>
@@ -146,7 +146,7 @@ Don't duplicate items that already exist in the sidebar or elsewhere on the UI.
 ### Don't use a collapsed sidebar and hamburger menu
 
 <figure>
-  <img src="../../images/header/sidebar-and-hamburger.png" alt="" />
+  <img src="../../images/header/sidebar-and-hamburger.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p class="title title-incorrect">Incorrect</p>
     <p>Sidebar controls should never co-exist with the hamburger menu</p>

--- a/website/react-magma-docs/src/pages/design/icon.mdx
+++ b/website/react-magma-docs/src/pages/design/icon.mdx
@@ -40,7 +40,7 @@ This example illustrates how 12px, 14px, 16px, and 20px text strings are paired 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/icons/icon-text-balance-correct.png" alt="" />
+        <img src="../../images/icons/icon-text-balance-correct.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -52,7 +52,7 @@ This example illustrates how 12px, 14px, 16px, and 20px text strings are paired 
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/icons/icon-text-balance-incorrect.png" alt="" />
+        <img src="../../images/icons/icon-text-balance-incorrect.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -77,7 +77,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/icons/icon-color-correct.png" alt="" />
+        <img src="../../images/icons/icon-color-correct.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -90,7 +90,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/icons/icon-color-too-light.png" alt="" />
+        <img src="../../images/icons/icon-color-too-light.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -105,7 +105,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/icons/icon-mixed-colors.png" alt="" />
+        <img src="../../images/icons/icon-mixed-colors.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -130,7 +130,7 @@ When positioning an icon next to text you should always center-align them.
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/icons/icon-text-centered.png" alt="" />
+        <img src="../../images/icons/icon-text-centered.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -141,7 +141,7 @@ When positioning an icon next to text you should always center-align them.
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/icons/icon-text-wrong-alignment.png" alt="" />
+        <img src="../../images/icons/icon-text-wrong-alignment.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>

--- a/website/react-magma-docs/src/pages/design/indeterminate.mdx
+++ b/website/react-magma-docs/src/pages/design/indeterminate.mdx
@@ -24,7 +24,7 @@ View the <Link to="/design/checkboxes/">documentation for checkboxes</Link> for 
   <div class="image-container">
     <img
       src="../../images/selection-controls/Checkbox-parent-child-example.png"
-      alt=""
+      alt="GATSBY_EMPTY_ALT"
     />
   </div>
   <figcaption>

--- a/website/react-magma-docs/src/pages/design/input.mdx
+++ b/website/react-magma-docs/src/pages/design/input.mdx
@@ -19,7 +19,7 @@ Inputs can be used alone or they can be combined with other types of inputs to c
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/inputs-intro-image.png" alt="" />
+    <img src="../../images/inputs/inputs-intro-image.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -53,7 +53,7 @@ View <Link to="/api/input/">component API</Link> for text fields.
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/text-field-example.png" alt="" />
+    <img src="../../images/inputs/text-field-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -65,7 +65,7 @@ View <Link to="/api/textarea/">component API</Link> for text areas.
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/text-area-example.png" alt="" />
+    <img src="../../images/inputs/text-area-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -77,7 +77,7 @@ View the <Link to="/design/password-input/">password input documentation</Link> 
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/password-input-example.png" alt="" />
+    <img src="../../images/inputs/password-input-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -89,7 +89,7 @@ View <Link to="/api/input/">component API</Link> for number inputs.
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/number-field-example.png" alt="" />
+    <img src="../../images/inputs/number-field-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -101,7 +101,7 @@ View <Link to="/api/search/">component API</Link> or <Link to="/design/search/">
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/search-input-example.png" alt="" />
+    <img src="../../images/inputs/search-input-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -113,7 +113,7 @@ View <Link to="/api/date-pickers/">component API</Link> for date inputs.
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/date-input-example.png" alt="" />
+    <img src="../../images/inputs/date-input-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -147,7 +147,7 @@ The field label tells the user what information they need to input. Using placeh
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/wrong-truncate-label.png" alt="" />
+        <img src="../../images/inputs/wrong-truncate-label.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>Do not truncate field labels.</p>
@@ -156,7 +156,7 @@ The field label tells the user what information they need to input. Using placeh
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/inputs/caution-wrap-label.png" alt="" />
+        <img src="../../images/inputs/caution-wrap-label.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-caution">Caution</p>
           <p>
@@ -178,7 +178,7 @@ Placeholder text provides hints or examples of what to enter. Placeholder text d
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-text.png" alt="" />
+        <img src="../../images/inputs/input-text.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             This example shows how the placeholder text provides a hint to the
@@ -199,7 +199,7 @@ Helper text is pertinent information that assists the user in completing a field
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-helper-text.png" alt="" />
+        <img src="../../images/inputs/input-helper-text.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Example of input helper text</p>
         </figcaption>
@@ -217,7 +217,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/single-required-field.png" alt="" />
+        <img src="../../images/inputs/single-required-field.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -230,7 +230,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/inputs/multiple-required-fields.png" alt="" />
+        <img src="../../images/inputs/multiple-required-fields.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -244,7 +244,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/wrong-optional-field.png" alt="" />
+        <img src="../../images/inputs/wrong-optional-field.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -274,7 +274,7 @@ Inputs have a 5px border radius to be consistent with buttons, which often accom
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-container.png" alt="" />
+        <img src="../../images/inputs/input-container.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Examples of text fields on light and dark backgrounds.</p>
         </figcaption>
@@ -294,7 +294,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-leading-icon.png" alt="" />
+        <img src="../../images/inputs/input-leading-icon.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             Example of input with leading icon. The Visa icon helps identify the
@@ -305,7 +305,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/inputs/input-trailing-icon.png" alt="" />
+        <img src="../../images/inputs/input-trailing-icon.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             Example of input with trailing icon. The calendar icon is a button
@@ -327,7 +327,7 @@ The icon can be configured to simply display a message within a tooltip or also 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-what-is-this.png" alt="" />
+        <img src="../../images/inputs/input-what-is-this.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Example of input with Help icon</p>
         </figcaption>
@@ -345,7 +345,7 @@ The icon can be configured to simply display a message within a tooltip or also 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-states.png" alt="" />
+        <img src="../../images/inputs/input-states.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>
             Inputs can display the following states: active, disabled, focused,
@@ -373,7 +373,7 @@ When the input provided is invalid, an error message should be used to provide i
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/input-error-message.png" alt="" />
+        <img src="../../images/inputs/input-error-message.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p>Example of input with error message</p>
         </figcaption>

--- a/website/react-magma-docs/src/pages/design/list.mdx
+++ b/website/react-magma-docs/src/pages/design/list.mdx
@@ -29,7 +29,7 @@ Use ordered (numbered) lists when you need to convey a sequence or hierarchy bet
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/lists/unordered-list.png" alt="" />
+        <img src="../../images/lists/unordered-list.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           The list in this image shows a list of grocery items in no particular
           order.
@@ -38,7 +38,7 @@ Use ordered (numbered) lists when you need to convey a sequence or hierarchy bet
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/lists/ordered-list.png" alt="" />
+        <img src="../../images/lists/ordered-list.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           The list in this image shows a list of the top 7 best-selling car
           brands.
@@ -78,12 +78,12 @@ You can use the spacing tokens in React Magma to increase the vertical space bet
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/lists/small-spacing.png" alt="" />
+        <img src="../../images/lists/small-spacing.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/lists/larger-spacing.png" alt="" />
+        <img src="../../images/lists/larger-spacing.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -97,7 +97,7 @@ The icon list is really just a variant of the Unordered List, but instead of bul
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/lists/icon-list.png" alt="" />
+        <img src="../../images/lists/icon-list.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -112,7 +112,7 @@ There are three icon size choices, including small, medium, and large. These siz
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/lists/icon-sizes.png" alt="" />
+        <img src="../../images/lists/icon-sizes.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -127,7 +127,7 @@ You can align the icon with the center or top of the associated content. This la
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/lists/icon-alignment.png" alt="" />
+        <img src="../../images/lists/icon-alignment.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>

--- a/website/react-magma-docs/src/pages/design/loading-indicator.mdx
+++ b/website/react-magma-docs/src/pages/design/loading-indicator.mdx
@@ -33,7 +33,7 @@ Circular spinners are used when the amount of time needed to run a process or lo
       <figure>
         <img
           src="../../images/loading-indicators/circular-spinner.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
       </figure>
     </div>
@@ -49,7 +49,7 @@ Progress bars should be used when real progress data can be fed to it, and you a
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/loading-indicators/progress-bar.png" alt="" />
+        <img src="../../images/loading-indicators/progress-bar.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2"></div>
@@ -67,7 +67,7 @@ Many actions happen quickly, such as saving updates, submitting a form, or loadi
 If you know that it will take less than a second to complete an action, then no loading indicator is necessary. If you know the action is going to take 1 - 5 seconds to complete, you should use a circular spinner.
 
 <figure>
-  <img src="../../images/loading-indicators/Button-loading.png" alt="" />
+  <img src="../../images/loading-indicators/Button-loading.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       Replace the label in the button with the circular spinner after clicking
@@ -82,7 +82,7 @@ If you know that it will take less than a second to complete an action, then no 
 If you are loading large amounts of data like an entire page or large areas of data, the amount of time it takes to load can vary greatly. We need to effectively communicate with the user what is happening, but that takes some informed decisions on our part.
 
 <figure>
-  <img src="../../images/loading-indicators/mindtap-loading.png" alt="" />
+  <img src="../../images/loading-indicators/mindtap-loading.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       In this example, we are using a loading indicator while the Learning Path
@@ -99,7 +99,7 @@ If there is no way of measuring how long it will take in real-time, but you know
 <figure>
   <img
     src="../../images/loading-indicators/example-spinner-message.png"
-    alt=""
+    alt="GATSBY_EMPTY_ALT"
   />
   <figcaption>
     <p>Messaging should tell the user what is happening and what to expect.</p>
@@ -116,7 +116,7 @@ If you know from testing that it typically takes more than 15 seconds to load, *
 
 <figure>
   <div class="image-container">
-    <img src="../../images/progress-bars/Progress-bar-dynamic.png" alt="" />
+    <img src="../../images/progress-bars/Progress-bar-dynamic.png" alt="GATSBY_EMPTY_ALT" />
   </div>
   <figcaption>
     <p>
@@ -133,7 +133,7 @@ This component also allows for three messages, although at different intervals t
 <figure>
   <img
     src="../../images/loading-indicators/example-progress-bar-message.png"
-    alt=""
+    alt="GATSBY_EMPTY_ALT"
   />
   <figcaption>
     <p>Messaging should tell the user what is happening and what to expect.</p>

--- a/website/react-magma-docs/src/pages/design/modal.mdx
+++ b/website/react-magma-docs/src/pages/design/modal.mdx
@@ -28,13 +28,13 @@ A modal is intentionally interruptive and blocks the user from interacting with 
 
 Clearly describe the decision being made by the user, and explain any possible consequences it could cause. The primary button should also reinforce the action being taken. If the action being taken is irreversible, make that clear to the user as well. The user should also be able to cancel the action with a secondary button or closing the modal.
 
-<img src="../../images/modals/confirm-decision.png" alt="" />
+<img src="../../images/modals/confirm-decision.png" alt="GATSBY_EMPTY_ALT" />
 
 ### Edit or Manage Tasks
 
 It's very common to use a modal to quickly edit or manage one or more items on a page without going back and forth between multiple pages. The emphasis here is "quickly". If the settings or management of an item becomes relatively complex and requires many decisions or multiple steps, please consider using a separate page or something other than a modal. If a particular action is often done repeatedly, consider allowing the action to be done directly on the main page rather than in a modal.
 
-<img src="../../images/modals/edit-item-example.png" alt="" />
+<img src="../../images/modals/edit-item-example.png" alt="GATSBY_EMPTY_ALT" />
 
 ---
 
@@ -42,7 +42,7 @@ It's very common to use a modal to quickly edit or manage one or more items on a
 
 Modals come in three responsive sizes: small, medium, and large.
 
-<img src="../../images/modals/modal-sizes.png" alt="" />
+<img src="../../images/modals/modal-sizes.png" alt="GATSBY_EMPTY_ALT" />
 
 ### Small
 
@@ -86,12 +86,12 @@ Modals should always contain a way to close them, and there are typically multip
 
 When a modal is opened, the focus is automatically put on the title of the modal rather than the first actionable element. We intentionally do this to provide an optimal experience for both people using assistive technologies and those who don't.
 
-<img src="../../images/modals/modal-focus-example.png" alt="" />
+<img src="../../images/modals/modal-focus-example.png" alt="GATSBY_EMPTY_ALT" />
 
 ### Validation
 
 Always validate a user's input entries before a modal is closed. If there are any errors, an inline error alert should be displayed above the form, as well as error messages on any specific inputs that failed validation. The error messages should provide clear instructions on how to resolve the errors and complete the action.
 
-<img src="../../images/modals/modal-validation.png" alt="" />
+<img src="../../images/modals/modal-validation.png" alt="GATSBY_EMPTY_ALT" />
 
 </PageContent>

--- a/website/react-magma-docs/src/pages/design/password-input.mdx
+++ b/website/react-magma-docs/src/pages/design/password-input.mdx
@@ -15,7 +15,7 @@ import { Link } from 'gatsby';
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/password-input-example.png" alt="" />
+    <img src="../../images/inputs/password-input-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/progress-bar.mdx
+++ b/website/react-magma-docs/src/pages/design/progress-bar.mdx
@@ -25,7 +25,7 @@ To see how progress bars are used as loading indicators, view the [loading indic
 
 <figure>
   <div class="image-container">
-    <img src="../../images/progress-bars/Progress-bar-intro.png" alt="" />
+    <img src="../../images/progress-bars/Progress-bar-intro.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -35,7 +35,7 @@ To see how progress bars are used as loading indicators, view the [loading indic
 
 <figure>
   <div class="image-container">
-    <img src="../../images/progress-bars/Progress-bar-anatomy.png" alt="" />
+    <img src="../../images/progress-bars/Progress-bar-anatomy.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -58,7 +58,7 @@ The width of the progress bar is controlled by the container it is within. For m
 When a static progress bar is used, it represents the progress of something at that point in time and does not change until an explicit action is performed that updates the progress bar.
 
 <figure>
-  <img src="../../images/progress-bars/Progress-bar-static.png" alt="" />
+  <img src="../../images/progress-bars/Progress-bar-static.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       Example of using progress bar to help communicate that the user is on step
@@ -67,7 +67,7 @@ When a static progress bar is used, it represents the progress of something at t
   </figcaption>
 </figure>
 <figure>
-  <img src="../../images/progress-bars/Progress-bar-compare.png" alt="" />
+  <img src="../../images/progress-bars/Progress-bar-compare.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       Progress bars can be used to visually display the same data point for
@@ -82,7 +82,7 @@ When a static progress bar is used, it represents the progress of something at t
 When a dynamic progress bar is used, it means it's updating in real-time while you wait for a series of processes outside of your control to complete.
 
 <figure>
-  <img src="../../images/progress-bars/Progress-bar-dynamic.png" alt="" />
+  <img src="../../images/progress-bars/Progress-bar-dynamic.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       Example of using progress bar to help communicate that the data is loading
@@ -107,7 +107,7 @@ The track on the dark/inverse progress bar has a black background at 25% opacity
 
 <figure>
   <div class="image-container">
-    <img src="../../images/progress-bars/Progress-bar-colors1.png" alt="" />
+    <img src="../../images/progress-bars/Progress-bar-colors1.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/radio.mdx
+++ b/website/react-magma-docs/src/pages/design/radio.mdx
@@ -21,7 +21,7 @@ Radio buttons should have the most commonly used option selected by default.
   <div class="image-container">
     <img
       src="../../images/selection-controls/Radio-buttons-example.png"
-      alt=""
+      alt="GATSBY_EMPTY_ALT"
     />
   </div>
   <figcaption>
@@ -34,7 +34,7 @@ Radio buttons should have the most commonly used option selected by default.
       <figure>
         <img
           src="../../images/selection-controls/Radio-select-only-one.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
         <figcaption>
           <p class="title title-correct">Correct</p>
@@ -48,7 +48,7 @@ Radio buttons should have the most commonly used option selected by default.
       <figure>
         <img
           src="../../images/selection-controls/Radio-select-only-one-incorrect.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
@@ -63,7 +63,7 @@ Radio buttons should have the most commonly used option selected by default.
 </div>
 <figure>
   <div class="image-container">
-    <img src="../../images/selection-controls/Radio-example-2.png" alt="" />
+    <img src="../../images/selection-controls/Radio-example-2.png" alt="GATSBY_EMPTY_ALT" />
   </div>
   <figcaption>
     <p>Radio buttons - only one option can be selected at a time.</p>
@@ -76,7 +76,7 @@ Radio buttons can be off or on. Radio buttons have enabled, focused and pressed 
 
 <figure>
   <div class="image-container">
-    <img src="../../images/selection-controls/Radio-states.png" alt="" />
+    <img src="../../images/selection-controls/Radio-states.png" alt="GATSBY_EMPTY_ALT" />
   </div>
   <figcaption>
     <p>Radio states</p>
@@ -89,7 +89,7 @@ Use the inverse version when using the radio buttons on a dark background.
 
 <figure>
   <div class="image-container">
-    <img src="../../images/selection-controls/Radio-inverse.png" alt="" />
+    <img src="../../images/selection-controls/Radio-inverse.png" alt="GATSBY_EMPTY_ALT" />
   </div>
   <figcaption>
     <p>Inverse colors</p>

--- a/website/react-magma-docs/src/pages/design/search.mdx
+++ b/website/react-magma-docs/src/pages/design/search.mdx
@@ -29,12 +29,12 @@ Set the user’s context for the search with helpful placeholder text within the
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/inputs/header-search.png" alt="" />
+        <img src="../../images/inputs/header-search.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/inputs/inline-search.png" alt="" />
+        <img src="../../images/inputs/inline-search.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>

--- a/website/react-magma-docs/src/pages/design/stepper.mdx
+++ b/website/react-magma-docs/src/pages/design/stepper.mdx
@@ -18,7 +18,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 Steppers aid in guiding a user's expectations while navigating through a multistep process. They indicate the current step, the total number of steps, and the overall progress towards task completion.
 
 <figure>
-  <img src="../../images/stepper/stepper-intro.png" alt="" />
+  <img src="../../images/stepper/stepper-intro.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### When to use
@@ -43,7 +43,7 @@ Steppers aid in guiding a user's expectations while navigating through a multist
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/stepper/step-anatomy.png" alt="" />
+        <img src="../../images/stepper/step-anatomy.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -65,7 +65,7 @@ Steppers aid in guiding a user's expectations while navigating through a multist
 The default placement of the labels is under each status indicator on the line. This layout benefits from short labels, especially as the number of steps increases.
 
 <figure>
-  <img src="../../images/stepper/standard-labels.png" alt="" />
+  <img src="../../images/stepper/standard-labels.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 #### No Labels
@@ -73,7 +73,7 @@ The default placement of the labels is under each status indicator on the line. 
 If the nature of the labels would simply be too much text to reasonably fit, then it is acceptable to hide the labels on the stepper component. However, this means having clear titles within the content of the step itself is extremely important. It can be helpful to change to this layout on small screens.
 
 <figure>
-  <img src="../../images/stepper/no-labels.png" alt="" />
+  <img src="../../images/stepper/no-labels.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 #### Summary View
@@ -81,7 +81,7 @@ If the nature of the labels would simply be too much text to reasonably fit, the
 The step summary layout shows the primary and secondary labels, but only for the step you are currently on. It also tells you what number step you are on, and how many steps there are in total. This layout can be a nice middle-point between showing all labels and not showing labels at all, and you can use it on large or small screens.
 
 <figure>
-  <img src="../../images/stepper/summary-view.png" alt="" />
+  <img src="../../images/stepper/summary-view.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Placement
@@ -89,15 +89,15 @@ The step summary layout shows the primary and secondary labels, but only for the
 The stepper component can be placed on a full page, in a modal, or in a side panel.
 
 <figure>
-  <img src="../../images/stepper/placement-full-page.png" alt="" />
+  <img src="../../images/stepper/placement-full-page.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 <figure>
-  <img src="../../images/stepper/placement-side-panel.png" alt="" />
+  <img src="../../images/stepper/placement-side-panel.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 <figure>
-  <img src="../../images/stepper/placement-modal.png" alt="" />
+  <img src="../../images/stepper/placement-modal.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -114,7 +114,7 @@ The label should succinctly convey the user's objectives for each step in one or
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/stepper/primary-label.png" alt="" />
+        <img src="../../images/stepper/primary-label.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -130,7 +130,7 @@ Secondary labels are optional and should be used if some additional description 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/stepper/secondary-label.png" alt="" />
+        <img src="../../images/stepper/secondary-label.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -148,7 +148,7 @@ When there isn’t enough space, the labels will wrap to as many lines as necess
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/stepper/text-wrap.png" alt="" />
+        <img src="../../images/stepper/text-wrap.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -172,7 +172,7 @@ A step is complete when a user has filled out the required information within a 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/stepper/step-complete.png" alt="" />
+        <img src="../../images/stepper/step-complete.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -188,7 +188,7 @@ A step is current when a user is interacting with the information within that st
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/stepper/step-active.png" alt="" />
+        <img src="../../images/stepper/step-active.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -204,7 +204,7 @@ A step is not started when a user has not yet interacted with that step. Steps t
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/stepper/step-incomplete.png" alt="" />
+        <img src="../../images/stepper/step-incomplete.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -220,7 +220,7 @@ A step may be in error when a user has entered invalid or incomplete information
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/stepper/step-error.png" alt="" />
+        <img src="../../images/stepper/step-error.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -235,7 +235,7 @@ Currently, the stepper is not interactive, providing only a visual update of the
 A common example includes buttons labeled as “Next” and “Back”, and often ending with a button labeled “Finish.” But the labels themselves need to make sense for the process being completed, so there isn’t any mandated language to use. You can also choose to not include a “Back” button if you don’t want the user to go back to previous steps. Whatever you do, we suggest conducting usability tests to ensure you have created the best experience possible. 
 
 <figure>
-  <img src="../../images/stepper/step-navigation.png" alt="" />
+  <img src="../../images/stepper/step-navigation.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Validation
@@ -245,7 +245,7 @@ When possible, use validation to confirm that a step has been completed before t
 If the user cannot proceed due to a server-side issue, then an inline alert should appear. 
 
 <figure>
-  <img src="../../images/stepper/validation-error.png" alt="" />
+  <img src="../../images/stepper/validation-error.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Responsive Behavior
@@ -258,7 +258,7 @@ If you don’t have very many steps and the labels are short, it is very possibl
 
 <figure>
   <div class="image-container">
-    <img src="../../images/stepper/mobile-standard-labels.png" alt="" />
+    <img src="../../images/stepper/mobile-standard-labels.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure> 
 
@@ -268,7 +268,7 @@ Hiding the labels on small screens is acceptable, but only if you are using very
 
 <figure>
   <div class="image-container">
-    <img src="../../images/stepper/mobile-no-labels.png" alt="" />
+    <img src="../../images/stepper/mobile-no-labels.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -278,7 +278,7 @@ This may be the most common format for small screens or zooming in. You only dis
 
 <figure>
   <div class="image-container">
-    <img src="../../images/stepper/mobile-summary-view.png" alt="" />
+    <img src="../../images/stepper/mobile-summary-view.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>  
 

--- a/website/react-magma-docs/src/pages/design/table.mdx
+++ b/website/react-magma-docs/src/pages/design/table.mdx
@@ -42,7 +42,7 @@ Tables display information in a grid-like format of rows and columns. They organ
 ## Anatomy
 
 <figure>
-  <img src="../../images/tables/table-anatomy.png" alt="" />
+  <img src="../../images/tables/table-anatomy.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 1. Table title
@@ -56,7 +56,7 @@ Tables display information in a grid-like format of rows and columns. They organ
 Tables come in three different sizes or densities: compact, normal, and loose. This is applied to the entire table and not just a specific row or cell.
 
 <figure>
-  <img src="../../images/tables/table-densities.png" alt="" />
+  <img src="../../images/tables/table-densities.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Compact Density
@@ -64,7 +64,7 @@ Tables come in three different sizes or densities: compact, normal, and loose. T
 The compact density can be useful for tables with a relatively large number of columns and rows by allowing you to simply fit more on the screen at once.
 
 <figure>
-  <img src="../../images/tables/compact-density.png" alt="" />
+  <img src="../../images/tables/compact-density.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Normal Density
@@ -72,7 +72,7 @@ The compact density can be useful for tables with a relatively large number of c
 The default padding of tables is optimized for a nice balance between compact and loose densities.
 
 <figure>
-  <img src="../../images/tables/normal-density.png" alt="" />
+  <img src="../../images/tables/normal-density.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Loose Density
@@ -80,7 +80,7 @@ The default padding of tables is optimized for a nice balance between compact an
 The loose density can be useful if you have a relatively small amount of data and if the user would benefit from the table having more white-space within it.
 
 <figure>
-  <img src="../../images/tables/loose-density.png" alt="" />
+  <img src="../../images/tables/loose-density.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -96,12 +96,12 @@ The loose density can be useful if you have a relatively small amount of data an
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/tables/table-title.png" alt="" />
+        <img src="../../images/tables/table-title.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/tables/table-description.png" alt="" />
+        <img src="../../images/tables/table-description.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -113,13 +113,13 @@ The loose density can be useful if you have a relatively small amount of data an
 - In cases where a column title is too long, the text will wrap to two lines.
 
 <figure>
-  <img src="../../images/tables/column-titles.png" alt="" />
+  <img src="../../images/tables/column-titles.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 <div class="two-col">
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/tables/column-header-truncate.png" alt="" />
+        <img src="../../images/tables/column-header-truncate.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>Don't truncate column titles.</p>
@@ -128,7 +128,7 @@ The loose density can be useful if you have a relatively small amount of data an
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/tables/column-header-wrap.png" alt="" />
+        <img src="../../images/tables/column-header-wrap.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>Let long column titles wrap naturally.</p>
@@ -153,7 +153,7 @@ The loose density can be useful if you have a relatively small amount of data an
 Striped rows (zebra striping) is an optional styling you may apply to your table. This can make data-heavy tables easier for your user to read, as the stripes help guide the eye across the table and then back to the next row.
 
 <figure>
-  <img src="../../images/tables/striped-rows.png" alt="" />
+  <img src="../../images/tables/striped-rows.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Hover
@@ -161,7 +161,7 @@ Striped rows (zebra striping) is an optional styling you may apply to your table
 The table’s row hover state can help your user visually scan the columns of data in a row even if the row is not interactive. This feature is optional and is easily enabled for any table, and may be used in combination with striped rows.
 
 <figure>
-  <img src="../../images/tables/row-hover.png" alt="" />
+  <img src="../../images/tables/row-hover.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Sorting
@@ -171,7 +171,7 @@ Columns can be sorted in ascending or descending order. Sorting controls are loc
 A sorted table has three states: unsorted (sort-double-arrow), sorted-up (arrow-upward) or sorted-down (arrow-downward). The icon indicates the current sorted state. All sortable columns display an arrow icon, but only one can be actively sorted at a time.
 
 <figure>
-  <img src="../../images/tables/table-sorting.png" alt="" />
+  <img src="../../images/tables/table-sorting.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ### Inline Actions
@@ -182,12 +182,12 @@ Inline actions are functions that may be performed on a specific table row. In o
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/tables/inline-actions.png" alt="" />
+        <img src="../../images/tables/inline-actions.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/tables/inline-actions-overflow.png" alt="" />
+        <img src="../../images/tables/inline-actions-overflow.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>

--- a/website/react-magma-docs/src/pages/design/tabs.mdx
+++ b/website/react-magma-docs/src/pages/design/tabs.mdx
@@ -22,7 +22,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 ## Anatomy
 
 <figure>
-  <img src="../../images/tabs/tabs-anatomy.png" alt="" aria-hidden="true" />
+  <img src="../../images/tabs/tabs-anatomy.png" alt="GATSBY_EMPTY_ALT" aria-hidden="true" />
 </figure>
 
 1. Tab
@@ -40,7 +40,7 @@ Text labels should clearly and succinctly describe the content they represent. T
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/tabs/tabs-line-wrap.png" alt="" />
+        <img src="../../images/tabs/tabs-line-wrap.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-caution">Caution</p>
           <p>
@@ -52,7 +52,7 @@ Text labels should clearly and succinctly describe the content they represent. T
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/tabs/tabs-resize-text.png" alt="" />
+        <img src="../../images/tabs/tabs-resize-text.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -65,7 +65,7 @@ Text labels should clearly and succinctly describe the content they represent. T
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/tabs/tabs-truncate-text.png" alt="" />
+        <img src="../../images/tabs/tabs-truncate-text.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -77,7 +77,7 @@ Text labels should clearly and succinctly describe the content they represent. T
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/tabs/tabs-icon-and-text-incorrect.png" alt="" />
+        <img src="../../images/tabs/tabs-icon-and-text-incorrect.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -99,7 +99,7 @@ Icons can be very helpful in helping identify the type or context of the content
 Icons can be placed to the left of the label or on top of the label, depending on the desired outcome or constraints of the layout. The added space required by the icon requires even greater effort to make the text label as short as possible.
 
 <figure>
-  <img src="../../images/tabs/tabs-icon-and-text.png" alt="" />
+  <img src="../../images/tabs/tabs-icon-and-text.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       Icons and text labels can be used together to help communicate what the
@@ -109,7 +109,7 @@ Icons can be placed to the left of the label or on top of the label, depending o
 </figure>
 <span class="horizontal-spacer"></span>
 <figure>
-  <img src="../../images/tabs/tabs-icon-and-label-stacked.png" alt="" />
+  <img src="../../images/tabs/tabs-icon-and-label-stacked.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       Icons can be stacked on top of the label which saves horizontal space, but
@@ -123,7 +123,7 @@ Icons can be placed to the left of the label or on top of the label, depending o
 Icon-only tabs can be very useful for communicating the content they represent, especially in small areas or on small devices.
 
 <figure>
-  <img src="../../images/tabs/tabs-icon-only.png" alt="" />
+  <img src="../../images/tabs/tabs-icon-only.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p class="title title-caution">Caution</p>
     <p>
@@ -142,7 +142,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/tabs/tabs-active-indicator-bottom.png" alt="" />
+        <img src="../../images/tabs/tabs-active-indicator-bottom.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>The indicator appears on the bottom of the tab by default.</p>
@@ -151,7 +151,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/tabs/tabs-active-indicator-top.png" alt="" />
+        <img src="../../images/tabs/tabs-active-indicator-top.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-caution">Caution</p>
           <p>
@@ -172,7 +172,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
 ## States
 
 <figure>
-  <img src="../../images/tabs/tabs-states.png" alt="" />
+  <img src="../../images/tabs/tabs-states.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 1. Inactive
@@ -188,14 +188,14 @@ The active tab indicator helps make it very clear which tab is currently selecte
 Tabs are displayed in a single row or column, with each tab connected to the content they represent. Tabs can be attached to headers, main content areas, side panels, and nestled into cards.
 
 <figure>
-  <img src="../../images/tabs/tabs-header.png" alt="" />
+  <img src="../../images/tabs/tabs-header.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>Example of tabs in the header of a panel.</p>
   </figcaption>
 </figure>
 <span class="horizontal-spacer"></span>
 <figure>
-  <img src="../../images/tabs/tabs-column.png" alt="" />
+  <img src="../../images/tabs/tabs-column.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>Example of tabs in a column.</p>
   </figcaption>
@@ -205,7 +205,7 @@ Tabs are displayed in a single row or column, with each tab connected to the con
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/tabs/nesting-tabs-wrong.png" alt="" />
+        <img src="../../images/tabs/nesting-tabs-wrong.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>Don't nest tabs to create multiple levels.</p>
@@ -214,7 +214,7 @@ Tabs are displayed in a single row or column, with each tab connected to the con
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/tabs/stacking-tabs-wrong.png" alt="" />
+        <img src="../../images/tabs/stacking-tabs-wrong.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>Don't stack tabs meant to be horizontal on top of each other.</p>
@@ -237,21 +237,21 @@ The default width of a tab is undefined and is determined by the content within 
 Auto-width tabs can be left-aligned, right-aligned, or centered.
 
 <figure>
-  <img src="../../images/tabs/tabs-left-aligned.png" alt="" />
+  <img src="../../images/tabs/tabs-left-aligned.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>By default, auto-width tabs are left aligned.</p>
   </figcaption>
 </figure>
 <span class="horizontal-spacer"></span>
 <figure>
-  <img src="../../images/tabs/tabs-right-aligned.png" alt="" />
+  <img src="../../images/tabs/tabs-right-aligned.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>You may also right-align the tabs with the content below or above.</p>
   </figcaption>
 </figure>
 <span class="horizontal-spacer"></span>
 <figure>
-  <img src="../../images/tabs/tabs-centered.png" alt="" />
+  <img src="../../images/tabs/tabs-centered.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>On wider layouts, centering the tabs may work well.</p>
   </figcaption>
@@ -262,7 +262,7 @@ Auto-width tabs can be left-aligned, right-aligned, or centered.
 The tab container for auto-width tabs will automatically scroll if the container becomes too small to show all the tabs. Buttons to scroll left and right will automatically be added, but users with touch-based devices will also be able to drag the tab container left and right.
 
 <figure>
-  <img src="../../images/tabs/horizontal-scrolling-tabs.png" alt="" />
+  <img src="../../images/tabs/horizontal-scrolling-tabs.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       If there are more tabs to see beyond the edge of the container, you will
@@ -276,14 +276,14 @@ The tab container for auto-width tabs will automatically scroll if the container
 Full-width tabs can be calculated by the width of the container divided by the number of tabs. Full-width tabs should only be used if you can guarantee that all tabs will be visible without truncation regardless of the size of the container.
 
 <figure>
-  <img src="../../images/tabs/tabs-full-width.png" alt="" />
+  <img src="../../images/tabs/tabs-full-width.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>Simple example of full-width tabs, each tab being of equal width.</p>
   </figcaption>
 </figure>
 <span class="horizontal-spacer"></span>
 <figure>
-  <img src="../../images/tabs/tabs-alignment-with-content.png" alt="" />
+  <img src="../../images/tabs/tabs-alignment-with-content.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p class="title title-caution">Caution</p>
     <p>
@@ -301,7 +301,7 @@ Tabs may also be placed to the left of their corresponding content in a vertical
 **NOTE:** There isn’t any default Responsive behavior for when the content area gets too narrow to display the tabs next to the content. You are encouraged to reuse solutions from other instances of vertical tabs. In the event no solution exists that will work in your scenario, a new solution will have to be designed.
 
 <figure>
-  <img src="../../images/tabs/tabs-vertical.png" alt="" />
+  <img src="../../images/tabs/tabs-vertical.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>Simple example of vertical tabs on the left side of the content.</p>
   </figcaption>
@@ -312,7 +312,7 @@ Tabs may also be placed to the left of their corresponding content in a vertical
 Vertical tabs will also automatically scroll when the height of their container is too small to display all of the tabs.
 
 <figure>
-  <img src="../../images/tabs/tabs-vertical-scrolling.png" alt="" />
+  <img src="../../images/tabs/tabs-vertical-scrolling.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>
       If there are more tabs to see beyond the bottom of the container, you will
@@ -328,7 +328,7 @@ Vertical tabs will also automatically scroll when the height of their container 
 The tabs have inverse styling available for use on dark backgrounds. Take care with the color you choose for the background to make sure the necessary contrast ratios are upheld for accessibility compliance.
 
 <figure>
-  <img src="../../images/tabs/tabs-inverse-example.png" alt="" />
+  <img src="../../images/tabs/tabs-inverse-example.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>Example of tabs on a dark blue background.</p>
   </figcaption>

--- a/website/react-magma-docs/src/pages/design/time-picker.mdx
+++ b/website/react-magma-docs/src/pages/design/time-picker.mdx
@@ -19,7 +19,7 @@ The Time input gives the user the ability to input a time in a format the develo
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/time-input-example.png" alt="" />
+    <img src="../../images/inputs/time-input-example.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -29,7 +29,7 @@ You can tab into the Time input to individually manipulate the hours, minutes, a
 
 <figure>
   <div class="image-container">
-    <img src="../../images/inputs/time-input-keyboard.png" alt="" />
+    <img src="../../images/inputs/time-input-keyboard.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/toast.mdx
+++ b/website/react-magma-docs/src/pages/design/toast.mdx
@@ -20,7 +20,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 Toasts are the least intrusive of the three types of alerts and are used primarily for communicating non-critical information to the user. Toasts appear in the lower-left corner of the viewport.
 
 <figure>
-  <img src="../../images/alerts/toast-alert-example.png" alt="" />
+  <img src="../../images/alerts/toast-alert-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---
@@ -30,7 +30,7 @@ Toasts are the least intrusive of the three types of alerts and are used primari
 The basic anatomy of the alert is the same across all three types (banner, inline, toast).
 
 <figure>
-  <img src="../../images/alerts/alert-anatomy.png" alt="" />
+  <img src="../../images/alerts/alert-anatomy.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 1. Container
@@ -46,7 +46,7 @@ The basic anatomy of the alert is the same across all three types (banner, inlin
 If multiple toasts are triggered, they will automatically stack vertically. When at all possible, try to group batch-like actions into a single toast instead of triggering multiple alerts.
 
 <figure>
-  <img src="../../images/alerts/stack-toasts-incorrect.png" alt="" />
+  <img src="../../images/alerts/stack-toasts-incorrect.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p class="title title-incorrect">Incorrect</p>
     <p>
@@ -56,7 +56,7 @@ If multiple toasts are triggered, they will automatically stack vertically. When
   </figcaption>
 </figure>
 <figure>
-  <img src="../../images/alerts/batch-actions-toast.png" alt="" />
+  <img src="../../images/alerts/batch-actions-toast.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p class="title title-correct">Correct</p>
     <p>Combine the results from a single action into a single toast alert.</p>
@@ -77,7 +77,7 @@ Avoid displaying errors or warnings with toasts, but if you have to, then these 
       <figure>
         <img
           src="../../images/alerts/toast-error-manually-dismiss.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
         <figcaption>
           <p class="title title-correct">Correct</p>
@@ -92,7 +92,7 @@ Avoid displaying errors or warnings with toasts, but if you have to, then these 
       <figure>
         <img
           src="../../images/alerts/toast-successful-auto-dismiss.png"
-          alt=""
+          alt="GATSBY_EMPTY_ALT"
         />
         <figcaption>
           <p class="title title-correct">Correct</p>
@@ -125,7 +125,7 @@ Take the following guidelines into consideration when crafting your message:
 When the viewport is 600px wide and smaller, we automatically reduce the icon and font size to optimize the amount of space given to the message and optional links or buttons in the alert. The toast will also automatically stretch to 100% of the viewport width with spacing around it.
 
 <figure>
-  <img src="../../images/alerts/mobile-toast-alert-example.png" alt="" />
+  <img src="../../images/alerts/mobile-toast-alert-example.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
 
 ---

--- a/website/react-magma-docs/src/pages/design/toggle.mdx
+++ b/website/react-magma-docs/src/pages/design/toggle.mdx
@@ -19,7 +19,7 @@ Toggle switches are a great way to adjust settings when you are simply turning s
   <div class="image-container">
     <img
       src="../../images/selection-controls/Toggle-switch-example.png"
-      alt=""
+      alt="GATSBY_EMPTY_ALT"
     />
   </div>
   <figcaption>
@@ -35,7 +35,7 @@ Toggles can be on, off, or disabled.
   <div class="image-container">
     <img
       src="../../images/selection-controls/Toggle-switch-states.png"
-      alt=""
+      alt="GATSBY_EMPTY_ALT"
     />
   </div>
   <figcaption>

--- a/website/react-magma-docs/src/pages/design/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/design/tooltip.mdx
@@ -23,7 +23,7 @@ Tooltips are necessary for interactive elements whose function may not be clearl
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/tooltips/Tooltip-imagery.png" alt="" />
+        <img src="../../images/tooltips/Tooltip-imagery.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>Use tooltips for interactive imagery like icon buttons.</p>
@@ -32,7 +32,7 @@ Tooltips are necessary for interactive elements whose function may not be clearl
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/tooltips/Tooltip-repeat-word.png" alt="" />
+        <img src="../../images/tooltips/Tooltip-repeat-word.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>Don’t use tooltips to restate visible UI text.</p>

--- a/website/react-magma-docs/src/pages/design/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/design/tree-view.mdx
@@ -19,7 +19,7 @@ A tree view comprises nested heading levels, establishing a content hierarchy fo
 
 <figure>
   <div class="image-container">
-    <img src="../../images/treeview/intro-image.png" alt="" />
+    <img src="../../images/treeview/intro-image.png" alt="GATSBY_EMPTY_ALT" />
   </div>
 </figure>
 
@@ -46,7 +46,7 @@ When dealing with a single level of nested information, consider utilizing an al
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/treeview/anatomy.png" alt="" />
+        <img src="../../images/treeview/anatomy.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -70,7 +70,7 @@ Nodes stack directly on top of each other with 0px space between them. Having no
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/treeview/stacking-nodes.png" alt="" />
+        <img src="../../images/treeview/stacking-nodes.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -86,12 +86,12 @@ Nested nodes in a tree view rely on organized and consistent alignment to group 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/treeview/nesting-alignment-1.png" alt="" />
+        <img src="../../images/treeview/nesting-alignment-1.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/treeview/nesting-alignment-1-1.png" alt="" />
+        <img src="../../images/treeview/nesting-alignment-1-1.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -117,7 +117,7 @@ Icons can be a helpful way of scanning a list for various item types. Icons shou
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/treeview/node-icons-correct.png" alt="" />
+        <img src="../../images/treeview/node-icons-correct.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-correct">Correct</p>
           <p>
@@ -128,7 +128,7 @@ Icons can be a helpful way of scanning a list for various item types. Icons shou
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/treeview/node-icons-wrong.png" alt="" />
+        <img src="../../images/treeview/node-icons-wrong.png" alt="GATSBY_EMPTY_ALT" />
         <figcaption>
           <p class="title title-incorrect">Incorrect</p>
           <p>
@@ -152,12 +152,12 @@ Branch nodes and leaf nodes exhibit identical styles across various states. The 
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/treeview/single-select-states.png" alt="" />
+        <img src="../../images/treeview/single-select-states.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
       <figure>
-        <img src="../../images/treeview/multi-select-states.png" alt="" />
+        <img src="../../images/treeview/multi-select-states.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
   </div>
@@ -177,7 +177,7 @@ To expand or collapse a branch node the user can click anywhere within the arrow
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/treeview/expanding-behavior.png" alt="" />
+        <img src="../../images/treeview/expanding-behavior.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">
@@ -194,7 +194,7 @@ To expand or collapse a branch node the user can click anywhere within the arrow
   <div class="row">
     <div class="col col-1">
       <figure>
-        <img src="../../images/treeview/selecting-behavior.png" alt="" />
+        <img src="../../images/treeview/selecting-behavior.png" alt="GATSBY_EMPTY_ALT" />
       </figure>
     </div>
     <div class="col col-2">


### PR DESCRIPTION
Issue: #1349

## What I did
replace empty alts with "GATSBY_EMPTY_ALT"

## Screenshots:
![image](https://github.com/user-attachments/assets/12cc64f3-b94f-4760-8bc3-c9cb6d1fd12b)

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
navigate to a page that contains decorative images with empty alts like "/design/button/" and check for image alts
