### PR TITLE
fix(ProgressBar): Remove the animation if the user has a `prefers-reduced-motion` media query set.

### DIFF
--- a/.changeset/a11y-progressBar-animation.md
+++ b/.changeset/a11y-progressBar-animation.md
@@ -1,5 +1,5 @@
 ---
-'react-magma-dom': patch
+'react-magma-docs': patch
 ---
 
 fix(ProgressBar): Remove animation if the user has `prefers-reduced-motion` media query set.

--- a/.changeset/a11y-progressBar-animation.md
+++ b/.changeset/a11y-progressBar-animation.md
@@ -1,5 +1,5 @@
 ---
-'react-magma-docs': patch
+'react-magma-dom': patch
 ---
 
 fix(ProgressBar): Remove animation if the user has `prefers-reduced-motion` media query set.

--- a/.changeset/a11y-progressBar-animation.md
+++ b/.changeset/a11y-progressBar-animation.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(ProgressBar): Remove animation if the user has `prefers-reduced-motion` media query set.

--- a/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.test.js
+++ b/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.test.js
@@ -118,10 +118,18 @@ describe('ProgressBar', () => {
     );
   });
 
-  it('should render the progress bar component shimmer animation', () => {
+  it('should render the progress bar component shimmer animation', async () => {
     const { container } = render(<ProgressBar percentage={50} isAnimated />);
 
     expect(container.querySelector('[role="progressbar"]')).toHaveStyleRule(
+      'animation-name',
+      'placeholderShimmer',
+      {
+        media: 'prefers-reduced-motion: no-preference',
+      }
+    );
+
+    expect(container.querySelector('[role="progressbar"]')).not.toHaveStyleRule(
       'animation-name',
       'placeholderShimmer'
     );

--- a/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.test.js
+++ b/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.test.js
@@ -118,7 +118,7 @@ describe('ProgressBar', () => {
     );
   });
 
-  it('should render the progress bar component shimmer animation', async () => {
+  it('should render the progress bar component with shimmer animation according to the prefers-reduced-motion query', () => {
     const { container } = render(<ProgressBar percentage={50} isAnimated />);
 
     expect(container.querySelector('[role="progressbar"]')).toHaveStyleRule(

--- a/packages/react-magma-dom/src/components/ProgressBar/index.tsx
+++ b/packages/react-magma-dom/src/components/ProgressBar/index.tsx
@@ -108,37 +108,39 @@ const Bar = styled.div<ProgressBarProps>`
   transition: width 0.3s;
   width: ${props => props.percentage}%;
 
-  ${props =>
-    props.isAnimated &&
-    css`
-      background-image: linear-gradient(
-        to right,
-        ${buildProgressBarBackground(props)} 0%,
-        rgba(255, 255, 255, 0.5) 20%,
-        ${buildProgressBarBackground(props)} 40%,
-        ${buildProgressBarBackground(props)} 100%
-      );
-      background-repeat: no-repeat;
-      background-size: 1800px 104px;
-      display: inline-block;
-      position: relative;
+  @media (prefers-reduced-motion: no-preference) {
+    ${props =>
+      props.isAnimated &&
+      css`
+        background-image: linear-gradient(
+          to right,
+          ${buildProgressBarBackground(props)} 0%,
+          rgba(255, 255, 255, 0.5) 20%,
+          ${buildProgressBarBackground(props)} 40%,
+          ${buildProgressBarBackground(props)} 100%
+        );
+        background-repeat: no-repeat;
+        background-size: 1800px 104px;
+        display: inline-block;
+        position: relative;
 
-      animation-duration: 1s;
-      animation-fill-mode: forwards;
-      animation-iteration-count: infinite;
-      animation-name: placeholderShimmer;
-      animation-timing-function: linear;
+        animation-duration: 1s;
+        animation-fill-mode: forwards;
+        animation-iteration-count: infinite;
+        animation-name: placeholderShimmer;
+        animation-timing-function: linear;
 
-      @keyframes placeholderShimmer {
-        0% {
-          background-position: -600px 0;
+        @keyframes placeholderShimmer {
+          0% {
+            background-position: -600px 0;
+          }
+
+          100% {
+            background-position: 600px 0;
+          }
         }
-
-        100% {
-          background-position: 600px 0;
-        }
-      }
-    `}
+      `}
+  }
 `;
 
 const Percentage = styled.span`

--- a/packages/react-magma-dom/src/components/Select/SelectContainer.tsx
+++ b/packages/react-magma-dom/src/components/Select/SelectContainer.tsx
@@ -29,7 +29,6 @@ export const SelectContainerElement = styled.div<{
 
 const InputMessageContainer = styled.div`
   flex-grow: 1;
-  /* overflow: hidden; */
   padding: 0.25em;
   margin: -0.25em;
   min-width: 0%;

--- a/website/react-magma-docs/src/pages/api/progress-bar.mdx
+++ b/website/react-magma-docs/src/pages/api/progress-bar.mdx
@@ -64,6 +64,8 @@ export function Example() {
 
 ## Animated
 
+The `isAnimated` prop can be used to set animation in the progress bar. Because of the problems that animation can create for people who are sensitive to such things, we automatically disable it in the progress bar if we detect that the `prefers-reduced-motion` media query is set.
+
 ```tsx
 import React from 'react';
 import { ProgressBar } from 'react-magma-dom';


### PR DESCRIPTION
Issue: #1242

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Remove the animation if the user has a `prefers-reduced-motion` media query set. 

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->