### PR TITLE
fix(combobox): Fix focus issue after triggering the clear button

### DIFF
--- a/.changeset/a11y-combobox-clear-focus.md
+++ b/.changeset/a11y-combobox-clear-focus.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(combobox): Fix focus issue after triggering the clear button

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
@@ -240,7 +240,10 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
     event.stopPropagation();
 
     if (inputRef.current) {
-      inputRef.current.focus();
+      const inputElement = inputRef.current.querySelector('input');
+      if (inputElement) {
+        inputElement.focus();
+      }
     }
 
     reset();

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -308,7 +308,10 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
     event.stopPropagation();
 
     if (inputRef.current) {
-      inputRef.current.focus();
+      const inputElement = inputRef.current.querySelector('input');
+      if (inputElement) {
+        inputElement.focus();
+      }
     }
 
     reset();


### PR DESCRIPTION
Issue: #1234

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

After interacting with the clear button, the focus was returning to the container instead of the input field. The focus has been restored to the input for both the combobox and the multiselect combobox.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->

1. Navigate to Components > Combobox > Clearable
2. Tab to the input
3. Press Space bar and the panel of choices opens
4. Press Enter to select an option
5. Tab to the Clear button
6. Press Enter to clear the input
7. The Clear button disappears and the focus goes back to the input
