### PR TITLE
fix(drawer): Fix focus return to the trigger button after the drawer closes

### DIFF
--- a/.changeset/a11y-docs-drawer-focus.md
+++ b/.changeset/a11y-docs-drawer-focus.md
@@ -1,0 +1,7 @@
+---
+'react-magma-docs': patch
+---
+
+fix(drawer): Corrected examples for a `drawer` component to ensure focus returns to the opening button after the `drawer` closes.
+
+.

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
@@ -23,12 +23,16 @@ export default info;
 
 export const Default = args => {
   const [showDrawer, setShowDrawer] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
 
   return (
     <>
       <Drawer
         header="Drawer Title"
-        onClose={() => setShowDrawer(false)}
+        onClose={() => {
+          setShowDrawer(false);
+          buttonRef.current.focus();
+        }}
         isOpen={showDrawer}
         closeAriaLabel="Close drawer"
         {...args}
@@ -38,7 +42,7 @@ export const Default = args => {
           <Button>This is a button</Button>
         </p>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)}>
+      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
         Show Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
@@ -48,11 +52,15 @@ export const Default = args => {
 
 export const SiteNavigation = args => {
   const [showDrawer, setShowDrawer] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
 
   return (
     <>
       <Drawer
-        onClose={() => setShowDrawer(false)}
+        onClose={() => {
+          setShowDrawer(false);
+          buttonRef.current.focus();
+        }}
         isOpen={showDrawer}
         position={DrawerPosition.right}
         ariaLabel="Site Navigation Drawer"
@@ -65,7 +73,7 @@ export const SiteNavigation = args => {
           <NavTab to="#">Four</NavTab>
         </NavTabs>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)}>
+      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
         Show Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>

--- a/website/react-magma-docs/src/pages/api/drawer.mdx
+++ b/website/react-magma-docs/src/pages/api/drawer.mdx
@@ -17,10 +17,16 @@ Drawer accepts a position (top, right, bottom, or left)
 
 ```typescript
 import React from 'react';
-import { Button, Drawer, DrawerPosition, VisuallyHidden } from 'react-magma-dom';
+import {
+  Button,
+  Drawer,
+  DrawerPosition,
+  VisuallyHidden,
+} from 'react-magma-dom';
 
 export function Example() {
   const [showDrawer, setShowDrawer] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
 
   return (
     <>
@@ -28,7 +34,10 @@ export function Example() {
         closeAriaLabel="Close drawer"
         header="Drawer Title"
         isOpen={showDrawer}
-        onClose={() => setShowDrawer(false)}
+        onClose={() => {
+          setShowDrawer(false);
+          buttonRef.current.focus();
+        }}
         position={DrawerPosition.bottom}
       >
         <p>This is a Drawer, doing Drawer things.</p>
@@ -36,7 +45,7 @@ export function Example() {
           <Button>This is a button</Button>
         </p>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)}>
+      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
         Show Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
@@ -60,6 +69,7 @@ import {
 } from 'react-magma-dom';
 export function Example() {
   const [showDrawer, setShowDrawer] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
 
   return (
     <>
@@ -67,7 +77,10 @@ export function Example() {
         ariaLabel="drawer"
         closeAriaLabel="Close drawer"
         isOpen={showDrawer}
-        onClose={() => setShowDrawer(false)}
+        onClose={() => {
+          setShowDrawer(false);
+          buttonRef.current.focus();
+        }}
         position={DrawerPosition.right}
       >
         <NavTabs orientation={TabsOrientation.vertical}>
@@ -77,7 +90,7 @@ export function Example() {
           <NavTab to="#">Four</NavTab>
         </NavTabs>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)}>
+      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
         Show Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
@@ -101,6 +114,7 @@ import {
 
 export function Example() {
   const [showDrawer, setShowDrawer] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
 
   return (
     <Card isInverse>
@@ -110,7 +124,10 @@ export function Example() {
           header="Drawer Title"
           isInverse
           isOpen={showDrawer}
-          onClose={() => setShowDrawer(false)}
+          onClose={() => {
+            setShowDrawer(false);
+            buttonRef.current.focus();
+          }}
           position={DrawerPosition.right}
         >
           <p>This is a Drawer, doing Drawer things.</p>
@@ -118,7 +135,7 @@ export function Example() {
             <Button isInverse>This is a button</Button>
           </p>
         </Drawer>
-        <Button onClick={() => setShowDrawer(true)} isInverse>
+        <Button onClick={() => setShowDrawer(true)} ref={buttonRef} isInverse>
           Show Drawer
           <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
         </Button>
@@ -146,25 +163,29 @@ import { I18nContext, defaultI18n } from 'react-magma-dom';
 
 export function Example() {
   const [showDrawer, setShowDrawer] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
 
   return (
     <I18nContext.Provider
       value={{
         ...defaultI18n,
         modal: {
-          closeAriaLabel: 'Cerrar'
-        }
+          closeAriaLabel: 'Cerrar',
+        },
       }}
     >
       <Drawer
         header="Drawer Title"
         isOpen={showDrawer}
-        onClose={() => setShowDrawer(false)}
+        onClose={() => {
+          setShowDrawer(false);
+          buttonRef.current.focus();
+        }}
         position={DrawerPosition.bottom}
       >
         <p>override default i18n value:</p>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)}>
+      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
         Show Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>


### PR DESCRIPTION

Issue: #1240

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
fix(drawer): Corrected examples for a `drawer` component to ensure focus returns to the opening button after the `drawer` closes.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
