### PR TITLE
feat(treeview): add support for isDisabled

### DIFF
--- a/.changeset/feat-treeview-add-support-for-isdisabled.md
+++ b/.changeset/feat-treeview-add-support-for-isdisabled.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): Add support for isDisabled

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
@@ -75,12 +75,14 @@ describe('TreeItem', () => {
   describe('isDisabled', () => {
     it('the label is disabled', () => {
       const { getByTestId } = render(
-        <TreeItem
-          label={labelText}
-          testId={testId}
-          itemId={itemId}
-          isDisabled
-        />
+        <TreeView>
+          <TreeItem
+            label={labelText}
+            testId={testId}
+            itemId={itemId}
+            isDisabled
+          />
+        </TreeView>
       );
 
       expect(getByTestId(`${testId}-label`)).toHaveStyleRule(

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -277,6 +277,7 @@ export const Complex = args => {
                   </>
                 }
                 itemId="pt2ch5.1"
+                isDisabled
               >
                 <TreeItem
                   icon={<ArticleIcon aria-hidden={true} />}
@@ -287,6 +288,7 @@ export const Complex = args => {
                     </>
                   }
                   itemId="pt2ch5.1.1"
+                  isDisabled
                 />
                 <TreeItem
                   icon={<ArticleIcon aria-hidden={true} />}
@@ -413,15 +415,18 @@ Complex.args = {
     { itemId: 'pt1ch1', checkedStatus: IndeterminateCheckboxStatus.checked },
     { itemId: 'pt1', checkedStatus: IndeterminateCheckboxStatus.indeterminate },
     { itemId: 'pt2ch4', checkedStatus: IndeterminateCheckboxStatus.checked },
+    { itemId: 'pt2ch5.1.1', checkedStatus: IndeterminateCheckboxStatus.checked },
     {
-      itemId: 'pt2ch5.1.1',
-      checkedStatus: IndeterminateCheckboxStatus.checked,
+      itemId: 'pt2ch5.1.2',
+      checkedStatus: IndeterminateCheckboxStatus.unchecked,
+      isDisabled: true,
     },
     { itemId: 'pt2ch5.2', checkedStatus: IndeterminateCheckboxStatus.checked },
     { itemId: 'pt2ch5.3', checkedStatus: IndeterminateCheckboxStatus.checked },
   ],
   checkParents: true,
   checkChildren: true,
+  isDisabled: false,
   testId: 'complex-example',
 };
 

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -1942,7 +1942,7 @@ describe('TreeView', () => {
         });
       });
 
-      it('parent should have correct checkbox state and toggle children selection when some disabled children are partially selected', () => {
+      it('parent should have indeterminate checkbox state and toggle children selection when some disabled children are partially selected', () => {
         const onSelectedItemChange = jest.fn();
         const { getByTestId, debug } = render(
           getTreeItemsWithDisabledChildren({
@@ -1986,7 +1986,7 @@ describe('TreeView', () => {
         ]);
       });
       
-      it('parent should have correct checkbox state and toggle children selection when all disabled children are not selected', () => {
+      it('parent should have unchecked checkbox state when all disabled children and all enabled children are not selected. parent should have indeterminate checkbox state when all disabled children are not selected and some enabled children are selected. parent should have indeterminate checkbox state when all disabled children are not selected and all enabled children are selected. and toggle children selection', () => {
         const onSelectedItemChange = jest.fn();
         const { getByTestId, debug } = render(
           getTreeItemsWithDisabledChildren({
@@ -2018,7 +2018,7 @@ describe('TreeView', () => {
         expect(onSelectedItemChange).toHaveBeenCalledWith([]);
       });
 
-      it('parent should have correct checkbox state and toggle children selection when all disabled children are selected', () => {
+      it('parent should have checked checkbox state when all disabled children are selected and all enabled children are selected. parent should have indeterminate checkbox state when all disabled children are selected and enabled children are partially selected. parent should have indeterminate checkbox state when all disabled children are selected and all enabled children are not selected. and toggle children selection', () => {
         const onSelectedItemChange = jest.fn();
         const { getByTestId, debug } = render(
           getTreeItemsWithDisabledChildren({
@@ -2077,7 +2077,7 @@ describe('TreeView', () => {
             preselectedItems: [
               { itemId: 'item-child1', checkedStatus: IndeterminateCheckboxStatus.unchecked, isDisabled: false },
               { itemId: 'item-child2', checkedStatus: IndeterminateCheckboxStatus.unchecked, isDisabled: false },
-              { itemId: 'item-child3', checkedStatus: IndeterminateCheckboxStatus.unchecked, isDisabled: true },
+              { itemId: 'item-child3', checkedStatus: IndeterminateCheckboxStatus.checked, isDisabled: true },
             ],
             initialExpandedItems: ['item1'],
             onSelectedItemChange

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
@@ -5,6 +5,7 @@ import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
 export interface TreeItemSelectedInterface {
   itemId?: string;
   checkedStatus: IndeterminateCheckboxStatus;
+  isDisabled?: boolean;
 }
 
 export interface TreeViewItemInterface {
@@ -13,6 +14,7 @@ export interface TreeViewItemInterface {
   icon?: React.ReactNode;
   checkedStatus: IndeterminateCheckboxStatus;
   hasOwnTreeItems: boolean
+  isDisabled?: boolean
 }
 
 export interface TreeViewContextInterface {

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -114,7 +114,6 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   const generatedId = useGenerateId();
 
   React.useEffect(() => {
-    //
     if (!isDisabled && ownRef.current !== null) {
       registerTreeItem(treeItemRefArray, ownRef);
     }

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -69,7 +69,6 @@ export const checkedStatusToBoolean = (
 export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   const {
     children,
-    isDisabled = false,
     itemDepth,
     itemId,
     onClick,
@@ -91,6 +90,8 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   const treeViewItemData = React.useMemo(() => {
     return items.find((item) => item.itemId === itemId)
   }, [itemId, items])
+
+  const isDisabled = treeViewItemData?.isDisabled;
   
   const checkedStatus = React.useMemo(() => {
     return treeViewItemData?.checkedStatus ?? IndeterminateCheckboxStatus.unchecked
@@ -113,6 +114,7 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   const generatedId = useGenerateId();
 
   React.useEffect(() => {
+    //
     if (!isDisabled && ownRef.current !== null) {
       registerTreeItem(treeItemRefArray, ownRef);
     }
@@ -127,7 +129,7 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   }, [initialExpandedItemsNeedUpdate]);
 
   const updateInitialExpanded = () => {
-    if (initialExpandedItems?.length !== 0 && !isDisabled) {
+    if (initialExpandedItems?.length !== 0) {
       const childrenItemIds = getChildrenItemIdsFlat(treeItemChildren);
       const allExpanded = [...initialExpandedItems, ...childrenItemIds];
       if (allExpanded?.some(item => item === itemId)) {
@@ -368,6 +370,7 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     selectedItems,
     setExpanded,
     treeItemChildren,
+    isDisabled,
   };
 
   return { contextValue, handleClick, handleKeyDown };

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -215,7 +215,7 @@ export function useTreeView(props: UseTreeViewProps) {
       apiRef.current = {
         selectItem,
         selectAll() {
-          if ([TreeViewSelectable.single, TreeViewSelectable.single].includes(selectable)) {
+          if ([TreeViewSelectable.single, TreeViewSelectable.single].includes(selectable) || isDisabled) {
             return;
           }
 
@@ -225,13 +225,17 @@ export function useTreeView(props: UseTreeViewProps) {
         },
         
         clearAll() {
+          if (isDisabled) {
+            return;
+          }
+
           setItems(prevItems => {
             return toggleAllMulti({ items, checkedStatus: IndeterminateCheckboxStatus.unchecked, checkChildren, checkParents })
           })
         },
       };
     }  
-  }, [selectItem])
+  }, [selectItem, isDisabled])
   
   const [initialExpandedItemsNeedUpdate, setInitialExpandedItemsNeedUpdate] =
     React.useState(false);

--- a/packages/react-magma-dom/src/components/TreeView/utils.ts
+++ b/packages/react-magma-dom/src/components/TreeView/utils.ts
@@ -4,7 +4,7 @@ import { UseTreeViewProps } from './useTreeView';
 import { TreeViewSelectable } from './types';
 import React from 'react';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
-import { TreeViewItemInterface } from './TreeViewContext';
+import { TreeItemSelectedInterface, TreeViewItemInterface } from './TreeViewContext';
 import { TreeItem } from './TreeItem';
 
 export enum TreeNodeType {
@@ -408,4 +408,15 @@ export const getInitialExpandedIds = ({ items, initialExpandedItems }: { items: 
   return initialExpandedItems.reduce((result, itemId) => {
     return [...result, itemId, ...getParentIds({ itemId, items })];
   }, []);
+}
+
+export const isSelectedItemsChanged = (prevSelectedItems: TreeItemSelectedInterface[] | null, selectedItems: TreeItemSelectedInterface[]) => {
+  if (!prevSelectedItems && selectedItems) {
+    return true;
+  }
+  
+  const stringifiedPrevSelectedItems = JSON.stringify(prevSelectedItems);
+  const stringifiedSelectedItems = JSON.stringify(selectedItems);
+
+  return stringifiedPrevSelectedItems !== stringifiedSelectedItems;
 }

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -648,6 +648,116 @@ export function Example() {
 }
 ```
 
+## Disabling TreeView
+
+Use the `isDisabled` prop to disable all items inside TreeView
+
+```typescript
+import React from 'react';
+import {
+  TreeView,
+  TreeItem,
+  TreeViewSelectable,
+  Toggle,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <TreeView
+        ariaLabelledBy="animals-multi-checkparentschildren"
+        selectable={TreeViewSelectable.multi}
+        initialExpandedItems={['selectable-parrots 1', 'selectable-birds of Prey 1']}
+        isDisabled
+      >
+        <TreeItem label="Birds" itemId="selectable-birds">
+          <TreeItem label="Parrots" itemId="selectable-parrots 1">
+            <TreeItem label="African Grey" itemId="selectable-african Grey 1" />
+            <TreeItem label="Cockatiel" itemId="selectable-cockatiel 1" />
+            <TreeItem label="Budgerigar" itemId="selectable-budgerigar 1" />
+          </TreeItem>
+          <TreeItem label="Birds of Prey" itemId="selectable-birds of Prey 1">
+            <TreeItem label="Eagles" itemId="selectable-eagles 1" />
+            <TreeItem label="Hawks" itemId="selectable-hawks 1" />
+            <TreeItem label="Falcons" itemId="selectable-falcons 1" />
+          </TreeItem>
+        </TreeItem>
+        <TreeItem label="Aquatic Animals" itemId="selectable-aquatic Animals 1">
+          <TreeItem label="Fish" itemId="selectable-fish 1">
+            <TreeItem label="Goldfish" itemId="selectable-goldfish 1" />
+            <TreeItem label="Betta Fish" itemId="selectable-betta Fish 1" />
+            <TreeItem label="Guppies" itemId="selectable-guppies 1" />
+          </TreeItem>
+          <TreeItem label="Marine Mammals" itemId="selectable-marine Mammals 1">
+            <TreeItem label="Dolphins" itemId="selectable-dolphins 1" />
+            <TreeItem label="Whales" itemId="selectable-whales 1" />
+            <TreeItem label="Seals" itemId="selectable-seals 1" />
+          </TreeItem>
+        </TreeItem>
+      </TreeView>
+    </>
+  );
+}
+```
+
+## Disabling items
+
+Pass the `isDisabled` prop to item inside `preselectedItems` prop to manage disabled state for the item
+
+```typescript
+import React from 'react';
+import {
+  TreeView,
+  TreeItem,
+  TreeViewSelectable,
+  Toggle,
+  IndeterminateCheckboxStatus,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <TreeView
+        ariaLabelledBy="animals-multi-checkparentschildren"
+        selectable={TreeViewSelectable.multi}
+        initialExpandedItems={['selectable-parrots 2', 'selectable-birds of Prey 2']}
+        preselectedItems={[
+            { itemId: 'selectable-cockatiel 2', checkedStatus: IndeterminateCheckboxStatus.unchecked, isDisabled: true },
+            { itemId: 'selectable-budgerigar 2', checkedStatus: IndeterminateCheckboxStatus.checked, isDisabled: false }
+        ]}
+     
+      >
+        <TreeItem label="Birds" itemId="selectable-birds 2">
+          <TreeItem label="Parrots" itemId="selectable-parrots 2">
+            <TreeItem label="African Grey" itemId="selectable-african Grey 2" />
+            <TreeItem label="Cockatiel" itemId="selectable-cockatiel 2" />
+            <TreeItem label="Budgerigar" itemId="selectable-budgerigar 2" />
+          </TreeItem>
+          <TreeItem label="Birds of Prey" itemId="selectable-birds of Prey 2">
+            <TreeItem label="Eagles" itemId="selectable-eagles 2" />
+            <TreeItem label="Hawks" itemId="selectable-hawks 2" />
+            <TreeItem label="Falcons" itemId="selectable-falcons 2" />
+          </TreeItem>
+        </TreeItem>
+        <TreeItem label="Aquatic Animals" itemId="selectable-aquatic Animals 2">
+          <TreeItem label="Fish" itemId="selectable-fish 2">
+            <TreeItem label="Goldfish" itemId="selectable-goldfish 2" />
+            <TreeItem label="Betta Fish" itemId="selectable-betta Fish 2" />
+            <TreeItem label="Guppies" itemId="selectable-guppies 2" />
+          </TreeItem>
+          <TreeItem label="Marine Mammals" itemId="selectable-marine Mammals 2">
+            <TreeItem label="Dolphins" itemId="selectable-dolphins 2" />
+            <TreeItem label="Whales" itemId="selectable-whales 2" />
+            <TreeItem label="Seals" itemId="selectable-seals 2" />
+          </TreeItem>
+        </TreeItem>
+      </TreeView>
+    </>
+  );
+}
+```
+
+
 ## Change Events
 
 The following events are available: `onSelectedItemChange` and `onExpandedChange`.

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -660,7 +660,6 @@ import {
   TreeView,
   TreeItem,
   TreeViewSelectable,
-  Toggle,
 } from 'react-magma-dom';
 
 export function Example() {
@@ -672,7 +671,7 @@ export function Example() {
         initialExpandedItems={['selectable-parrots 1', 'selectable-birds of Prey 1']}
         isDisabled
       >
-        <TreeItem label="Birds" itemId="selectable-birds">
+        <TreeItem label="Birds" itemId="selectable-birds 1">
           <TreeItem label="Parrots" itemId="selectable-parrots 1">
             <TreeItem label="African Grey" itemId="selectable-african Grey 1" />
             <TreeItem label="Cockatiel" itemId="selectable-cockatiel 1" />
@@ -712,7 +711,6 @@ import {
   TreeView,
   TreeItem,
   TreeViewSelectable,
-  Toggle,
   IndeterminateCheckboxStatus,
 } from 'react-magma-dom';
 

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -650,7 +650,9 @@ export function Example() {
 
 ## Disabling TreeView
 
-Use the `isDisabled` prop to disable all items inside TreeView
+**Styling for disabled item may not be visible if the user is passing a node to the label.**
+
+Use the `isDisabled` prop to disable all items inside TreeView.
 
 ```typescript
 import React from 'react';
@@ -702,7 +704,7 @@ export function Example() {
 
 ## Disabling items
 
-Pass the `isDisabled` prop to item inside `preselectedItems` prop to manage disabled state for the item
+Pass the `isDisabled` prop to item inside `preselectedItems` prop to manage disabled state for the item.
 
 ```typescript
 import React from 'react';
@@ -734,7 +736,7 @@ export function Example() {
             <TreeItem label="Budgerigar" itemId="selectable-budgerigar 2" />
           </TreeItem>
           <TreeItem label="Birds of Prey" itemId="selectable-birds of Prey 2">
-            <TreeItem label="Eagles" itemId="selectable-eagles 2" />
+            <TreeItem label="Eagles" itemId="selectable-eagles 2" isDisabled />
             <TreeItem label="Hawks" itemId="selectable-hawks 2" />
             <TreeItem label="Falcons" itemId="selectable-falcons 2" />
           </TreeItem>


### PR DESCRIPTION
Issue: #1305

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
New feature: add support `isDisabled` prop for TreeView to disable all items
New feature: add support `isDisabled` field for items of `preselectedItems` prop to manage disabled state for items

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
Storybook > TreeView > Complex:
We can see that item 'Section 5.1.2' is disabled by setting `isDisabled` to true via  preselectedItems
We can switch TreeView's `isDisabled` prop to true to disable all items 
