### PR TITLE
fix(Input): Style update: Focus style on inputs.

### DIFF
--- a/.changeset/fix-input-focus-outline.md
+++ b/.changeset/fix-input-focus-outline.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Input): Style update: Focus style on inputs.

--- a/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
-import { inputBaseStyles } from '../InputBase';
-import { defaultComponents, SelectComponents } from '../Select/components';
-import { ThemeContext } from '../../theme/ThemeContext';
-import styled from '@emotion/styled';
 import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import {
   UseComboboxGetComboboxPropsOptions,
   UseComboboxGetInputPropsOptions,
   UseComboboxGetToggleButtonPropsOptions,
 } from 'downshift';
+import React from 'react';
+import { ThemeContext } from '../../theme/ThemeContext';
+import { inputBaseStyles } from '../InputBase';
+import { defaultComponents, SelectComponents } from '../Select/components';
 
-import { SelectedItemsWrapper } from '../Select/shared';
-import { transparentize } from 'polished';
 import { ReferenceType } from '@floating-ui/react-dom';
+import { transparentize } from 'polished';
+import { SelectedItemsWrapper } from '../Select/shared';
 
 const ComboBoxContainer = styled.div<{
   hasError?: boolean;
@@ -53,7 +53,7 @@ const InputContainer = styled.div<{
         ${props.isInverse
           ? props.theme.colors.focusInverse
           : props.theme.colors.focus};
-      outline-offset: 2px;
+      outline-offset: -1px;
     `}
 
   ${props =>

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react';
 import { css } from '@emotion/react';
-import { ThemeContext } from '../../theme/ThemeContext';
-import { ButtonShape, ButtonSize, ButtonType, ButtonVariant } from '../Button';
-import { IconButton } from '../IconButton';
+import styled from '@emotion/styled';
+import { ReferenceType } from '@floating-ui/react-dom/dist/floating-ui.react-dom';
+import { transparentize } from 'polished';
+import * as React from 'react';
 import { ClearIcon, IconProps } from 'react-magma-icons';
+import { I18nContext } from '../../i18n';
 import { useIsInverse } from '../../inverse';
 import { ThemeInterface } from '../../theme/magma';
-import { I18nContext } from '../../i18n';
+import { ThemeContext } from '../../theme/ThemeContext';
 import { useForkedRef } from '../../utils';
-import { transparentize } from 'polished';
-import { ReferenceType } from '@floating-ui/react-dom/dist/floating-ui.react-dom';
-import styled from '@emotion/styled';
+import { ButtonShape, ButtonSize, ButtonType, ButtonVariant } from '../Button';
+import { IconButton } from '../IconButton';
 
 export enum InputSize {
   large = 'large',
@@ -187,7 +187,7 @@ export const inputWrapperStyles = (props: InputWrapperStylesProps) => css`
       ${props.isInverse
         ? props.theme.colors.focusInverse
         : props.theme.colors.focus};
-    outline-offset: 2px;
+    outline-offset: -1px;
   }
 
   ${props.hasError &&

--- a/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
+++ b/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import { Global, css } from '@emotion/react';
-import { ThemeContext } from '../ThemeContext';
+import * as React from 'react';
 import { useIsInverse } from '../../inverse';
+import { ThemeContext } from '../ThemeContext';
 
 function getStyles(theme, isInverse: boolean) {
   return css`
@@ -17,7 +17,7 @@ function getStyles(theme, isInverse: boolean) {
     *:focus {
       outline: 2px solid
         ${isInverse ? theme.colors.focusInverse : theme.colors.focus};
-      outline-offset: 2px;
+      outline-offset: -1px;
     }
 
     html {


### PR DESCRIPTION
Issue: #1294 

## What I did
update focus outline offset on inputs to -1px 

## Screenshots:
![image](https://github.com/user-attachments/assets/9d1c9a60-4407-4e4d-891a-c754fe6a5b7c)


## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
confirm that Inputs have -1px border outline when focused instead of 2px
- Text field
- Text area
- Number
- Date
- Time
- Search
- Password
- Select
- Native select
- Combobox
