### PR TITLE
fix(DatePicker): Fix navigation and accessibility issues.

### DIFF
--- a/.changeset/a11y-datePicker-nav-issues.md
+++ b/.changeset/a11y-datePicker-nav-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Fix navigation and accessibility issues.

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarContext.ts
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarContext.ts
@@ -11,6 +11,7 @@ export interface CalendarContextInterface {
   buildCalendarMonth: (date: Date, enableOutsideDates?: boolean) => Date[][];
   showHelperInformation: () => void;
   hideHelperInformation: () => void;
+  onClose: (event?: React.SyntheticEvent) => void;
   onDateChange: (day: Date, event: React.SyntheticEvent) => void;
   onKeyDown: (event: React.KeyboardEvent) => void;
   onPrevMonthClick: () => void;
@@ -26,6 +27,7 @@ export const CalendarContext = React.createContext<CalendarContextInterface>({
   ],
   showHelperInformation: () => {},
   hideHelperInformation: () => {},
+  onClose: () => {},
   onDateChange: (newDate: Date, event: React.SyntheticEvent) => {},
   onKeyDown: (event: React.KeyboardEvent) => {},
   onPrevMonthClick: () => {},

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -82,6 +82,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
 ) => {
   const lastFocus = React.useRef<any>();
   const headingRef = React.useRef<any>();
+  const helperButtonRef = React.useRef<any>();
   const context = React.useContext(CalendarContext);
   const [dayFocusable, setDayFocusable] = React.useState<boolean>(false);
   const [focusHeader, setFocusHeader] = React.useState<boolean>(false);
@@ -107,6 +108,12 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
       setFocusHeader(false);
     }
   }, [props.calendarOpened, props.focusOnOpen]);
+
+  React.useEffect(() => {
+    if (prevCalendarOpened && !context.helperInformationShown) {
+      helperButtonRef.current.focus();
+    }
+  }, [context.helperInformationShown]);
 
   function onCalendarTableFocus() {
     setDayFocusable(true);
@@ -149,6 +156,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
         theme={theme}
         onKeyDown={context.onKeyDown}
         isInverse={context.isInverse}
+        ref={focusTrapElement}
       >
         {context.helperInformationShown ? (
           <HelperInformation
@@ -163,7 +171,6 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
             data-visible="true"
             isInverse={context.isInverse}
             theme={theme}
-            ref={focusTrapElement}
           >
             <CalendarHeader
               ref={headingRef}
@@ -201,6 +208,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
             >
               <HelperButton theme={theme}>
                 <IconButton
+                  ref={helperButtonRef}
                   aria-label={i18n.datePicker.helpModal.helpButtonAriaLabel}
                   icon={<KeyboardIcon />}
                   onClick={context.showHelperInformation}

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -182,6 +182,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
               onBlur={onCalendarTableBlur}
               onFocus={onCalendarTableFocus}
               theme={theme}
+              role="application"
             >
               <tbody>
                 <tr>{tableDaysHeaders}</tr>

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -154,7 +154,8 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
           <HelperInformation
             isOpen={context.helperInformationShown}
             isInverse={context.isInverse}
-            onClose={context.hideHelperInformation}
+            onReturnBack={context.hideHelperInformation}
+            onClose={context.onClose}
           />
         ) : (
           <MonthContainer

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -169,18 +169,26 @@ describe('Date Picker', () => {
     expect(selectedDateButton).toHaveFocus();
 
     userEvent.keyboard('[ArrowLeft]');
-    userEvent.keyboard('[ArrowUp]');
-
-    expect(selectedDateButton).toHaveFocus();
-
-    userEvent.keyboard('[ArrowRight]');
 
     expect(selectedDateButton).not.toHaveFocus();
-    expect(getByText(12)).toHaveFocus();
+
+    const startDateButton = getByText(10);
+    expect(startDateButton).toBeInTheDocument();
+    expect(startDateButton).toHaveFocus();
+
+    userEvent.keyboard('[ArrowUp]');
+    userEvent.keyboard('[ArrowLeft]');
+
+    expect(startDateButton).toHaveFocus();
+    
+    userEvent.keyboard('[ArrowRight]');
+    
+    expect(startDateButton).not.toHaveFocus();
+    expect(selectedDateButton).toHaveFocus();
 
     userEvent.keyboard('[ArrowDown]');
 
-    expect(getByText(19)).toHaveFocus();
+    expect(getByText(18)).toHaveFocus();
   });
 
   it('should lock focus inside', () => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -68,9 +68,12 @@ describe('Date Picker', () => {
   it('should clear input and Chosen Date value after clicking on isClearable X button', () => {
     const labelText = 'Date Picker Label';
     const now = new Date();
-    const day = format(now, 'dd')[0] === '0' ? format(now, 'dd')[1] : format(now, 'dd');
-    const chosenDate = `${now.getMonth() + 1}/${now.getDate()}/${now.getFullYear()}`
-    
+    const day =
+      format(now, 'dd')[0] === '0' ? format(now, 'dd')[1] : format(now, 'dd');
+    const chosenDate = `${
+      now.getMonth() + 1
+    }/${now.getDate()}/${now.getFullYear()}`;
+
     const { getByText, getByTestId, getByLabelText } = render(
       <ClearingTheDate labelText={labelText} />
     );
@@ -81,20 +84,22 @@ describe('Date Picker', () => {
     fireEvent.click(getByText(day));
 
     expect(getByText('Chosen Date:').nextSibling.innerHTML).toEqual(chosenDate);
-    
+
     fireEvent.click(getByTestId('clear-button'));
 
-    expect(getByLabelText('Date Picker Label')).toHaveAttribute(
-      'value', '')
+    expect(getByLabelText('Date Picker Label')).toHaveAttribute('value', '');
     expect(getByText('Chosen Date:').nextSibling).not.toBeInTheDocument();
   });
 
   it('should clear input and Chosen Date value after clicking on Clear Date button', () => {
     const labelText = 'Date Picker Label';
     const now = new Date();
-    const day = format(now, 'dd')[0] === '0' ? format(now, 'dd')[1] : format(now, 'dd');
-    const chosenDate = `${now.getMonth() + 1}/${now.getDate()}/${now.getFullYear()}`
-    
+    const day =
+      format(now, 'dd')[0] === '0' ? format(now, 'dd')[1] : format(now, 'dd');
+    const chosenDate = `${
+      now.getMonth() + 1
+    }/${now.getDate()}/${now.getFullYear()}`;
+
     const { getByText, getByTestId, getByLabelText } = render(
       <ClearingTheDate labelText={labelText} />
     );
@@ -105,11 +110,10 @@ describe('Date Picker', () => {
     fireEvent.click(getByText(day));
 
     expect(getByText('Chosen Date:').nextSibling.innerHTML).toEqual(chosenDate);
-    
+
     fireEvent.click(getByText('Clear Date').parentElement);
 
-    expect(getByLabelText('Date Picker Label')).toHaveAttribute(
-      'value', '')
+    expect(getByLabelText('Date Picker Label')).toHaveAttribute('value', '');
     expect(getByText('Chosen Date:').nextSibling).not.toBeInTheDocument();
   });
 
@@ -144,6 +148,63 @@ describe('Date Picker', () => {
     );
 
     expect(getByLabelText('Date Picker Label')).toHaveAttribute('value', '');
+  });
+
+  it('should not allow to navigate through inactive days', () => {
+    const minDate = new Date('January 10, 2020');
+    const valueDate = new Date('January 11, 2020');
+
+    const { getByText, getByRole } = render(
+      <DatePicker minDate={minDate} value={valueDate} />
+    );
+
+    expect(getByText('January 2020')).toBeInTheDocument();
+
+    const selectedDateButton = getByText(11);
+    const button = getByRole('button');
+
+    userEvent.click(button);
+
+    expect(selectedDateButton).toBeInTheDocument();
+    expect(selectedDateButton).toHaveFocus();
+
+    userEvent.keyboard('[ArrowLeft]');
+    userEvent.keyboard('[ArrowUp]');
+
+    expect(selectedDateButton).toHaveFocus();
+
+    userEvent.keyboard('[ArrowRight]');
+
+    expect(selectedDateButton).not.toHaveFocus();
+    expect(getByText(12)).toHaveFocus();
+
+    userEvent.keyboard('[ArrowDown]');
+
+    expect(getByText(19)).toHaveFocus();
+  });
+
+  it('should lock focus inside', () => {
+    const valueDate = new Date('January 1, 2020');
+
+    const { getByText, getByRole } = render(
+      <DatePicker value={valueDate} />
+    );
+
+    const selectedDateButton = getByText(1);
+    const button = getByRole('button');
+
+    userEvent.click(button);
+
+    expect(selectedDateButton).toBeInTheDocument();
+    expect(selectedDateButton).toHaveFocus();
+
+    userEvent.tab();
+    userEvent.tab();
+    userEvent.tab();
+    userEvent.tab();
+    userEvent.tab();
+
+    expect(selectedDateButton).toHaveFocus();
   });
 
   it('should not set the value to the date if it is after the maxDate', () => {

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, render, fireEvent } from '@testing-library/react';
 import { HelperInformation } from './HelperInformation';
+import userEvent from '@testing-library/user-event';
 
 describe('Calendar Month', () => {
   beforeEach(() => {
@@ -44,5 +45,23 @@ describe('Calendar Month', () => {
     });
 
     expect(onCloseSpy).toHaveBeenCalled();
+  });
+
+  it('should hold focus inside the helper information', () => {
+    const { getByLabelText } = render(
+      <HelperInformation isOpen={true} />
+    );
+
+    const button = getByLabelText('Close Calendar Widget');
+
+    userEvent.tab();
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveFocus();
+
+    userEvent.tab();
+    userEvent.tab();
+
+    expect(button).toHaveFocus();
   });
 });

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
@@ -10,10 +10,12 @@ import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { useIsInverse } from '../../inverse';
 import styled from '@emotion/styled';
+import { useFocusLock } from '../../hooks/useFocusLock';
 
 interface HelperInformationProps {
   isInverse?: boolean;
   isOpen?: boolean;
+  onReturnBack?: (event?: React.SyntheticEvent) => void;
   onClose?: (event?: React.SyntheticEvent) => void;
 }
 
@@ -95,11 +97,12 @@ export const HelperInformation: React.FunctionComponent<
 > = (props: HelperInformationProps) => {
   const i18n = React.useContext(I18nContext);
   const theme = React.useContext(ThemeContext);
+  const helperInformationRef = useFocusLock(true);
 
   const isInverse = useIsInverse(props.isInverse);
 
   return (
-    <StyledPopup>
+    <StyledPopup ref={helperInformationRef}>
       <StyledNavContainer>
         <IconButton
           icon={<ArrowBackIcon />}
@@ -107,7 +110,7 @@ export const HelperInformation: React.FunctionComponent<
           size={ButtonSize.small}
           style={{ top: '4px', left: '-12px' }}
           variant={ButtonVariant.link}
-          onClick={props.onClose}
+          onClick={props.onReturnBack}
         >
           Back to Calendar
         </IconButton>

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -39,7 +39,6 @@ import {
   flip,
   useFloating,
 } from '@floating-ui/react-dom';
-import { useFocusLock } from '../../hooks/useFocusLock';
 
 export interface DatePickerProps
   extends Omit<
@@ -177,7 +176,6 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       React.useState<boolean>(false);
     const [calendarOpened, setCalendarOpened] = React.useState<boolean>(false);
     const [dateFocused, setDateFocused] = React.useState<boolean>(false);
-    const datePickerRef = useFocusLock(calendarOpened);
 
     const [focusedDate, setFocusedDate] = React.useState<Date>(
       setDateFromConsumer(props.value || props.defaultDate) ||
@@ -211,8 +209,8 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
     }
 
     function hideHelperInformation() {
-      setHelperInformationShown(false);
       lastFocus.current.focus();
+      setHelperInformationShown(false);
     }
 
     function closeHelperInformation() {
@@ -506,7 +504,6 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
               style={{ ...floatingStyles, zIndex: '998' }}
             >
               <DatePickerCalendar
-                ref={datePickerRef}
                 data-testid="calendarContainer"
                 opened={calendarOpened}
                 isInverse={isInverse}

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -6,12 +6,14 @@ import { Input } from '../Input';
 import { InputType } from '../InputBase';
 import {
   addDays,
+  endOfDay,
   isAfter,
   isBefore,
   isMatch,
   isSameMonth,
   isValid,
   parse,
+  setHours,
   startOfDay,
 } from 'date-fns';
 import { ThemeContext } from '../../theme/ThemeContext';
@@ -359,8 +361,25 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
           onDateChange,
           iconRef
         );
-        if (newChosenDate && isAfter(startOfDay(newChosenDate), minDate)) {
-          setFocusedDate(newChosenDate);
+        if (newChosenDate) {
+          if (minDate && maxDate) {
+            if (
+              isAfter(setHours(newChosenDate, 12), startOfDay(minDate)) &&
+              isBefore(setHours(newChosenDate, 12), endOfDay(maxDate))
+            ) {
+              setFocusedDate(newChosenDate);
+            }
+          } else if (minDate && !maxDate) {
+            if (isAfter(setHours(newChosenDate, 12), startOfDay(minDate))) {
+              setFocusedDate(newChosenDate);
+            }
+          } else if (maxDate && !minDate) {
+            if (isBefore(setHours(newChosenDate, 12), endOfDay(maxDate))) {
+              setFocusedDate(newChosenDate);
+            }
+          } else {
+            setFocusedDate(newChosenDate);
+          }
         }
       }
     }
@@ -379,7 +398,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
 
       onDateChange(day);
       setFocusedDate(
-        isAfter(startOfDay(day), minDate) ? day : setDefaultFocusedDate
+        isAfter(setHours(day, 12), minDate) ? day : setDefaultFocusedDate
       );
     }
 

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -106,8 +106,7 @@ export const defaultI18n: I18nInterface = {
   datePicker: {
     startOfWeek: 'sunday',
     calendarIconAriaLabel: 'Toggle Calendar Widget',
-    calendarOpenAnnounce:
-      'Calendar Widget is now open. Press the question mark key to get the keyboard shortcuts for changing dates. If you are using the NVDA screen reader, you may need to switch it to Focus Mode for proper interaction with the calendar.',
+    calendarOpenAnnounce: 'Calendar Widget is now open.',
     calendarCloseAriaLabel: 'Close Calendar Widget',
     previousMonthAriaLabel: 'Previous Month',
     nextMonthAriaLabel: 'Next Month',

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -107,7 +107,7 @@ export const defaultI18n: I18nInterface = {
     startOfWeek: 'sunday',
     calendarIconAriaLabel: 'Toggle Calendar Widget',
     calendarOpenAnnounce:
-      'Calendar Widget is now open. Press the question mark key to get the keyboard shortcuts for changing dates.',
+      'Calendar Widget is now open. Press the question mark key to get the keyboard shortcuts for changing dates. If you are using the NVDA screen reader, you may need to switch it to Focus Mode for proper interaction with the calendar.',
     calendarCloseAriaLabel: 'Close Calendar Widget',
     previousMonthAriaLabel: 'Previous Month',
     nextMonthAriaLabel: 'Next Month',


### PR DESCRIPTION
Issue: #1080

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
This problem is related to the operation of the NVDA screen reader. Users with this screen reader must change the NVDA mode to `focus` to properly interact with the calendar. Added additional text to the `calendarOpenAnnounce` label.
Fix navigation and accessibility issues.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->

## Other bugs and fixes for them:
#### 1. Focus is not locked in `DatePicker` and `HelperInformation`
**Previous behavior:** 
- Open `DatePicker` -> Open `HelperInformation` -> Press `Tab` several times -> Focus outside `HelperInformation`.
- Open `DatePicker` -> Open `HelperInformation` -> Return back to `DatePicker` -> Press `Tab` several times -> Focus outside `DatePicker`.

**Current behavior:**
- Open `DatePicker` -> Open `HelperInformation` -> Press `Tab` several times -> Focus inside `HelperInformation`.
- Open `DatePicker` -> Open `HelperInformation` -> Return back to `DatePicker` -> Press `Tab` several times -> Focus inside `DatePicker`.

#### 2. Button `X` (Close `HelperInformation`) in `HelperInformation` has the same behavior as the `Return back to Calendar` button.
**Previous behavior:** 
- Open `DatePicker` -> Open `HelperInformation` -> Press `X` -> Opened `DatePicker`.

**Current behavior:** 
- Open `DatePicker` -> Open `HelperInformation` -> Press `X` -> Closed `DatePicker`.

#### 3. Unable to select a date if there are disabled days in the current month.
**Previous behavior:** 
- Open `DatePicker` -> Press `Tab` several times -> No focus on dates.

**Current behavior:** 
- Open `DatePicker` -> Press `Tab` several times -> Focus on dates.

#### 4. May use arrows on inactive days.
**Previous behavior:** 
- Open `DatePicker` with inactive days (minDate) -> Select the day right after inactive -> Press `ArrowUp` or `ArrowLeft` several times -> Need to press several times `ArrowDown` or `ArrowRight` to come back to the focused day.

**Current behavior:** 
- Open `DatePicker` with inactive days (minDate) -> Select the day right after inactive -> Press `ArrowUp` or `ArrowLeft` several times -> No need to press several times `ArrowDown` or `ArrowRight` to come back to the focused day. The focus shows the exact position selected.