### PR TITLE
feat(ProgressBar): Update colors from danger200/success200 to danger300/success300 in dark mode.

### DIFF
--- a/.changeset/feat-progressBar-update-colors.md
+++ b/.changeset/feat-progressBar-update-colors.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(ProgressBar): Update colors from danger200/success200 to danger300/success300 in dark mode.

--- a/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.test.js
+++ b/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.test.js
@@ -103,7 +103,7 @@ describe('ProgressBar', () => {
 
     expect(container.querySelector('[role="progressbar"]')).toHaveStyleRule(
       'background',
-      magma.colors.danger200
+      magma.colors.danger300
     );
   });
 
@@ -114,7 +114,7 @@ describe('ProgressBar', () => {
 
     expect(container.querySelector('[role="progressbar"]')).toHaveStyleRule(
       'background',
-      magma.colors.success200
+      magma.colors.success300
     );
   });
 

--- a/packages/react-magma-dom/src/components/ProgressBar/index.tsx
+++ b/packages/react-magma-dom/src/components/ProgressBar/index.tsx
@@ -60,9 +60,9 @@ function buildProgressBarBackground(props) {
     } else if (props.color === ProgressBarColor.primary) {
       return props.theme.colors.tertiary;
     } else if (props.color === ProgressBarColor.danger) {
-      return props.theme.colors.danger200;
+      return props.theme.colors.danger300;
     } else if (props.color === ProgressBarColor.success) {
-      return props.theme.colors.success200;
+      return props.theme.colors.success300;
     }
   }
   if (


### PR DESCRIPTION
Issue: #1424

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Update colors from danger200/success200 to danger300/success300 in dark mode.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Open `ProgressBar` -> Set dark mode (`isInverse` prop) -> Set custom `danger` or `success` color -> Check `ProgressBar`'s color.