### PR TITLE
fix(Toast): Fixed loading ring alignment when zooming in Safari.

### DIFF
--- a/.changeset/fix-toast-loading-ring-misaligned.md
+++ b/.changeset/fix-toast-loading-ring-misaligned.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Toast): Fixed loading ring alignment when zooming in Safari.

--- a/packages/react-magma-dom/src/components/ProgressRing/index.tsx
+++ b/packages/react-magma-dom/src/components/ProgressRing/index.tsx
@@ -18,6 +18,9 @@ export interface ProgressRingProps
 
 const Circle = styled.circle`
   transition: stroke-dashoffset 0.35s;
+`;
+
+const Svg = styled.svg`
   transform: rotate(-90deg);
   transform-origin: 50% 50%;
 `;
@@ -64,7 +67,7 @@ export const ProgressRing = React.forwardRef<HTMLDivElement, ProgressRingProps>(
 
     return (
       <div {...other} ref={ref} data-testid={testId}>
-        <svg height={radius * 2} width={radius * 2}>
+        <Svg height={radius * 2} width={radius * 2}>
           <Circle
             cx={radius}
             cy={radius}
@@ -73,9 +76,9 @@ export const ProgressRing = React.forwardRef<HTMLDivElement, ProgressRingProps>(
             stroke={color ? color : theme.colors.neutral}
             strokeWidth={strokeWidth}
             strokeDasharray={`${circumference} ${circumference}`}
-            style={{ strokeDashoffset }}
+            strokeDashoffset={strokeDashoffset}
           />
-        </svg>
+        </Svg>
       </div>
     );
   }


### PR DESCRIPTION
Issue: #1265

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fixed loading ring alignment when zooming in Safari.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Open Toast in docs/storybook -> Change viewport in Safari (Zoom in or zoom out) -> Click the button to Toast -> Make sure the loading ring is in the correct position.