### PR TITLE
chore(dropdown): Deprecate `dropDirection` prop

### DIFF
--- a/.changeset/dropdown-deprecate.md
+++ b/.changeset/dropdown-deprecate.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+chore(dropdown): Deprecate `dropDirection` prop. This is no longer necessary with viewport detection support.

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -40,6 +40,7 @@ export interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Position of the dropdown content
    * @default DropdownDropDirection.down
+   * @deprecated = true
    */
   dropDirection?: DropdownDropDirection;
   /**

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -89,9 +89,11 @@ export function Example() {
 }
 ```
 
-## Drop Direction
+## Drop Direction (deprecated)
 
-Using the `dropDirection` prop will change where the menu appears. Options are `down` and `up`, with `down` being default.
+Using the `dropDirection` prop will change where the menu appears and the arrow direction. Options are `down`, `up`, `left` and `right` with `down` being default.
+
+Deprecation note: Dropdowns now support viewport detection, so there is no need to use the `dropDirection` prop. The dropdown will always open where there is enough space, and the arrow will always face down.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
Issue: #1457

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

Deprecate `dropDirection` prop and update documentation

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
- Confirm that documentation is descriptive
- Confirm that the prop is marked as deprecated on the props table