### PR TITLE
Deprecate schema-renderer and header patterns

### DIFF
--- a/.changeset/chore-deprecate-header.md
+++ b/.changeset/chore-deprecate-header.md
@@ -1,0 +1,5 @@
+---
+'@cengage-patterns/header': patch
+---
+
+Deprecate @cengage-patterns/header package.

--- a/.changeset/chore-deprecate-schema.md
+++ b/.changeset/chore-deprecate-schema.md
@@ -1,0 +1,5 @@
+---
+'@react-magma/schema-renderer': patch
+---
+
+Deprecate @react-magma/schema-renderer package.

--- a/packages/schema-renderer/README.md
+++ b/packages/schema-renderer/README.md
@@ -1,6 +1,6 @@
 # React Magma Schema Renderer
 
-** THIS PACKAGE IS CURRENTLY A WORK IN PROGRESS AND EXTREMELY BETA. THERE MAY BE BREAKING CHANGES. **
+** THIS PACKAGE HAS BEEN DEPRECATED **
 
 ````
 import * as React from 'react';

--- a/patterns/header/README.md
+++ b/patterns/header/README.md
@@ -1,3 +1,5 @@
 # Header
 
+** THIS PACKAGE HAS BEEN DEPRECATED **
+
 The Header pattern is a highly-opinionated, advanced component composed of smaller React Magma components. It includes options for a logo, a call to action, a search bar, and icon buttons. The Header pattern will handle the order and placement of these elements.

--- a/website/react-magma-docs/src/pages/api/schema-renderer.mdx
+++ b/website/react-magma-docs/src/pages/api/schema-renderer.mdx
@@ -7,6 +7,10 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 <PageContent componentName="schema_renderer" type="api">
 
+<Alert variant="danger">
+  <strong>SchemaRenderer is deprecated.</strong>
+</Alert>
+
 <LeadParagraph>
   The SchemaRenderer is an advanced component which maps other React Magma
   components to a defined Schema. This allows developers to render data driven

--- a/website/react-magma-docs/src/pages/patterns/header.mdx
+++ b/website/react-magma-docs/src/pages/patterns/header.mdx
@@ -7,6 +7,10 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 <PageContent componentName="header" type="api">
 
+<Alert variant="danger">
+  <strong>Header pattern is deprecated.</strong>
+</Alert>
+
 <LeadParagraph>
   The Header pattern is a highly-opinionated, advanced component composed of
   smaller React Magma components. It includes options for a logo, a call to


### PR DESCRIPTION
Issue: #1498

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

Deprecate 2 unused packages:
- Marked as deprecated on README
- Added an alert on the docs site
- Deprecated them on npmjs

In addition, there were a few other old magma packages that have hung around for a while that we don't even have the source code for, so I marked those as deprecated on NPM as well.

## Screenshots:
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/ea829ed5-4d5b-4df0-b4c1-101529cc026b">
<img width="1188" alt="image" src="https://github.com/user-attachments/assets/6ea4a827-d06e-4399-8976-ef861a902259">

--

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/8ed67e70-9e5a-43e4-af9d-8d0776c29f7c">
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/35a47316-3966-49f9-83c5-3625009a104b">
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/cf86d66c-573b-4911-9d4d-14f8c3273510">

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [-] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm on NPM js + docs site.
