### PR TITLE
fix(Tabs): Center preselected `Tab` on the `Scrollable Tabs`.

### DIFF
--- a/.changeset/fix-tabs-center-active-tab.md
+++ b/.changeset/fix-tabs-center-active-tab.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tabs): Center preselected `Tab` on the `Scrollable Tabs`.

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.stories.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.stories.tsx
@@ -5,7 +5,12 @@ import { Card } from '../Card';
 import { magma } from '../../theme/magma';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { AndroidIcon, EmailIcon, NotificationsIcon } from 'react-magma-icons';
-import { TabsAlignment, TabsBorderPosition, TabsIconPosition } from '../Tabs';
+import {
+  TabsAlignment,
+  TabsBorderPosition,
+  TabsContainer,
+  TabsIconPosition,
+} from '../Tabs';
 import { TabsOrientation, TabsTextTransform } from '../Tabs/shared';
 
 export default {
@@ -129,4 +134,42 @@ export const CustomTab: Story<NavTabsProps> = args => {
       </NavTabs>
     </Card>
   );
+};
+
+const ScrollingTemplate: Story<
+  NavTabsProps & { activeIndex: number }
+> = args => {
+  const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  return (
+    <div>
+      <TabsContainer
+        style={{
+          maxWidth: '600px',
+          height:
+            args.orientation === TabsOrientation.vertical ? '300px' : 'auto',
+        }}
+        activeIndex={args.activeIndex}
+      >
+        <NavTabs aria-label="Sample Tabs" {...args}>
+          {arr.map((item, index) => (
+            <NavTab
+              to={`#${item}`}
+              key={item}
+              isActive={index === args.activeIndex}
+            >
+              {`Link ${item}`}
+            </NavTab>
+          ))}
+        </NavTabs>
+      </TabsContainer>
+    </div>
+  );
+};
+
+export const Scrolling = ScrollingTemplate.bind({});
+Scrolling.args = {
+  ...Default.args,
+  orientation: TabsOrientation.vertical,
+  activeIndex: 0,
 };

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
@@ -8,10 +8,11 @@ import {
   TabsIconPosition,
   TabsProps,
   Orientation,
+  TabsContainerContext,
 } from '../Tabs';
 import { NavTabProps, NavTab } from './NavTab';
 import { TabsOrientation, TabsTextTransform } from '../Tabs/shared';
-import { Omit } from '../../utils';
+import { getNormalizedScrollLeft, Omit } from '../../utils';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { ButtonNext, ButtonPrev } from '../Tabs/TabsScrollButtons';
 import { useTabsMeta } from '../Tabs/utils';
@@ -66,12 +67,18 @@ export const NavTabs = React.forwardRef<
     isInverse
   );
 
-  const { displayScroll } = tabsMeta;
-  const { handleStartScrollClick, handleEndScrollClick, handleTabsScroll } =
-    tabsHandleMethods;
+  const { displayScroll, scrollStart } = tabsMeta;
+  const { activeTabIndex } = React.useContext(TabsContainerContext);
+  const {
+    handleStartScrollClick,
+    handleEndScrollClick,
+    handleTabsScroll,
+    scroll,
+  } = tabsHandleMethods;
   const { prevButtonRef, nextButtonRef, tabsWrapperRef } = tabsRefs;
 
   const navTabChildren = React.Children.toArray(children);
+  const childrenWrapperRef = React.useRef<HTMLUListElement>();
 
   const hasChildFocus = navTabChildren.some(child => {
     if (React.isValidElement(child)) {
@@ -91,6 +98,60 @@ export const NavTabs = React.forwardRef<
     }
     return child;
   });
+
+  function getTabsMeta() {
+    const tabsNode = tabsWrapperRef.current;
+    let tabsMeta;
+    if (tabsNode) {
+      const rect = tabsNode.getBoundingClientRect();
+      tabsMeta = {
+        clientWidth: tabsNode.clientWidth,
+        scrollLeft: tabsNode.scrollLeft,
+        scrollTop: tabsNode.scrollTop,
+        scrollLeftNormalized: getNormalizedScrollLeft(
+          tabsNode,
+          theme.direction
+        ),
+        scrollWidth: tabsNode.scrollWidth,
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+        right: rect.right,
+      };
+    }
+
+    let tabMeta;
+    if (tabsNode) {
+      const childrenArray = childrenWrapperRef.current.children;
+      if (childrenArray.length > 0) {
+        const tab = childrenArray[activeTabIndex];
+        tabMeta = tab ? (tab as any).getBoundingClientRect() : null;
+      }
+    }
+    return { tabsMeta, tabMeta };
+  }
+
+  const scrollInitialActiveIndexIntoView = () => {
+    const { tabsMeta, tabMeta } = getTabsMeta();
+
+    if (!tabMeta || !tabsMeta) {
+      return;
+    }
+
+    const start = orientation === TabsOrientation.vertical ? 'top' : 'left';
+    const end = orientation === TabsOrientation.vertical ? 'bottom' : 'right';
+
+    const tabCenter = (tabMeta[start] + tabMeta[end]) / 2;
+    const containerCenter = (tabsMeta[start] + tabsMeta[end]) / 2;
+
+    const scrollDelta = tabCenter - containerCenter;
+
+    const nextScrollStart = Number(tabsMeta[scrollStart]) + scrollDelta;
+
+    scroll(nextScrollStart);
+  };
+
+  React.useEffect(scrollInitialActiveIndexIntoView, []);
 
   return (
     <StyledContainer
@@ -123,6 +184,7 @@ export const NavTabs = React.forwardRef<
         <StyledTabs
           alignment={alignment ? alignment : TabsAlignment.left}
           orientation={orientation}
+          ref={childrenWrapperRef}
         >
           <NavTabsContext.Provider
             value={{

--- a/packages/react-magma-dom/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/Tabs.stories.tsx
@@ -154,7 +154,7 @@ export const IconOnly = IconOnlyTemplate.bind({});
 IconOnly.args = { ...Default.args };
 IconOnly.parameters = { ...Default.parameters };
 
-const ScrollingTemplate: Story<TabsProps> = args => (
+const ScrollingTemplate: Story<TabsProps & { activeIndex: number }> = args => (
   <div>
     <TabsContainer
       style={{
@@ -162,6 +162,7 @@ const ScrollingTemplate: Story<TabsProps> = args => (
         height:
           args.orientation === TabsOrientation.vertical ? '300px' : 'auto',
       }}
+      activeIndex={args.activeIndex}
     >
       <Tabs aria-label="Sample Tabs" {...args}>
         <Tab>First item</Tab>
@@ -220,7 +221,11 @@ const ScrollingTemplate: Story<TabsProps> = args => (
 );
 
 export const Scrolling = ScrollingTemplate.bind({});
-Scrolling.args = { ...Default.args, orientation: TabsOrientation.vertical };
+Scrolling.args = {
+  ...Default.args,
+  orientation: TabsOrientation.vertical,
+  activeIndex: 0,
+};
 Scrolling.parameters = { ...Default.parameters };
 
 const scrollContent = (

--- a/packages/react-magma-dom/src/components/Tabs/Tabs.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/Tabs.tsx
@@ -282,9 +282,26 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
       }
     }
 
-    React.useEffect(scrollSelectedIntoView, []);
+    const scrollInitialActiveIndexIntoView = () => {
+      const { tabsMeta, tabMeta } = getTabsMeta();
+
+      if (!tabMeta || !tabsMeta) {
+        return;
+      }
+
+      const tabCenter = (tabMeta[start] + tabMeta[end]) / 2;
+      const containerCenter = (tabsMeta[start] + tabsMeta[end]) / 2;
+
+      const scrollDelta = tabCenter - containerCenter;
+
+      const nextScrollStart = Number(tabsMeta[scrollStart]) + scrollDelta;
+
+      scroll(nextScrollStart);
+    };
 
     React.useEffect(scrollSelectedIntoView, [activeTabIndex]);
+
+    React.useEffect(scrollInitialActiveIndexIntoView, []);
 
     function changeHandler(
       newActiveIndex: number,


### PR DESCRIPTION
Issue: #1481

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Center preselected `Tab` on the `Scrollable Tabs`.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Open `Scrollable Tabs` -> Preselect active `Tab` using the `activeIndex` property -> Check that it is centered.