### PR TITLE
fix(CheckBox): Hide SVGs from screen readers by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

### DIFF
--- a/.changeset/a11y-checkbox-hide-svg-from-screen-readers.md
+++ b/.changeset/a11y-checkbox-hide-svg-from-screen-readers.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(CheckBox): Hide SVGs from screen readers by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

--- a/packages/react-magma-dom/src/components/Checkbox/Checkbox.test.js
+++ b/packages/react-magma-dom/src/components/Checkbox/Checkbox.test.js
@@ -32,6 +32,14 @@ describe('Checkbox', () => {
     expect(checkbox).not.toHaveAttribute('autoFocus');
   });
 
+  it('should render the checkbox with aria-hidden', () => {
+    const { container } = render(<Checkbox />);
+
+    const span = container.querySelector('span');
+
+    expect(span).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('should render a checkbox that is checked on render with defaultChecked', () => {
     const label = 'test label';
     const { getByLabelText } = render(

--- a/packages/react-magma-dom/src/components/Checkbox/index.tsx
+++ b/packages/react-magma-dom/src/components/Checkbox/index.tsx
@@ -255,6 +255,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
               style={inputStyle}
               textPosition={textPosition}
               theme={theme}
+              aria-hidden="true"
             >
               {isChecked ? (
                 <CheckBoxIcon size={theme.iconSizes.medium} />

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.test.js
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.test.js
@@ -33,6 +33,14 @@ describe('Indeterminate Checkbox', () => {
     expect(getByLabelText('Hello')).toBeInTheDocument();
   });
 
+  it('should render the indeterminate checkbox with aria-hidden', () => {
+    const { container } = render(<IndeterminateCheckbox />);
+
+    const span = container.querySelector('span');
+
+    expect(span).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('should give the checkbox an indeterminate value', () => {
     const label = 'test label';
     const { getByLabelText } = render(

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
@@ -171,6 +171,7 @@ export const IndeterminateCheckbox = React.forwardRef<
             isInverse={isInverse}
             style={inputStyle}
             theme={theme}
+            aria-hidden="true"
           >
             {isIndeterminate ? (
               <IndeterminateCheckBoxIcon


### PR DESCRIPTION
Issue: #1249

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Hide SVGs from screen readers by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Open `Checkbox` -> Open DevTools -> Check styles.