### PR TITLE
fix(Breadcrumb): Hide SVGs from screen readers by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

### DIFF
--- a/.changeset/a11y-breadcrumb-hide-svg-from-screen-readers.md
+++ b/.changeset/a11y-breadcrumb-hide-svg-from-screen-readers.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Breadcrumb): Hide SVGs from screen readers by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

--- a/packages/react-magma-dom/src/components/Breadcrumb/Breadcrumb.test.js
+++ b/packages/react-magma-dom/src/components/Breadcrumb/Breadcrumb.test.js
@@ -58,6 +58,19 @@ describe('Breadcrumb', () => {
     expect(getByLabelText('Test label')).toBeInTheDocument();
   });
 
+  it('should render the breadcrumb component with aria-hidden', () => {
+    const { container } = render(
+      <Breadcrumb>
+        <BreadcrumbItem to="#">{LINK_TEXT}</BreadcrumbItem>
+        <BreadcrumbItem>{SPAN_TEXT}</BreadcrumbItem>
+      </Breadcrumb>
+    );
+
+    const span = container.querySelector('span');
+
+    expect(span).toHaveAttribute('aria-hidden', 'true');
+  });
+
   describe('i18n', () => {
     it('should use the nav aria-label', () => {
       const navAriaLabel = 'test aria label';

--- a/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -36,7 +36,7 @@ const StyledLink = styled.a<{ isInverse?: boolean }>`
       : props.theme.colors.neutral700};
   text-decoration: none;
   cursor: default;
-  
+
   &:hover,
   &:focus {
     color: ${props =>
@@ -82,7 +82,7 @@ export const BreadcrumbItem = React.forwardRef<
           <Hyperlink to={to} isInverse={isInverse}>
             {children}
           </Hyperlink>
-          <StyledSpan isInverse={isInverse} theme={theme}>
+          <StyledSpan isInverse={isInverse} theme={theme} aria-hidden="true">
             <ChevronRightIcon size={theme.iconSizes.small} />
           </StyledSpan>
         </>


### PR DESCRIPTION
Issue: #1248

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Hide SVGs from screen readers by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Open `Breadcrumb` -> Open DevTools -> Check styles.