### PR TITLE
fix(List): Hide SVGs from assistive tech by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

### DIFF
--- a/.changeset/a11y-list-hide-icons-from-assistive-tech.md
+++ b/.changeset/a11y-list-hide-icons-from-assistive-tech.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(List): Hide SVGs from assistive tech by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

--- a/packages/react-magma-dom/src/components/List/List.test.js
+++ b/packages/react-magma-dom/src/components/List/List.test.js
@@ -53,6 +53,10 @@ describe('List', () => {
       'borderRadius',
       '50%'
     );
+    expect(container.querySelector('span')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
   });
 
   it('should render a list item with a small icon', () => {

--- a/packages/react-magma-dom/src/components/List/ListItem.tsx
+++ b/packages/react-magma-dom/src/components/List/ListItem.tsx
@@ -96,6 +96,7 @@ export const ListItem = React.forwardRef<HTMLDivElement, ListItemProps>(
               }
               iconColor={theme.colors[iconColor] || theme.colors.neutral100}
               theme={theme}
+              aria-hidden="true"
             >
               {icon}
             </StyledIcon>


### PR DESCRIPTION
Issue: #1244

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Hide SVGs from assistive tech by adding `aria-hidden="true"` to the `span` element that wraps the SVGs.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Open `List with icons` -> Open DevTools -> Check styles.