### PR TITLE
docs: Update changelog to explain possible issue with emotion/css.

### DIFF
--- a/.changeset/docs-emotion.md
+++ b/.changeset/docs-emotion.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+docs(emotion): Update changelog to explain possible issue with emotion/css.

--- a/website/react-magma-docs/src/pages/api-intro/changelog.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/changelog.mdx
@@ -9,7 +9,7 @@ order: 4
 
 ### Minor Changes
 
-- ae668a3e5: chore: Updating emotion to v11. **Note: adopters will need to upgrade** their packages to the following versions `"@emotion/react": "^11.13.0", "@emotion/styled": "^11.13.0"`. Notice that `@emotion/core` has been replaced with `@emotion/styled` and that's the only breaking change.
+- ae668a3e5: chore: Updating emotion to v11. **Note: adopters will need to upgrade** their packages to the following versions `"@emotion/react": "^11.13.0", "@emotion/styled": "^11.13.0"`. Notice that `@emotion/core` has been replaced with `@emotion/styled` and that's the only breaking change, unless your project is using `@emotion/css` which may not work the same. Please review the emotion documentation when upgrading.
 - 9e38e9e7f: feat(Stepper): New Stepper component. Displays step based content for use in multi-step interfaces.
 
 ### Patch Changes


### PR DESCRIPTION
Issue: -

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

I received a message from a team having issues with upgrading from 4.3.0 to 4.6.0. Turns out they were using the emotion `css` prop, and that's not working for them anymore

```
const bodyStyle = css`
    padding: 16px 16px 0 16px;
`;

return (
        <Card
            css={cardCss}
            background={theme.colors.neutral600}
            isInverse
        >
            <CardBody css={bodyStyle}>
...
```
Turns out that with the latest version of emotion that we upgraded to, that is no longer supported. These are the supported ways of styling components:
https://codesandbox.io/p/sandbox/emotion-11-and-magma-2tg5w5?file=%2Fexample.tsx

This PR just makes a note in the changeset for adopters to be aware of this.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
