### PR TITLE
feat(TreeView): onExpandedChange returns an array of expanded IDs

### DIFF
--- a/.changeset/feat-treeview-onexpandedchange.md
+++ b/.changeset/feat-treeview-onexpandedchange.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): onExpandedChange returns an array of expanded IDs

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -202,7 +202,7 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
     const theme = React.useContext(ThemeContext);
     const isInverse = useIsInverse();
 
-    const { selectable, hasIcons, onExpandedChange, itemToFocus } =
+    const { selectable, hasIcons, onExpandedChange, itemToFocus, handleExpandedChange } =
       React.useContext(TreeViewContext);
 
     const { contextValue, handleClick, handleKeyDown } = useTreeItem(
@@ -299,8 +299,8 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
       event.preventDefault();
 
       onExpandedChange &&
-        typeof onExpandedChange === 'function' &&
-        onExpandedChange(event);
+      typeof onExpandedChange === 'function' &&
+      handleExpandedChange(event, itemId);
     };
 
     const tabIndex = React.useMemo(() => {

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -23,6 +23,8 @@ import {
   TreeViewProps,
   ButtonVariant,
   ButtonGroup,
+  Spacer,
+  SpacerAxis,
 } from '../..';
 import { ButtonSize } from '../Button';
 import { FlexAlignContent, FlexAlignItems } from '../Flex';
@@ -201,13 +203,19 @@ export const Complex = (args: Partial<TreeViewProps>) => {
   const [selectedItems, setSelectedItems] =
     React.useState<TreeItemSelectedInterface[]>();
 
+  const [expandedItems, setExpandedItems] = React.useState<string[]>();
   const apiRef = React.useRef<TreeViewApi>();
 
   const { selected, indeterminate } = createControlledTags(
     selectedItems,
     apiRef?.current
   );
-  const total = selectedItems?.length || 0;
+  const total = selectedItems?.length ?? 0;
+
+  const handleExpandedChange = (event: React.SyntheticEvent, expandedItems: string[]) => {
+    console.log(event);
+    setExpandedItems(expandedItems);
+  };
 
   return (
     <>
@@ -216,6 +224,7 @@ export const Complex = (args: Partial<TreeViewProps>) => {
           {...args}
           apiRef={apiRef}
           onSelectedItemChange={setSelectedItems}
+          onExpandedChange={handleExpandedChange}
         >
           <TreeItem label={<>Part 1: Introduction</>} itemId="pt1" testId="pt1">
             <TreeItem
@@ -313,7 +322,6 @@ export const Complex = (args: Partial<TreeViewProps>) => {
                   </>
                 }
                 itemId="pt2ch5.1"
-                isDisabled
               >
                 <TreeItem
                   icon={<ArticleIcon aria-hidden={true} />}
@@ -336,6 +344,47 @@ export const Complex = (args: Partial<TreeViewProps>) => {
                   }
                   itemId="pt2ch5.1.2"
                 />
+                <TreeItem
+                  icon={<ArticleIcon aria-hidden={true} />}
+                  label={
+                    <>
+                      Section 5.1.3: Apple pie apple pie tart macaroon topping
+                      chocolate cake
+                    </>
+                  }
+                  itemId="pt2ch5.1.3"
+                >
+                  <TreeItem
+                    icon={<ArticleIcon aria-hidden={true} />}
+                    label={
+                      <>
+                        Section 5.1.3.1: Apple pie apple pie tart macaroon topping
+                        chocolate cake
+                      </>
+                    }
+                    itemId="pt2ch5.1.3.1"
+                  />
+                  <TreeItem
+                    icon={<ArticleIcon aria-hidden={true} />}
+                    label={
+                      <>
+                        Section 5.1.3.2: Apple pie apple pie tart macaroon topping
+                        chocolate cake
+                      </>
+                    }
+                    itemId="pt2ch5.1.3.2"
+                  />
+                  <TreeItem
+                    icon={<ArticleIcon aria-hidden={true} />}
+                    label={
+                      <>
+                        Section 5.1.3.3: Apple pie apple pie tart macaroon topping
+                        chocolate cake
+                      </>
+                    }
+                    itemId="pt2ch5.1.3.3"
+                  />
+                </TreeItem>
               </TreeItem>
               <TreeItem
                 icon={<ArticleIcon aria-hidden={true} />}
@@ -439,6 +488,8 @@ export const Complex = (args: Partial<TreeViewProps>) => {
         <Button onClick={() => apiRef.current?.selectAll()}>Select all</Button>
         <Button onClick={() => apiRef.current?.clearAll()}>Clear all</Button>
       </ButtonGroup>
+      <Spacer axis={SpacerAxis.vertical} size={24} />
+      <p>Expanded: {expandedItems?.join(', ')}</p>
     </>
   );
 };
@@ -446,7 +497,7 @@ export const Complex = (args: Partial<TreeViewProps>) => {
 Complex.args = {
   selectable: TreeViewSelectable.multi,
   ariaLabel: 'Textbook tree',
-  initialExpandedItems: ['pt1', 'pt1ch1', 'pt2ch5.1'],
+  initialExpandedItems: ['pt1', 'pt2ch5.1'],
   preselectedItems: [
     { itemId: 'pt1ch1', checkedStatus: IndeterminateCheckboxStatus.checked },
     { itemId: 'pt1', checkedStatus: IndeterminateCheckboxStatus.indeterminate },
@@ -462,6 +513,10 @@ Complex.args = {
     },
     { itemId: 'pt2ch5.2', checkedStatus: IndeterminateCheckboxStatus.checked },
     { itemId: 'pt2ch5.3', checkedStatus: IndeterminateCheckboxStatus.checked },
+    {
+      itemId: 'pt2ch5.1.3',
+      checkedStatus: IndeterminateCheckboxStatus.checked,
+    },
   ],
   checkParents: true,
   checkChildren: true,

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -213,7 +213,6 @@ export const Complex = (args: Partial<TreeViewProps>) => {
   const total = selectedItems?.length ?? 0;
 
   const handleExpandedChange = (event: React.SyntheticEvent, expandedItems: string[]) => {
-    console.log(event);
     setExpandedItems(expandedItems);
   };
 
@@ -322,6 +321,7 @@ export const Complex = (args: Partial<TreeViewProps>) => {
                   </>
                 }
                 itemId="pt2ch5.1"
+                isDisabled
               >
                 <TreeItem
                   icon={<ArticleIcon aria-hidden={true} />}

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
@@ -22,7 +22,10 @@ export interface TreeViewContextInterface {
   hasIcons: boolean;
   initialExpandedItems: Array<string>;
   initialExpandedItemsNeedUpdate: boolean;
-  onExpandedChange?: (event: React.SyntheticEvent) => void;
+  onExpandedChange?: (
+    event: React.SyntheticEvent,
+    expandedItems: Array<string>
+  ) => void;
   onSelectedItemChange?: (
     selectedItems: Array<TreeItemSelectedInterface>
   ) => void;
@@ -41,6 +44,10 @@ export interface TreeViewContextInterface {
   selectItem: (
     data: Pick<TreeViewItemInterface, 'itemId' | 'checkedStatus'>
   ) => void;
+  handleExpandedChange: (
+    event: React.SyntheticEvent,
+    expandedItemId: string
+  ) => void;
 }
 
 export const TreeViewContext = React.createContext<TreeViewContextInterface>({
@@ -55,4 +62,5 @@ export const TreeViewContext = React.createContext<TreeViewContextInterface>({
   checkChildren: true,
   items: [],
   selectItem: () => undefined,
+  handleExpandedChange: () => undefined,
 });

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -12,6 +12,7 @@ import {
   toggleAllMulti,
   isSelectedItemsChanged,
   isEqualArrays,
+  getChildrenIds,
 } from './utils';
 import { TreeViewSelectable } from './types';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
@@ -63,8 +64,13 @@ export interface UseTreeViewProps {
   testId?: string;
   /**
    * Action that fires when an item is expanded or collapsed
+   * Return an array of itemIds of items that are expanded
+   * Example: ['item0', 'item1', 'item3']
    */
-  onExpandedChange?: (event: React.SyntheticEvent) => void;
+  onExpandedChange?: (
+    event: React.SyntheticEvent,
+    expandedItems: Array<string>
+  ) => void;
   /**
    * Action that fires when an item is selected
    * Return an array of objects.
@@ -360,6 +366,43 @@ export function useTreeView(props: UseTreeViewProps) {
     }
   }, []);
 
+  const [expandedSet, setExpandedSet] = React.useState<Set<string>>(
+    new Set(initialExpandedItems)
+  );
+
+  const handleExpandedChange = (
+    event: React.SyntheticEvent,
+    itemId: string
+  ) => {
+    setExpandedSet(prevExpandedSet => {
+      const updatedExpandedSet = new Set(prevExpandedSet);
+      const childItemIds = getChildrenIds({
+        items,
+        itemId,
+      });
+
+      if (updatedExpandedSet.has(itemId)) {
+        updatedExpandedSet.delete(itemId);
+        childItemIds.forEach((childId: string) => {
+          updatedExpandedSet.delete(childId);
+        });
+      } else {
+        updatedExpandedSet.add(itemId);
+        childItemIds.forEach((childId: string) => {
+          if (initialExpandedItems?.includes(childId)) {
+            updatedExpandedSet.add(childId);
+          }
+        });
+      }
+
+      const expandedItemsArray = Array.from(updatedExpandedSet);
+      onExpandedChange &&
+        typeof onExpandedChange === 'function' &&
+        onExpandedChange(event, expandedItemsArray);
+      return updatedExpandedSet;
+    });
+  };
+
   const contextValue = {
     hasIcons,
     itemToFocus,
@@ -376,6 +419,8 @@ export function useTreeView(props: UseTreeViewProps) {
     checkParents,
     items,
     selectItem,
+    handleExpandedChange,
+    expandedSet,
   };
 
   return { contextValue };

--- a/packages/react-magma-dom/src/components/TreeView/utils.ts
+++ b/packages/react-magma-dom/src/components/TreeView/utils.ts
@@ -360,7 +360,7 @@ const processChildrenSelection = ({
   });
 };
 
-const getChildrenIds = ({
+export const getChildrenIds = ({
   items,
   itemId,
 }: {

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -770,19 +770,24 @@ export function Example() {
   const [currentTreeEvent, setCurrentTreeEvent] = React.useState<
     string | undefined
   >(undefined);
+  const [expandedItems, setExpandedItems] = React.useState<string[]>([]);
 
   function handleSelectedItemChange(event) {
     setCurrentTreeEvent('Selected');
   }
 
-  function handleExpandedChange(event) {
+  function handleExpandedChange(event: React.SyntheticEvent, expandedItems: string[]) {
     setCurrentTreeEvent('Expanded');
+    setExpandedItems(expandedItems);
   }
 
   return (
     <>
       <p>
         <strong>{currentTreeEvent || 'No'} event was triggered</strong>
+        <br />
+        <br />
+        <strong>Expanded Items: {expandedItems ? expandedItems.join(', ') : ' '}</strong>
       </p>
 
       <TreeView


### PR DESCRIPTION
Issue: #1499

## What I did

- Implemented functionality for onExpandedChange to return an array of expanded items similar to how onSelectedItemChange returns selected items. 

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
test the implementation example in 
- storybook: /treeview--complex
- documentation: api/tree-view/#change_events
