### PR TITLE
fix(Select) Multi Select and Multi Combobox selected item focus outline

### DIFF
--- a/.changeset/fix-select-combobox-multi-outline.md
+++ b/.changeset/fix-select-combobox-multi-outline.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Select): Fix multi Select selected item outline.

--- a/packages/react-magma-dom/src/components/Select/shared.ts
+++ b/packages/react-magma-dom/src/components/Select/shared.ts
@@ -168,6 +168,7 @@ export const SelectedItemButton = styled.button<{
   position: relative;
   white-space: nowrap;
   min-width: 0%;
+  outline-offset: 2px;
 `;
 
 export const IconWrapper = styled.span`


### PR DESCRIPTION
Issue: #1499

## What I did
change outline offset on Combobox and Select selected items

## Screenshots:
![image](https://github.com/user-attachments/assets/a12014a8-0cb2-49b3-8dac-203d8a4a9848)


## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [-] I have added tests that prove my fix is effective or that my feature works

## How to test
check the outline on selected items in 
- /story/select--multi
- /story/combobox--multi