### PR TITLE
feat(Table, Datagrid): Added new `tableTitle` prop

### DIFF
--- a/.changeset/feat-table-datagrid-caption.md
+++ b/.changeset/feat-table-datagrid-caption.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Table, Datagrid): Added new prop `tableTitle` to `Table` and `Datagrid` which supports a captioned title above each Table and Datagrid.

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -342,18 +342,20 @@ const defaultArgs = {
 };
 
 export const Default = Template.bind({});
-Default.args = defaultArgs;
+Default.args = { ...defaultArgs, tableTitle: 'Default' };
 
 export const ColoredRows = Template.bind({});
 ColoredRows.args = {
   ...defaultArgs,
   rows: coloredRows,
+  tableTitle: 'Colored rows',
 };
 
 export const Selectable = Template.bind({});
 Selectable.args = {
   ...defaultArgs,
   isSelectable: true,
+  tableTitle: 'Selectable',
 };
 
 export const SelectableAndSortable: Story<DatagridProps> = ({
@@ -541,18 +543,21 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
 SelectableAndSortable.args = {
   isSelectable: true,
   isSortableBySelected: true,
+  tableTitle: 'Selectable and sortable',
 };
 
 export const ControlledSelectable = ControlledTemplate.bind({});
 ControlledSelectable.args = {
   ...defaultArgs,
   isSelectable: true,
+  tableTitle: 'Controlled selectable',
 };
 
 export const DisabledSelectableRow = Template.bind({});
 DisabledSelectableRow.args = {
   ...defaultArgs,
   isSelectable: true,
+  tableTitle: 'Disabled selectable row',
   rows: [
     ...defaultArgs.rows,
     {
@@ -569,6 +574,7 @@ DisabledSelectableRow.args = {
 export const PaginationChangedDefaults = Template.bind({});
 PaginationChangedDefaults.args = {
   ...defaultArgs,
+  tableTitle: 'Pagination changed defaults',
   paginationProps: {
     defaultPage: 2,
     defaultRowsPerPage: 5,
@@ -579,6 +585,7 @@ PaginationChangedDefaults.args = {
 export const ControlledPagination = ControlledPaginatedTemplate.bind({});
 ControlledPagination.args = {
   ...defaultArgs,
+  tableTitle: 'Controlled pagination',
   paginationProps: {
     rowsPerPageValues: [5, 10, 20],
   },
@@ -587,6 +594,7 @@ ControlledPagination.args = {
 export const WithoutPagination = Template.bind({});
 WithoutPagination.args = {
   ...defaultArgs,
+  tableTitle: 'Without pagination',
   hasPagination: false,
 };
 
@@ -632,6 +640,7 @@ const CustomPaginationComponent: React.FunctionComponent<
 export const PaginationWithCustomComponent = Template.bind({});
 PaginationWithCustomComponent.args = {
   ...defaultArgs,
+  tableTitle: 'Pagination with custom component',
   components: {
     Pagination: CustomPaginationComponent,
   },

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -340,13 +340,17 @@ const defaultArgs = {
   isInverse: false,
   isSortableBySelected: false,
   paginationProps: {},
+  tableTitle: 'Default'
 };
 
 export const Default = Template.bind({});
-Default.args = { ...defaultArgs, tableTitle: 'Default' };
+Default.args = { ...defaultArgs };
 
 export const TitleWithNode = Template.bind({});
+
 TitleWithNode.args = { ...defaultArgs, tableTitle: <Heading level={1}>Title with node</Heading> };
+
+TitleWithNode.parameters = { controls: { exclude: ['tableTitle'] } };
 
 export const ColoredRows = Template.bind({});
 ColoredRows.args = {

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -282,6 +282,11 @@ export default {
         type: 'boolean',
       },
     },
+    tableTitle: {
+      control: {
+        type: 'text',
+      },
+    },
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -15,6 +15,7 @@ import { magma } from '../../theme/magma';
 import { Spacer, SpacerAxis } from '../Spacer';
 import { Announce } from '../Announce';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { Heading } from '../Heading';
 
 const rowsForPagination = [
   {
@@ -343,6 +344,9 @@ const defaultArgs = {
 
 export const Default = Template.bind({});
 Default.args = { ...defaultArgs, tableTitle: 'Default' };
+
+export const TitleWithNode = Template.bind({});
+TitleWithNode.args = { ...defaultArgs, tableTitle: <Heading level={1}>Title with node</Heading> };
 
 export const ColoredRows = Template.bind({});
 ColoredRows.args = {

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -4,7 +4,12 @@ import { Datagrid } from '.';
 import { TableRowColor } from '../Table';
 import { Button } from '../Button';
 import { usePagination } from '../Pagination/usePagination';
-import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  getByDisplayValue,
+} from '@testing-library/react';
 import { magma } from '../../theme/magma';
 
 const columns = [
@@ -834,6 +839,18 @@ describe('Datagrid', () => {
       expect(getByText(/previous page/i)).toBeInTheDocument();
       expect(getByText(/next page/i)).toBeInTheDocument();
     });
+  });
+
+  it('should have a title above the Datagrid', () => {
+    const { getByText } = render(
+      <Datagrid
+        columns={columns}
+        rows={rowsForPagination}
+        tableTitle="Datagrid title"
+      />
+    );
+
+    expect(getByText('Datagrid title')).toBeInTheDocument();
   });
 
   it('Does not violate accessibility standards', () => {

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -841,7 +841,7 @@ describe('Datagrid', () => {
     });
   });
 
-  it('should have a title above the Datagrid', () => {
+  it('should display the title', () => {
     const { getByText } = render(
       <Datagrid
         columns={columns}

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -3,6 +3,8 @@ import { useControlled } from '../../hooks/useControlled';
 import { useDataPagination } from '../../hooks/useDataPagination';
 import { XOR } from '../../utils';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
+import styled from '@emotion/styled';
+
 import {
   Table,
   TableBody,
@@ -51,6 +53,7 @@ export interface DatagridRow {
    * Used to allow each unique column field as a key with the row content as the value
    */
   [key: string]: any;
+  tableTitle?: any;
 }
 
 export interface DatagridComponents {
@@ -138,6 +141,11 @@ export interface UncontrolledSelectedRowsProps {
   defaultSelectedRows?: (string | number)[];
 }
 
+export const StyledCaption = styled.caption`
+  display: flex;
+  flex: 1;
+`;
+
 export type DatagridSelectedRowsProps = XOR<
   ControlledSelectedRowsProps,
   UncontrolledSelectedRowsProps
@@ -160,6 +168,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       selectedRows: selectedRowsProp,
       hasPagination = true,
       onSortBySelected,
+      tableTitle,
       sortDirection,
       ...other
     } = props;
@@ -278,6 +287,8 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
 
     return (
       <>
+        {tableTitle && <StyledCaption>{tableTitle}</StyledCaption>}
+
         <Table {...other} ref={ref} aria-live="polite">
           <TableHead>
             <TableRow

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -289,7 +289,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
     return (
       <>
         {tableTitle && (
-          <StyledCaption isInverse={props.isInverse} theme={theme}>
+          <StyledCaption isInverse={props.isInverse} tableTitleNode={typeof tableTitle !== 'string' ? true : false} theme={theme}>
             {tableTitle}
           </StyledCaption>
         )}

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -55,7 +55,8 @@ export interface DatagridRow {
    */
   [key: string]: any;
   /**
-   * Title that appears above the Datagrid
+   * The title or caption of a table inside a <caption> HTML element that provides the table an accessible 
+   * description
    */
   tableTitle?: React.ReactNode | string;
 }
@@ -288,13 +289,13 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
 
     return (
       <>
+
+        <Table {...other} ref={ref} aria-live="polite">
         {tableTitle && (
           <StyledCaption isInverse={props.isInverse} isTitleNode={typeof tableTitle !== 'string'} theme={theme}>
             {tableTitle}
           </StyledCaption>
         )}
-
-        <Table {...other} ref={ref} aria-live="polite">
           <TableHead>
             <TableRow
               headerRowStatus={headerRowStatus}

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -54,7 +54,10 @@ export interface DatagridRow {
    * Used to allow each unique column field as a key with the row content as the value
    */
   [key: string]: any;
-  tableTitle?: any;
+  /**
+   * Title that appears above the Datagrid
+   */
+  tableTitle?: React.ReactNode | string;
 }
 
 export interface DatagridComponents {
@@ -286,7 +289,9 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
     return (
       <>
         {tableTitle && (
-          <StyledCaption theme={theme}>{tableTitle}</StyledCaption>
+          <StyledCaption isInverse={props.isInverse} theme={theme}>
+            {tableTitle}
+          </StyledCaption>
         )}
 
         <Table {...other} ref={ref} aria-live="polite">

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -289,7 +289,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
     return (
       <>
         {tableTitle && (
-          <StyledCaption isInverse={props.isInverse} tableTitleNode={typeof tableTitle !== 'string' ? true : false} theme={theme}>
+          <StyledCaption isInverse={props.isInverse} isTitleNode={typeof tableTitle !== 'string'} theme={theme}>
             {tableTitle}
           </StyledCaption>
         )}

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -3,7 +3,8 @@ import { useControlled } from '../../hooks/useControlled';
 import { useDataPagination } from '../../hooks/useDataPagination';
 import { XOR } from '../../utils';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
-import styled from '@emotion/styled';
+import { StyledCaption } from '../Table';
+import { ThemeContext } from '../../theme/ThemeContext';
 
 import {
   Table,
@@ -141,11 +142,6 @@ export interface UncontrolledSelectedRowsProps {
   defaultSelectedRows?: (string | number)[];
 }
 
-export const StyledCaption = styled.caption`
-  display: flex;
-  flex: 1;
-`;
-
 export type DatagridSelectedRowsProps = XOR<
   ControlledSelectedRowsProps,
   UncontrolledSelectedRowsProps
@@ -177,6 +173,8 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       controlled: selectedRowsProp,
       default: defaultSelectedRows,
     });
+
+    const theme = React.useContext(ThemeContext);
 
     const isControlled = selectedRowsProp ? true : false;
 
@@ -287,7 +285,9 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
 
     return (
       <>
-        {tableTitle && <StyledCaption>{tableTitle}</StyledCaption>}
+        {tableTitle && (
+          <StyledCaption theme={theme}>{tableTitle}</StyledCaption>
+        )}
 
         <Table {...other} ref={ref} aria-live="polite">
           <TableHead>

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -52,7 +52,7 @@ const rows = [
 
 const Template: Story<TableProps> = args => (
   <Card isInverse={args.isInverse}>
-    <Table tableTitle="Basic usage">
+    <Table tableTitle="Basic usage" {...args}>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -890,7 +890,7 @@ export const NoRowsPerPageControl = args => {
 
 export const TableTitleWithNode = args => {
   return (
-    <Table tableTitle={<Heading level={1} {...args}>Heading component example</Heading>}>
+    <Table tableTitle={<Heading level={1}>Heading component example</Heading>} {...args}>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -88,6 +88,11 @@ export default {
         type: 'number',
       },
     },
+    tableTitle: {
+      control: {
+        type: 'text',
+      },
+    },
   },
 } as Meta;
 
@@ -797,13 +802,17 @@ export const AdjustableRowNumber = args => {
       tableRows.push(
         <TableRow key={`row${i}`}>
           <TableCell key={`cell${i}-left`}>{i}</TableCell>
-          <TableCell key={`cell${i}-middle`}>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</TableCell>
-          <TableCell key={`cell${i}-right`}>Nullam bibendum diam vel felis consequat lacinia.</TableCell>
+          <TableCell key={`cell${i}-middle`}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </TableCell>
+          <TableCell key={`cell${i}-right`}>
+            Nullam bibendum diam vel felis consequat lacinia.
+          </TableCell>
         </TableRow>
       );
     }
     return tableRows;
-  };
+  }
 
   return (
     <Table {...args}>
@@ -814,9 +823,7 @@ export const AdjustableRowNumber = args => {
           <TableHeaderCell>Column</TableHeaderCell>
         </TableRow>
       </TableHead>
-      <TableBody>
-        {getTableRows()}
-      </TableBody>
+      <TableBody>{getTableRows()}</TableBody>
     </Table>
   );
 };

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -27,6 +27,7 @@ import { Select } from '../Select';
 import { Combobox } from '../Combobox';
 
 import { Story, Meta } from '@storybook/react/types-6-0';
+import { Heading } from '../Heading';
 
 const rows = [
   [
@@ -51,7 +52,7 @@ const rows = [
 
 const Template: Story<TableProps> = args => (
   <Card isInverse={args.isInverse}>
-    <Table {...args}>
+    <Table tableTitle="Basic usage">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -103,7 +104,7 @@ Default.args = {
   hasVerticalBorders: false,
   hasZebraStripes: false,
   isInverse: false,
-  tableTitle: `Basic usage table`,
+  tableTitle: "Basic usage table",
 };
 
 export const SquareCorners = args => {
@@ -144,7 +145,7 @@ SquareCorners.args = {
   hasHoverStyles: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,
-  tableTitle: `Square corners table`,
+  tableTitle: "Square corners",
 };
 
 const rowsLong = [
@@ -341,7 +342,7 @@ export const ControlledPagination = args => {
 };
 ControlledPagination.args = {
   ...Default.args,
-  tableTitle: `Controlled Pagination`,
+  tableTitle: "Controlled Pagination",
 };
 
 export const UncontrolledPagination = args => {
@@ -446,7 +447,7 @@ PaginationWithSquareCorners.args = {
   hasHoverStyles: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,
-  tableTitle: `Pagination with square corners`,
+  tableTitle: "Pagination with square corners",
 };
 
 export const PaginationInverse = args => {
@@ -499,7 +500,7 @@ export const PaginationInverse = args => {
 PaginationInverse.args = {
   ...Default.args,
   isInverse: true,
-  tableTitle: `Pagination inverse`,
+  tableTitle: "Pagination inverse",
 };
 
 export const RowColors = args => {
@@ -551,7 +552,7 @@ RowColors.args = {
   ...Default.args,
   hasHoverStyles: true,
   hasZebraStripe: true,
-  tableTitle: `Row colors`,
+  tableTitle: "Row colors",
 };
 
 export const RowColorsInverse = args => {
@@ -609,7 +610,7 @@ export const RowColorsInverse = args => {
 RowColorsInverse.args = {
   ...Default.args,
   isInverse: true,
-  tableTitle: `Row colors inverse`,
+  tableTitle: "Row colors inverse",
 };
 
 export const Sortable = args => {
@@ -725,7 +726,7 @@ export const Sortable = args => {
 
 Sortable.args = {
   ...Default.args,
-  tableTitle: `Sortable`,
+  tableTitle: "Sortable",
 };
 
 export const WithDropdown = args => {
@@ -801,7 +802,7 @@ export const WithDropdown = args => {
 };
 WithDropdown.args = {
   ...Default.args,
-  tableTitle: `With Dropdown`,
+  tableTitle: "With Dropdown",
 };
 
 export const AdjustableRowNumber = args => {
@@ -838,7 +839,7 @@ export const AdjustableRowNumber = args => {
 };
 AdjustableRowNumber.args = {
   numberRows: 300,
-  tableTitle: `Adjustable row number`,
+  tableTitle: "Adjustable row number",
 };
 
 export const NoRowsPerPageControl = args => {
@@ -885,4 +886,56 @@ export const NoRowsPerPageControl = args => {
       />
     </Card>
   );
+};
+
+export const TableTitleWithNode = args => {
+  return (
+    <Table tableTitle={<Heading level={1} {...args}>Heading component example</Heading>}>
+      <TableHead>
+        <TableRow>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell>Lorem ipsum</TableCell>
+          <TableCell>dolar sit</TableCell>
+          <TableCell>amet</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Lorem ipsum</TableCell>
+          <TableCell>dolar sit</TableCell>
+          <TableCell>amet</TableCell>
+        </TableRow>
+        <TableRow color={TableRowColor.success}>
+          <TableCell>Lorem ipsum</TableCell>
+          <TableCell>dolar sit</TableCell>
+          <TableCell>amet</TableCell>
+        </TableRow>
+        <TableRow color={TableRowColor.danger}>
+          <TableCell>Lorem ipsum</TableCell>
+          <TableCell>dolar sit</TableCell>
+          <TableCell>amet</TableCell>
+        </TableRow>
+        <TableRow color={TableRowColor.info}>
+          <TableCell>Lorem ipsum</TableCell>
+          <TableCell>dolar sit</TableCell>
+          <TableCell>amet</TableCell>
+        </TableRow>
+        <TableRow color={TableRowColor.warning}>
+          <TableCell>Lorem ipsum</TableCell>
+          <TableCell>dolar sit</TableCell>
+          <TableCell>amet</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+};
+TableTitleWithNode.args = {
+  ...Default.args,
+  hasHoverStyles: true,
+  hasZebraStripe: true,
+  tableTitle: "Row colors",
 };

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -103,6 +103,7 @@ Default.args = {
   hasVerticalBorders: false,
   hasZebraStripes: false,
   isInverse: false,
+  tableTitle: `Basic usage table`,
 };
 
 export const SquareCorners = args => {
@@ -115,7 +116,7 @@ export const SquareCorners = args => {
   );
 
   return (
-    <div style={{ background: magma.colors.primary600, padding: '20px' }}>
+    <div style={{ background: magma.colors.neutral300, padding: '20px' }}>
       <Table style={{ background: magma.colors.neutral100 }} {...args}>
         <TableHead>
           <TableRow>
@@ -143,6 +144,7 @@ SquareCorners.args = {
   hasHoverStyles: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,
+  tableTitle: `Square corners table`,
 };
 
 const rowsLong = [
@@ -339,6 +341,7 @@ export const ControlledPagination = args => {
 };
 ControlledPagination.args = {
   ...Default.args,
+  tableTitle: `Controlled Pagination`,
 };
 
 export const UncontrolledPagination = args => {
@@ -360,7 +363,7 @@ export const UncontrolledPagination = args => {
 
   return (
     <>
-      <Table>
+      <Table tableTitle="Uncontrolled Pagination">
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -406,7 +409,7 @@ export const PaginationWithSquareCorners = args => {
   );
 
   return (
-    <div style={{ background: magma.colors.primary600, padding: '20px' }}>
+    <div style={{ background: magma.colors.neutral300, padding: '20px' }}>
       <Table style={{ background: magma.colors.neutral100 }} {...args}>
         <TableHead>
           <TableRow>
@@ -443,6 +446,7 @@ PaginationWithSquareCorners.args = {
   hasHoverStyles: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,
+  tableTitle: `Pagination with square corners`,
 };
 
 export const PaginationInverse = args => {
@@ -495,6 +499,7 @@ export const PaginationInverse = args => {
 PaginationInverse.args = {
   ...Default.args,
   isInverse: true,
+  tableTitle: `Pagination inverse`,
 };
 
 export const RowColors = args => {
@@ -546,6 +551,7 @@ RowColors.args = {
   ...Default.args,
   hasHoverStyles: true,
   hasZebraStripe: true,
+  tableTitle: `Row colors`,
 };
 
 export const RowColorsInverse = args => {
@@ -603,6 +609,7 @@ export const RowColorsInverse = args => {
 RowColorsInverse.args = {
   ...Default.args,
   isInverse: true,
+  tableTitle: `Row colors inverse`,
 };
 
 export const Sortable = args => {
@@ -718,6 +725,7 @@ export const Sortable = args => {
 
 Sortable.args = {
   ...Default.args,
+  tableTitle: `Sortable`,
 };
 
 export const WithDropdown = args => {
@@ -793,6 +801,7 @@ export const WithDropdown = args => {
 };
 WithDropdown.args = {
   ...Default.args,
+  tableTitle: `With Dropdown`,
 };
 
 export const AdjustableRowNumber = args => {
@@ -829,6 +838,7 @@ export const AdjustableRowNumber = args => {
 };
 AdjustableRowNumber.args = {
   numberRows: 300,
+  tableTitle: `Adjustable row number`,
 };
 
 export const NoRowsPerPageControl = args => {
@@ -846,7 +856,7 @@ export const NoRowsPerPageControl = args => {
 
   return (
     <Card isInverse={args.isInverse}>
-      <Table {...args}>
+      <Table {...args} tableTitle="No rows per page control">
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -52,7 +52,7 @@ const rows = [
 
 const Template: Story<TableProps> = args => (
   <Card isInverse={args.isInverse}>
-    <Table tableTitle="Basic usage" {...args}>
+    <Table {...args}>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -890,7 +890,7 @@ export const NoRowsPerPageControl = args => {
 
 export const TableTitleWithNode = args => {
   return (
-    <Table tableTitle={<Heading level={1}>Heading component example</Heading>} {...args}>
+    <Table {...args} tableTitle={<Heading level={1}>Heading component example</Heading>}>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -355,7 +355,7 @@ describe('Table', () => {
     });
   });
 
-  it('should have a title above the Table', () => {
+  it('should display the title', () => {
     const { getByText } = render(
       <Table tableTitle="Table title">
         <TableHead>

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -355,6 +355,27 @@ describe('Table', () => {
     });
   });
 
+  it('should have a title above the Table', () => {
+    const { getByText } = render(
+      <Table tableTitle="Table title">
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>heading 1</TableHeaderCell>
+            <TableHeaderCell>heading 2</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>cell 1</TableCell>
+            <TableCell>cell 2</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByText('Table title')).toBeInTheDocument();
+  });
+
   it('should render sortable table header cells with inverse styles', () => {
     const { getByTestId } = render(
       <Table isInverse>

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -47,7 +47,8 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
   minWidth?: number;
   rowCount?: number;
   /**
-   * Title that appears above the Datagrid
+   * The title or caption of a table inside a <caption> HTML element that provides the table an accessible 
+   * description
    */
   tableTitle?: React.ReactNode | string;
 
@@ -130,6 +131,7 @@ export const TableContainer = styled.div<{
 `;
 export const StyledCaption = styled.caption<{ isInverse: boolean; isTitleNode: boolean; }>`
   ${headingMediumStyles};
+  text-align:left;
   margin: ${props => props.isTitleNode || props.theme.spaceScale.spacing04};
   display: flex;
   flex: 1;
@@ -199,11 +201,6 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           theme={theme}
           tabIndex={0}
         >
-          {tableTitle && (
-            <StyledCaption isInverse={isInverse} isTitleNode={typeof tableTitle !== 'string'} theme={theme}>
-              {tableTitle}
-            </StyledCaption>
-          )}
           <StyledTable
             {...other}
             data-testid={testId}
@@ -211,7 +208,12 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
             minWidth={minWidth || theme.breakpoints.small}
             ref={ref}
             theme={theme}
-          >
+            >
+            {tableTitle && (
+              <StyledCaption isInverse={isInverse} isTitleNode={typeof tableTitle !== 'string'} theme={theme}>
+                {tableTitle}
+              </StyledCaption>
+            )}
             {children}
           </StyledTable>
         </TableContainer>

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -128,9 +128,9 @@ export const TableContainer = styled.div<{
           : props.theme.colors.focus};
   }
 `;
-export const StyledCaption = styled.caption<{ isInverse: boolean; tableTitleNode: boolean; }>`
+export const StyledCaption = styled.caption<{ isInverse: boolean; isTitleNode: boolean; }>`
   ${headingMediumStyles};
-  margin: ${props => props.tableTitleNode ? `` : props.theme.spaceScale.spacing04};
+  margin: ${props => props.isTitleNode || props.theme.spaceScale.spacing04};
   display: flex;
   flex: 1;
 `;
@@ -200,7 +200,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           tabIndex={0}
         >
           {tableTitle && (
-            <StyledCaption isInverse={isInverse} tableTitleNode={typeof tableTitle !== 'string' ? true : false} theme={theme}>
+            <StyledCaption isInverse={isInverse} isTitleNode={typeof tableTitle !== 'string'} theme={theme}>
               {tableTitle}
             </StyledCaption>
           )}

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -133,8 +133,6 @@ export const StyledCaption = styled.caption<{ isInverse: boolean; isTitleNode: b
   ${headingMediumStyles};
   text-align:left;
   margin: ${props => props.isTitleNode || props.theme.spaceScale.spacing04};
-  display: flex;
-  flex: 1;
 `;
 
 export const StyledTable = styled.table<{

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -45,6 +45,8 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    */
   minWidth?: number;
   rowCount?: number;
+  tableTitle?: any;
+
   selectedItems?: Array<number>;
   /**
    * @internal
@@ -123,6 +125,11 @@ export const TableContainer = styled.div<{
   }
 `;
 
+export const StyledCaption = styled.caption`
+  display: flex;
+  flex: 1;
+`;
+
 export const StyledTable = styled.table<{
   isInverse?: boolean;
   minWidth: number;
@@ -154,6 +161,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       minWidth = 600,
       rowCount,
       selectedItems,
+      tableTitle,
       testId,
       isSortableBySelected,
       ...other
@@ -175,7 +183,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           isInverse: isInverse,
           isSelectable,
           isSortableBySelected,
-          rowCount
+          rowCount,
         }}
       >
         <TableContainer
@@ -186,6 +194,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           theme={theme}
           tabIndex={0}
         >
+          {tableTitle && <StyledCaption>{tableTitle}</StyledCaption>}
           <StyledTable
             {...other}
             data-testid={testId}

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
 import styled from '@emotion/styled';
+import { headingMediumStyles } from '../Typography';
 
 /**
  * @children required
@@ -127,21 +128,9 @@ export const TableContainer = styled.div<{
           : props.theme.colors.focus};
   }
 `;
-export const StyledCaption = styled.caption<{ isInverse: boolean }>`
-  color: ${props =>
-    props.isInverse
-      ? props.theme.colors.neutral100
-      : props.theme.colors.neutral700};
-  margin: ${props => props.theme.spaceScale.spacing04} 0;
-  border-bottom: 2px solid transparent;
-  font-size: ${props =>
-    props.theme.typographyVisualStyles.headingMedium.desktop.fontSize};
-  letter-spacing: ${props =>
-    props.theme.typographyVisualStyles.headingMedium.desktop.letterSpacing};
-  line-height: ${props =>
-    props.theme.typographyVisualStyles.headingMedium.desktop.lineHeight};
-  font-weight: ${props =>
-    props.theme.typographyVisualStyles.headingMedium.fontWeight};
+export const StyledCaption = styled.caption<{ isInverse: boolean; tableTitleNode: boolean; }>`
+  ${headingMediumStyles};
+  margin: ${props => props.tableTitleNode ? `` : props.theme.spaceScale.spacing04};
   display: flex;
   flex: 1;
 `;
@@ -211,7 +200,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           tabIndex={0}
         >
           {tableTitle && (
-            <StyledCaption isInverse={isInverse} theme={theme}>
+            <StyledCaption isInverse={isInverse} tableTitleNode={typeof tableTitle !== 'string' ? true : false} theme={theme}>
               {tableTitle}
             </StyledCaption>
           )}

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
 import styled from '@emotion/styled';
-import { TypographyVisualStyle } from '../Typography';
 
 /**
  * @children required

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -46,6 +46,9 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    */
   minWidth?: number;
   rowCount?: number;
+  /**
+   * Title that appears above the Datagrid
+   */
   tableTitle?: React.ReactNode | string;
 
   selectedItems?: Array<number>;

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
 import styled from '@emotion/styled';
+import { TypographyVisualStyle } from '../Typography';
 
 /**
  * @children required
@@ -45,7 +46,7 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    */
   minWidth?: number;
   rowCount?: number;
-  tableTitle?: any;
+  tableTitle?: React.ReactNode | string;
 
   selectedItems?: Array<number>;
   /**
@@ -124,8 +125,21 @@ export const TableContainer = styled.div<{
           : props.theme.colors.focus};
   }
 `;
-
-export const StyledCaption = styled.caption`
+export const StyledCaption = styled.caption<{ isInverse: boolean }>`
+  color: ${props =>
+    props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral700};
+  margin: ${props => props.theme.spaceScale.spacing04} 0;
+  border-bottom: 2px solid transparent;
+  font-size: ${props =>
+    props.theme.typographyVisualStyles.headingMedium.desktop.fontSize};
+  letter-spacing: ${props =>
+    props.theme.typographyVisualStyles.headingMedium.desktop.letterSpacing};
+  line-height: ${props =>
+    props.theme.typographyVisualStyles.headingMedium.desktop.lineHeight};
+  font-weight: ${props =>
+    props.theme.typographyVisualStyles.headingMedium.fontWeight};
   display: flex;
   flex: 1;
 `;
@@ -194,7 +208,11 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           theme={theme}
           tabIndex={0}
         >
-          {tableTitle && <StyledCaption>{tableTitle}</StyledCaption>}
+          {tableTitle && (
+            <StyledCaption isInverse={isInverse} theme={theme}>
+              {tableTitle}
+            </StyledCaption>
+          )}
           <StyledTable
             {...other}
             data-testid={testId}

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -285,7 +285,7 @@ Use `rowName` when using Selectable so that the aria labels on the checkboxes ca
 
 ```typescript
 import React from 'react';
-import { Datagrid, Card } from 'react-magma-dom';
+import { Datagrid, Heading, Card } from 'react-magma-dom';
 
 export function Example() {
   const columns = [
@@ -501,7 +501,7 @@ export function Example() {
   return (
     <Card>
       <Datagrid
-        tableTitle="Selectable Datagrid"
+        tableTitle={<Heading level={1}>Selectable Datagrid</Heading>}
         columns={columns}
         rows={rows}
         isSelectable

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -925,6 +925,7 @@ export function Example() {
         onRowSelect={handleSelectedItems}
         onHeaderSelect={handleHeaderSelect}
         sortDirection={selectedDirection}
+        tableTitle="Selectable and sortable"
       />
       <Announce>
         <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
@@ -1172,6 +1173,7 @@ export function Example() {
         isSelectable
         selectedRows={selectedRows}
         onSelectedRowsChange={updatedSelectedRows}
+        tableTitle="Controlled selectable column"
       />
     </Card>
   );
@@ -1860,6 +1862,7 @@ export function Example() {
       columns={columns}
       rows={rows}
       components={{ Pagination: CustomPaginationComponent }}
+      tableTitle="Custom pagination components"
     />
   );
 }

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -214,7 +214,11 @@ export function Example() {
 
   return (
     <Card>
-      <Datagrid columns={columns} rows={rows} />
+      <Datagrid
+        tableTitle="Basic usage Datagrid"
+        columns={columns}
+        rows={rows}
+      />
     </Card>
   );
 }
@@ -264,7 +268,14 @@ export function Example() {
     },
   ];
 
-  return <Datagrid columns={columns} rows={coloredRows} hasSquareCorners />;
+  return (
+    <Datagrid
+      tableTitle="Colored rows Datagrid"
+      columns={columns}
+      rows={coloredRows}
+      hasSquareCorners
+    />
+  );
 }
 ```
 
@@ -291,7 +302,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 1'
+      rowName: 'Row 1',
     },
     {
       id: 2,
@@ -299,7 +310,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 2'
+      rowName: 'Row 2',
     },
     {
       id: 3,
@@ -307,7 +318,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 3'
+      rowName: 'Row 3',
     },
     {
       id: 4,
@@ -315,7 +326,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 4'
+      rowName: 'Row 4',
     },
     {
       id: 5,
@@ -323,7 +334,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 5'
+      rowName: 'Row 5',
     },
     {
       id: 6,
@@ -331,7 +342,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 6'
+      rowName: 'Row 6',
     },
     {
       id: 7,
@@ -339,7 +350,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 7'
+      rowName: 'Row 7',
     },
     {
       id: 8,
@@ -347,7 +358,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 8'
+      rowName: 'Row 8',
     },
     {
       id: 9,
@@ -355,7 +366,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 9'
+      rowName: 'Row 9',
     },
     {
       id: 10,
@@ -363,7 +374,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 10'
+      rowName: 'Row 10',
     },
     {
       id: 11,
@@ -489,7 +500,12 @@ export function Example() {
 
   return (
     <Card>
-      <Datagrid columns={columns} rows={rows} isSelectable />
+      <Datagrid
+        tableTitle="Selectable Datagrid"
+        columns={columns}
+        rows={rows}
+        isSelectable
+      />
     </Card>
   );
 }
@@ -516,7 +532,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 1'
+      rowName: 'Row 1',
     },
     {
       id: 2,
@@ -524,7 +540,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 2'
+      rowName: 'Row 2',
     },
     {
       id: 3,
@@ -532,7 +548,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 3'
+      rowName: 'Row 3',
     },
     {
       id: 4,
@@ -541,7 +557,7 @@ export function Example() {
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
       isSelectableDisabled: true,
-      rowName: 'Row 4'
+      rowName: 'Row 4',
     },
     {
       id: 5,
@@ -549,7 +565,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 5'
+      rowName: 'Row 5',
     },
     {
       id: 6,
@@ -557,7 +573,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 6'
+      rowName: 'Row 6',
     },
     {
       id: 7,
@@ -565,7 +581,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 7'
+      rowName: 'Row 7',
     },
     {
       id: 8,
@@ -573,7 +589,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 8'
+      rowName: 'Row 8',
     },
     {
       id: 9,
@@ -581,7 +597,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 9'
+      rowName: 'Row 9',
     },
     {
       id: 10,
@@ -589,7 +605,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 10'
+      rowName: 'Row 10',
     },
     {
       id: 11,
@@ -715,7 +731,12 @@ export function Example() {
 
   return (
     <Card>
-      <Datagrid columns={columns} rows={rows} isSelectable />
+      <Datagrid
+        tableTitle="Disabled selectable row Datagrid"
+        columns={columns}
+        rows={rows}
+        isSelectable
+      />
     </Card>
   );
 }
@@ -938,7 +959,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 1'
+      rowName: 'Row 1',
     },
     {
       id: 2,
@@ -946,7 +967,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 2'
+      rowName: 'Row 2',
     },
     {
       id: 3,
@@ -954,7 +975,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 3'
+      rowName: 'Row 3',
     },
     {
       id: 4,
@@ -962,7 +983,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 4'
+      rowName: 'Row 4',
     },
     {
       id: 5,
@@ -970,7 +991,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 5'
+      rowName: 'Row 5',
     },
     {
       id: 6,
@@ -978,7 +999,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 6'
+      rowName: 'Row 6',
     },
     {
       id: 7,
@@ -986,7 +1007,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 7'
+      rowName: 'Row 7',
     },
     {
       id: 8,
@@ -994,7 +1015,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 8'
+      rowName: 'Row 8',
     },
     {
       id: 9,
@@ -1002,7 +1023,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 9'
+      rowName: 'Row 9',
     },
     {
       id: 10,
@@ -1010,7 +1031,7 @@ export function Example() {
       col2: 'Lorem ipsum dolor',
       col3: 'Lorem ipsum dolor',
       col4: 'Lorem ipsum',
-      rowName: 'Row 10'
+      rowName: 'Row 10',
     },
     {
       id: 11,
@@ -1356,7 +1377,12 @@ export function Example() {
   };
 
   return (
-    <Datagrid columns={columns} rows={rows} paginationProps={paginationProps} />
+    <Datagrid
+      tableTitle="Pagination defaults Datagrid"
+      columns={columns}
+      rows={rows}
+      paginationProps={paginationProps}
+    />
   );
 }
 ```
@@ -1579,7 +1605,12 @@ export function Example() {
   };
 
   return (
-    <Datagrid columns={columns} rows={rows} paginationProps={paginationProps} />
+    <Datagrid
+      tableTitle="Pagination controlled Datagrid"
+      columns={columns}
+      rows={rows}
+      paginationProps={paginationProps}
+    />
   );
 }
 ```
@@ -2028,7 +2059,14 @@ export function Example() {
     },
   ];
 
-  return <Datagrid columns={columns} rows={rows} hasPagination={false} />;
+  return (
+    <Datagrid
+      tableTitle="Without pagination Datagrid"
+      columns={columns}
+      rows={rows}
+      hasPagination={false}
+    />
+  );
 }
 ```
 
@@ -2075,7 +2113,12 @@ export function Example() {
 
   return (
     <Card isInverse>
-      <Datagrid columns={columns} isInverse rows={rows} />
+      <Datagrid
+        tableTitle="Inverse Datagrid"
+        columns={columns}
+        isInverse
+        rows={rows}
+      />
     </Card>
   );
 }

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -20,7 +20,9 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 <PageContent componentName="table" type="api">
 
 <LeadParagraph>
-Tables are used to organize and display information from a data set efficiently. A table contains a header row at the top that lists column names, followed by rows for data.
+  Tables are used to organize and display information from a data set
+  efficiently. A table contains a header row at the top that lists column names,
+  followed by rows for data.
 </LeadParagraph>
 
 ## Basic Usage
@@ -77,7 +79,7 @@ export function Example() {
   ];
 
   return (
-    <Table>
+    <Table tableTitle={<h1>Basic usage table</h1>}>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -109,6 +109,7 @@ The `hasVerticalBorders` boolean prop may be used to give table cells vertical b
 ```tsx
 import React from 'react';
 import {
+  Heading,
   Table,
   TableHead,
   TableRow,
@@ -119,7 +120,7 @@ import {
 
 export function Example() {
   return(
-    <Table tableTitle="Vertical borders table" hasVerticalBorders>
+    <Table tableTitle={<Heading level={1}>Vertical borders table</Heading>} hasVerticalBorders>
     <TableHead>
       <TableRow>
         <TableHeaderCell>Column</TableHeaderCell>

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -79,7 +79,7 @@ export function Example() {
   ];
 
   return (
-    <Table tableTitle=`Basic usage table`>
+    <Table tableTitle="Basic usage table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -118,8 +118,8 @@ import {
 } from 'react-magma-dom';
 
 export function Example() {
-  return;
-  <Table tableTitle="Vertical borders table" hasVerticalBorders>
+  return(
+    <Table tableTitle="Vertical borders table" hasVerticalBorders>
     <TableHead>
       <TableRow>
         <TableHeaderCell>Column</TableHeaderCell>
@@ -142,7 +142,8 @@ export function Example() {
         <TableCell>Lorem ipsum</TableCell>
       </TableRow>
     </TableBody>
-  </Table>;
+  </Table>
+  );
 }
 ```
 
@@ -163,7 +164,7 @@ import {
 
 export function Example() {
   return (
-    <Table tableTitle=`Hover style table` hasHoverStyles>
+    <Table tableTitle="Hover style table" hasHoverStyles>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -208,7 +209,7 @@ import {
 
 export function Example() {
   return (
-    <Table tableTitle=`Zebra stripes table` hasZebraStripes hasHoverStyles>
+    <Table tableTitle="Zebra stripes table" hasZebraStripes hasHoverStyles>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -267,7 +268,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table tableTitle=`Density table` density={TableDensity.compact}>
+      <Table tableTitle="Density table" density={TableDensity.compact}>
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -387,7 +388,7 @@ export function Example() {
 
   return (
     <>
-      <Table tableTitle=`Sortable table`>
+      <Table tableTitle="Sortable table">
         <TableHead>
           <TableRow>
             <TableHeaderCell
@@ -473,7 +474,13 @@ import {
 export function Example() {
   return (
     <Card isInverse>
-      <Table tableTitle=`Inverse table` isInverse hasZebraStripes hasVerticalBorders hasHoverStyles>
+      <Table
+        tableTitle="Inverse table"
+        isInverse
+        hasZebraStripes
+        hasVerticalBorders
+        hasHoverStyles
+      >
         <TableHead>
           <TableRow>
             <TableHeaderCell sortDirection={TableSortDirection.descending}>
@@ -526,7 +533,7 @@ import {
 
 export function Example() {
   return (
-    <Table tableTitle=`Cell alignment table`>
+    <Table tableTitle="Cell alignment table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -570,7 +577,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table tableTitle=`Cell width table`>
+      <Table tableTitle="Cell width table">
         <TableHead>
           <TableRow>
             <TableHeaderCell width="25%">Column 25%</TableHeaderCell>
@@ -636,7 +643,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table tableTitle=`Min-width table` minWidth={920}>
+      <Table tableTitle="Min-width table" minWidth={920}>
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column 1</TableHeaderCell>
@@ -694,7 +701,7 @@ import {
 
 export function Example() {
   return (
-    <Table tableTitle=`Other content table` hasVerticalBorders>
+    <Table tableTitle="Other content table" hasVerticalBorders>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column 1</TableHeaderCell>
@@ -910,7 +917,7 @@ export function Example() {
 
   return (
     <>
-      <Table tableTitle=`Pagination table`>
+      <Table tableTitle="Pagination table">
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -959,7 +966,7 @@ import {
 
 export function Example() {
   return (
-    <Table tableTitle=`Table row color table`>
+    <Table tableTitle="Table row color table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -79,7 +79,7 @@ export function Example() {
   ];
 
   return (
-    <Table tableTitle={<h1>Basic usage table</h1>}>
+    <Table tableTitle=`Basic usage table`>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -118,32 +118,31 @@ import {
 } from 'react-magma-dom';
 
 export function Example() {
-  return (
-    <Table hasVerticalBorders>
-      <TableHead>
-        <TableRow>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        <TableRow>
-          <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-          <TableCell>Lorem ipsum dolor</TableCell>
-          <TableCell>Lorem ipsum dolor</TableCell>
-          <TableCell>Lorem ipsum</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Lorem ipsum dolor sit amet</TableCell>
-          <TableCell>Lorem ipsum dolor</TableCell>
-          <TableCell>Lorem ipsum dolor</TableCell>
-          <TableCell>Lorem ipsum</TableCell>
-        </TableRow>
-      </TableBody>
-    </Table>
-  );
+  return;
+  <Table tableTitle="Vertical borders table" hasVerticalBorders>
+    <TableHead>
+      <TableRow>
+        <TableHeaderCell>Column</TableHeaderCell>
+        <TableHeaderCell>Column</TableHeaderCell>
+        <TableHeaderCell>Column</TableHeaderCell>
+        <TableHeaderCell>Column</TableHeaderCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      <TableRow>
+        <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+        <TableCell>Lorem ipsum dolor</TableCell>
+        <TableCell>Lorem ipsum dolor</TableCell>
+        <TableCell>Lorem ipsum</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell>Lorem ipsum dolor sit amet</TableCell>
+        <TableCell>Lorem ipsum dolor</TableCell>
+        <TableCell>Lorem ipsum dolor</TableCell>
+        <TableCell>Lorem ipsum</TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>;
 }
 ```
 
@@ -164,7 +163,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasHoverStyles>
+    <Table tableTitle=`Hover style table` hasHoverStyles>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -209,7 +208,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasZebraStripes hasHoverStyles>
+    <Table tableTitle=`Zebra stripes table` hasZebraStripes hasHoverStyles>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -268,7 +267,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table density={TableDensity.compact}>
+      <Table tableTitle=`Density table` density={TableDensity.compact}>
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -388,7 +387,7 @@ export function Example() {
 
   return (
     <>
-      <Table>
+      <Table tableTitle=`Sortable table`>
         <TableHead>
           <TableRow>
             <TableHeaderCell
@@ -474,7 +473,7 @@ import {
 export function Example() {
   return (
     <Card isInverse>
-      <Table isInverse hasZebraStripes hasVerticalBorders hasHoverStyles>
+      <Table tableTitle=`Inverse table` isInverse hasZebraStripes hasVerticalBorders hasHoverStyles>
         <TableHead>
           <TableRow>
             <TableHeaderCell sortDirection={TableSortDirection.descending}>
@@ -527,7 +526,7 @@ import {
 
 export function Example() {
   return (
-    <Table>
+    <Table tableTitle=`Cell alignment table`>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -571,7 +570,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table>
+      <Table tableTitle=`Cell width table`>
         <TableHead>
           <TableRow>
             <TableHeaderCell width="25%">Column 25%</TableHeaderCell>
@@ -637,7 +636,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table minWidth={920}>
+      <Table tableTitle=`Min-width table` minWidth={920}>
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column 1</TableHeaderCell>
@@ -695,7 +694,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasVerticalBorders>
+    <Table tableTitle=`Other content table` hasVerticalBorders>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column 1</TableHeaderCell>
@@ -911,7 +910,7 @@ export function Example() {
 
   return (
     <>
-      <Table>
+      <Table tableTitle=`Pagination table`>
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -960,7 +959,7 @@ import {
 
 export function Example() {
   return (
-    <Table>
+    <Table tableTitle=`Table row color table`>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>


### PR DESCRIPTION
Issue: # [1395](https://github.com/cengage/react-magma/issues/1395)

## What I did
- New `tableTitle` prop for both `Table` and `Datagrid` to enable the use of captions and further improve accessibility across both components.

## Screenshots:


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test

