### PR TITLE
fix(Heading): Update margins for `heading2XLarge`

### DIFF
--- a/.changeset/heading-margins.md
+++ b/.changeset/heading-margins.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Heading): Update margins for `heading2XLarge`

--- a/packages/react-magma-dom/src/components/Heading/Heading.test.js
+++ b/packages/react-magma-dom/src/components/Heading/Heading.test.js
@@ -3,6 +3,7 @@ import { axe } from '../../../axe-helper';
 import { Heading } from '.';
 import { render } from '@testing-library/react';
 import { magma } from '../../theme/magma';
+import { TypographyContextVariant, TypographyVisualStyle } from '../Typography';
 
 describe('Heading', () => {
   it('should find element by testId', () => {
@@ -136,6 +137,7 @@ describe('Heading', () => {
   });
 
   it('should render headings without margins styles', () => {
+    const headingText1Exp = 'test 1 expressive';
     const headingText1 = 'test 1';
     const headingText2 = 'test 2';
     const headingText3 = 'test 3';
@@ -145,6 +147,14 @@ describe('Heading', () => {
 
     const { getByText } = render(
       <>
+        <Heading
+          noMargins
+          level={1}
+          contextVariant={TypographyContextVariant.expressive}
+          visualStyle={TypographyVisualStyle.heading2XLarge}
+        >
+          {headingText1Exp}
+        </Heading>
         <Heading noMargins level={1}>
           {headingText1}
         </Heading>
@@ -166,6 +176,7 @@ describe('Heading', () => {
       </>
     );
 
+    expect(getByText(headingText1Exp)).toHaveStyleRule('margin', '0');
     expect(getByText(headingText1)).toHaveStyleRule('margin', '0');
     expect(getByText(headingText2)).toHaveStyleRule('margin', '0');
     expect(getByText(headingText3)).toHaveStyleRule('margin', '0');
@@ -175,6 +186,7 @@ describe('Heading', () => {
   });
 
   it('should render headings without top margin styles', () => {
+    const headingText1Exp = 'test 1 expressive';
     const headingText1 = 'test 1';
     const headingText2 = 'test 2';
     const headingText3 = 'test 3';
@@ -184,6 +196,14 @@ describe('Heading', () => {
 
     const { getByText } = render(
       <>
+        <Heading
+          noTopMargin
+          level={1}
+          contextVariant={TypographyContextVariant.expressive}
+          visualStyle={TypographyVisualStyle.heading2XLarge}
+        >
+          {headingText1Exp}
+        </Heading>
         <Heading noTopMargin level={1}>
           {headingText1}
         </Heading>
@@ -205,6 +225,10 @@ describe('Heading', () => {
       </>
     );
 
+    expect(getByText(headingText1Exp)).toHaveStyleRule(
+      'margin',
+      `0 0 ${magma.spaceScale.spacing06} 0`
+    );
     expect(getByText(headingText1)).toHaveStyleRule(
       'margin',
       `0 0 ${magma.spaceScale.spacing05} 0`
@@ -232,6 +256,7 @@ describe('Heading', () => {
   });
 
   it('should render headings without bottom margin styles', () => {
+    const headingText1Exp = 'test 1 expressive';
     const headingText1 = 'test 1';
     const headingText2 = 'test 2';
     const headingText3 = 'test 3';
@@ -241,6 +266,14 @@ describe('Heading', () => {
 
     const { getByText } = render(
       <>
+        <Heading
+          noBottomMargin
+          level={1}
+          contextVariant={TypographyContextVariant.expressive}
+          visualStyle={TypographyVisualStyle.heading2XLarge}
+        >
+          {headingText1Exp}
+        </Heading>
         <Heading noBottomMargin level={1}>
           {headingText1}
         </Heading>
@@ -262,10 +295,8 @@ describe('Heading', () => {
       </>
     );
 
-    expect(getByText(headingText1)).toHaveStyleRule(
-      'margin',
-      `${magma.spaceScale.spacing05} 0 0 0`
-    );
+    expect(getByText(headingText1Exp)).toHaveStyleRule('margin', '0');
+    expect(getByText(headingText1)).toHaveStyleRule('margin', `0`);
     expect(getByText(headingText2)).toHaveStyleRule(
       'margin',
       `${magma.spaceScale.spacing10} 0 0 0`
@@ -358,6 +389,36 @@ describe('Heading', () => {
 
     it('should render heading 6 correctly', () => {
       const { container } = render(<Heading level={6}>Heading 6</Heading>);
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should render expressive heading2XLarge correctly', () => {
+      const { container } = render(
+        <Heading
+          level={1}
+          contextVariant={TypographyContextVariant.expressive}
+          visualStyle={TypographyVisualStyle.heading2XLarge}
+          id="testId"
+        >
+          Heading 1
+        </Heading>
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should render expressive headingXLarge correctly', () => {
+      const { container } = render(
+        <Heading
+          level={2}
+          contextVariant={TypographyContextVariant.expressive}
+          visualStyle={TypographyVisualStyle.headingXLarge}
+          id="testId"
+        >
+          Heading 2
+        </Heading>
+      );
 
       expect(container).toMatchSnapshot();
     });

--- a/packages/react-magma-dom/src/components/Heading/__snapshots__/Heading.test.js.snap
+++ b/packages/react-magma-dom/src/components/Heading/__snapshots__/Heading.test.js.snap
@@ -1,5 +1,147 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Heading Snapshot should render expressive heading2XLarge correctly 1`] = `
+.emotion-0 {
+  border-bottom: 2px solid transparent;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  padding: 0;
+  color: #292F7C;
+  font-size: 48px;
+  font-weight: 500;
+  line-height: 64px;
+  margin: 0 0 24px;
+}
+
+.emotion-0:focus {
+  border-bottom: 2px solid #0074B7;
+  outline: 0;
+  -webkit-transition: border 0.1s linear;
+  transition: border 0.1s linear;
+}
+
+@media (min-width: 600px) {
+  .emotion-0 {
+    font-size: 64px;
+    line-height: 84px;
+  }
+}
+
+.emotion-0 {
+  border-bottom: 2px solid transparent;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  padding: 0;
+  color: #292F7C;
+  font-size: 48px;
+  font-weight: 500;
+  line-height: 64px;
+  margin: 0 0 24px;
+}
+
+.emotion-0:focus {
+  border-bottom: 2px solid #0074B7;
+  outline: 0;
+  -webkit-transition: border 0.1s linear;
+  transition: border 0.1s linear;
+}
+
+@media (min-width: 600px) {
+  .emotion-0 {
+    font-size: 64px;
+    line-height: 84px;
+  }
+}
+
+<div>
+  <h1
+    class="emotion-0 emotion-1"
+    id="testId"
+  >
+    Heading 1
+  </h1>
+</div>
+`;
+
+exports[`Heading Snapshot should render expressive headingXLarge correctly 1`] = `
+.emotion-0 {
+  border-bottom: 2px solid transparent;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  padding: 0;
+  color: #292F7C;
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 40px;
+  margin: 0 0 16px;
+  font-size: 36px;
+  font-weight: 600;
+  line-height: 48px;
+}
+
+.emotion-0:focus {
+  border-bottom: 2px solid #0074B7;
+  outline: 0;
+  -webkit-transition: border 0.1s linear;
+  transition: border 0.1s linear;
+}
+
+@media (min-width: 600px) {
+  .emotion-0 {
+    font-size: 36px;
+    line-height: 48px;
+  }
+}
+
+@media (min-width: 600px) {
+  .emotion-0 {
+    font-size: 48px;
+    line-height: 64px;
+  }
+}
+
+.emotion-0 {
+  border-bottom: 2px solid transparent;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  padding: 0;
+  color: #292F7C;
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 40px;
+  margin: 0 0 16px;
+  font-size: 36px;
+  font-weight: 600;
+  line-height: 48px;
+}
+
+.emotion-0:focus {
+  border-bottom: 2px solid #0074B7;
+  outline: 0;
+  -webkit-transition: border 0.1s linear;
+  transition: border 0.1s linear;
+}
+
+@media (min-width: 600px) {
+  .emotion-0 {
+    font-size: 36px;
+    line-height: 48px;
+  }
+}
+
+@media (min-width: 600px) {
+  .emotion-0 {
+    font-size: 48px;
+    line-height: 64px;
+  }
+}
+
+<div>
+  <h2
+    class="emotion-0 emotion-1"
+    id="testId"
+  >
+    Heading 2
+  </h2>
+</div>
+`;
+
 exports[`Heading Snapshot should render heading 1 correctly 1`] = `
 .emotion-0 {
   border-bottom: 2px solid transparent;

--- a/packages/react-magma-dom/src/components/Typography/index.tsx
+++ b/packages/react-magma-dom/src/components/Typography/index.tsx
@@ -272,6 +272,12 @@ export const heading2XLargeStyles = props => css`
     line-height: ${props.theme.typographyExpressiveVisualStyles.heading2XLarge
       .mobile.lineHeight};
 
+    margin: ${props.noMargins || props.noBottomMargin
+      ? '0'
+      : props.noTopMargin
+      ? `0 0 ${props.theme.spaceScale.spacing06} 0`
+      : `0 0 ${props.theme.spaceScale.spacing06}`};
+
     @media (min-width: ${props.theme.breakpoints.small}px) {
       font-size: ${props.theme.typographyExpressiveVisualStyles.heading2XLarge
         .desktop.fontSize};
@@ -289,10 +295,8 @@ export const headingXLargeStyles = props => css`
   font-weight: ${props.theme.typographyVisualStyles.headingXLarge.fontWeight};
   line-height: ${props.theme.typographyVisualStyles.headingXLarge.mobile
     .lineHeight};
-  margin: ${props.noMargins
+  margin: ${props.noMargins || props.noBottomMargin
     ? '0'
-    : props.noBottomMargin
-    ? `${props.theme.spaceScale.spacing05} 0 0 0`
     : props.noTopMargin
     ? `0 0 ${props.theme.spaceScale.spacing05} 0`
     : `0 0 ${props.theme.spaceScale.spacing05}`};


### PR DESCRIPTION
Issue: #1555 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Update margins for heading2XLarge
- Fix headingLarge + noBottomMargin (it was adding top margin it never had)

## Screenshots:
<!-- Include screenshot of your change -->
Before:
![image](https://github.com/user-attachments/assets/8bcf6df8-2952-4de9-873e-37606d59c9fd)

After:
![image](https://github.com/user-attachments/assets/d3295261-598f-4d22-9886-acbb04e0cd89)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
- Navigate to https://storybook-preview-dev--upbeat-sinoussi-f675aa.netlify.app/?path=/story/heading--default
- Confirm the expected margins for heading2XLarge + headingXLarge while switching on and off the noMargins, noTopMargin and noBottomMargin props