### PR TITLE
fix(Combobox/Select:): Fix focus color for selected items when using `isMulti` + `isInverse`

### DIFF
--- a/.changeset/selecteItemButton-focus.md
+++ b/.changeset/selecteItemButton-focus.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Combobox/Select:): Fix focus color for selected items when using `isMulti` + `isInverse`

--- a/packages/react-magma-dom/src/components/Select/shared.ts
+++ b/packages/react-magma-dom/src/components/Select/shared.ts
@@ -55,9 +55,12 @@ export const SelectText = styled.span<{
         : props.theme.colors.neutral500;
     }
   }};
-  ${props => props.isDisabled && props.isShowPlaceholder && css`
-    opacity: ${props.isInverse ? 0.4 : 0.6}
-  `}
+  ${props =>
+    props.isDisabled &&
+    props.isShowPlaceholder &&
+    css`
+      opacity: ${props.isInverse ? 0.4 : 0.6};
+    `}
 `;
 
 export const StyledCard = styled(Card)<{
@@ -169,6 +172,13 @@ export const SelectedItemButton = styled.button<{
   white-space: nowrap;
   min-width: 0%;
   outline-offset: 2px;
+  &:focus {
+    outline: 2px solid
+      ${props =>
+        props.isInverse
+          ? props.theme.colors.focusInverse
+          : props.theme.colors.focus};
+  }
 `;
 
 export const IconWrapper = styled.span`


### PR DESCRIPTION
Issue: #1559

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix focus color for `isInverse`

## Screenshots:
<!-- Include screenshot of your change -->
Before:
![image](https://github.com/user-attachments/assets/b53f84d1-ae2d-4cbd-a8b2-f9b52011d841)


After:
![image](https://github.com/user-attachments/assets/e5f6fd2d-43e3-484e-b184-49f742154e8f)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Confirm focus styles in:
- Combobox: https://storybook-preview-dev--upbeat-sinoussi-f675aa.netlify.app/?path=/story/combobox--inverse&args=isMulti:true
- Select: https://storybook-preview-dev--upbeat-sinoussi-f675aa.netlify.app/?path=/story/select--inverse&args=isMulti:true