### PR TITLE
fix(ToggleButtonGroup): Fix `enforced` and `exclusive` props

### DIFF
--- a/.changeset/toggleButtonGroup.md
+++ b/.changeset/toggleButtonGroup.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(ToggleButtonGroup): Fix `enforced` and `exlusive` props

--- a/.changeset/toggleButtonGroup.md
+++ b/.changeset/toggleButtonGroup.md
@@ -2,4 +2,4 @@
 'react-magma-dom': patch
 ---
 
-fix(ToggleButtonGroup): Fix `enforced` and `exlusive` props
+fix(ToggleButtonGroup): Fix `enforced` and `exclusive` props

--- a/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
+++ b/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
@@ -111,21 +111,25 @@ export const AlignmentExample = args => {
         aria-label="Left align"
         icon={<FormatAlignLeftIcon />}
         value="left"
+        testId="left"
       />
       <ToggleButton
         aria-label="Center align"
         icon={<FormatAlignCenterIcon />}
         value="center"
+        testId="center"
       />
       <ToggleButton
         aria-label="Right align"
         icon={<FormatAlignRightIcon />}
         value="right"
+        testId="right"
       />
       <ToggleButton
         aria-label="Justify align"
         icon={<FormatAlignJustifyIcon />}
         value="justify"
+        testId="justify"
       />
     </ToggleButtonGroup>
   );
@@ -146,7 +150,11 @@ export const DifferentToggleButtons = args => {
         value="settings"
       />
       <ToggleButton value="text">Text</ToggleButton>
-      <ToggleButton icon={<SettingsIcon />} value="iconAndText" size={ButtonSize.small}>
+      <ToggleButton
+        icon={<SettingsIcon />}
+        value="iconAndText"
+        size={ButtonSize.small}
+      >
         Icon and Text
       </ToggleButton>
     </ToggleButtonGroup>

--- a/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -59,7 +59,8 @@ describe('ToggleButtonGroup', () => {
         );
 
         const buttonOne = getByTestId(testId);
-        const buttonOneSvg = buttonOne.children[0]; // ensure that clicking either the button or child SVG works
+        // ensure that clicking either the button or child SVG works
+        const buttonOneSvg = buttonOne.children[0];
         expect(buttonOne).toHaveAttribute('aria-checked', 'false');
         fireEvent.click(buttonOneSvg);
         expect(buttonOne).toHaveAttribute('aria-checked', 'true');
@@ -82,7 +83,8 @@ describe('ToggleButtonGroup', () => {
         );
 
         const buttonOne = getByTestId(testId);
-        const buttonOneSvg = buttonOne.children[0]; // ensure that clicking either the button or child SVG works
+        // ensure that clicking either the button or child SVG works
+        const buttonOneSvg = buttonOne.children[0];
         const buttonTwo = getByTestId(`${testId}-1`);
 
         expect(buttonOne).toHaveAttribute('aria-checked', 'false');
@@ -107,7 +109,8 @@ describe('ToggleButtonGroup', () => {
         );
 
         const buttonOne = getByTestId(testId);
-        const buttonOneSvg = buttonOne.children[0]; // ensure that clicking either the button or child SVG works
+        // ensure that clicking either the button or child SVG works
+        const buttonOneSvg = buttonOne.children[0];
         const buttonTwo = getByTestId(`${testId}-1`);
 
         expect(buttonOne).toHaveAttribute('aria-checked', 'false');
@@ -198,7 +201,7 @@ describe('ToggleButtonGroup', () => {
     );
 
     const buttonOne = getByTestId(testId);
-    
+
     expect(buttonOne).toHaveAttribute('aria-checked', 'true');
     fireEvent.click(buttonOne);
     expect(onChangeMock).toHaveBeenCalledTimes(1);

--- a/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -59,8 +59,9 @@ describe('ToggleButtonGroup', () => {
         );
 
         const buttonOne = getByTestId(testId);
+        const buttonOneSvg = buttonOne.children[0]; // ensure that clicking either the button or child SVG works
         expect(buttonOne).toHaveAttribute('aria-checked', 'false');
-        fireEvent.click(buttonOne);
+        fireEvent.click(buttonOneSvg);
         expect(buttonOne).toHaveAttribute('aria-checked', 'true');
         fireEvent.click(buttonOne);
         expect(buttonOne).toHaveAttribute('aria-checked', 'true');
@@ -81,10 +82,11 @@ describe('ToggleButtonGroup', () => {
         );
 
         const buttonOne = getByTestId(testId);
+        const buttonOneSvg = buttonOne.children[0]; // ensure that clicking either the button or child SVG works
         const buttonTwo = getByTestId(`${testId}-1`);
 
         expect(buttonOne).toHaveAttribute('aria-checked', 'false');
-        fireEvent.click(buttonOne);
+        fireEvent.click(buttonOneSvg);
         expect(buttonOne).toHaveAttribute('aria-checked', 'true');
         fireEvent.click(buttonTwo);
         expect(buttonOne).toHaveAttribute('aria-checked', 'false');
@@ -105,12 +107,13 @@ describe('ToggleButtonGroup', () => {
         );
 
         const buttonOne = getByTestId(testId);
+        const buttonOneSvg = buttonOne.children[0]; // ensure that clicking either the button or child SVG works
         const buttonTwo = getByTestId(`${testId}-1`);
 
         expect(buttonOne).toHaveAttribute('aria-checked', 'false');
-        fireEvent.click(buttonOne);
+        fireEvent.click(buttonOneSvg);
         expect(buttonOne).toHaveAttribute('aria-checked', 'true');
-        fireEvent.click(buttonOne);
+        fireEvent.click(buttonOneSvg);
         expect(buttonOne).toHaveAttribute('aria-checked', 'true');
         fireEvent.click(buttonTwo);
         expect(buttonOne).toHaveAttribute('aria-checked', 'false');

--- a/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -98,7 +98,7 @@ export const ToggleButtonGroup = React.forwardRef<
   }, [value]);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const { value: newSelectedValue } = event.target;
+    const { value: newSelectedValue } = event.currentTarget;
 
     const oneBtnSelected = selectedValues.length === 1;
     const newValueAlreadySelected = selectedValues.includes(newSelectedValue);


### PR DESCRIPTION
Issue: #1565 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Replace `event.target` with `event.currentTarget` so that whether the icon or the edge of a button gets clicked, the toggle button still gets selected as expected
- Add unit tests

## Screenshots:
N/A

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
- Navigate to https://storybook-preview-dev--upbeat-sinoussi-f675aa.netlify.app/?path=/story/togglebuttongroup--alignment-example
- Ensure that clicking either the button (on the edge) or the icon (the middle) behaves as expected
