### PR TITLE
FIxes > Various Docs site issues

### DIFF
--- a/.changeset/fix-docs-examples.md
+++ b/.changeset/fix-docs-examples.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Docs): Within the Docs site, these components have had fixes for missing references and general clean-up for CodeSandbox examples: Grid, Container, Stepper, Combobox, Hyperlink, IconButton, Toast, DatePicker, Dropdown, Form, FormGroup, useFocusLock

--- a/website/react-magma-docs/src/components/ButtonProps/index.js
+++ b/website/react-magma-docs/src/components/ButtonProps/index.js
@@ -18,6 +18,7 @@ export const ButtonProps = () => (
             options: [
               'ButtonColor.primary',
               'ButtonColor.secondary',
+              'ButtonColor.success',
               'ButtonColor.danger',
               'ButtonColor.marketing',
             ],

--- a/website/react-magma-docs/src/components/IconButtonProps/index.js
+++ b/website/react-magma-docs/src/components/IconButtonProps/index.js
@@ -27,6 +27,7 @@ export function IconButtonProps() {
             options: [
               'ButtonColor.primary',
               'ButtonColor.secondary',
+              'ButtonColor.success',
               'ButtonColor.danger',
               'ButtonColor.marketing',
             ],

--- a/website/react-magma-docs/src/pages/api/accordion.mdx
+++ b/website/react-magma-docs/src/pages/api/accordion.mdx
@@ -25,7 +25,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 An accordion is made up of four components: `Accordion`, `AccordionItem`, `AccordionButton` and `AccordionPanel`. The `Accordion` is the wrapper for all of the items. It can contain one or more `AccordionItems`, each of which should contain one `AccordionButton` and one `AccordionPanel`. An `AccordionButton` can be wrapped in an element with the role of heading (such as an h1-h6) to provide semantic structure to the document.
 
-By default, multiple items are expandable. The `defaultIndex` prop which takes a of zero-based array can be used to set panels open by default.
+By default, multiple items are expandable. The `defaultIndex` prop which takes a zero-based array can be used to set panels open by default.
 
 ```typescript
 import React from 'react';

--- a/website/react-magma-docs/src/pages/api/accordion.mdx
+++ b/website/react-magma-docs/src/pages/api/accordion.mdx
@@ -25,7 +25,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 An accordion is made up of four components: `Accordion`, `AccordionItem`, `AccordionButton` and `AccordionPanel`. The `Accordion` is the wrapper for all of the items. It can contain one or more `AccordionItems`, each of which should contain one `AccordionButton` and one `AccordionPanel`. An `AccordionButton` can be wrapped in an element with the role of heading (such as an h1-h6) to provide semantic structure to the document.
 
-By default, multiple items will can be expanded. The `defaultIndex` prop, which takes an array of zero-based indices, can be used to set panels open by default.
+By default, multiple items are expandable. The `defaultIndex` prop which takes a of zero-based array can be used to set panels open by default.
 
 ```typescript
 import React from 'react';
@@ -38,7 +38,7 @@ import {
 
 export function Example() {
   return (
-    <Accordion defaultIndex={[0]}>
+    <Accordion isMulti defaultIndex={[1]}>
       <AccordionItem>
         <h3>
           <AccordionButton>Section 1</AccordionButton>

--- a/website/react-magma-docs/src/pages/api/checkboxes.mdx
+++ b/website/react-magma-docs/src/pages/api/checkboxes.mdx
@@ -26,7 +26,7 @@ If you do not want to have your checkbox be in a controlled state, but need the 
 <Link to="/api/indeterminate">Indeterminate Checkboxes</Link> are similar to standard
 checkboxes but with three available statuses.
 
-See also: <Link to="/api/radio">Radio Buttons</Link>, <Link to="/api/toggle">Toggle Switches</Link>, and the <Link to="/design/selection-controls">Design Guidelines</Link> for selection controls in general.
+See also: <Link to="/api/radio">Radio Buttons</Link> and <Link to="/api/toggle">Toggle Switches</Link>.
 
 ```tsx
 import React from 'react';

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -637,18 +637,18 @@ export function Example() {
 ## Async
 
 ```tsx
-import React from 'react';
-import { Combobox } from 'react-magma-dom';
+import React from "react";
+import { Combobox } from "react-magma-dom";
 
 export function Example() {
   const [isLoading, updateIsLoading] = React.useState<boolean>(false);
 
-  function loadItems(inputValue) {
-    return new Promise(resolve =>
+  function loadItems() {
+    return new Promise((resolve) =>
       resolve([
-        { label: 'Yellow', value: 'yellow' },
-        { label: 'Pink', value: 'pink' },
-        { label: 'Periwinkle', value: 'periwinkle' },
+        { label: "Yellow", value: "yellow" },
+        { label: "Pink", value: "pink" },
+        { label: "Periwinkle", value: "periwinkle" },
       ])
     );
   }
@@ -660,18 +660,16 @@ export function Example() {
 
     updateIsLoading(true);
 
-    if(inputValue){
     setTimeout(() => {
       updateIsLoading(false);
-      loadItems(inputValue).then(items => {
+      loadItems().then((items: any) => {
         setInputItems(
-          items.filter(item =>
+          items.filter((item) =>
             item.label.toLowerCase().startsWith(inputValue.toLowerCase())
           )
         );
       });
     }, 1000);
-    }
   }
 
   return (
@@ -680,9 +678,9 @@ export function Example() {
       labelText="Async"
       isLoading={isLoading}
       defaultItems={[
-        { label: 'Red', value: 'red' },
-        { label: 'Blue', value: 'blue' },
-        { label: 'Green', value: 'green' },
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" },
+        { label: "Green", value: "green" },
       ]}
       onInputValueChange={handleInputValueChange}
     />
@@ -1276,7 +1274,7 @@ import { Combobox } from 'react-magma-dom';
 export function Example() {
   const [isLoading, updateIsLoading] = React.useState<boolean>(false);
 
-  function loadItems(inputValue) {
+  function loadItems() {
     return new Promise(resolve =>
       resolve([
         { label: 'Yellow', value: 'yellow' },
@@ -1293,10 +1291,9 @@ export function Example() {
 
     updateIsLoading(true);
 
-    if(inputValue){
     setTimeout(() => {
       updateIsLoading(false);
-      loadItems(inputValue).then(items => {
+      loadItems().then((items: any) => {
         setInputItems(
           items.filter(item =>
             item.label.toLowerCase().startsWith(inputValue.toLowerCase())
@@ -1304,7 +1301,6 @@ export function Example() {
         );
       });
     }, 1000);
-    }
   }
 
   return (

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -660,6 +660,7 @@ export function Example() {
 
     updateIsLoading(true);
 
+    if(inputValue){
     setTimeout(() => {
       updateIsLoading(false);
       loadItems(inputValue).then(items => {
@@ -670,6 +671,7 @@ export function Example() {
         );
       });
     }, 1000);
+    }
   }
 
   return (
@@ -1021,6 +1023,7 @@ custom `type`](/api/combobox#custom_items_typescript).
 ```tsx
 import React from 'react';
 import { Combobox } from 'react-magma-dom';
+import { v4 as uuidv4 } from "uuid";
 
 export function Example() {
   const [controlledSelectedItem, updateControlledSelectedItem] =
@@ -1041,7 +1044,7 @@ export function Example() {
     const { value } = item;
 
     return {
-      id: uuid(),
+      id: uuidv4(),
       name: value,
       representation: value.charAt(0).toUpperCase() + value.slice(1),
     };
@@ -1100,6 +1103,7 @@ element with the shape of the `items` you are passing in.
 ```tsx
 import React from 'react';
 import { Combobox } from 'react-magma-dom';
+import { v4 as uuidv4 } from "uuid";
 
 interface CustomComboboxItem {
   id: number;
@@ -1141,7 +1145,7 @@ export function Example() {
     const { value } = item;
 
     return {
-      id: uuid(),
+      id: uuidv4(),
       name: value,
       representation: value.charAt(0).toUpperCase() + value.slice(1),
     };
@@ -1289,6 +1293,7 @@ export function Example() {
 
     updateIsLoading(true);
 
+    if(inputValue){
     setTimeout(() => {
       updateIsLoading(false);
       loadItems(inputValue).then(items => {
@@ -1299,6 +1304,7 @@ export function Example() {
         );
       });
     }, 1000);
+    }
   }
 
   return (

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -944,7 +944,7 @@ import { Combobox, LabelPosition } from 'react-magma-dom';
 export function Example() {
   return (
     <Combobox
-      labelPosition={LabelPosition.top}
+      labelPosition={LabelPosition.left}
       labelText="Left-aligned label"
       defaultItems={[
         { label: 'Red', value: 'red' },

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -1044,6 +1044,7 @@ export function Example() {
     return {
       id: uuidv4(),
       name: value,
+      hex: item.hex,
       representation: value.charAt(0).toUpperCase() + value.slice(1),
     };
   }
@@ -1144,7 +1145,7 @@ export function Example() {
 
     return {
       id: uuidv4(),
-      name: value,
+      actual: value,
       representation: value.charAt(0).toUpperCase() + value.slice(1),
     };
   }

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -637,8 +637,8 @@ export function Example() {
 ## Async
 
 ```tsx
-import React from "react";
-import { Combobox } from "react-magma-dom";
+import React from 'react';
+import { Combobox } from 'react-magma-dom';
 
 export function Example() {
   const [isLoading, updateIsLoading] = React.useState<boolean>(false);
@@ -1021,7 +1021,7 @@ custom `type`](/api/combobox#custom_items_typescript).
 ```tsx
 import React from 'react';
 import { Combobox } from 'react-magma-dom';
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from 'uuid';
 
 export function Example() {
   const [controlledSelectedItem, updateControlledSelectedItem] =
@@ -1101,7 +1101,7 @@ element with the shape of the `items` you are passing in.
 ```tsx
 import React from 'react';
 import { Combobox } from 'react-magma-dom';
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from 'uuid';
 
 interface CustomComboboxItem {
   id: number;

--- a/website/react-magma-docs/src/pages/api/container.mdx
+++ b/website/react-magma-docs/src/pages/api/container.mdx
@@ -23,7 +23,7 @@ import { Container, Heading, Hyperlink, Paragraph } from 'react-magma-dom';
 export function Example() {
   return (
     <Container>
-      <Heading level="3">Basic Container</Heading>
+      <Heading level={3}>Basic Container</Heading>
       <Paragraph>
         Paragraph with <Hyperlink to="#">hyperlink</Hyperlink>
       </Paragraph>
@@ -43,7 +43,7 @@ import { Container, Heading, Paragraph, Hyperlink } from 'react-magma-dom';
 export function Example() {
   return (
     <Container isInverse>
-      <Heading level="3">Basic Container</Heading>
+      <Heading level={3}>Basic Container</Heading>
       <Paragraph>
         Paragraph with <Hyperlink to="#">hyperlink</Hyperlink>
       </Paragraph>
@@ -63,7 +63,7 @@ import { Container, Heading, Paragraph, Hyperlink } from 'react-magma-dom';
 export function Example() {
   return (
     <Container isInverse maxWidth={600}>
-      <Heading level="3">Basic Container</Heading>
+      <Heading level={3}>Basic Container</Heading>
       <Paragraph>
         Paragraph with <Hyperlink to="#">hyperlink</Hyperlink>
       </Paragraph>
@@ -83,7 +83,7 @@ import { Container, Heading, Paragraph, Hyperlink } from 'react-magma-dom';
 export function Example() {
   return (
     <Container isInverse gutterWidth={80}>
-      <Heading level="3">Basic Container</Heading>
+      <Heading level={3}>Basic Container</Heading>
       <Paragraph>
         Paragraph with <Hyperlink to="#">hyperlink</Hyperlink>
       </Paragraph>

--- a/website/react-magma-docs/src/pages/api/date-pickers.mdx
+++ b/website/react-magma-docs/src/pages/api/date-pickers.mdx
@@ -58,8 +58,8 @@ export function Example() {
 Minimum and Maximum dates can be passed in as `props` to disallow the selection of a date outside of a specific range. If a date value is passed in that does not fit in to the range given, the date picker will try to give focus when entering the calendar on today's date, then the minimum date, and finally the maximum date.
 
 ```tsx
-import React from "react";
-import { DatePicker, getDateFromString, inDateRange } from "react-magma-dom";
+import React from 'react';
+import { DatePicker, getDateFromString, inDateRange } from 'react-magma-dom';
 
 export function Example() {
   const [chosenDate, setChosenDate] = React.useState<Date | undefined>(

--- a/website/react-magma-docs/src/pages/api/date-pickers.mdx
+++ b/website/react-magma-docs/src/pages/api/date-pickers.mdx
@@ -48,7 +48,7 @@ import { DatePicker } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <DatePicker defaultDate={new Date(2025, 1, 0)} labelText="Date" value="03/12/2024" />
+    <DatePicker defaultDate={new Date(2025, 1, 0)} labelText="Date" value={new Date(2000, 1, 0)} />
   );
 }
 ```
@@ -58,15 +58,15 @@ export function Example() {
 Minimum and Maximum dates can be passed in as `props` to disallow the selection of a date outside of a specific range. If a date value is passed in that does not fit in to the range given, the date picker will try to give focus when entering the calendar on today's date, then the minimum date, and finally the maximum date.
 
 ```tsx
-import React from 'react';
-import { DatePicker, getDateFromString, inDateRange } from 'react-magma-dom';
+import React from "react";
+import { DatePicker, getDateFromString, inDateRange } from "react-magma-dom";
 
 export function Example() {
   const [chosenDate, setChosenDate] = React.useState<Date | undefined>(
     undefined
   );
-  const minDate = '01/09/2024';
-  const maxDate = '02/10/2024';
+  const minDate = new Date(2025, 1, 2);
+  const maxDate = new Date(2025, 1, 20);
 
   function handleDateChange(newChosenDate: Date) {
     setChosenDate(newChosenDate);
@@ -111,7 +111,7 @@ export function Example() {
     undefined
   );
 
-  function handleDateChange(newChosenDate: Date) {
+  function handleDateChange(newChosenDate: Date | null) {
     setChosenDate(newChosenDate);
   }
 

--- a/website/react-magma-docs/src/pages/api/date-pickers.mdx
+++ b/website/react-magma-docs/src/pages/api/date-pickers.mdx
@@ -34,7 +34,7 @@ import React from 'react';
 import { DatePicker } from 'react-magma-dom';
 
 export function Example() {
-  return <DatePicker defaultDate="07/23/2024" labelText="Date" />;
+  return <DatePicker defaultDate={new Date(2025, 1, 0)} labelText="Date" />;
 }
 ```
 
@@ -48,7 +48,7 @@ import { DatePicker } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <DatePicker defaultDate="07/23/2024" labelText="Date" value="03/12/2024" />
+    <DatePicker defaultDate={new Date(2025, 1, 0)} labelText="Date" value="03/12/2024" />
   );
 }
 ```
@@ -187,7 +187,7 @@ export function Example() {
 
 ```tsx
 import React from 'react';
-import { DatePicker, Card, CardBody, magma } from 'react-magma-dom';
+import { DatePicker, Card, CardBody } from 'react-magma-dom';
 
 export function Example() {
   return (
@@ -352,7 +352,7 @@ export function Example() {
 
 ## Keyboard Navigation
 
-The `DatePicker` is keyboard navigable for allowing the user to navigate between days, weeks, and months. If you would like to see all of the options for keyboard navigation click on the `?` button in the bottom right corner of the `DatePicker` or press the `?` key.
+The `DatePicker` is keyboard navigable for allowing the user to navigate between days, weeks, and months. 
 
 ```tsx
 import React from 'react';

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -575,28 +575,24 @@ import {
 } from 'react-magma-dom';
 
 export function Example() {
-  const showItem2 = true;
-
-  const OptionalDropdownMenuItem = ({
-    toggle,
-    children,
-    dropdownMenuItemProps,
-  }) => {
+  const OptionalDropdownMenuItem = ({ toggle, ...dropdownMenuItemProps }) => {
     return toggle ? (
-      <DropdownMenuItem {...dropdownMenuItemProps}>{children}</DropdownMenuItem>
+      <DropdownMenuItem {...dropdownMenuItemProps}>
+        Hello There
+      </DropdownMenuItem>
     ) : null;
   };
 
   function handleMenuItem1Click() {
-    alert("Item 1 clicked");
+    alert('Item 1 clicked');
   }
 
   function handleMenuItem2Click() {
-    alert("Item 2 clicked");
+    alert('Item 2 clicked');
   }
 
   function handleMenuItem3Click() {
-    alert("Item 3 clicked");
+    alert('Item 3 clicked');
   }
 
   return (
@@ -606,11 +602,8 @@ export function Example() {
         <DropdownMenuItem onClick={handleMenuItem1Click}>
           Menu item 1
         </DropdownMenuItem>
-        <OptionalDropdownMenuItem
-          toggle={showItem2}
-          onClick={handleMenuItem2Click}
-        >
-          Menu item 2 (optional)
+        <OptionalDropdownMenuItem toggle onClick={handleMenuItem2Click}>
+          Menu item 2
         </OptionalDropdownMenuItem>
         <div>
           <DropdownMenuItem onClick={handleMenuItem3Click}>
@@ -621,6 +614,7 @@ export function Example() {
     </Dropdown>
   );
 }
+
 
 ```
 

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -566,13 +566,13 @@ that returns a `DropdownMenuItem`.
 For a custom component you'll receive a `dropdownMenuItemProps` prop that you must spread in to the `DropdownMenuItem` component in your renderer.
 
 ```tsx
-import React from "react";
+import React from 'react';
 import {
   Dropdown,
   DropdownButton,
   DropdownContent,
   DropdownMenuItem,
-} from "react-magma-dom";
+} from 'react-magma-dom';
 
 export function Example() {
   const showItem2 = true;

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -77,7 +77,7 @@ export function Example() {
 
   return (
     <Dropdown>
-      <DropdownSplitButton onClick={handleSplitButtonClick}>
+      <DropdownSplitButton aria-label="Split Button" onClick={handleSplitButtonClick}>
         Split Button
       </DropdownSplitButton>
       <DropdownContent>
@@ -465,7 +465,7 @@ export function Example() {
     <Dropdown width={240}>
       <DropdownButton>Expandable Items Dropdown</DropdownButton>
       <DropdownContent>
-        <DropdownExpandableMenuGroup defaultIndex={[0]}>
+        <DropdownExpandableMenuGroup isMulti defaultIndex={[0]}>
           <DropdownExpandableMenuItem>
             <DropdownExpandableMenuButton icon={<RestaurantMenuIcon />}>
               Pasta
@@ -566,33 +566,37 @@ that returns a `DropdownMenuItem`.
 For a custom component you'll receive a `dropdownMenuItemProps` prop that you must spread in to the `DropdownMenuItem` component in your renderer.
 
 ```tsx
-import React from 'react';
+import React from "react";
 import {
   Dropdown,
   DropdownButton,
   DropdownContent,
   DropdownMenuItem,
-} from 'react-magma-dom';
+} from "react-magma-dom";
 
 export function Example() {
-  const OptionalDropdownMenuItem = ({ toggle, dropdownMenuItemProps }) => {
+  const showItem2 = true;
+
+  const OptionalDropdownMenuItem = ({
+    toggle,
+    children,
+    dropdownMenuItemProps,
+  }) => {
     return toggle ? (
-      <DropdownMenuItem {...dropdownMenuItemProps}>
-        Hello There
-      </DropdownMenuItem>
+      <DropdownMenuItem {...dropdownMenuItemProps}>{children}</DropdownMenuItem>
     ) : null;
   };
 
   function handleMenuItem1Click() {
-    alert('Item 1 clicked');
+    alert("Item 1 clicked");
   }
 
   function handleMenuItem2Click() {
-    alert('Item 2 clicked');
+    alert("Item 2 clicked");
   }
 
   function handleMenuItem3Click() {
-    alert('Item 3 clicked');
+    alert("Item 3 clicked");
   }
 
   return (
@@ -602,8 +606,11 @@ export function Example() {
         <DropdownMenuItem onClick={handleMenuItem1Click}>
           Menu item 1
         </DropdownMenuItem>
-        <OptionalDropdownMenuItem toggle onClick={handleMenuItem2Click}>
-          Menu item 2
+        <OptionalDropdownMenuItem
+          toggle={showItem2}
+          onClick={handleMenuItem2Click}
+        >
+          Menu item 2 (optional)
         </OptionalDropdownMenuItem>
         <div>
           <DropdownMenuItem onClick={handleMenuItem3Click}>
@@ -614,6 +621,7 @@ export function Example() {
     </Dropdown>
   );
 }
+
 ```
 
 ### Leading Icons
@@ -752,6 +760,7 @@ import {
   ButtonColor,
   ButtonSize,
   ButtonGroup,
+  ButtonVariant,
   Dropdown,
   DropdownButton,
   DropdownContent,

--- a/website/react-magma-docs/src/pages/api/form.mdx
+++ b/website/react-magma-docs/src/pages/api/form.mdx
@@ -103,7 +103,7 @@ export function Example() {
 }
 ```
 
-# Form Props
+## Form Props
 
 **Any other props supplied will be provided to the wrapping `form` element.**
 

--- a/website/react-magma-docs/src/pages/api/formgroup.mdx
+++ b/website/react-magma-docs/src/pages/api/formgroup.mdx
@@ -69,12 +69,11 @@ export function Example() {
             Labelled by <i>label</i>
           </>
         }
-        name="labelledByGroup"
       >
         <Checkbox labelText="Label" />
         <Checkbox labelText="Label" />
       </FormGroup>
-      <FormGroup labelledById="h3Label" name="labelledByGroup">
+      <FormGroup labelledById="h3Label" >
         <Heading id="h3Label" level={3}>
           Labelled by H3
         </Heading>
@@ -100,7 +99,6 @@ export function Example() {
       containerStyle={{ border: '1px solid gray', padding: '10px' }}
       labelStyle={{ fontWeight: '500', color: 'red' }}
       labelText="Group label"
-      name="labelledByGroup"
     >
       <Checkbox labelText="Checkbox label" />
       <Checkbox labelText="Checkbox label" />
@@ -121,7 +119,6 @@ export function Example() {
   return (
     <FormGroup
       labelText="Group Label"
-      name="labelledByGroup"
       isTextVisuallyHidden
     >
       <Checkbox labelText="Checkbox label" />

--- a/website/react-magma-docs/src/pages/api/formgroup.mdx
+++ b/website/react-magma-docs/src/pages/api/formgroup.mdx
@@ -132,7 +132,7 @@ export function Example() {
 
 ```tsx
 import React from 'react';
-import { FormGroup, Checkbox, Toggle, Card, CardBody } from 'react-magma-dom';
+import { FormGroup, Checkbox, Card, CardBody } from 'react-magma-dom';
 
 export function Example() {
   return (

--- a/website/react-magma-docs/src/pages/api/grid.mdx
+++ b/website/react-magma-docs/src/pages/api/grid.mdx
@@ -155,7 +155,7 @@ export function Example() {
       gridTemplateColumns="repeat(4, 1fr)"
       gridGap="1em"
       gridJustifyContent={GridJustifyContent.center}
-      gridAlignItems={gridAlignItems.center}
+      gridAlignItems={GridAlignItems.center}
     >
       <GridItem
         gridRow="1 / 4"

--- a/website/react-magma-docs/src/pages/api/grid.mdx
+++ b/website/react-magma-docs/src/pages/api/grid.mdx
@@ -147,7 +147,7 @@ export function Example() {
 
 ```typescript
 import React from 'react';
-import { Grid, GridItem, gridAlignItems, GridJustifyContent } from 'react-magma-dom';
+import { Grid, GridItem, GridAlignItems, GridJustifyContent } from 'react-magma-dom';
 
 export function Example() {
   return (

--- a/website/react-magma-docs/src/pages/api/grid.mdx
+++ b/website/react-magma-docs/src/pages/api/grid.mdx
@@ -20,7 +20,6 @@ Child elements can be added as they are, or inside of `<GridItem></GridItem>`. `
 
 ```typescript
 import React from 'react';
-import styled from '@emotion/styled';
 import {
   Grid,
   GridItem,
@@ -148,15 +147,15 @@ export function Example() {
 
 ```typescript
 import React from 'react';
-import { Grid, GridItem } from 'react-magma-dom';
+import { Grid, GridItem, gridAlignItems, GridJustifyContent } from 'react-magma-dom';
 
 export function Example() {
   return (
     <Grid
       gridTemplateColumns="repeat(4, 1fr)"
       gridGap="1em"
-      gridJustifyContent="center"
-      gridAlignItems="center"
+      gridJustifyContent={GridJustifyContent.center}
+      gridAlignItems={gridAlignItems.center}
     >
       <GridItem
         gridRow="1 / 4"

--- a/website/react-magma-docs/src/pages/api/hyperlink.mdx
+++ b/website/react-magma-docs/src/pages/api/hyperlink.mdx
@@ -108,7 +108,7 @@ export function Example() {
 ## Icon
 
 ```tsx
-import React from "react";
+import React from 'react';
 import {
   Hyperlink,
   HyperlinkIconPosition,

--- a/website/react-magma-docs/src/pages/api/hyperlink.mdx
+++ b/website/react-magma-docs/src/pages/api/hyperlink.mdx
@@ -120,13 +120,13 @@ import {
   FlexBehavior,
   FlexJustify,
   TypographyVisualStyle,
-} from "react-magma-dom";
+} from 'react-magma-dom';
 import {
   KeyboardArrowLeftIcon,
   KeyboardArrowRightIcon,
   CalendarTodayIcon,
   OpenInNewIcon,
-} from "react-magma-icons";
+} from 'react-magma-icons';
 
 export function Example() {
   return (

--- a/website/react-magma-docs/src/pages/api/hyperlink.mdx
+++ b/website/react-magma-docs/src/pages/api/hyperlink.mdx
@@ -108,23 +108,25 @@ export function Example() {
 ## Icon
 
 ```tsx
-import React from 'react';
+import React from "react";
 import {
   Hyperlink,
   HyperlinkIconPosition,
+  magma,
   Spacer,
   SpacerAxis,
-  ButtonTextTransform,
+  Paragraph,
   Flex,
   FlexBehavior,
   FlexJustify,
-} from 'react-magma-dom';
+  TypographyVisualStyle,
+} from "react-magma-dom";
 import {
   KeyboardArrowLeftIcon,
   KeyboardArrowRightIcon,
   CalendarTodayIcon,
-  OpenInNewIcon
-} from 'react-magma-icons';
+  OpenInNewIcon,
+} from "react-magma-icons";
 
 export function Example() {
   return (

--- a/website/react-magma-docs/src/pages/api/icon-button.mdx
+++ b/website/react-magma-docs/src/pages/api/icon-button.mdx
@@ -382,15 +382,38 @@ import React from 'react';
 import {
   IconButton,
   ButtonVariant,
-  ButtonColor,
   ButtonGroup,
+  Card,
+  CardBody,
 } from 'react-magma-dom';
 import {
   PriorityHighIcon,
   NotificationsIcon,
-  Card,
-  CardBody,
 } from 'react-magma-icons';
+
+export function Example() {
+  return (
+    <Card isInverse>
+      <CardBody>
+        <ButtonGroup>
+          <IconButton
+            aria-label="Alert"
+            variant={ButtonVariant.solid}
+            icon={<PriorityHighIcon />}
+            isInverse
+          />
+          <IconButton
+            aria-label="Notifications"
+            variant={ButtonVariant.solid}
+            icon={<NotificationsIcon />}
+            isInverse
+          />
+        </ButtonGroup>
+      </CardBody>
+    </Card>
+  );
+}
+
 
 export function Example() {
   return (

--- a/website/react-magma-docs/src/pages/api/icon-button.mdx
+++ b/website/react-magma-docs/src/pages/api/icon-button.mdx
@@ -380,40 +380,16 @@ export function Example() {
 ```tsx
 import React from 'react';
 import {
+  Card,
+  CardBody,
   IconButton,
   ButtonVariant,
   ButtonGroup,
-  Card,
-  CardBody,
 } from 'react-magma-dom';
 import {
   PriorityHighIcon,
   NotificationsIcon,
 } from 'react-magma-icons';
-
-export function Example() {
-  return (
-    <Card isInverse>
-      <CardBody>
-        <ButtonGroup>
-          <IconButton
-            aria-label="Alert"
-            variant={ButtonVariant.solid}
-            icon={<PriorityHighIcon />}
-            isInverse
-          />
-          <IconButton
-            aria-label="Notifications"
-            variant={ButtonVariant.solid}
-            icon={<NotificationsIcon />}
-            isInverse
-          />
-        </ButtonGroup>
-      </CardBody>
-    </Card>
-  );
-}
-
 
 export function Example() {
   return (

--- a/website/react-magma-docs/src/pages/api/icon-button.mdx
+++ b/website/react-magma-docs/src/pages/api/icon-button.mdx
@@ -447,7 +447,6 @@ export function Example() {
         <IconButton
           icon={<NotificationsIcon />}
           aria-label="Notifications"
-          textPosition="left"
           onClick={() => {
             setTextIconButtonCounter(count => count + 1);
           }}

--- a/website/react-magma-docs/src/pages/api/radio.mdx
+++ b/website/react-magma-docs/src/pages/api/radio.mdx
@@ -470,22 +470,25 @@ export function Example() {
 Using React's `forwardRef` feature you can gain access to the reference of the internal radio.
 
 ```tsx
-import React from 'react';
+import React from "react";
 import {
   RadioGroup,
   Radio,
   Button,
   ButtonColor,
   ButtonGroup,
-} from 'react-magma-dom';
+} from "react-magma-dom";
 
 export function Example() {
-  const [refValue, setRefValue] = React.useState();
-
   const radioRef = React.useRef();
 
+  const [refValue, setRefValue] = React.useState();
+
   function handleButtonClick() {
-    setRefValue(radioRef.current.value);
+    setRefValue((refValue) => (refValue = "1"));
+    if (refValue === "1") {
+      setRefValue((refValue) => (refValue = ""));
+    }
   }
 
   function handleSecondaryButtonClick() {
@@ -501,7 +504,6 @@ export function Example() {
         name="forwardRef"
       >
         <Radio
-          isChecked
           ref={radioRef}
           id="forwardRefRadio1"
           labelText="Option one label"

--- a/website/react-magma-docs/src/pages/api/radio.mdx
+++ b/website/react-magma-docs/src/pages/api/radio.mdx
@@ -470,14 +470,14 @@ export function Example() {
 Using React's `forwardRef` feature you can gain access to the reference of the internal radio.
 
 ```tsx
-import React from "react";
+import React from 'react';
 import {
   RadioGroup,
   Radio,
   Button,
   ButtonColor,
   ButtonGroup,
-} from "react-magma-dom";
+} from 'react-magma-dom';
 
 export function Example() {
   const [refValue, setRefValue] = React.useState();
@@ -491,8 +491,6 @@ export function Example() {
   function handleSecondaryButtonClick() {
     radioRef.current.focus();
   }
-
-  console.log(radioRef);
 
   return (
     <>

--- a/website/react-magma-docs/src/pages/api/radio.mdx
+++ b/website/react-magma-docs/src/pages/api/radio.mdx
@@ -470,38 +470,40 @@ export function Example() {
 Using React's `forwardRef` feature you can gain access to the reference of the internal radio.
 
 ```tsx
-import React from "react";
+import React from 'react';
 import {
   RadioGroup,
   Radio,
   Button,
   ButtonColor,
   ButtonGroup,
-} from "react-magma-dom";
+} from 'react-magma-dom';
 
 export function Example() {
   const radioRef = React.useRef();
+  const [radioGroupVal, setRadioGroupVal] = React.useState(null);
 
-  const [refValue, setRefValue] = React.useState();
-
-  function handleButtonClick() {
-    setRefValue((refValue) => (refValue = "1"));
-    if (refValue === "1") {
-      setRefValue((refValue) => (refValue = ""));
+  function handleSelectOne() {
+    if (!radioRef.current) {
+      setRadioGroupVal(null);
+    } else if (radioRef.current.checked) {
+      setRadioGroupVal("");
+    } else if (!radioRef.current.checked) {
+      setRadioGroupVal("1");
     }
   }
 
-  function handleSecondaryButtonClick() {
+  function handleFocusOne() {
     radioRef.current.focus();
   }
 
   return (
     <>
       <RadioGroup
-        value={refValue}
         labelText="Forward ref usage"
         id="forwardRefGroup"
         name="forwardRef"
+        value={radioGroupVal}
       >
         <Radio
           ref={radioRef}
@@ -514,11 +516,8 @@ export function Example() {
       </RadioGroup>
 
       <ButtonGroup>
-        <Button onClick={handleButtonClick}>Toggle option 1</Button>
-        <Button
-          color={ButtonColor.secondary}
-          onClick={handleSecondaryButtonClick}
-        >
+        <Button onClick={handleSelectOne}>Toggle option 1 selection</Button>
+        <Button color={ButtonColor.secondary} onClick={handleFocusOne}>
           Focus option 1
         </Button>
       </ButtonGroup>

--- a/website/react-magma-docs/src/pages/api/radio.mdx
+++ b/website/react-magma-docs/src/pages/api/radio.mdx
@@ -19,7 +19,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
 
 The `RadioGroup` component is used as the container for the set of options. The `Radio` component is used for each of the options themselves.
 
-See also: <Link to="/api/checkboxes">Checkboxes</Link>, <Link to="/api/toggle">Toggle Switches</Link>, and the <Link to="/design/selection-controls">Design Guidelines</Link> for selection controls in general.
+See also: <Link to="/api/checkboxes">Checkboxes</Link> and <Link to="/api/toggle">Toggle Switches</Link>.
 
 The label/radio association will be handled via the passed in `id` if one is supplied or via an auto-generated `id` if not supplied.
 
@@ -470,34 +470,40 @@ export function Example() {
 Using React's `forwardRef` feature you can gain access to the reference of the internal radio.
 
 ```tsx
-import React from 'react';
+import React from "react";
 import {
   RadioGroup,
   Radio,
   Button,
   ButtonColor,
   ButtonGroup,
-} from 'react-magma-dom';
+} from "react-magma-dom";
 
 export function Example() {
+  const [refValue, setRefValue] = React.useState();
+
   const radioRef = React.useRef();
 
   function handleButtonClick() {
-    radioRef.current.checked = !radioRef.current.checked;
+    setRefValue(radioRef.current.value);
   }
 
   function handleSecondaryButtonClick() {
     radioRef.current.focus();
   }
 
+  console.log(radioRef);
+
   return (
     <>
       <RadioGroup
+        value={refValue}
         labelText="Forward ref usage"
         id="forwardRefGroup"
         name="forwardRef"
       >
         <Radio
+          isChecked
           ref={radioRef}
           id="forwardRefRadio1"
           labelText="Option one label"

--- a/website/react-magma-docs/src/pages/api/select.mdx
+++ b/website/react-magma-docs/src/pages/api/select.mdx
@@ -1150,7 +1150,7 @@ corresponds to a `stateChangeTypes` property. The list of all the possible types
 
 ### Select
 
-<div style={{ overflowX: 'scroll' }}>
+<div>
   <ul>
     <li>
       <inlineCode>SelectStateChangeTypes.MenuKeyDownArrowDown</inlineCode>

--- a/website/react-magma-docs/src/pages/api/select.mdx
+++ b/website/react-magma-docs/src/pages/api/select.mdx
@@ -1135,7 +1135,7 @@ The `type` property in the `changes` object that is returned from the `onStateCh
 corresponds to a `stateChangeTypes` property. The list of all the possible types for a `select` or a
 `multi-select` are listed below.
 
-<Alert variant="info" style={{ maxWidth: '100%', overflow: 'scroll' }}>
+<Alert variant="info" style={{ maxWidth: '100%' }}>
   In the development environment these types equate to strings
   <br />
   (eg:{' '}
@@ -1232,7 +1232,7 @@ corresponds to a `stateChangeTypes` property. The list of all the possible types
 
 ### MultiSelect
 
-<div style={{ overflowX: 'scroll' }}>
+<div >
   <ul>
     <li>
       <inlineCode>

--- a/website/react-magma-docs/src/pages/api/stepper.mdx
+++ b/website/react-magma-docs/src/pages/api/stepper.mdx
@@ -99,7 +99,7 @@ When using `layout` with `StepperLayout.summaryView`, the option to change the s
 
 ```typescript
 import React from 'react';
-import { Container, Stepper, Step, Button, ButtonGroup } from 'react-magma-dom';
+import { Container, Stepper, Step, StepperLayout, Button, ButtonGroup } from 'react-magma-dom';
 
 export function Example() {
   const [currentStep, setCurrentStep] = React.useState(0);
@@ -161,13 +161,13 @@ export function Example() {
 }
 ```
 
-## Completed Step Description
+## Completion Label
 
-When using layout `StepperLayout.summaryView`, after all of the steps are complete, the `completedStepDescription` prop takes a string and changes the title.
+When using layout `StepperLayout.summaryView`, after all of the steps are complete, the `completionLabel` prop takes a string and changes the title.
 
 ```typescript
 import React from 'react';
-import { Container, Stepper, Step, Button, ButtonGroup } from 'react-magma-dom';
+import { Container, Stepper, Step, StepperLayout, Button, ButtonGroup } from 'react-magma-dom';
 
 export function Example() {
   const [currentStep, setCurrentStep] = React.useState(4);
@@ -192,7 +192,7 @@ export function Example() {
     <>
       <Stepper
         ariaLabel="progress"
-        completedStepDescription="Steps Complete!"
+        completionLabel="Steps Complete!"
         layout={StepperLayout.summaryView}
         currentStep={currentStep}
       >

--- a/website/react-magma-docs/src/pages/api/toast.mdx
+++ b/website/react-magma-docs/src/pages/api/toast.mdx
@@ -168,7 +168,7 @@ Toasts are intended to be small interruptions to users, so when a `Toast` compon
 read the new content. One way to do this is to use the <Link to="/api/announce">Announce component</Link>, which employs the `aria-live` attribute. Be sure to place
 the conditional logic to display the Toast _inside_ the Announce component.
 
-While toasts appear visually in centered at bottom of the screen, they will exist in the dom where ever they are placed. Keep this in mind when you are structuring your
+While toasts appear visually at the bottom left of the screen, they will exist in the dom wherever they are placed. Keep this in mind when you are structuring your
 markup, to ensure that they have the expected tab order.
 
 ```tsx

--- a/website/react-magma-docs/src/pages/api/toggle.mdx
+++ b/website/react-magma-docs/src/pages/api/toggle.mdx
@@ -14,7 +14,7 @@ import { LeadParagraph } from '../../components/LeadParagraph';
   either an on or off value.
 </LeadParagraph>
 
-See also: <Link to="/api/checkboxes">Checkboxes</Link>, <Link to="/api/radio">Radio Buttons</Link>, and the <Link to="/design/selection-controls">Design Guidelines</Link> for selection controls in general.
+See also: <Link to="/api/checkboxes">Checkboxes</Link> and <Link to="/api/radio">Radio Buttons</Link>.
 
 ## Basic Usage
 

--- a/website/react-magma-docs/src/pages/api/use-focus-lock.mdx
+++ b/website/react-magma-docs/src/pages/api/use-focus-lock.mdx
@@ -85,7 +85,7 @@ If your container has no focusable elements you can pass a ref that is on an ele
 
 ```tsx codesandbox=magma
 import React from 'react';
-import { useFocusLock, Toggle, Input, Button, Heading } from 'react-magma-dom';
+import { useFocusLock, Toggle } from 'react-magma-dom';
 
 export function Example() {
   const bodyRef = React.useRef<HTMLDivElement>();

--- a/website/react-magma-docs/src/pages/design/progress-bar.mdx
+++ b/website/react-magma-docs/src/pages/design/progress-bar.mdx
@@ -21,7 +21,7 @@ Progress bars can be used in different ways depending on where they are used or 
 
 Perhaps most importantly, the progress bar should reflect real data or progress, and not be faked in order to just give the impression of progress.
 
-To see how progress bars are used as loading indicators, view the [loading indicator component](/design/loading-indicators/).
+To see how progress bars are used as loading indicators, view the [loading indicator component](/design/loading-indicator/).
 
 <figure>
   <div class="image-container">


### PR DESCRIPTION
Issue: # [1554](https://github.com/cengage/react-magma/issues/1554)

## What I did
Cleaned up CodeSandbox examples for: **Grid, Container, Stepper, Combobox, Hyperlink, IconButton, Toast, DatePicker, Dropdown, Form, FormGroup, & useFocusLock**

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test

Go to: https://next--upbeat-sinoussi-f675aa.netlify.app/api/

**1. Grid**

Basic Usage example


**2. Container**

All examples


**3. Stepper**

Step label example

Completed Step Description example


**4. Combobox**

Label Position example

Async example

Custom Items example

**5. Hyperlink**

Icon example


**6. IconButton**

Basic Usage example

Inverse example


**7. Toast**

Toast Documentation

There are a couple items in the "Accessibility Considerations" section that need to be fixed.

The toast is displayed in the bottom-left corner of the window, not the center
"Where ever" should be "Wherever".


**8. DatePicker**

Default Date example

Value example

The description under Keyboard Navigation is no longer accurate now that we've removed ?
If you would like to see all of the options for keyboard navigation click on the ? button in the bottom right corner of the DatePicker or press the ? key. should be removed


**9. Dropdown**

DropdownSplitButton example

Custom DropdownMenuItem Wrappers example

Expandable Menu examples have a new bug so the CodeSandbox will still show the error with icon:

https://github.com/cengage/react-magma/issues/1573


**10. Form**

Form Props should be heading 2 ## instead of 1 so it can show up on the side nav


**11. FormGroup**

Visually Hidden Label, Custom Styles and Labeling Form Groups all use name prop which is not needed


**12. useFocusLock**

Optional Header Without Focusable Element example (removed references of Input, Button, Heading)
