### PR TITLE
fix(TreeView): Fix invalid tree item children

### DIFF
--- a/.changeset/tree-validity.md
+++ b/.changeset/tree-validity.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(TreeView): Fix invalid tree item children

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -212,7 +212,10 @@ export const Complex = (args: Partial<TreeViewProps>) => {
   );
   const total = selectedItems?.length ?? 0;
 
-  const handleExpandedChange = (event: React.SyntheticEvent, expandedItems: string[]) => {
+  const handleExpandedChange = (
+    event: React.SyntheticEvent,
+    expandedItems: string[]
+  ) => {
     setExpandedItems(expandedItems);
   };
 
@@ -358,8 +361,8 @@ export const Complex = (args: Partial<TreeViewProps>) => {
                     icon={<ArticleIcon aria-hidden={true} />}
                     label={
                       <>
-                        Section 5.1.3.1: Apple pie apple pie tart macaroon topping
-                        chocolate cake
+                        Section 5.1.3.1: Apple pie apple pie tart macaroon
+                        topping chocolate cake
                       </>
                     }
                     itemId="pt2ch5.1.3.1"
@@ -368,8 +371,8 @@ export const Complex = (args: Partial<TreeViewProps>) => {
                     icon={<ArticleIcon aria-hidden={true} />}
                     label={
                       <>
-                        Section 5.1.3.2: Apple pie apple pie tart macaroon topping
-                        chocolate cake
+                        Section 5.1.3.2: Apple pie apple pie tart macaroon
+                        topping chocolate cake
                       </>
                     }
                     itemId="pt2ch5.1.3.2"
@@ -378,8 +381,8 @@ export const Complex = (args: Partial<TreeViewProps>) => {
                     icon={<ArticleIcon aria-hidden={true} />}
                     label={
                       <>
-                        Section 5.1.3.3: Apple pie apple pie tart macaroon topping
-                        chocolate cake
+                        Section 5.1.3.3: Apple pie apple pie tart macaroon
+                        topping chocolate cake
                       </>
                     }
                     itemId="pt2ch5.1.3.3"
@@ -1034,6 +1037,49 @@ ParentsAndChildrenNotAutoChecked.args = {
 };
 
 ParentsAndChildrenNotAutoChecked.parameters = {
+  controls: {
+    exclude: ['isInverse', 'initialExpandedItems', 'ariaLabelledBy'],
+  },
+};
+
+export const InvalidTreeItems = (args: Partial<TreeViewProps>) => {
+  return (
+    <>
+      <p>
+        <em>
+          This is an example of a tree with badly structured tree items. 
+          Expect only the following items to be expandable: Node 1, Child 1, Node 2, Child 2, Grandchild 2.
+        </em>
+      </p>
+      <TreeView {...args}>
+        <TreeItem label="Node 0 - fragment" itemId="item0" testId="item0">
+          <></>
+        </TreeItem>
+        <TreeItem label="Node 1" itemId="item1" testId="item1">
+          <TreeItem label="Child 1" itemId="item-child1">
+            <TreeItem label="Grandchild 1" itemId="item-gchild1">
+              <Tag>This is a tag as a child of Grandchild 1</Tag>
+            </TreeItem>
+          </TreeItem>
+        </TreeItem>
+        <TreeItem label="Node 2" itemId="item2">
+          <TreeItem label="Child 2" itemId="item-child2">
+            <TreeItem label="Grandchild 2" itemId="item-gchild2">
+              <TreeItem label="Great-grandchild 2" itemId="item-ggchild2" />
+              <TreeItem label="Great-grandchild 3" itemId="item-ggchild3" />
+            </TreeItem>
+          </TreeItem>
+        </TreeItem>
+        <TreeItem label="Node 3" itemId="item3"></TreeItem>
+        <TreeItem label="Node 4" itemId="item4">
+          Child of node 4 is just text
+        </TreeItem>
+      </TreeView>
+    </>
+  );
+};
+
+InvalidTreeItems.parameters = {
   controls: {
     exclude: ['isInverse', 'initialExpandedItems', 'ariaLabelledBy'],
   },

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -1047,8 +1047,9 @@ export const InvalidTreeItems = (args: Partial<TreeViewProps>) => {
     <>
       <p>
         <em>
-          This is an example of a tree with badly structured tree items. 
-          Expect only the following items to be expandable: Node 1, Child 1, Node 2, Child 2, Grandchild 2.
+          This is an example of a tree with badly structured tree items. Expect
+          only the following items to be expandable: Node 1, Child 1, Node 2,
+          Child 2, Grandchild 2.
         </em>
       </p>
       <TreeView {...args}>
@@ -1066,7 +1067,9 @@ export const InvalidTreeItems = (args: Partial<TreeViewProps>) => {
           <TreeItem label="Child 2" itemId="item-child2">
             <TreeItem label="Grandchild 2" itemId="item-gchild2">
               <TreeItem label="Great-grandchild 2" itemId="item-ggchild2" />
-              <TreeItem label="Great-grandchild 3" itemId="item-ggchild3" />
+              <TreeItem label="Great-grandchild 3" itemId="item-ggchild3">
+                <>Invalid child</>
+              </TreeItem>
             </TreeItem>
           </TreeItem>
         </TreeItem>

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -2469,6 +2469,30 @@ describe('TreeView', () => {
       expect(getByTestId('item-child3-expand')).toBeInTheDocument();
     });
 
+    it('when multiple TreeViews are passed as a child and at least one is valid, the tree item is expandable', () => {
+      const { getByTestId } = render(
+        <TreeView>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem label="Child 1" itemId="item-child1" testId="item-child1">
+              <></>
+            </TreeItem>
+            <TreeItem label="Child 2" itemId="item-child2" testId="item-child2">
+              <TreeItem
+                label="Child 2.1"
+                itemId="item-child2.1"
+                testId="item-child2.1"
+              />
+            </TreeItem>
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(getByTestId('item1-expand')).toBeInTheDocument();
+      userEvent.click(getByTestId('item1-expand'));
+      expect(getByTestId('item-child2-expand')).toBeInTheDocument();
+    });
+
+
     it('when a fragment is passed as a child, the tree item is not expandable', () => {
       const { queryByTestId } = render(
         <TreeView>

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -7,6 +7,8 @@ import userEvent from '@testing-library/user-event';
 import { FavoriteIcon } from 'react-magma-icons';
 import { transparentize } from 'polished';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
+import { Tag } from '../Tag';
+import { Paragraph } from '../Paragraph';
 
 const TEXT = 'Test Text Tree Item';
 const testId = 'tree-view';
@@ -2385,6 +2387,138 @@ describe('TreeView', () => {
 
       userEvent.click(getByTestId('item2-expand'));
       expect(item2).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('tree validity', () => {
+    it('when a TreeView is passed as a child, the tree item is expandable', () => {
+      const { getByTestId } = render(
+        <TreeView>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(getByTestId('item1-expand')).toBeInTheDocument();
+    });
+
+    it('when multiple TreeViews are passed as a child, the tree item is expandable', () => {
+      const { getByTestId } = render(
+        <TreeView>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+            <TreeItem
+              label="Child 2"
+              itemId="item-child2"
+              testId="item-child2"
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(getByTestId('item1-expand')).toBeInTheDocument();
+    });
+
+    it('when multiple TreeViews with nested children are passed as a child, the tree items are expandable', () => {
+      const { getByTestId } = render(
+        <TreeView>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+            <TreeItem label="Child 2" itemId="item-child2" testId="item-child2">
+              <TreeItem
+                label="Child 2.1"
+                itemId="item-child2.1"
+                testId="item-child2.1"
+              >
+                <TreeItem
+                  label="Child 2.1.1"
+                  itemId="item-child2.1.1"
+                  testId="item-child2.1.1"
+                />
+              </TreeItem>
+            </TreeItem>
+            <TreeItem label="Child 3" itemId="item-child3" testId="item-child3">
+              <TreeItem
+                label="Child 3.1"
+                itemId="item-child3.1"
+                testId="item-child3.1"
+              />
+            </TreeItem>
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(getByTestId('item1-expand')).toBeInTheDocument();
+      userEvent.click(getByTestId('item1-expand'));
+      expect(getByTestId('item-child2-expand')).toBeInTheDocument();
+      userEvent.click(getByTestId('item-child2-expand'));
+      expect(getByTestId('item-child2.1-expand')).toBeInTheDocument();
+      expect(getByTestId('item-child3-expand')).toBeInTheDocument();
+    });
+
+    it('when a fragment is passed as a child, the tree item is not expandable', () => {
+      const { queryByTestId } = render(
+        <TreeView>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <></>
+          </TreeItem>
+          <TreeItem label="Node 2" itemId="item2" testId="item2"></TreeItem>
+        </TreeView>
+      );
+
+      expect(queryByTestId('item1-expand')).not.toBeInTheDocument();
+      expect(queryByTestId('item2-expand')).not.toBeInTheDocument();
+    });
+
+    it('when any other component is passed as a child, the tree item is not expandable', () => {
+      const { queryByTestId } = render(
+        <TreeView>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <Tag>This is a tag</Tag>
+          </TreeItem>
+          <TreeItem label="Node 2" itemId="item2" testId="item2">
+            <Paragraph>This is a paragraph</Paragraph>
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(queryByTestId('item1-expand')).not.toBeInTheDocument();
+      expect(queryByTestId('item2-expand')).not.toBeInTheDocument();
+    });
+
+    it('when text is passed as a child, the tree item is not expandable', () => {
+      const { queryByTestId } = render(
+        <TreeView>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            This is sample text
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(queryByTestId('item1-expand')).not.toBeInTheDocument();
+    });
+
+    it('when a TreeView does not have a child, the tree item is not expandable', () => {
+      const { queryByTestId } = render(
+        <TreeView>
+          <TreeItem label="Node 1" itemId="item1" testId="item1" />
+        </TreeView>
+      );
+
+      expect(queryByTestId('item1-expand')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/react-magma-dom/src/components/TreeView/utils.ts
+++ b/packages/react-magma-dom/src/components/TreeView/utils.ts
@@ -197,19 +197,28 @@ const getIsDisabled = ({
   return isParentDisabled || isDisabled;
 };
 
-// Returns a boolean indicating whether all the children are valid.
-// A child is considered valid if it can be counted as an item that would make the parent expandable.
-const areAllChildrenValid = children => {
+/* Returns a boolean indicating whether at least one child is valid.
+A child is considered valid if it can be counted as an item that would make the parent expandable.
+This is used to set `hasOwnTreeItems` which manages visibility of the expandable arrow.
+*/
+const areChildrenValid = children => {
   if (!children) {
     return false;
   } else if (!children.length && children.type !== TreeItem) {
     return false;
   }
 
+  let hasValidChild = true;
+
   for (let i = 0; i < children.length; i++) {
     const child = children[i];
+
+    if (typeof child === 'string') {
+      return false; // Return false if a child is a string
+    }
+
     if (child.type !== TreeItem) {
-      return false;
+      return hasValidChild;
     }
     // Recursively check the validity of nested children
     if (child.props.children) {
@@ -217,13 +226,14 @@ const areAllChildrenValid = children => {
         ? child.props.children
         : [child.props.children];
 
-      if (!areAllChildrenValid(nestedChildren)) {
-        return false;
+      if (areChildrenValid(nestedChildren)) {
+        hasValidChild = true;
+        return hasValidChild;
       }
     }
   }
 
-  return true;
+  return hasValidChild;
 };
 
 const getTreeViewData = ({
@@ -262,7 +272,7 @@ const getTreeViewData = ({
           itemId: props.itemId,
           parentId,
           icon: props.icon,
-          hasOwnTreeItems: areAllChildrenValid(props.children),
+          hasOwnTreeItems: areChildrenValid(props.children),
           isDisabled,
         },
         ...(props.children


### PR DESCRIPTION
Issue: none

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
MAST engineers reported a change in behavior from `4.6.0` to our prerelease. Items that had invalid children would get the expandable arrow when they shouldn't. In addition, I added unit tests so we don't break this accidentally in the future.

## Screenshots:
All examples with the same code:
```
   <TreeView>
        <TreeItem label="Node 0 - fragment" itemId="item0" testId="item0">
          <></>
        </TreeItem>
        <TreeItem label="Node 1" itemId="item1" testId="item1">
          <TreeItem label="Child 1" itemId="item-child1">
            <TreeItem label="Grandchild 1" itemId="item-gchild1">
              <Tag>This is a tag as a child of Grandchild 1</Tag>
            </TreeItem>
          </TreeItem>
        </TreeItem>
        <TreeItem label="Node 2" itemId="item2">
          <TreeItem label="Child 2" itemId="item-child2">
            <TreeItem label="Grandchild 2" itemId="item-gchild2">
              <TreeItem label="Great-grandchild 2" itemId="item-ggchild2" />
              <TreeItem label="Great-grandchild 3" itemId="item-ggchild3" />
            </TreeItem>
          </TreeItem>
        </TreeItem>
        <TreeItem label="Node 3" itemId="item3"></TreeItem>
        <TreeItem label="Node 4" itemId="item4">
          Child of node 4 is just text
        </TreeItem>
      </TreeView>
   ```
**In 4.6.0**
![image](https://github.com/user-attachments/assets/693e4df0-7453-42da-aa09-ef0bec5ccace)

**In 4.7.0-next.50**
![image](https://github.com/user-attachments/assets/8632f125-fe8c-47f9-b47d-d10ff8caaa77)

**Update from this PR**
![image](https://github.com/user-attachments/assets/e67623e5-9317-42c3-b519-218c2012d5d5)


## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [-] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
Open CodeSandbox and try different kinds of tree structures. Ensure that the items that are expandable are the expected ones (ones with valid children, whether that's a single TreeItem or multiple).

_Note: to test previous behavior, open CS and change the package version from 4.6.0 to the latest prerelease_