### PR TITLE
fix @import rule warning in GlobalStyles

### DIFF
--- a/.changeset/fix-GlobalStyles-import-warning.md
+++ b/.changeset/fix-GlobalStyles-import-warning.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(GlobalStyles): fix @import rule warning in GlobalStyles

--- a/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
+++ b/packages/react-magma-dom/src/theme/GlobalStyles/index.tsx
@@ -3,11 +3,14 @@ import * as React from 'react';
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../ThemeContext';
 
+function getGlobalImports() {
+  return css`
+    @import url('https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,100..900;1,100..900&family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap');
+  `;
+}
+
 function getStyles(theme, isInverse: boolean) {
   return css`
-    @import url('https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
-    @import url('https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap');
-
     *,
     *:before,
     *:after {
@@ -81,7 +84,12 @@ export const GlobalStyles: React.FunctionComponent = () => {
   const isInverse = useIsInverse();
   return (
     <ThemeContext.Consumer>
-      {theme => <Global styles={getStyles(theme, isInverse)} />}
+      {theme => (
+        <>
+          <Global styles={getGlobalImports()} />
+          <Global styles={getStyles(theme, isInverse)} />
+        </>
+      )}
     </ThemeContext.Consumer>
   );
 };


### PR DESCRIPTION
Issue: #1604

## What I did
* moved font import to a separate `Global` 
* update the font import link from google fonts
 
from **[emotion docs](https://emotion.sh/docs/emotion-11#stylis-v4)** 
> @import rules are no longer special-cased. The responsibility to put them first has been moved to the author of the styles. They also can't be nested within other rules now. It's only possible to write them at the top level of global styles.



## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test
navigate to 
https://docs-preview-1607--upbeat-sinoussi-f675aa.netlify.app/api/global-styles/
check console for the `@import` warning
