### PR TITLE
fix(Table): Reconfigured the table CSS to better allow for content within a table to overlay the container, such as dropdowns.

### DIFF
--- a/.changeset/fix-tableOverflow.md
+++ b/.changeset/fix-tableOverflow.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Table): Reconfigured the table CSS to better allow for content within a table to overlay the container, such as dropdowns.

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -50,7 +50,14 @@ const rows = [
 ];
 
 const Template: Story<TableProps> = args => (
-  <Card isInverse={args.isInverse}>
+  <Card
+    style={
+      args.hasSquareCorners
+        ? { borderRadius: '0' }
+        : { borderRadius: `${magma.borderRadius}` }
+    }
+    isInverse={args.isInverse}
+  >
     <Table {...args}>
       <TableHead>
         <TableRow>
@@ -300,7 +307,14 @@ export const ControlledPagination = args => {
   );
 
   return (
-    <Card isInverse={args.isInverse}>
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0' }
+          : { borderRadius: `${magma.borderRadius}` }
+      }
+    >
       <Table {...args}>
         <TableHead>
           <TableRow>
@@ -458,7 +472,14 @@ export const PaginationInverse = args => {
   );
 
   return (
-    <Card isInverse>
+    <Card
+      isInverse
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0' }
+          : { borderRadius: `${magma.borderRadius}` }
+      }
+    >
       <Table {...args} isInverse>
         <TableHead>
           <TableRow>
@@ -545,7 +566,14 @@ RowColors.args = {
 
 export const RowColorsInverse = args => {
   return (
-    <Card isInverse>
+    <Card
+      isInverse
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0' }
+          : { borderRadius: `${magma.borderRadius}` }
+      }
+    >
       <Table {...args}>
         <TableHead>
           <TableRow>
@@ -646,7 +674,14 @@ export const Sortable = args => {
   };
 
   return (
-    <Card isInverse={args.isInverse}>
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0' }
+          : { borderRadius: `${magma.borderRadius}` }
+      }
+    >
       <Table {...args}>
         <TableHead>
           <TableRow>
@@ -717,7 +752,14 @@ Sortable.args = {
 
 export const WithDropdown = args => {
   return (
-    <Card isInverse={args.isInverse}>
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0' }
+          : { borderRadius: `${magma.borderRadius}` }
+      }
+    >
       <Table maxWidth={500} {...args}>
         <TableHead>
           <TableRow>
@@ -797,13 +839,17 @@ export const AdjustableRowNumber = args => {
       tableRows.push(
         <TableRow key={`row${i}`}>
           <TableCell key={`cell${i}-left`}>{i}</TableCell>
-          <TableCell key={`cell${i}-middle`}>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</TableCell>
-          <TableCell key={`cell${i}-right`}>Nullam bibendum diam vel felis consequat lacinia.</TableCell>
+          <TableCell key={`cell${i}-middle`}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </TableCell>
+          <TableCell key={`cell${i}-right`}>
+            Nullam bibendum diam vel felis consequat lacinia.
+          </TableCell>
         </TableRow>
       );
     }
     return tableRows;
-  };
+  }
 
   return (
     <Table {...args}>
@@ -814,9 +860,7 @@ export const AdjustableRowNumber = args => {
           <TableHeaderCell>Column</TableHeaderCell>
         </TableRow>
       </TableHead>
-      <TableBody>
-        {getTableRows()}
-      </TableBody>
+      <TableBody>{getTableRows()}</TableBody>
     </Table>
   );
 };

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -41,24 +41,24 @@ describe('Table', () => {
 
     expect(getByTestId('heading-1')).toHaveStyleRule(
       'border-radius',
-      `${magma.spaceScale.spacing03} 0 0 0`,
+      `${magma.borderRadius} 0 0 0`,
       { target: 'first-child' }
     );
     expect(getByTestId('heading-2')).toHaveStyleRule(
       'border-radius',
-      `0 ${magma.spaceScale.spacing03} 0 0`,
+      `0 ${magma.borderRadius} 0 0`,
 
       { target: 'last-child' }
     );
     expect(getByTestId('table-row-2')).toHaveStyleRule(
       'border-radius',
-      `0 0 0 ${magma.spaceScale.spacing03}`,
+      `0 0 0 ${magma.borderRadius}`,
 
       { target: 'first-child' }
     );
     expect(getByTestId('table-row-2')).toHaveStyleRule(
       'border-radius',
-      `0 0 ${magma.spaceScale.spacing03} 0`,
+      `0 0 ${magma.borderRadius} 0`,
       { target: 'last-child' }
     );
   });
@@ -193,11 +193,11 @@ describe('Table', () => {
 
     expect(getByText('cell 1')).toHaveStyleRule(
       'padding',
-      `${magma.spaceScale.spacing02} ${magma.spaceScale.spacing03}`
+      `${magma.spaceScale.spacing02} ${magma.borderRadius}`
     );
     expect(getByText('heading 1')).toHaveStyleRule(
       'padding',
-      `${magma.spaceScale.spacing02} ${magma.spaceScale.spacing03}`
+      `${magma.spaceScale.spacing02} ${magma.borderRadius}`
     );
   });
 

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -23,50 +23,82 @@ describe('Table', () => {
 
   it('should render table with a border radius', () => {
     const { getByTestId } = render(
-      <Table isInverse testId="test-id">
+      <Table>
         <TableHead>
           <TableRow>
-            <TableHeaderCell>heading 1</TableHeaderCell>
-            <TableHeaderCell>heading 2</TableHeaderCell>
+            <TableHeaderCell testId="heading-1">heading 1</TableHeaderCell>
+            <TableHeaderCell testId="heading-2">heading 2</TableHeaderCell>
           </TableRow>
         </TableHead>
         <TableBody>
           <TableRow>
-            <TableCell>cell 1</TableCell>
-            <TableCell>cell 2</TableCell>
+            <TableCell testId="cell-1">cell 1</TableCell>
+            <TableCell testId="cell-2">cell 2</TableCell>
           </TableRow>
         </TableBody>
       </Table>
     );
 
-    expect(getByTestId('table-wrapper-test-id')).toHaveStyleRule(
+    expect(getByTestId('heading-1')).toHaveStyleRule(
       'border-radius',
-      magma.spaceScale.spacing03
+      `${magma.spaceScale.spacing03} 0 0 0`,
+      { target: 'first-child' }
+    );
+    expect(getByTestId('heading-2')).toHaveStyleRule(
+      'border-radius',
+      `0 ${magma.spaceScale.spacing03} 0 0`,
+
+      { target: 'last-child' }
+    );
+    expect(getByTestId('cell-1')).toHaveStyleRule(
+      'border-radius',
+      `0 0 0 ${magma.spaceScale.spacing03}`,
+
+      { target: 'first-child' }
+    );
+    expect(getByTestId('cell-2')).toHaveStyleRule(
+      'border-radius',
+      `0 0 ${magma.spaceScale.spacing03} 0`,
+      { target: 'last-child' }
     );
   });
 
   it('should render table without a border radius', () => {
     const { getByTestId } = render(
-      <Table hasSquareCorners isInverse testId="test-id">
+      <Table hasSquareCorners>
         <TableHead>
           <TableRow>
-            <TableHeaderCell>heading 1</TableHeaderCell>
-            <TableHeaderCell>heading 2</TableHeaderCell>
+            <TableHeaderCell testId="heading-1">heading 1</TableHeaderCell>
+            <TableHeaderCell testId="heading-2">heading 2</TableHeaderCell>
           </TableRow>
         </TableHead>
         <TableBody>
           <TableRow>
-            <TableCell>cell 1</TableCell>
-            <TableCell>cell 2</TableCell>
+            <TableCell testId="cell-1">cell 1</TableCell>
+            <TableCell testId="cell-2">cell 2</TableCell>
           </TableRow>
         </TableBody>
       </Table>
     );
 
-    expect(getByTestId('table-wrapper-test-id')).toHaveStyleRule(
+    expect(getByTestId('heading-1')).toHaveStyleRule('border-radius', '0', {
+      target: 'first-child',
+    });
+    expect(getByTestId('heading-2')).toHaveStyleRule(
       'border-radius',
-      '0'
+      '0',
+
+      { target: 'last-child' }
     );
+    expect(getByTestId('cell-1')).toHaveStyleRule(
+      'border-radius',
+      '0',
+
+      { target: 'first-child' }
+    );
+    expect(getByTestId('cell-2')).toHaveStyleRule('border-radius', '0', {
+      target: 'last-child',
+    });
   });
 
   it('should render table with vertical borders', () => {

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -31,9 +31,9 @@ describe('Table', () => {
           </TableRow>
         </TableHead>
         <TableBody>
-          <TableRow>
-            <TableCell testId="cell-1">cell 1</TableCell>
-            <TableCell testId="cell-2">cell 2</TableCell>
+          <TableRow testId="table-row-2">
+            <TableCell>cell 1</TableCell>
+            <TableCell>cell 2</TableCell>
           </TableRow>
         </TableBody>
       </Table>
@@ -50,13 +50,13 @@ describe('Table', () => {
 
       { target: 'last-child' }
     );
-    expect(getByTestId('cell-1')).toHaveStyleRule(
+    expect(getByTestId('table-row-2')).toHaveStyleRule(
       'border-radius',
       `0 0 0 ${magma.spaceScale.spacing03}`,
 
       { target: 'first-child' }
     );
-    expect(getByTestId('cell-2')).toHaveStyleRule(
+    expect(getByTestId('table-row-2')).toHaveStyleRule(
       'border-radius',
       `0 0 ${magma.spaceScale.spacing03} 0`,
       { target: 'last-child' }
@@ -73,9 +73,9 @@ describe('Table', () => {
           </TableRow>
         </TableHead>
         <TableBody>
-          <TableRow>
-            <TableCell testId="cell-1">cell 1</TableCell>
-            <TableCell testId="cell-2">cell 2</TableCell>
+          <TableRow testId="table-row-2">
+            <TableCell>cell 1</TableCell>
+            <TableCell>cell 2</TableCell>
           </TableRow>
         </TableBody>
       </Table>
@@ -90,13 +90,13 @@ describe('Table', () => {
 
       { target: 'last-child' }
     );
-    expect(getByTestId('cell-1')).toHaveStyleRule(
+    expect(getByTestId('table-row-2')).toHaveStyleRule(
       'border-radius',
       '0',
 
       { target: 'first-child' }
     );
-    expect(getByTestId('cell-2')).toHaveStyleRule('border-radius', '0', {
+    expect(getByTestId('table-row-2')).toHaveStyleRule('border-radius', '0', {
       target: 'last-child',
     });
   });

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -424,23 +424,4 @@ describe('Table', () => {
       }
     );
   });
-
-  it('should change the table layout to `overflow: auto` when the minimum table size is greater than the screen width', () => {
-    const { getByTestId } = render(
-      <Table minWidth={600} testId="main-table">
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>heading 1</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-      </Table>
-    );
-    act(() => {
-      global.innerWidth = 500;
-      global.dispatchEvent(new Event('resize'));
-    });
-    const table = getByTestId('main-table').parentElement;
-
-    expect(table).toHaveStyleRule('overflow', 'auto');
-  });
 });

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -10,7 +10,7 @@ import {
 
 import { magma } from '../../theme/magma';
 
-import { act, render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent, getByTestId } from '@testing-library/react';
 import { transparentize } from 'polished';
 
 describe('Table', () => {
@@ -423,5 +423,24 @@ describe('Table', () => {
         target: ':hover',
       }
     );
+  });
+
+  it('should change the table layout to `overflow: auto` when the minimum table size is greater than the screen width', () => {
+    const { getByTestId } = render(
+      <Table minWidth={600} testId="main-table">
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>heading 1</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+      </Table>
+    );
+    act(() => {
+      global.innerWidth = 500;
+      global.dispatchEvent(new Event('resize'));
+    });
+    const table = getByTestId('main-table').parentElement;
+
+    expect(table).toHaveStyleRule('overflow', 'auto');
   });
 });

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -172,26 +172,25 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
 
-    const isBrowser = typeof window !== 'undefined';
+    const isBrowser = () => typeof window !== 'undefined';
 
     React.useEffect(() => {
       function handleResize() {
         setWindowWidth(window.innerWidth);
-        if (window.innerWidth < minWidth && minWidth) {
+        if (isBrowser && window.innerWidth < minWidth && minWidth) {
           setTableOverFlow('auto');
         }
 
-        if (window.innerWidth > minWidth) {
+        if (isBrowser && window.innerWidth > minWidth) {
           setTableOverFlow('visible');
         }
       }
 
-      window.addEventListener('resize', handleResize);
+      isBrowser && window.addEventListener('resize', handleResize);
       handleResize();
 
-      if (isBrowser) {
-        return () => window.removeEventListener('resize', handleResize);
-      }
+      return () =>
+        isBrowser && window.removeEventListener('resize', handleResize);
     }, [windowWidth]);
 
     return (

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -107,9 +107,12 @@ export const TableContext = React.createContext<TableContextInterface>({
 
 export const TableContainer = styled.div<{
   isInverse?: boolean;
+  minWidth: number;
   tableOverFlow?: string;
 }>`
-  overflow: ${props => props.tableOverFlow};
+  @media screen and (max-width: ${props => props.minWidth}px) {
+    overflow: auto;
+  }
   &:focus {
     outline: none;
   }
@@ -167,27 +170,27 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const tableWrapper = `table-wrapper-${testId}`;
 
-    const [tableOverFlow, setTableOverFlow] = React.useState<string>('visible');
+    // const [tableOverFlow, setTableOverFlow] = React.useState<string>('visible');
 
-    const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
+    // const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
 
-    React.useEffect(() => {
-      function handleResize() {
-        setWindowWidth(window.innerWidth);
-        if (window.innerWidth < minWidth && minWidth) {
-          setTableOverFlow('auto');
-        }
+    // React.useEffect(() => {
+    //   function handleResize() {
+    //     setWindowWidth(window.innerWidth);
+    //     if (window.innerWidth < minWidth && minWidth) {
+    //       setTableOverFlow('auto');
+    //     }
 
-        if (window.innerWidth > minWidth) {
-          setTableOverFlow('visible');
-        }
-      }
+    //     if (window.innerWidth > minWidth) {
+    //       setTableOverFlow('visible');
+    //     }
+    //   }
 
-      window.addEventListener('resize', handleResize);
-      handleResize();
+    //   window.addEventListener('resize', handleResize);
+    //   handleResize();
 
-      return () => window.removeEventListener('resize', handleResize);
-    }, [windowWidth]);
+    //   return () => window.removeEventListener('resize', handleResize);
+    // }, [windowWidth]);
 
     return (
       <TableContext.Provider
@@ -206,7 +209,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
         <TableContainer
           data-testid={tableWrapper}
           isInverse={isInverse}
-          tableOverFlow={tableOverFlow ? tableOverFlow : null}
+          minWidth={minWidth}
           theme={theme}
           tabIndex={0}
         >

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -108,9 +108,19 @@ export const TableContainer = styled.div<{
   hasSquareCorners?: boolean;
   isInverse?: boolean;
 }>`
-  border-radius: ${props =>
-    props.hasSquareCorners ? 0 : props.theme.borderRadius};
-  overflow: ${props => (props.minWidth ? 'auto' : 'visible')};
+  table thead tr th:first-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '8px 0 0 0')};
+  }
+  table thead tr th:last-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 8px 0 0')};
+  }
+  table tr:last-child td:first-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 0 8px')};
+  }
+  table tr:last-child td:last-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 8px 0')};
+  }
+
   &:focus {
     outline: none;
   }
@@ -165,6 +175,8 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const tableWrapper = `table-wrapper-${testId}`;
 
+    console.log(hasSquareCorners);
+
     return (
       <TableContext.Provider
         value={{
@@ -175,7 +187,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           isInverse: isInverse,
           isSelectable,
           isSortableBySelected,
-          rowCount
+          rowCount,
         }}
       >
         <TableContainer

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -172,24 +172,25 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
 
-    React.useEffect(() => {
-      function handleResize() {
-        setWindowWidth(window.innerWidth);
-        if (window.innerWidth < minWidth && minWidth) {
-          setTableOverFlow('auto');
+    if (typeof window !== 'undefined') {
+      React.useEffect(() => {
+        function handleResize() {
+          setWindowWidth(window.innerWidth);
+          if (window.innerWidth < minWidth && minWidth) {
+            setTableOverFlow('auto');
+          }
+
+          if (window.innerWidth > minWidth) {
+            setTableOverFlow('visible');
+          }
         }
 
-        if (window.innerWidth > minWidth) {
-          setTableOverFlow('visible');
-        }
-      }
+        window.addEventListener('resize', handleResize);
+        handleResize();
 
-      window.addEventListener('resize', handleResize);
-      handleResize();
-
-      return () => window.removeEventListener('resize', handleResize);
-    }, [windowWidth]);
-
+        return () => window.removeEventListener('resize', handleResize);
+      }, [windowWidth]);
+    }
     return (
       <TableContext.Provider
         value={{

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -170,28 +170,6 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const tableWrapper = `table-wrapper-${testId}`;
 
-    // const [tableOverFlow, setTableOverFlow] = React.useState<string>('visible');
-
-    // const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
-
-    // React.useEffect(() => {
-    //   function handleResize() {
-    //     setWindowWidth(window.innerWidth);
-    //     if (window.innerWidth < minWidth && minWidth) {
-    //       setTableOverFlow('auto');
-    //     }
-
-    //     if (window.innerWidth > minWidth) {
-    //       setTableOverFlow('visible');
-    //     }
-    //   }
-
-    //   window.addEventListener('resize', handleResize);
-    //   handleResize();
-
-    //   return () => window.removeEventListener('resize', handleResize);
-    // }, [windowWidth]);
-
     return (
       <TableContext.Provider
         value={{

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -172,6 +172,8 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
 
+    const isBrowser = typeof window !== 'undefined';
+
     React.useEffect(() => {
       function handleResize() {
         setWindowWidth(window.innerWidth);
@@ -187,7 +189,9 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       window.addEventListener('resize', handleResize);
       handleResize();
 
-      return () => window.removeEventListener('resize', handleResize);
+      if (isBrowser) {
+        return () => window.removeEventListener('resize', handleResize);
+      }
     }, [windowWidth]);
 
     return (

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -122,11 +122,14 @@ export const TableContainer = styled.div<{
 `;
 
 export const StyledTable = styled.table<{
+  hasSquareCorners?: boolean;
   isInverse?: boolean;
   minWidth: number;
 }>`
   border-collapse: collapse;
   border-spacing: 0;
+  border-radius: ${props =>
+    props.hasSquareCorners ? '0' : props.theme.borderRadius};
   color: ${props =>
     props.isInverse
       ? props.theme.colors.neutral100
@@ -174,7 +177,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           isInverse: isInverse,
           isSelectable,
           isSortableBySelected,
-          rowCount
+          rowCount,
         }}
       >
         <TableContainer
@@ -187,6 +190,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           <StyledTable
             {...other}
             data-testid={testId}
+            hasSquareCorners={hasSquareCorners}
             isInverse={isInverse}
             minWidth={minWidth || theme.breakpoints.small}
             ref={ref}

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -82,6 +82,7 @@ export enum TableRowColor {
 interface TableContextInterface {
   density?: TableDensity;
   hasHoverStyles?: boolean;
+  hasSquareCorners?: boolean;
   hasVerticalBorders?: boolean;
   hasZebraStripes?: boolean;
   isInverse?: boolean;
@@ -94,6 +95,7 @@ interface TableContextInterface {
 export const TableContext = React.createContext<TableContextInterface>({
   density: TableDensity.normal,
   hasHoverStyles: false,
+  hasSquareCorners: false,
   hasZebraStripes: false,
   hasVerticalBorders: false,
   isInverse: false,
@@ -109,16 +111,16 @@ export const TableContainer = styled.div<{
   isInverse?: boolean;
 }>`
   table thead tr th:first-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '8px 0 0 0')};
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '')};
   }
   table thead tr th:last-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 8px 0 0')};
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '')};
   }
   table tr:last-child td:first-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 0 8px')};
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '')};
   }
   table tr:last-child td:last-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 8px 0')};
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '')};
   }
 
   &:focus {
@@ -180,12 +182,13 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
         value={{
           density,
           hasHoverStyles,
+          hasSquareCorners,
           hasZebraStripes,
           hasVerticalBorders,
           isInverse: isInverse,
           isSelectable,
           isSortableBySelected,
-          rowCount
+          rowCount,
         }}
       >
         <TableContainer

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -107,22 +107,8 @@ export const TableContext = React.createContext<TableContextInterface>({
 
 export const TableContainer = styled.div<{
   minWidth: number;
-  hasSquareCorners?: boolean;
   isInverse?: boolean;
 }>`
-  table thead tr th:first-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '')};
-  }
-  table thead tr th:last-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '')};
-  }
-  table tr:last-child td:first-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '')};
-  }
-  table tr:last-child td:last-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '')};
-  }
-
   &:focus {
     outline: none;
   }
@@ -188,12 +174,11 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           isInverse: isInverse,
           isSelectable,
           isSortableBySelected,
-          rowCount,
+          rowCount
         }}
       >
         <TableContainer
           data-testid={tableWrapper}
-          hasSquareCorners={hasSquareCorners}
           isInverse={isInverse}
           minWidth={minWidth}
           theme={theme}

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -106,7 +106,6 @@ export const TableContext = React.createContext<TableContextInterface>({
 });
 
 export const TableContainer = styled.div<{
-  minWidth: number;
   isInverse?: boolean;
   tableOverFlow?: string;
 }>`
@@ -172,8 +171,6 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
 
-    const isBrowser = () => typeof window !== 'undefined';
-
     React.useEffect(() => {
       function handleResize() {
         setWindowWidth(window.innerWidth);
@@ -192,8 +189,6 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       return () => window.removeEventListener('resize', handleResize);
     }, [windowWidth]);
 
-    const handleTableOverFlow = isBrowser && tableOverFlow;
-
     return (
       <TableContext.Provider
         value={{
@@ -211,8 +206,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
         <TableContainer
           data-testid={tableWrapper}
           isInverse={isInverse}
-          minWidth={minWidth}
-          tableOverFlow={handleTableOverFlow}
+          tableOverFlow={minWidth && tableOverFlow}
           theme={theme}
           tabIndex={0}
         >

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -175,8 +175,6 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const tableWrapper = `table-wrapper-${testId}`;
 
-    console.log(hasSquareCorners);
-
     return (
       <TableContext.Provider
         value={{

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -187,7 +187,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           isInverse: isInverse,
           isSelectable,
           isSortableBySelected,
-          rowCount,
+          rowCount
         }}
       >
         <TableContainer

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -108,7 +108,9 @@ export const TableContext = React.createContext<TableContextInterface>({
 export const TableContainer = styled.div<{
   minWidth: number;
   isInverse?: boolean;
+  tableOverFlow?: string;
 }>`
+  overflow: ${props => props.tableOverFlow};
   &:focus {
     outline: none;
   }
@@ -166,6 +168,28 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const tableWrapper = `table-wrapper-${testId}`;
 
+    const [tableOverFlow, setTableOverFlow] = React.useState<string>();
+
+    const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
+
+    React.useEffect(() => {
+      function handleResize() {
+        setWindowWidth(window.innerWidth);
+        if (window.innerWidth < minWidth && minWidth) {
+          setTableOverFlow('auto');
+        }
+
+        if (window.innerWidth > minWidth) {
+          setTableOverFlow('visible');
+        }
+      }
+
+      window.addEventListener('resize', handleResize);
+      handleResize();
+
+      return () => window.removeEventListener('resize', handleResize);
+    }, [windowWidth]);
+
     return (
       <TableContext.Provider
         value={{
@@ -184,6 +208,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           data-testid={tableWrapper}
           isInverse={isInverse}
           minWidth={minWidth}
+          tableOverFlow={tableOverFlow}
           theme={theme}
           tabIndex={0}
         >

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -206,7 +206,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
         <TableContainer
           data-testid={tableWrapper}
           isInverse={isInverse}
-          tableOverFlow={minWidth && tableOverFlow}
+          tableOverFlow={tableOverFlow ? tableOverFlow : null}
           theme={theme}
           tabIndex={0}
         >

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -177,21 +177,22 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
     React.useEffect(() => {
       function handleResize() {
         setWindowWidth(window.innerWidth);
-        if (isBrowser && window.innerWidth < minWidth && minWidth) {
+        if (window.innerWidth < minWidth && minWidth) {
           setTableOverFlow('auto');
         }
 
-        if (isBrowser && window.innerWidth > minWidth) {
+        if (window.innerWidth > minWidth) {
           setTableOverFlow('visible');
         }
       }
 
-      isBrowser && window.addEventListener('resize', handleResize);
+      window.addEventListener('resize', handleResize);
       handleResize();
 
-      return () =>
-        isBrowser && window.removeEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
     }, [windowWidth]);
+
+    const handleTableOverFlow = isBrowser && tableOverFlow;
 
     return (
       <TableContext.Provider
@@ -211,7 +212,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           data-testid={tableWrapper}
           isInverse={isInverse}
           minWidth={minWidth}
-          tableOverFlow={tableOverFlow}
+          tableOverFlow={handleTableOverFlow}
           theme={theme}
           tabIndex={0}
         >

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -168,29 +168,28 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const tableWrapper = `table-wrapper-${testId}`;
 
-    const [tableOverFlow, setTableOverFlow] = React.useState<string>();
+    const [tableOverFlow, setTableOverFlow] = React.useState<string>('visible');
 
     const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
 
-    if (typeof window !== 'undefined') {
-      React.useEffect(() => {
-        function handleResize() {
-          setWindowWidth(window.innerWidth);
-          if (window.innerWidth < minWidth && minWidth) {
-            setTableOverFlow('auto');
-          }
-
-          if (window.innerWidth > minWidth) {
-            setTableOverFlow('visible');
-          }
+    React.useEffect(() => {
+      function handleResize() {
+        setWindowWidth(window.innerWidth);
+        if (window.innerWidth < minWidth && minWidth) {
+          setTableOverFlow('auto');
         }
 
-        window.addEventListener('resize', handleResize);
-        handleResize();
+        if (window.innerWidth > minWidth) {
+          setTableOverFlow('visible');
+        }
+      }
 
-        return () => window.removeEventListener('resize', handleResize);
-      }, [windowWidth]);
-    }
+      window.addEventListener('resize', handleResize);
+      handleResize();
+
+      return () => window.removeEventListener('resize', handleResize);
+    }, [windowWidth]);
+
     return (
       <TableContext.Provider
         value={{

--- a/packages/react-magma-dom/src/components/Table/TableCell.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableCell.tsx
@@ -53,6 +53,7 @@ export function buildCellPaddingStyle(density, theme: any) {
 
 const StyledCell = styled.td<{
   density?: TableDensity;
+  hasSquareCorners?: boolean;
   hasVerticalBorders?: boolean;
   isInverse?: boolean;
   textAlign?: TableCellAlign;
@@ -60,6 +61,13 @@ const StyledCell = styled.td<{
   width?: string;
 }>`
   ${baseTableCellStyle}
+
+  &:first-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 0 8px')};
+  }
+  &:last-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 8px 0')};
+  }
 
   ${props =>
     props.width &&
@@ -81,6 +89,7 @@ export const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
         {...other}
         data-testid={testId}
         density={tableContext.density}
+        hasSquareCorners={tableContext.hasSquareCorners}
         hasVerticalBorders={tableContext.hasVerticalBorders}
         isInverse={tableContext.isInverse}
         ref={ref}

--- a/packages/react-magma-dom/src/components/Table/TableCell.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableCell.tsx
@@ -53,7 +53,6 @@ export function buildCellPaddingStyle(density, theme: any) {
 
 const StyledCell = styled.td<{
   density?: TableDensity;
-  hasSquareCorners?: boolean;
   hasVerticalBorders?: boolean;
   isInverse?: boolean;
   textAlign?: TableCellAlign;
@@ -61,13 +60,6 @@ const StyledCell = styled.td<{
   width?: string;
 }>`
   ${baseTableCellStyle}
-
-  &:first-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 0 8px')};
-  }
-  &:last-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 8px 0')};
-  }
 
   ${props =>
     props.width &&
@@ -89,7 +81,6 @@ export const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
         {...other}
         data-testid={testId}
         density={tableContext.density}
-        hasSquareCorners={tableContext.hasSquareCorners}
         hasVerticalBorders={tableContext.hasVerticalBorders}
         isInverse={tableContext.isInverse}
         ref={ref}

--- a/packages/react-magma-dom/src/components/Table/TableHeaderCell.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableHeaderCell.tsx
@@ -86,10 +86,12 @@ const StyledTableHeaderCell = styled.th<{
   ${baseTableCellStyle}
 
    &:first-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '8px 0 0 0')};
+    border-radius: ${props =>
+      props.hasSquareCorners ? '0' : `${props.theme.borderRadius} 0 0 0`};
   }
   &:last-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 8px 0 0')};
+    border-radius: ${props =>
+      props.hasSquareCorners ? '0' : `0 ${props.theme.borderRadius} 0 0`};
   }
 
   ${props =>

--- a/packages/react-magma-dom/src/components/Table/TableHeaderCell.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableHeaderCell.tsx
@@ -62,6 +62,7 @@ export enum TableHeaderCellScope {
 
 const StyledTableHeaderCell = styled.th<{
   density?: TableDensity;
+  hasSquareCorners?: boolean;
   hasVerticalBorders?: boolean;
   isInverse?: boolean;
   isRowHeader?: boolean;
@@ -84,13 +85,20 @@ const StyledTableHeaderCell = styled.th<{
 
   ${baseTableCellStyle}
 
+   &:first-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '8px 0 0 0')};
+  }
+  &:last-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 8px 0 0')};
+  }
+
   ${props =>
     props.isSortable &&
     css`
       padding: 0;
     `}
 
-    ${props =>
+  ${props =>
     props.width &&
     css`
       width: ${props.width};
@@ -195,6 +203,7 @@ export const TableHeaderCell = React.forwardRef<
       {...other}
       data-testid={testId}
       density={tableContext.density}
+      hasSquareCorners={tableContext.hasSquareCorners}
       hasVerticalBorders={tableContext.hasVerticalBorders}
       isInverse={tableContext.isInverse}
       ref={ref}

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -115,10 +115,12 @@ const StyledTableRow = styled.tr<{
   &:last-child {
     border-bottom: 0;
     td:first-child {
-      border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 0 8px')};
+      border-radius: ${props =>
+        props.hasSquareCorners ? '0' : `0 0 0 ${props.theme.borderRadius}`};
     }
     td:last-child {
-      border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 8px 0')};
+      border-radius: ${props =>
+        props.hasSquareCorners ? '0' : `0 0 ${props.theme.borderRadius} 0`};
     }
   }
 

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -97,6 +97,7 @@ function buildTableRowColor(props) {
 
 const StyledTableRow = styled.tr<{
   color?: string;
+  hasSquareCorners?: boolean;
   hasHoverStyles?: boolean;
   hasZebraStripes?: boolean;
   isInverse?: boolean;
@@ -113,6 +114,12 @@ const StyledTableRow = styled.tr<{
 
   &:last-child {
     border-bottom: 0;
+    td:first-child {
+      border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 0 8px')};
+    }
+  td:last-child {
+    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 8px 0')};
+  }
   }
 
   ${props =>
@@ -281,6 +288,7 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
       <StyledTableRow
         {...other}
         data-testid={testId}
+        hasSquareCorners={tableContext.hasSquareCorners}
         hasHoverStyles={tableContext.hasHoverStyles && !isHeaderRow}
         hasZebraStripes={tableContext.hasZebraStripes}
         isInverse={tableContext.isInverse}

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -117,9 +117,9 @@ const StyledTableRow = styled.tr<{
     td:first-child {
       border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 0 8px')};
     }
-  td:last-child {
-    border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 8px 0')};
-  }
+    td:last-child {
+      border-radius: ${props => (props.hasSquareCorners ? '0' : '0 0 8px 0')};
+    }
   }
 
   ${props =>
@@ -346,8 +346,12 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
               labelStyle={{ padding: 0 }}
               labelText={
                 isSelected
-                  ? `${i18n.table.selectable.deselectRowAriaLabel} ${rowName || ''}`
-                  : `${i18n.table.selectable.selectRowAriaLabel} ${rowName || ''}`
+                  ? `${i18n.table.selectable.deselectRowAriaLabel} ${
+                      rowName || ''
+                    }`
+                  : `${i18n.table.selectable.selectRowAriaLabel} ${
+                      rowName || ''
+                    }`
               }
               isTextVisuallyHidden
               isInverse={getIsCheckboxInverse()}


### PR DESCRIPTION
Issue: # [1556](https://github.com/cengage/react-magma/issues/1556)

## What I did
- Corrected CSS that was limiting dropdowns and other such UI elements that were being clipped within the `Table` container.

## Screenshots:
<img width="1002" alt="noclip" src="https://github.com/user-attachments/assets/71deed0f-7c51-4a08-a052-7a56002ad2fd" />

## Checklist 
- [X] changeset has been added
- [X] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## How to test
- Head over to Storybook
- Table example > With Dropdown
- Click any of the dropdowns to verify they extend outside of the container appropriately
