### PR TITLE
fix(FormGroup): Fix validation for `InputMessage`

### DIFF
--- a/.changeset/fix-FormGroup-input-message.md
+++ b/.changeset/fix-FormGroup-input-message.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(FormGroup): Fix validation for `InputMessage`.

--- a/packages/react-magma-dom/src/components/FormGroup/FormGroup.test.js
+++ b/packages/react-magma-dom/src/components/FormGroup/FormGroup.test.js
@@ -121,7 +121,7 @@ describe('Form Group', () => {
     );
   });
 
-  it('should not render anything except container and message container when invalid children are present', () => {
+  it('should not render anything except container when invalid children are present', () => {
     const { container } = render(
       <FormGroup>
         <Checkbox labelText="Default Color" value="default" />
@@ -129,7 +129,7 @@ describe('Form Group', () => {
       </FormGroup>
     );
 
-    expect(container.firstChild.children.length).toBe(2);
+    expect(container.firstChild.children.length).toBe(1);
   });
 
   it('Does not violate accessibility standards', () => {

--- a/packages/react-magma-dom/src/components/FormGroup/index.tsx
+++ b/packages/react-magma-dom/src/components/FormGroup/index.tsx
@@ -115,15 +115,15 @@ export const FormGroup = React.forwardRef<HTMLDivElement, FormGroupProps>(
           )}
           {children}
 
-          <InputMessage
-            id={descriptionId}
-            hasError={!!errorMessage}
-            isInverse={isInverse}
-          >
-            {(errorMessage || helperMessage) && (
-              <>{errorMessage ? errorMessage : helperMessage}</>
-            )}
-          </InputMessage>
+          {(errorMessage || helperMessage) && (
+            <InputMessage
+              id={descriptionId}
+              hasError={!!errorMessage}
+              isInverse={isInverse}
+            >
+              {errorMessage ? errorMessage : helperMessage}
+            </InputMessage>
+          )}
         </FormGroupContext.Provider>
       </div>
     );


### PR DESCRIPTION
Issue: #

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Validation for `InputMessage` in `FormGroup` created an empty container when there was no message. Fixed this validation.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
