### PR TITLE
fix(TimePicker): Fix input wrong number validation

### DIFF
--- a/.changeset/fix-DatePicker-input-wrong-number.md
+++ b/.changeset/fix-DatePicker-input-wrong-number.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(TimePicker): Fix input wrong number validation.

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
@@ -35,18 +35,18 @@ describe('TimePicker', () => {
       expect(hoursInput.value).toEqual('12');
     });
 
-    it('should set the hour to the first number if the number inputted is 24 or above', () => {
+    it('should set the hour to the second number if the number inputted is 24 or above', () => {
       const { getByTestId } = render(<TimePicker label="label" />);
 
       const hoursInput = getByTestId('hoursTimeInput');
 
       fireEvent.change(hoursInput, { target: { value: '24' } });
 
-      expect(hoursInput.value).toEqual('02');
+      expect(hoursInput.value).toEqual('04');
 
       fireEvent.change(hoursInput, { target: { value: '34' } });
 
-      expect(hoursInput.value).toEqual('03');
+      expect(hoursInput.value).toEqual('04');
     });
 
     it('should set the hour to null if the backspace key is clicked', () => {
@@ -70,12 +70,12 @@ describe('TimePicker', () => {
       fireEvent.keyDown(hoursInput, { key: 'Backspace' });
 
       expect(onKeyDown).toHaveBeenCalled();
-    });    
-    
+    });
+
     it('should call the onChange when backspace is clicked on the hours input', () => {
       const onChange = jest.fn();
       const { getByTestId } = render(
-        <TimePicker label="label" onChange={onChange} value={'02:04 AM'}/>
+        <TimePicker label="label" onChange={onChange} value={'02:04 AM'} />
       );
 
       const hoursInput = getByTestId('hoursTimeInput');
@@ -141,18 +141,18 @@ describe('TimePicker', () => {
       expect(minutesInput.value).toEqual('34');
     });
 
-    it('should set the minute to the first number if the number inputted is 60 or above', () => {
+    it('should set the minute to the second number if the number inputted is 60 or above', () => {
       const { getByTestId } = render(<TimePicker label="label" />);
 
       const hoursInput = getByTestId('hoursTimeInput');
 
       fireEvent.change(hoursInput, { target: { value: '60' } });
 
-      expect(hoursInput.value).toEqual('06');
+      expect(hoursInput.value).toEqual('00');
 
       fireEvent.change(hoursInput, { target: { value: '89' } });
 
-      expect(hoursInput.value).toEqual('08');
+      expect(hoursInput.value).toEqual('09');
     });
 
     it('should set the minutes to null if the backspace key is clicked', () => {
@@ -163,7 +163,6 @@ describe('TimePicker', () => {
       fireEvent.keyDown(minutesInput, { key: 'Backspace' });
 
       expect(minutesInput.value).toEqual('');
-
     });
 
     it('should focus the hour input if the left arrow key is clicked', () => {
@@ -200,11 +199,11 @@ describe('TimePicker', () => {
 
       expect(onKeyDown).toHaveBeenCalled();
     });
-    
+
     it('should call the onChange when backspace is clicked on the minutes input', () => {
       const onChange = jest.fn();
       const { getByTestId } = render(
-        <TimePicker label="label" onChange={onChange} value={'02:04 AM'}/>
+        <TimePicker label="label" onChange={onChange} value={'02:04 AM'} />
       );
 
       const minsInput = getByTestId('minutesTimeInput');

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.tsx
@@ -175,6 +175,7 @@ export const TimePicker = React.forwardRef<HTMLInputElement, TimePickerProps>(
             theme={theme}
             type="number"
             value={hour}
+            onFocus={e => e.target.select()}
           />
           <Divider> : </Divider>
           <StyledNumInput
@@ -193,6 +194,7 @@ export const TimePicker = React.forwardRef<HTMLInputElement, TimePickerProps>(
             theme={theme}
             type="number"
             value={minute}
+            onFocus={e => e.target.select()}
           />
           <AmPmToggle
             aria-label={amPmLabel}

--- a/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
+++ b/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
@@ -48,7 +48,7 @@ export function useTimePicker(props: UseTimePickerProps) {
   const id = useGenerateId(props.id);
 
   React.useEffect(() => {
-    if(typeof props.value === 'undefined') {
+    if (typeof props.value === 'undefined') {
       setHour('');
       setMinute('');
       setAmPm(am);
@@ -115,15 +115,46 @@ export function useTimePicker(props: UseTimePickerProps) {
     return newMinute.toString();
   }
 
+  const sanitizeMinute = (newMinute: string): number => {
+    if (Number(newMinute) > 99) {
+      return Number(newMinute.slice(2));
+    }
+
+    if (newMinute.length > 2) {
+      return Number(newMinute.slice(-2));
+    }
+
+    return Number(newMinute);
+  };
+
+  const sanitizeHour = (newHour: string): number => {
+    console.log(newHour);
+    if (Number(newHour) > 99) {
+      return Number(newHour.slice(-1));
+    }
+
+    if (newHour.length > 2) {
+      if (Number(newHour) > 12) {
+        return Number(newHour.slice(-1));
+      }
+
+      return Number(newHour.slice(-2));
+    }
+
+    return Number(newHour);
+  };
+
   function handleHourChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const newHour = calculateHour(Number(event.target.value));
+    const sanitizedHour = sanitizeHour(event.target.value);
+    const newHour = calculateHour(sanitizedHour);
 
     setHour(newHour);
     updateTime(`${newHour}:${minute} ${amPm}`);
   }
 
   function handleMinuteChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const newMinute = calculateMinute(Number(event.target.value));
+    const sanitizedMinute = sanitizeMinute(event.target.value);
+    const newMinute = calculateMinute(sanitizedMinute);
 
     setMinute(newMinute);
     updateTime(`${hour}:${newMinute} ${amPm}`);

--- a/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
+++ b/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
@@ -116,7 +116,7 @@ export function useTimePicker(props: UseTimePickerProps) {
   }
 
   const sanitizeMinute = (newMinute: string): number => {
-    if (Number(newMinute) > 99) {
+    if (Number(newMinute) > 59) {
       return Number(newMinute.slice(2));
     }
 
@@ -128,8 +128,7 @@ export function useTimePicker(props: UseTimePickerProps) {
   };
 
   const sanitizeHour = (newHour: string): number => {
-    console.log(newHour);
-    if (Number(newHour) > 99) {
+    if (Number(newHour) > 12) {
       return Number(newHour.slice(-1));
     }
 


### PR DESCRIPTION
Issue: #1517 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix TimePicker validation.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
- Open Storybook -> TimePicker -> Replace the time with '11:59' -> Try replacing the minutes from 59 to 30 by pressing the number 3 when the minutes are selected, then 0 -> Notice that the time ends up being '30'. 
- Same for Hours -> '11:59' -> Replacing from 11 to 9 -> Notice that the time ends up being '9'. 