### PR TITLE
fix(Indeterminate Checkbox): Fixed issue with voice over not recognizing the mixed state when using keyboard navigation.

### DIFF
--- a/.changeset/fix-IndeterminateCheckbox.md
+++ b/.changeset/fix-IndeterminateCheckbox.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Indeterminate Checkbox): Fixed issue with voice over not recognizing the mixed state when using keyboard navigation.

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.stories.tsx
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, CardBody } from '../Card';
+import { Container } from '../Container';
 import { Checkbox } from '../Checkbox';
 import { FormGroup } from '../FormGroup';
 import {
@@ -7,121 +7,135 @@ import {
   IndeterminateCheckboxStatus,
 } from '../IndeterminateCheckbox';
 import { magma } from '../../theme/magma';
-import { Meta } from '@storybook/react/types-6-0';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { IndeterminateCheckboxProps } from '../../../dist';
+
+const Template: Story<IndeterminateCheckboxProps> = args => (
+  <FormGroup labelText="Indeterminate Checkbox Examples">
+    <IndeterminateCheckbox
+      {...args}
+      color={magma.colors.primary}
+      defaultChecked={true}
+      labelText="Indeterminate checkbox"
+      id="0"
+    />
+    <IndeterminateCheckbox
+      {...args}
+      disabled
+      defaultChecked={true}
+      labelText="Disabled indeterminate checkbox"
+      id="1"
+    />
+    <IndeterminateCheckbox
+      {...args}
+      defaultChecked={true}
+      labelText="Error indeterminate checkbox"
+      id="2"
+      errorMessage="Error"
+    />
+  </FormGroup>
+);
 
 export default {
   component: IndeterminateCheckbox,
   title: 'Indeterminate Checkbox',
+  argTypes: {
+    status: {
+      control: { type: 'select' },
+      options: IndeterminateCheckboxStatus,
+    },
+    isInverse: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      <Container isInverse={context.args.isInverse} style={{ padding: '20px' }}>
+        <Story />
+      </Container>
+    ),
+  ],
 } as Meta;
 
-export const Default = () => {
-  return (
-    <FormGroup labelText="Indeterminate Checkbox Examples">
-      <IndeterminateCheckbox
-        color={magma.colors.primary}
-        defaultChecked={true}
-        status={IndeterminateCheckboxStatus.indeterminate}
-        labelText="Indeterminate checkbox"
-        id="0"
-      />
-      <IndeterminateCheckbox
-        disabled
-        defaultChecked={true}
-        status={IndeterminateCheckboxStatus.indeterminate}
-        labelText="Disabled indeterminate checkbox"
-        id="1"
-      />
-      <IndeterminateCheckbox
-        defaultChecked={true}
-        status={IndeterminateCheckboxStatus.indeterminate}
-        labelText="Error indeterminate checkbox"
-        id="2"
-        errorMessage="Error"
-      />
-    </FormGroup>
-  );
-};
-
-export const Inverse = () => {
-  return (
-    <Card isInverse>
-      <CardBody>
-        <FormGroup
-          labelText="Inverse Indeterminate Checkbox Examples"
-          isInverse
-        >
-          <IndeterminateCheckbox
-            isInverse
-            labelText="Indeterminate checkbox inverse"
-            status={IndeterminateCheckboxStatus.indeterminate}
-            id="3"
-          />
-          <IndeterminateCheckbox
-            disabled
-            isInverse
-            labelText="Disabled indeterminate checkbox inverse"
-            status={IndeterminateCheckboxStatus.indeterminate}
-            id="4"
-          />
-          <IndeterminateCheckbox
-            isInverse
-            labelText="Error indeterminate checkbox"
-            status={IndeterminateCheckboxStatus.indeterminate}
-            id="5"
-            errorMessage="Error"
-          />
-        </FormGroup>
-      </CardBody>
-    </Card>
-  );
-};
+export const Default = Template.bind({});
+Default.args = {};
 
 export const Behavior = () => {
   const [checkedItems, setCheckedItems] = React.useState<Array<boolean>>([
     true,
     false,
+    false,
+    false,
   ]);
 
-  const status: IndeterminateCheckboxStatus = checkedItems.every(Boolean)
-    ? IndeterminateCheckboxStatus.checked
-    : checkedItems.some(Boolean)
-    ? IndeterminateCheckboxStatus.indeterminate
-    : IndeterminateCheckboxStatus.unchecked;
+  const [status, setStatus] = React.useState<IndeterminateCheckboxStatus>(
+    IndeterminateCheckboxStatus.indeterminate
+  );
+
+  function getStatus(items: Array<boolean>) {
+    return items.every(Boolean)
+      ? IndeterminateCheckboxStatus.checked
+      : items.some(Boolean)
+      ? IndeterminateCheckboxStatus.indeterminate
+      : IndeterminateCheckboxStatus.unchecked;
+  }
 
   function handleUpdateIndeterminateChecked(
     event: React.ChangeEvent<HTMLInputElement>
   ) {
-    setCheckedItems([event.target.checked, event.target.checked]);
+    const updatedCheckedItems = Array(4).fill(event.target.checked);
+    setCheckedItems(updatedCheckedItems);
+    setStatus(getStatus(updatedCheckedItems));
   }
 
-  function handleUpdateRedChecked(event: React.ChangeEvent<HTMLInputElement>) {
-    setCheckedItems([event.target.checked, checkedItems[1]]);
-  }
-
-  function handleUpdateBlueChecked(event: React.ChangeEvent<HTMLInputElement>) {
-    setCheckedItems([checkedItems[0], event.target.checked]);
+  function handleColorChecked(
+    index: number,
+    event: React.ChangeEvent<HTMLInputElement>
+  ) {
+    const updatedCheckedItems = [...checkedItems];
+    updatedCheckedItems[index] = event.target.checked;
+    setCheckedItems(updatedCheckedItems);
+    setStatus(getStatus(updatedCheckedItems));
   }
 
   return (
     <>
-      <IndeterminateCheckbox
-        onChange={handleUpdateIndeterminateChecked}
-        status={status}
-        labelText="Colors"
-        id="5"
-      />
-      <div style={{ marginLeft: magma.spaceScale.spacing08 }}>
-        <Checkbox
-          checked={checkedItems[0]}
-          onChange={handleUpdateRedChecked}
-          labelText="Red"
+      <FormGroup labelText="Colors group" isTextVisuallyHidden>
+        <IndeterminateCheckbox
+          onChange={handleUpdateIndeterminateChecked}
+          status={status}
+          labelText="Colors"
+          id="indeterminateCheckbox"
         />
-        <Checkbox
-          checked={checkedItems[1]}
-          onChange={handleUpdateBlueChecked}
-          labelText="Blue"
-        />
-      </div>
+        <div style={{ marginLeft: magma.spaceScale.spacing08 }}>
+          <Checkbox
+            checked={checkedItems[0]}
+            onChange={e => handleColorChecked(0, e)}
+            labelText="Red"
+            id="Red"
+          />
+          <Checkbox
+            checked={checkedItems[1]}
+            onChange={e => handleColorChecked(1, e)}
+            labelText="Blue"
+            id="Blue"
+          />
+          <Checkbox
+            checked={checkedItems[2]}
+            onChange={e => handleColorChecked(2, e)}
+            labelText="Green"
+            id="Green"
+          />
+          <Checkbox
+            checked={checkedItems[3]}
+            onChange={e => handleColorChecked(3, e)}
+            labelText="Yellow"
+            id="Yellow"
+          />
+        </div>
+      </FormGroup>
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
@@ -77,7 +77,7 @@ export const IndeterminateCheckbox = React.forwardRef<
   }
 
   function handleOnKeyDown(event: React.KeyboardEvent) {
-    if (event.key === ' ') {
+    if (event.key === ' ' && !disabled) {
       event.preventDefault();
       const syntheticEvent = {
         ...event,
@@ -173,7 +173,7 @@ export const IndeterminateCheckbox = React.forwardRef<
           tabIndex={-1}
         />
         <div
-          tabIndex={0}
+          tabIndex={!disabled && 0}
           role="checkbox"
           aria-checked="mixed"
           onKeyDown={handleOnKeyDown}

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
@@ -172,43 +172,42 @@ export const IndeterminateCheckbox = React.forwardRef<
           onChange={handleChange}
           tabIndex={-1}
         />
-        <div
-          tabIndex={!disabled && 0}
-          role="checkbox"
-          aria-checked="mixed"
-          onKeyDown={handleOnKeyDown}
-        >
-          <StyledLabel htmlFor={id} isInverse={isInverse} style={labelStyle}>
-            <StyledFakeInput
-              isChecked={isChecked}
-              color={color}
-              disabled={disabled}
-              hasError={hasError}
-              hideFocus={props.hideFocus}
-              isIndeterminate={isIndeterminate}
-              isInverse={isInverse}
-              style={inputStyle}
-              theme={theme}
-              aria-hidden="true"
-            >
-              {isIndeterminate ? (
-                <IndeterminateCheckBoxIcon
-                  testId="indeterminateIcon"
-                  size={theme.iconSizes.medium}
-                />
-              ) : isChecked ? (
-                <CheckBoxIcon size={theme.iconSizes.medium} />
-              ) : (
-                <CheckBoxOutlineBlankIcon size={theme.iconSizes.medium} />
-              )}
-            </StyledFakeInput>
-            {isTextVisuallyHidden ? (
-              <HiddenLabelText>{labelText}</HiddenLabelText>
+
+        <StyledLabel htmlFor={id} isInverse={isInverse} style={labelStyle}>
+          <StyledFakeInput
+            isChecked={isChecked}
+            color={color}
+            disabled={disabled}
+            hasError={hasError}
+            hideFocus={props.hideFocus}
+            isIndeterminate={isIndeterminate}
+            isInverse={isInverse}
+            style={inputStyle}
+            theme={theme}
+            aria-hidden="true"
+            tabIndex={0}
+            role="checkbox"
+            aria-checked={isIndeterminate ? 'mixed' : isChecked}
+            onKeyDown={handleOnKeyDown}
+          >
+            {isIndeterminate ? (
+              <IndeterminateCheckBoxIcon
+                testId="indeterminateIcon"
+                size={theme.iconSizes.medium}
+              />
+            ) : isChecked ? (
+              <CheckBoxIcon size={theme.iconSizes.medium} />
             ) : (
-              labelText
+              <CheckBoxOutlineBlankIcon size={theme.iconSizes.medium} />
             )}
-          </StyledLabel>
-        </div>
+          </StyledFakeInput>
+          {isTextVisuallyHidden ? (
+            <HiddenLabelText>{labelText}</HiddenLabelText>
+          ) : (
+            labelText
+          )}
+        </StyledLabel>
+
         <Announce>
           {showAnnounce && <VisuallyHidden>{announceText}</VisuallyHidden>}
         </Announce>

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
@@ -76,6 +76,17 @@ export const IndeterminateCheckbox = React.forwardRef<
     }
   }
 
+  function handleOnKeyDown(event: React.KeyboardEvent) {
+    if (event.key === ' ') {
+      event.preventDefault();
+      const syntheticEvent = {
+        ...event,
+        target: { checked: !isChecked },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+      handleChange(syntheticEvent);
+    }
+  }
+
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
   const context = React.useContext(FormGroupContext);
@@ -159,37 +170,45 @@ export const IndeterminateCheckbox = React.forwardRef<
           ref={ref}
           type="checkbox"
           onChange={handleChange}
+          tabIndex={-1}
         />
-        <StyledLabel htmlFor={id} isInverse={isInverse} style={labelStyle}>
-          <StyledFakeInput
-            isChecked={isChecked}
-            color={color}
-            disabled={disabled}
-            hasError={hasError}
-            hideFocus={props.hideFocus}
-            isIndeterminate={isIndeterminate}
-            isInverse={isInverse}
-            style={inputStyle}
-            theme={theme}
-            aria-hidden="true"
-          >
-            {isIndeterminate ? (
-              <IndeterminateCheckBoxIcon
-                testId="indeterminateIcon"
-                size={theme.iconSizes.medium}
-              />
-            ) : isChecked ? (
-              <CheckBoxIcon size={theme.iconSizes.medium} />
+        <div
+          tabIndex={0}
+          role="checkbox"
+          aria-checked="mixed"
+          onKeyDown={handleOnKeyDown}
+        >
+          <StyledLabel htmlFor={id} isInverse={isInverse} style={labelStyle}>
+            <StyledFakeInput
+              isChecked={isChecked}
+              color={color}
+              disabled={disabled}
+              hasError={hasError}
+              hideFocus={props.hideFocus}
+              isIndeterminate={isIndeterminate}
+              isInverse={isInverse}
+              style={inputStyle}
+              theme={theme}
+              aria-hidden="true"
+            >
+              {isIndeterminate ? (
+                <IndeterminateCheckBoxIcon
+                  testId="indeterminateIcon"
+                  size={theme.iconSizes.medium}
+                />
+              ) : isChecked ? (
+                <CheckBoxIcon size={theme.iconSizes.medium} />
+              ) : (
+                <CheckBoxOutlineBlankIcon size={theme.iconSizes.medium} />
+              )}
+            </StyledFakeInput>
+            {isTextVisuallyHidden ? (
+              <HiddenLabelText>{labelText}</HiddenLabelText>
             ) : (
-              <CheckBoxOutlineBlankIcon size={theme.iconSizes.medium} />
+              labelText
             )}
-          </StyledFakeInput>
-          {isTextVisuallyHidden ? (
-            <HiddenLabelText>{labelText}</HiddenLabelText>
-          ) : (
-            labelText
-          )}
-        </StyledLabel>
+          </StyledLabel>
+        </div>
         <Announce>
           {showAnnounce && <VisuallyHidden>{announceText}</VisuallyHidden>}
         </Announce>

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -1501,46 +1501,43 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <div
-                      aria-checked="mixed"
-                      role="checkbox"
-                      tabindex="0"
+                    <label
+                      class="emotion-24 emotion-25"
+                      for="item-id-5-checkbox"
+                      style="padding: 0px;"
                     >
-                      <label
-                        class="emotion-24 emotion-25"
-                        for="item-id-5-checkbox"
-                        style="padding: 0px;"
+                      <span
+                        aria-checked="false"
+                        aria-hidden="true"
+                        class="emotion-42 emotion-27"
+                        color="#3942B0"
+                        role="checkbox"
+                        style="margin-right: 8px;"
+                        tabindex="0"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="emotion-42 emotion-27"
-                          color="#3942B0"
-                          style="margin-right: 8px;"
+                        <svg
+                          class="icon"
+                          fill="currentColor"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            class="icon"
-                            fill="currentColor"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="emotion-44 emotion-29"
-                          data-testid="item-id-5-label"
-                          id="item-id-5-label"
-                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                        >
-                          item-title-5
-                        </span>
-                      </label>
-                    </div>
+                          <path
+                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="emotion-44 emotion-29"
+                        data-testid="item-id-5-label"
+                        id="item-id-5-label"
+                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                      >
+                        item-title-5
+                      </span>
+                    </label>
                     <div
                       aria-live="polite"
                     >
@@ -3183,46 +3180,43 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <div
-                      aria-checked="mixed"
-                      role="checkbox"
-                      tabindex="0"
+                    <label
+                      class="emotion-24 emotion-25"
+                      for="item-id-4-checkbox"
+                      style="padding: 0px;"
                     >
-                      <label
-                        class="emotion-24 emotion-25"
-                        for="item-id-4-checkbox"
-                        style="padding: 0px;"
+                      <span
+                        aria-checked="false"
+                        aria-hidden="true"
+                        class="emotion-58 emotion-27"
+                        color="#3942B0"
+                        role="checkbox"
+                        style="margin-right: 8px;"
+                        tabindex="0"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="emotion-58 emotion-27"
-                          color="#3942B0"
-                          style="margin-right: 8px;"
+                        <svg
+                          class="icon"
+                          fill="currentColor"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            class="icon"
-                            fill="currentColor"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="emotion-44 emotion-29"
-                          data-testid="item-id-4-label"
-                          id="item-id-4-label"
-                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                        >
-                          item-title-4
-                        </span>
-                      </label>
-                    </div>
+                          <path
+                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="emotion-44 emotion-29"
+                        data-testid="item-id-4-label"
+                        id="item-id-4-label"
+                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                      >
+                        item-title-4
+                      </span>
+                    </label>
                     <div
                       aria-live="polite"
                     >
@@ -4931,46 +4925,43 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <div
-                      aria-checked="mixed"
-                      role="checkbox"
-                      tabindex="0"
+                    <label
+                      class="emotion-24 emotion-25"
+                      for="item-id-4-checkbox"
+                      style="padding: 0px;"
                     >
-                      <label
-                        class="emotion-24 emotion-25"
-                        for="item-id-4-checkbox"
-                        style="padding: 0px;"
+                      <span
+                        aria-checked="false"
+                        aria-hidden="true"
+                        class="emotion-58 emotion-27"
+                        color="#3942B0"
+                        role="checkbox"
+                        style="margin-right: 8px;"
+                        tabindex="0"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="emotion-58 emotion-27"
-                          color="#3942B0"
-                          style="margin-right: 8px;"
+                        <svg
+                          class="icon"
+                          fill="currentColor"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            class="icon"
-                            fill="currentColor"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="emotion-44 emotion-29"
-                          data-testid="item-id-4-label"
-                          id="item-id-4-label"
-                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                        >
-                          item-title-4
-                        </span>
-                      </label>
-                    </div>
+                          <path
+                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="emotion-44 emotion-29"
+                        data-testid="item-id-4-label"
+                        id="item-id-4-label"
+                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                      >
+                        item-title-4
+                      </span>
+                    </label>
                     <div
                       aria-live="polite"
                     >
@@ -6679,46 +6670,43 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <div
-                      aria-checked="mixed"
-                      role="checkbox"
-                      tabindex="0"
+                    <label
+                      class="emotion-24 emotion-25"
+                      for="item-id-4-checkbox"
+                      style="padding: 0px;"
                     >
-                      <label
-                        class="emotion-24 emotion-25"
-                        for="item-id-4-checkbox"
-                        style="padding: 0px;"
+                      <span
+                        aria-checked="false"
+                        aria-hidden="true"
+                        class="emotion-58 emotion-27"
+                        color="#3942B0"
+                        role="checkbox"
+                        style="margin-right: 8px;"
+                        tabindex="0"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="emotion-58 emotion-27"
-                          color="#3942B0"
-                          style="margin-right: 8px;"
+                        <svg
+                          class="icon"
+                          fill="currentColor"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            class="icon"
-                            fill="currentColor"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="emotion-44 emotion-29"
-                          data-testid="item-id-4-label"
-                          id="item-id-4-label"
-                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                        >
-                          item-title-4
-                        </span>
-                      </label>
-                    </div>
+                          <path
+                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="emotion-44 emotion-29"
+                        data-testid="item-id-4-label"
+                        id="item-id-4-label"
+                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                      >
+                        item-title-4
+                      </span>
+                    </label>
                     <div
                       aria-live="polite"
                     >
@@ -8276,46 +8264,43 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <div
-                      aria-checked="mixed"
-                      role="checkbox"
-                      tabindex="0"
+                    <label
+                      class="emotion-24 emotion-25"
+                      for="item-id-4-checkbox"
+                      style="padding: 0px;"
                     >
-                      <label
-                        class="emotion-24 emotion-25"
-                        for="item-id-4-checkbox"
-                        style="padding: 0px;"
+                      <span
+                        aria-checked="false"
+                        aria-hidden="true"
+                        class="emotion-42 emotion-27"
+                        color="#3942B0"
+                        role="checkbox"
+                        style="margin-right: 8px;"
+                        tabindex="0"
                       >
-                        <span
-                          aria-hidden="true"
-                          class="emotion-42 emotion-27"
-                          color="#3942B0"
-                          style="margin-right: 8px;"
+                        <svg
+                          class="icon"
+                          fill="currentColor"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          width="24"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <svg
-                            class="icon"
-                            fill="currentColor"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="emotion-44 emotion-29"
-                          data-testid="item-id-4-label"
-                          id="item-id-4-label"
-                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                        >
-                          item-title-4
-                        </span>
-                      </label>
-                    </div>
+                          <path
+                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="emotion-44 emotion-29"
+                        data-testid="item-id-4-label"
+                        id="item-id-4-label"
+                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                      >
+                        item-title-4
+                      </span>
+                    </label>
                     <div
                       aria-live="polite"
                     >

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -1501,40 +1501,46 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <label
-                      class="emotion-24 emotion-25"
-                      for="item-id-5-checkbox"
-                      style="padding: 0px;"
+                    <div
+                      aria-checked="mixed"
+                      role="checkbox"
+                      tabindex="0"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-42 emotion-27"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <label
+                        class="emotion-24 emotion-25"
+                        for="item-id-5-checkbox"
+                        style="padding: 0px;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-42 emotion-27"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-44 emotion-29"
-                        data-testid="item-id-5-label"
-                        id="item-id-5-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-5
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-44 emotion-29"
+                          data-testid="item-id-5-label"
+                          id="item-id-5-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-5
+                        </span>
+                      </label>
+                    </div>
                     <div
                       aria-live="polite"
                     >
@@ -3177,40 +3183,46 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <label
-                      class="emotion-24 emotion-25"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px;"
+                    <div
+                      aria-checked="mixed"
+                      role="checkbox"
+                      tabindex="0"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-58 emotion-27"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <label
+                        class="emotion-24 emotion-25"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-58 emotion-27"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-44 emotion-29"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-44 emotion-29"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                    </div>
                     <div
                       aria-live="polite"
                     >
@@ -4919,40 +4931,46 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <label
-                      class="emotion-24 emotion-25"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px;"
+                    <div
+                      aria-checked="mixed"
+                      role="checkbox"
+                      tabindex="0"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-58 emotion-27"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <label
+                        class="emotion-24 emotion-25"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-58 emotion-27"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-44 emotion-29"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-44 emotion-29"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                    </div>
                     <div
                       aria-live="polite"
                     >
@@ -6661,40 +6679,46 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <label
-                      class="emotion-24 emotion-25"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px;"
+                    <div
+                      aria-checked="mixed"
+                      role="checkbox"
+                      tabindex="0"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-58 emotion-27"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <label
+                        class="emotion-24 emotion-25"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-58 emotion-27"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-44 emotion-29"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-44 emotion-29"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                    </div>
                     <div
                       aria-live="polite"
                     >
@@ -8252,40 +8276,46 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                       tabindex="-1"
                       type="checkbox"
                     />
-                    <label
-                      class="emotion-24 emotion-25"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px;"
+                    <div
+                      aria-checked="mixed"
+                      role="checkbox"
+                      tabindex="0"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-42 emotion-27"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <label
+                        class="emotion-24 emotion-25"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-42 emotion-27"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-44 emotion-29"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-44 emotion-29"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                    </div>
                     <div
                       aria-live="polite"
                     >


### PR DESCRIPTION
Closes #1231 

## 🐢 What I did 🐢
Restructured DOM to recognize the "mixed" state when Voice Over tabs over indeterminate checkboxes

## 📺 Screenshots: 📺
<img width="855" alt="Example" src="https://github.com/user-attachments/assets/26668e40-a3a9-492d-87f8-9d3a92b5a597" />

## ✅ Checklist ✅
- [X] changeset has been added
- [X] Pull request description is descriptive
- [N/A] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works

## 🐎 How to test 🐎
1. Open Storybook
2. Go to Indeterminate Checkbox
3. Open Voice Over
4. Navigate to a Indeterminate Checkbox with keyboard
5. Verify "mixed" state is probably read
6. Go to Datagrid > Selectable
7. Verify Indeterminate Checkbox works appropriately here
8. Go to TreeView > First Item Branch
9. Verify Indeterminate Checkbox works appropriately here