### PR TITLE
fix(Table): fix logic for the default rowsPerPage value.

### DIFF
--- a/.changeset/fix-TablePagination-NativeSelect-rowsPerPage.md
+++ b/.changeset/fix-TablePagination-NativeSelect-rowsPerPage.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Table): fix logic for the default `rowsPerPage` value.

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -710,7 +710,7 @@ describe('Datagrid', () => {
       const pagination = {
         itemCount: rowsForPagination.length,
         page: 1,
-        rowsPerPage: 10,
+        defaultRowsPerPage: 10,
         rowsPerPageValues: [10, 20, 50, 100],
         onRowsPerPageChange,
       };

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -290,7 +290,9 @@ const rowsLong = [
 
 export const ControlledPagination = args => {
   const [pageIndex, setPageIndex] = React.useState<number>(1);
-  const [rowsPerPage, setRowsPerPage] = React.useState<number>(10);
+  const [rowsPerPage, setRowsPerPage] = React.useState<number>(
+    args.rowsPerPage ? args.rowsPerPage : 10
+  );
 
   function handleRowsPerPageChange(numberOfRows) {
     setRowsPerPage(numberOfRows);
@@ -342,17 +344,22 @@ export const ControlledPagination = args => {
         rowsPerPage={rowsPerPage}
         isInverse={args.isInverse}
         hasSquareCorners={args.hasSquareCorners}
+        rowsPerPageValues={args.rowsPerPageValues}
       />
     </Card>
   );
 };
 ControlledPagination.args = {
   ...Default.args,
+  rowsPerPage: 10,
+  rowsPerPageValues: [10, 20, 50, 100],
 };
 
 export const UncontrolledPagination = args => {
   const [pageIndex, setPageIndex] = React.useState<number>(1);
-  const [rowsPerPage, setRowsPerPage] = React.useState<number>(10);
+  const [rowsPerPage, setRowsPerPage] = React.useState<number>(
+    args.defaultRowsPerPage ? args.defaultRowsPerPage : 10
+  );
 
   function handlePageChange(_, page) {
     setPageIndex(page);
@@ -392,9 +399,15 @@ export const UncontrolledPagination = args => {
         itemCount={rowsLong.length}
         onPageChange={handlePageChange}
         onRowsPerPageChange={handleRowsPerPageChange}
+        defaultRowsPerPage={rowsPerPage}
+        rowsPerPageValues={args.rowsPerPageValues}
       />
     </>
   );
+};
+UncontrolledPagination.args = {
+  defaultRowsPerPage: 10,
+  rowsPerPageValues: [10, 20, 50, 100],
 };
 
 export const PaginationWithSquareCorners = args => {

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -218,9 +218,14 @@ export const TablePagination = React.forwardRef<
   });
 
   React.useEffect(() => {
-    if (!rowsPerPageValues.includes(rowsPerPageProp)) {
-      setRowsPerPageState(defaultRowsPerPage);
-      handleRowsPerPageChange(defaultRowsPerPage);
+    const checkedRowsPerPage = rowsPerPageProp
+      ? rowsPerPageProp
+      : defaultRowsPerPage;
+
+    if (!rowsPerPageValues.includes(checkedRowsPerPage)) {
+      console.log(rowsPerPageValues[0]);
+      setRowsPerPageState(rowsPerPageValues[0]);
+      handleRowsPerPageChange(rowsPerPageValues[0]);
     }
   }, []);
 

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -109,19 +109,19 @@ const StyledContainer = styled.div<{
       : props.theme.colors.neutral200};
   border-top: 1px solid
     ${props =>
-    props.isInverse
-      ? transparentize(0.6, props.theme.colors.neutral100)
-      : props.theme.colors.neutral300};
+      props.isInverse
+        ? transparentize(0.6, props.theme.colors.neutral100)
+        : props.theme.colors.neutral300};
   display: flex;
   justify-content: flex-end;
   padding: ${props => props.theme.spaceScale.spacing02};
-  border-radius: ${props => 
-    props.hasSquareCorners 
-    ? "0"
-    : `0 0 ${props.theme.borderRadius} ${props.theme.borderRadius}`};
+  border-radius: ${props =>
+    props.hasSquareCorners
+      ? '0'
+      : `0 0 ${props.theme.borderRadius} ${props.theme.borderRadius}`};
 `;
 
-const PageCount = styled(Label) <{ theme: ThemeInterface }>`
+const PageCount = styled(Label)<{ theme: ThemeInterface }>`
   margin: 0 ${props => props.theme.spaceScale.spacing08};
 `;
 
@@ -147,47 +147,43 @@ interface RowsPerPageControllerProps {
    */
   rowsPerPageValues: number[];
   isInverse?: boolean;
+  rowsPerPage: number;
 }
 
-const RowsPerPageController = ((props: RowsPerPageControllerProps) => {
-  const {
-    handleRowsPerPageChange,
-    rowsPerPageValues,
-    isInverse,
-  } = props;
+const RowsPerPageController = (props: RowsPerPageControllerProps) => {
+  const { handleRowsPerPageChange, rowsPerPageValues, isInverse, rowsPerPage } =
+    props;
 
-    const theme = React.useContext(ThemeContext);
-    const i18n = React.useContext(I18nContext);
+  const theme = React.useContext(ThemeContext);
+  const i18n = React.useContext(I18nContext);
 
-    const rowsPerPageItems = rowsPerPageValues.map(value => ({
-      label: value.toString(),
-      value,
-    }));
+  const rowsPerPageItems = rowsPerPageValues.map(value => ({
+    label: value.toString(),
+    value,
+  }));
 
   return (
     <>
       <RowsPerPageLabel isInverse={isInverse} theme={theme}>
-          {i18n.table.pagination.rowsPerPageLabel}:
-      </RowsPerPageLabel> 
+        {i18n.table.pagination.rowsPerPageLabel}:
+      </RowsPerPageLabel>
       <NativeSelect
-        onChange={(event) => handleRowsPerPageChange(event.target.value)}
+        onChange={event => handleRowsPerPageChange(event.target.value)}
         aria-label={i18n.table.pagination.rowsPerPageLabel}
-        style={{minWidth: 80}}
-        testId="rowPerPageSelect" 
+        style={{ minWidth: 80 }}
+        testId="rowPerPageSelect"
         fieldId={''}
+        value={rowsPerPage}
       >
         {rowsPerPageItems.map((row, index) => (
-          <option
-            key={index}
-            value={row.value}
-          >
+          <option key={index} value={row.value}>
             {row.label}
           </option>
         ))}
-      </NativeSelect> 
+      </NativeSelect>
     </>
-  )
-});
+  );
+};
 
 export const TablePagination = React.forwardRef<
   HTMLDivElement,
@@ -211,7 +207,8 @@ export const TablePagination = React.forwardRef<
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
 
-  const hasRowPerPageChangeFunction = onRowsPerPageChange && typeof onRowsPerPageChange === 'function';
+  const hasRowPerPageChangeFunction =
+    onRowsPerPageChange && typeof onRowsPerPageChange === 'function';
 
   const isInverse = useIsInverse(props.isInverse);
 
@@ -219,6 +216,13 @@ export const TablePagination = React.forwardRef<
     controlled: rowsPerPageProp,
     default: defaultRowsPerPage,
   });
+
+  React.useEffect(() => {
+    if (!rowsPerPageValues.includes(rowsPerPageProp)) {
+      setRowsPerPageState(defaultRowsPerPage);
+      handleRowsPerPageChange(defaultRowsPerPage);
+    }
+  }, []);
 
   const { page, pageButtons, setPageState } = usePagination({
     count: itemCount / rowsPerPage,
@@ -247,8 +251,7 @@ export const TablePagination = React.forwardRef<
       setRowsPerPageState(value);
     }
 
-    hasRowPerPageChangeFunction &&
-      onRowsPerPageChange(value);
+    hasRowPerPageChangeFunction && onRowsPerPageChange(value);
   }
 
   const previousButton = pageButtons[0];
@@ -263,14 +266,15 @@ export const TablePagination = React.forwardRef<
       ref={ref}
       theme={theme}
     >
-      { hasRowPerPageChangeFunction &&
-          <RowsPerPageController
-            isInverse={isInverse}
-            handleRowsPerPageChange={handleRowsPerPageChange}
-            rowsPerPageValues={rowsPerPageValues}
+      {hasRowPerPageChangeFunction && (
+        <RowsPerPageController
+          isInverse={isInverse}
+          handleRowsPerPageChange={handleRowsPerPageChange}
+          rowsPerPageValues={rowsPerPageValues}
+          rowsPerPage={rowsPerPage}
         />
-      }
-      
+      )}
+
       <PageCount isInverse={isInverse} theme={theme}>
         {`${displayPageStart}-${displayPageEnd} ${i18n.table.pagination.ofLabel} ${itemCount}`}
       </PageCount>

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -223,7 +223,6 @@ export const TablePagination = React.forwardRef<
       : defaultRowsPerPage;
 
     if (!rowsPerPageValues.includes(checkedRowsPerPage)) {
-      console.log(rowsPerPageValues[0]);
       setRowsPerPageState(rowsPerPageValues[0]);
       handleRowsPerPageChange(rowsPerPageValues[0]);
     }


### PR DESCRIPTION
Closes: #1599

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix logic for the default rowsPerPage value.

## Screenshots:
<!-- Include screenshot of your change -->

## Checklist 
- [x] changeset has been added
- [x] Pull request description is descriptive
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## How to test
<!-- Include testing steps, all edge cases, etc. -->
1. **Controlled Pagination**: 
- Open Storybook -> Table -> Controlled Pagination -> Select `rowsPerPage` that includes in the `rowsPerPageValues` array -> See that table shows the selected rows per page;
- Open Storybook -> Table -> Controlled Pagination -> Select `rowsPerPage` that DOESN'T include in the `rowsPerPageValues` array -> See that table shows the first number of `rowsPerPageValues` array.

2. **Uncontrolled Pagination**:
- Open Storybook -> Table -> Uncontrolled Pagination -> Select `defaultRowsPerPage` that includes in the `rowsPerPageValues` array -> See that table shows the selected rows per page;
- Open Storybook -> Table -> Controlled Pagination -> Select `rowsPerPage` that DOESN'T include in the `rowsPerPageValues` array -> See that table shows the first number of `rowsPerPageValues` array.