### PR TITLE
fix(Pagination): Changed the ellipsis characters to an HTML entity for accessibility compliance.

### DIFF
--- a/.changeset/fix-Pagination-screenreader.md
+++ b/.changeset/fix-Pagination-screenreader.md
@@ -2,4 +2,4 @@
 'react-magma-dom': patch
 ---
 
-fix(Pagination): Changed the ellipsis characters to an HTML entity for accessiblity compliance.
+fix(Pagination): Changed the ellipsis characters to an HTML entity for accessibility compliance.

--- a/.changeset/fix-Pagination-screenreader.md
+++ b/.changeset/fix-Pagination-screenreader.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Pagination): Changed the ellipsis characters to an HTML entity for accessiblity compliance.

--- a/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
@@ -227,7 +227,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
                         size={size}
                         theme={theme}
                       >
-                        ...
+                        &#8230;
                       </StyledEllipsis>
                     );
                   } else if (type === 'page') {


### PR DESCRIPTION
Closes: # [1557](https://github.com/cengage/react-magma/issues/1557)

## What I did
Converted to an HTML entity for the ellipsis in `Pagination` which resolves conflicts for screen readers.

## Screenshots
<img width="331" alt="stuff" src="https://github.com/user-attachments/assets/f4ba7374-d990-4b19-94d2-490a745419a2" />

## Checklist 
- [X] changeset has been added
- [X] Pull request is assigned, labels have been added and ticket is linked
- [X] Pull request description is descriptive and testing steps are listed
- [N/A] Corresponding changes to the documentation have been made
- [X] New and existing unit tests pass locally with the proposed changes
- [N/A] Tests that prove the fix is effective or that the feature works have been added

## How to test

Mac OS: VoiceOver with Chrome and Safari
Windows (native): NVDA, ensure the keyboard navigation mode is enabled with arrow keys (Insert + Space)

**Classic Pagination**
- Open Storybook & Voice Over
- Go to Pagination
- Ensure the count is high enough in options to display an ellipsis
- Navigate by arrow keys to the ellipsis
- Verify the screen reader reads "ellipsis" and not "dot dot dot"
- Verify that keyboard navigation works properly between the pagination objects
_- Repeat the same steps with tab navigation and verify it works similarly_

**Simple Pagination**
- Change to Pagination type to "simple" and confirm keyboard navigation works between elements
- Confirm keyboard navigation opens the simple pagination select
- Confirm voice over properly reads elements in opened select menu
- Make selection in select menu
- Ensure screen reader properly conveys the selected item
