### PR TITLE
fix(Pagination): Fix support for `page` in SimplePagination

### DIFF
--- a/.changeset/simple-pag.md
+++ b/.changeset/simple-pag.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Pagination): Fix support for `page` in SimplePagination

--- a/packages/react-magma-dom/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/Pagination.stories.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { Container } from '../Container';
 import { Pagination, PageButtonSize } from '.';
 import { Story, Meta } from '@storybook/react/types-6-0';
-import { PaginationProps, PaginationType } from './Pagination';
+import {
+  PaginationProps,
+  PaginationType,
+} from './Pagination';
 
 const Template: Story<PaginationProps> = args => <Pagination {...args} />;
 
@@ -26,6 +29,16 @@ export default {
       control: {
         type: 'select',
         options: PaginationType,
+      },
+    },
+    page: {
+      control: {
+        type: 'number',
+      },
+    },
+    defaultPage: {
+      control: {
+        type: 'number',
       },
     },
     size: {
@@ -63,6 +76,7 @@ Default.args = {
   hidePreviousButton: false,
   hideNextButton: false,
   isInverse: false,
+  disabled: false,
 };
 
 export const DefaultSelected = Template.bind({});
@@ -98,23 +112,39 @@ SimplePagination.args = {
   ...Default.args,
   type: PaginationType.simple,
   count: 4,
-  defaultPage: 2,
 };
 
-export const SimplePaginationOnPageChange = () => {
-  const [page, setPage] = React.useState(1);
-  function handleChange(_, pageNumber) {
+SimplePagination.parameters = {
+  controls: { exclude: ['showFirstButton', 'showLastButton', 'size'] },
+};
+
+export const SimplePaginationOnPageChange = (
+  args: Partial<PaginationProps>
+) => {
+  const [page, setPage] = React.useState<number>(Number(args.page));
+  function handleChange(_, pageNumber: number) {
     setPage(pageNumber);
   }
   return (
     <>
       <p>onPageChange result: {page}</p>
       <Pagination
+        {...args}
         onPageChange={handleChange}
         page={page}
-        count={4}
-        type={PaginationType.simple}
+        count={args.count}
       />
     </>
   );
+};
+
+SimplePaginationOnPageChange.args = {
+  ...Default.args,
+  type: PaginationType.simple,
+  page: 3,
+  count: 4,
+};
+
+SimplePaginationOnPageChange.parameters = {
+  controls: { exclude: ['showFirstButton', 'showLastButton', 'size'] },
 };

--- a/packages/react-magma-dom/src/components/Pagination/SimplePagination.test.js
+++ b/packages/react-magma-dom/src/components/Pagination/SimplePagination.test.js
@@ -78,6 +78,14 @@ describe('Simple Pagination', () => {
     expect(getByTestId(`${testId}-select`).value).toBe("2");
   });
 
+  it('should set the page number to 1 if the passed page is greater than the count', () => {
+    const { getByTestId } = render(
+      <Pagination type={PaginationType.simple} count={4} testId={testId} page={6} />
+    );
+
+    expect(getByTestId(`${testId}-select`).value).toBe("1");
+  });
+
   it('should set the page number to the page when both page and defaultPage are passed', () => {
     const { getByTestId } = render(
       <Pagination type={PaginationType.simple} count={4} testId={testId} defaultPage={2} page={3} />
@@ -205,7 +213,8 @@ describe('Simple Pagination', () => {
         <Pagination
           type={PaginationType.simple}
           count={3}
-          defaultPage={2}
+          defaultPage={1}
+          page={2}
           testId={testId}
         />
       );
@@ -350,7 +359,7 @@ describe('Simple Pagination', () => {
       <Pagination
         type={PaginationType.simple}
         count={4}
-        defaultPage={2}
+        page={2}
         testId={testId}
         onPageChange={onClickMock}
       />
@@ -386,6 +395,7 @@ describe('Simple Pagination', () => {
       <Pagination
         type={PaginationType.simple}
         count={3}
+        page={3}
         testId={testId}
         onPageChange={onClickMock}
       />

--- a/packages/react-magma-dom/src/components/Pagination/SimplePagination.test.js
+++ b/packages/react-magma-dom/src/components/Pagination/SimplePagination.test.js
@@ -62,6 +62,30 @@ describe('Simple Pagination', () => {
     expect(nextButton).not.toBeInTheDocument();
   });
 
+  it('should set the page number to the defaultPage', () => {
+    const { getByTestId } = render(
+      <Pagination type={PaginationType.simple} count={4} testId={testId} defaultPage={2} />
+    );
+
+    expect(getByTestId(`${testId}-select`).value).toBe("2");
+  });
+
+  it('should set the page number to the page', () => {
+    const { getByTestId } = render(
+      <Pagination type={PaginationType.simple} count={4} testId={testId} page={2} />
+    );
+
+    expect(getByTestId(`${testId}-select`).value).toBe("2");
+  });
+
+  it('should set the page number to the page when both page and defaultPage are passed', () => {
+    const { getByTestId } = render(
+      <Pagination type={PaginationType.simple} count={4} testId={testId} defaultPage={2} page={3} />
+    );
+
+    expect(getByTestId(`${testId}-select`).value).toBe("3");
+  });
+
   describe('Disabled', () => {
     it('Should render disabled navigation icons, text, and select', () => {
       const { getByText, getByLabelText } = render(

--- a/packages/react-magma-dom/src/components/Pagination/SimplePagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/SimplePagination.tsx
@@ -61,12 +61,14 @@ export const SimplePagination = React.forwardRef<
     hidePreviousButton,
     id: defaultId,
     isInverse,
+    page,
     testId,
     onClick,
     onChange,
     onPageChange,
     ...other
   } = props;
+  
   const theme = React.useContext(ThemeContext);
 
   const i18n = React.useContext(I18nContext);
@@ -74,11 +76,15 @@ export const SimplePagination = React.forwardRef<
   const id = useGenerateId(defaultId);
 
   let [selectedPage, setSelectedPage] = React.useState(
-    defaultPage ? defaultPage : 1
+    page || defaultPage
   );
 
   React.useEffect(() => {
-    setSelectedPage(defaultPage ? defaultPage : selectedPage);
+    setSelectedPage(page);
+  }, [page])
+
+  React.useEffect(() => {
+    setSelectedPage(selectedPage);
   }, [count]);
 
   function handleChange(event) {

--- a/packages/react-magma-dom/src/components/Pagination/SimplePagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/SimplePagination.tsx
@@ -81,7 +81,7 @@ export const SimplePagination = React.forwardRef<
 
   React.useEffect(() => {
     setSelectedPage(page);
-  }, [page])
+  }, [page]);
 
   React.useEffect(() => {
     setSelectedPage(selectedPage);

--- a/website/react-magma-docs/src/pages/api/pagination.mdx
+++ b/website/react-magma-docs/src/pages/api/pagination.mdx
@@ -22,7 +22,7 @@ import React from 'react';
 import { Pagination } from 'react-magma-dom';
 
 export function Example() {
-  return <Pagination count={4} />;
+  return <Pagination count={10} />;
 }
 ```
 
@@ -37,7 +37,7 @@ import React from 'react';
 import { Pagination, PaginationType } from 'react-magma-dom';
 
 export function Example() {
-  return <Pagination count={4} type={PaginationType.simple} />;
+  return <Pagination count={8} type={PaginationType.simple} page={2} />;
 }
 ```
 
@@ -54,7 +54,7 @@ export function Example() {
   return (
     <Card isInverse>
       <CardBody>
-        <Pagination isInverse count={4} />
+        <Pagination isInverse count={4} defaultPage={3} />
       </CardBody>
     </Card>
   );
@@ -70,7 +70,7 @@ import React from 'react';
 import { Pagination } from 'react-magma-dom';
 
 export function Example() {
-  return <Pagination size="large" count={4} />;
+  return <Pagination size="large" count={6} page={2} />;
 }
 ```
 


### PR DESCRIPTION
Closes: #1662

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
- Added support for `page` prop

## Screenshots
N/A

## Checklist 
- [X] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
- Use the `page` prop in simple pagination and ensure it updates appropriately
- Use the `defaultPage` prop in simple pagination and ensure it still behaves as expected (this requires a page refresh by design)
- Confirm that when using both `page` and `defaultPage`, `page` takes precedence
- Confirm that navigating with the arrows works when using page, defaultPage or both props together
