### PR TITLE
fix(SkipLink): Fix overlap with the SkipLink component when used with AppBar.

### DIFF
--- a/.changeset/fix-AppBar.md
+++ b/.changeset/fix-AppBar.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(SkipLink): Fix overlap with the SkipLink component when used with AppBar.

--- a/packages/react-magma-dom/src/components/AppBar/AppBar.stories.tsx
+++ b/packages/react-magma-dom/src/components/AppBar/AppBar.stories.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { AppBar, AppBarProps, AppBarPosition } from './index';
 import { NavTabs, NavTab } from '../NavTabs';
 import { Search } from '../Search';
+import { SkipLink } from '../SkipLink';
+import { SkipLinkContent } from '../SkipLinkContent';
+import { Paragraph } from '../Paragraph';
 import { Spacer } from '../Spacer';
 import { TabsIconPosition } from '../Tabs';
 import { magma } from '../../theme/magma';
@@ -72,4 +75,33 @@ export const Tabs = TabsTemplate.bind({});
 Tabs.args = {
   ...Default.args,
   children: null,
+};
+
+export const WithSkipLink = () => {
+  return (
+    <div style={{ height: '200px', overflow: 'auto', position: 'relative' }}>
+      <AppBar isInverse position={AppBarPosition.sticky}>
+        AppBar content
+      </AppBar>
+      <SkipLink to="#last-one" buttonText="Skip to the end!" />
+
+      <Paragraph>
+        Peel the onion peel the onion, so the horse is out of the barn per my
+        previous email, nor draw a line in the sand. I just wanted to give you a
+        heads-up drink from the firehose, game plan back-end of third quarter
+        viral engagement. Eat our own dog food driving the initiative forward
+        tribal knowledge increase the pipelines, but run it up the flag pole.
+      </Paragraph>
+      <SkipLinkContent>
+        <Paragraph id="last-one">
+          Turn the crank regroup can we align on lunch orders, so regroup, yet
+          the last person we talked to said this would be ready, for this vendor
+          is incompetent , or pipeline. We've bootstrapped the model zeitgeist,
+          so let's schedule a standup during the sprint to review our kpis, so
+          not the long pole in my tent we're ahead of the curve on that one, and
+          we're ahead of the curve on that one.{' '}
+        </Paragraph>
+      </SkipLinkContent>
+    </div>
+  );
 };

--- a/packages/react-magma-dom/src/components/SkipLink/__snapshots__/SkipLink.test.js.snap
+++ b/packages/react-magma-dom/src/components/SkipLink/__snapshots__/SkipLink.test.js.snap
@@ -88,6 +88,10 @@ exports[`SkipLink should render the skip link component 1`] = `
   z-index: 99999;
 }
 
+.emotion-1:not(:disabled):focus {
+  z-index: 99999;
+}
+
 .emotion-1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -172,6 +176,10 @@ exports[`SkipLink should render the skip link component 1`] = `
 .emotion-1:focus {
   left: 10px;
   top: 10px;
+  z-index: 99999;
+}
+
+.emotion-1:not(:disabled):focus {
   z-index: 99999;
 }
 

--- a/packages/react-magma-dom/src/components/SkipLink/index.tsx
+++ b/packages/react-magma-dom/src/components/SkipLink/index.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { ButtonColor, ButtonVariant } from '../Button';
 import { Hyperlink, HyperlinkProps } from '../Hyperlink';
+import { Omit } from '../../utils';
 import { I18nContext } from '../../i18n';
 import styled from '@emotion/styled';
 
 export const TARGET_ID = 'reactMagmaMainContent';
 
-export interface SkipLinkProps extends HyperlinkProps {
+export interface SkipLinkProps extends Omit<HyperlinkProps, 'children'> {
   /**
    * The text in the skip link
    * @default "Skip Navigation"
@@ -58,6 +59,9 @@ const StyledSkipLink = styled(Hyperlink)<{
     &:focus {
       left: ${props => props.positionLeft}px;
       top: ${props => props.positionTop}px;
+      z-index: 99999;
+    }
+    &:not(:disabled):focus {
       z-index: 99999;
     }
   }

--- a/website/react-magma-docs/src/pages/api/skip-link.mdx
+++ b/website/react-magma-docs/src/pages/api/skip-link.mdx
@@ -54,7 +54,7 @@ const SideNav = ({ length }) => {
 export function Example() {
   return (
     <div>
-      <SkipLink />
+      <SkipLink buttonText="Skip to main content" />
       <SideNav length={500} />
       <SkipLinkContent>
         <Paragraph>Content to jump to.</Paragraph>
@@ -102,7 +102,10 @@ const SideNav = ({ length }) => {
 export function Example() {
   return (
     <div>
-      <SkipLink variant={ButtonVariant.solid} />
+      <SkipLink
+        buttonText="Skip to main content"
+        variant={ButtonVariant.solid}
+      />
       <SideNav length={500} />
       <SkipLinkContent>
         <Paragraph>Content to jump to.</Paragraph>
@@ -181,12 +184,58 @@ const SideNav = ({ length }) => {
 export function Example() {
   return (
     <div>
-      <SkipLink positionLeft={25} positionTop={25} />
+      <SkipLink
+        buttonText="Skip to main content"
+        positionLeft={25}
+        positionTop={25}
+      />
       <SideNav length={500} />
       <SkipLinkContent>
         <Paragraph>Content to jump to.</Paragraph>
       </SkipLinkContent>
       <Paragraph>Additional content.</Paragraph>
+    </div>
+  );
+}
+```
+
+## With AppBar
+
+The `SkipLink` works concurrently with `AppBar` which assists in keyboard navigation.
+
+```tsx
+import React from 'react';
+import {
+  AppBar,
+  AppBarPosition,
+  SkipLink,
+  SkipLinkContent,
+  Paragraph,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <div style={{ height: '400px', overflow: 'auto', position: 'relative' }}>
+      <AppBar position={AppBarPosition.sticky}>AppBar content</AppBar>
+      <SkipLink buttonText="Skip to main content" to="#last-one" />
+
+      <Paragraph>
+        Peel the onion peel the onion, so the horse is out of the barn per my
+        previous email, nor draw a line in the sand. I just wanted to give you a
+        heads-up drink from the firehose, game plan back-end of third quarter
+        viral engagement. Eat our own dog food driving the initiative forward
+        tribal knowledge increase the pipelines, but run it up the flag pole.
+      </Paragraph>
+      <SkipLinkContent>
+        <Paragraph id="last-one">
+          Turn the crank regroup can we align on lunch orders, so regroup, yet
+          the last person we talked to said this would be ready, for this vendor
+          is incompetent , or pipeline. We've bootstrapped the model zeitgeist,
+          so let's schedule a standup during the sprint to review our kpis, so
+          not the long pole in my tent we're ahead of the curve on that one, and
+          we're ahead of the curve on that one.{' '}
+        </Paragraph>
+      </SkipLinkContent>
     </div>
   );
 }


### PR DESCRIPTION
Closes: #1654 

## What I did
- Added CSS property to ensure the `SkipLink` component properly displays above the `AppBar` when both are used.
- Added Doc / Storybook examples under `AppBar` to highlight the proper interaction.

## Screenshots
<img width="1209" alt="Skippy" src="https://github.com/user-attachments/assets/a013f9c5-6f1a-4c37-998b-6e5045c02249" />

## Checklist 
- [X] changeset has been added
- [X] Pull request is assigned, labels have been added and ticket is linked
- [X] Pull request description is descriptive and testing steps are listed
- [X] Corresponding changes to the documentation have been made
- [N/A] New and existing unit tests pass locally with the proposed changes
- [N/A] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs / Storybook `AppBar` example > Press tab > Verify `SkipLink` appears above `AppBar`.
