### PR TITLE
feat(Input): Support new types: `tel` and `url`

### DIFF
--- a/.changeset/feat-Input-new-types.md
+++ b/.changeset/feat-Input-new-types.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Input): Add new types: `tel` and `url`.

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -327,6 +327,83 @@ NumberInput.parameters = {
   controls: { exclude: ['type', 'iconPosition', 'labelWidth'] },
 };
 
+export const PhoneInput = args => {
+  const [inputVal, setInputVal] = React.useState('');
+  const [hasError, setHasError] = React.useState(false);
+  const phonePattern = '^[0-9]{3}-[0-9]{2}-[0-9]{3}$';
+
+  function handleChange(event) {
+    setInputVal(event.target.value);
+  }
+
+  React.useEffect(() => {
+    if (inputVal === '' || inputVal.match(phonePattern)) {
+      setHasError(false);
+    } else {
+      setHasError(true);
+    }
+  }, [inputVal]);
+
+  return (
+    <Input
+      pattern={phonePattern}
+      labelText={
+        <>
+          Phone <br /> Format: 123-45-678
+        </>
+      }
+      type={InputType.tel}
+      errorMessage={hasError ? 'Please enter a phone number' : null}
+      value={inputVal}
+      onChange={handleChange}
+      {...args}
+    />
+  );
+};
+
+PhoneInput.args = {
+  disabled: false,
+  helperMessage: 'Enter a phone number',
+  isClearable: false,
+};
+
+export const UrlInput = args => {
+  const [inputVal, setInputVal] = React.useState('');
+  const [hasError, setHasError] = React.useState(false);
+  const urlPattern =
+    '^(https?:\\/\\/)?([a-zA-Z0-9.-]+)\\.([a-zA-Z]{2,})(:[0-9]+)?(\\/.*)?$';
+
+  function handleChange(event) {
+    setInputVal(event.target.value);
+  }
+
+  React.useEffect(() => {
+    if (inputVal === '' || inputVal.match(urlPattern)) {
+      setHasError(false);
+    } else {
+      setHasError(true);
+    }
+  }, [hasError, inputVal]);
+
+  return (
+    <Input
+      pattern={urlPattern}
+      labelText="Url"
+      type={InputType.url}
+      errorMessage={hasError ? 'Please enter an url' : null}
+      value={inputVal}
+      onChange={handleChange}
+      {...args}
+    />
+  );
+};
+
+UrlInput.args = {
+  disabled: false,
+  helperMessage: 'Enter an url',
+  isClearable: false,
+};
+
 export const SeveralErrors = () => {
   const [inputValues, setInputValues] = React.useState({
     firstName: '',

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -327,7 +327,7 @@ NumberInput.parameters = {
   controls: { exclude: ['type', 'iconPosition', 'labelWidth'] },
 };
 
-export const PhoneInput = args => {
+export const PhoneInput = () => {
   const [inputVal, setInputVal] = React.useState('');
   const [hasError, setHasError] = React.useState(false);
   const phonePattern = '^[0-9]{3}-[0-9]{3}-[0-9]{4}$';
@@ -356,12 +356,11 @@ export const PhoneInput = args => {
       errorMessage={hasError ? 'Please enter a phone number' : null}
       value={inputVal}
       onChange={handleChange}
-      {...args}
     />
   );
 };
 
-export const UrlInput = args => {
+export const UrlInput = () => {
   const [inputVal, setInputVal] = React.useState('');
   const [hasError, setHasError] = React.useState(false);
   const urlPattern =
@@ -387,7 +386,6 @@ export const UrlInput = args => {
       errorMessage={hasError ? 'Please enter a url' : null}
       value={inputVal}
       onChange={handleChange}
-      {...args}
     />
   );
 };

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -330,7 +330,7 @@ NumberInput.parameters = {
 export const PhoneInput = args => {
   const [inputVal, setInputVal] = React.useState('');
   const [hasError, setHasError] = React.useState(false);
-  const phonePattern = '^[0-9]{3}-[0-9]{2}-[0-9]{3}$';
+  const phonePattern = '^[0-9]{3}-[0-9]{3}-[0-9]{4}$';
 
   function handleChange(event) {
     setInputVal(event.target.value);
@@ -349,7 +349,7 @@ export const PhoneInput = args => {
       pattern={phonePattern}
       labelText={
         <>
-          Phone <br /> Format: 123-45-678
+          Phone <br /> Format: 123-456-7890
         </>
       }
       type={InputType.tel}
@@ -359,12 +359,6 @@ export const PhoneInput = args => {
       {...args}
     />
   );
-};
-
-PhoneInput.args = {
-  disabled: false,
-  helperMessage: 'Enter a phone number',
-  isClearable: false,
 };
 
 export const UrlInput = args => {
@@ -390,18 +384,12 @@ export const UrlInput = args => {
       pattern={urlPattern}
       labelText="Url"
       type={InputType.url}
-      errorMessage={hasError ? 'Please enter an url' : null}
+      errorMessage={hasError ? 'Please enter a url' : null}
       value={inputVal}
       onChange={handleChange}
       {...args}
     />
   );
-};
-
-UrlInput.args = {
-  disabled: false,
-  helperMessage: 'Enter an url',
-  isClearable: false,
 };
 
 export const SeveralErrors = () => {

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -360,7 +360,7 @@ export const PhoneInput = () => {
   );
 };
 
-export const UrlInput = () => {
+export const URLInput = () => {
   const [inputVal, setInputVal] = React.useState('');
   const [hasError, setHasError] = React.useState(false);
   const urlPattern =
@@ -381,7 +381,7 @@ export const UrlInput = () => {
   return (
     <Input
       pattern={urlPattern}
-      labelText="Url"
+      labelText="URL"
       type={InputType.url}
       errorMessage={hasError ? 'Please enter a url' : null}
       value={inputVal}

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -7,6 +7,7 @@ import { CheckIcon } from 'react-magma-icons';
 import { axe } from '../../../axe-helper';
 import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
+import { InputType } from '../InputBase';
 
 import { Input } from '.';
 
@@ -604,6 +605,105 @@ describe('Input', () => {
 
       expect(getByText('4 ' + charactersAllowed)).toBeInTheDocument();
       expect(onClear).toBeCalled();
+    });
+  });
+
+  describe('Input types', () => {
+    it('should have "email" type of Input', () => {
+      const labelText = 'Email';
+
+      const { getByLabelText } = render(
+        <Input labelText={labelText} type={InputType.email} />
+      );
+
+      const inputElement = getByLabelText('Email');
+      expect(inputElement).toHaveAttribute('type', 'email');
+    });
+
+    it('should have "file" type of Input', () => {
+      const labelText = 'File';
+
+      const { getByLabelText } = render(
+        <Input labelText={labelText} type={InputType.file} />
+      );
+
+      const inputElement = getByLabelText('File');
+      expect(inputElement).toHaveAttribute('type', 'file');
+    });
+
+    it('should have "number" type of Input', () => {
+      const labelText = 'Number';
+
+      const { getByLabelText } = render(
+        <Input labelText={labelText} type={InputType.number} />
+      );
+
+      const inputElement = getByLabelText('Number');
+      expect(inputElement).toHaveAttribute('type', 'number');
+    });
+
+    it('should have "password" type of Input', () => {
+      const labelText = 'Password';
+
+      const { getByLabelText } = render(
+        <Input labelText={labelText} type={InputType.password} />
+      );
+
+      const inputElement = getByLabelText('Password');
+      expect(inputElement).toHaveAttribute('type', 'password');
+    });
+
+    it('should have "search" type of Input', () => {
+      const labelText = 'Search';
+
+      const { getByLabelText } = render(
+        <Input labelText={labelText} type={InputType.search} />
+      );
+
+      const inputElement = getByLabelText('Search');
+      expect(inputElement).toHaveAttribute('type', 'search');
+    });
+
+    it('should have "text" type of Input', () => {
+      const labelText = 'Text';
+
+      const { getByLabelText } = render(
+        <Input labelText={labelText} type={InputType.text} />
+      );
+
+      const inputElement = getByLabelText('Text');
+      expect(inputElement).toHaveAttribute('type', 'text');
+    });
+
+    it('should have "text" type of Input as a default value', () => {
+      const labelText = 'Text';
+
+      const { getByLabelText } = render(<Input labelText={labelText} />);
+
+      const inputElement = getByLabelText('Text');
+      expect(inputElement).toHaveAttribute('type', 'text');
+    });
+
+    it('should have "tel" type of Input', () => {
+      const labelText = 'Phone';
+
+      const { getByLabelText } = render(
+        <Input labelText={labelText} type={InputType.tel} />
+      );
+
+      const inputElement = getByLabelText('Phone');
+      expect(inputElement).toHaveAttribute('type', 'tel');
+    });
+
+    it('should have "url" type of Input', () => {
+      const labelText = 'Url';
+
+      const { getByLabelText } = render(
+        <Input labelText={labelText} type={InputType.url} />
+      );
+
+      const inputElement = getByLabelText('Url');
+      expect(inputElement).toHaveAttribute('type', 'url');
     });
   });
 });

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -27,6 +27,8 @@ export enum InputType {
   password = 'password',
   search = 'search',
   text = 'text', // default
+  url = 'url',
+  tel = 'tel',
 }
 
 export enum InputIconPosition {

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -120,7 +120,7 @@ return (
 }
 ```
 
-## Url
+## URL
 
 ```tsx
 import React from 'react';
@@ -148,7 +148,7 @@ export function Example() {
   return (
     <Input
       pattern={urlPattern}
-      labelText="Url"
+      labelText="URL"
       type={InputType.url}
       errorMessage={hasError ? 'Please enter a url' : null}
       value={inputVal}

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -89,7 +89,7 @@ import { Input, InputType } from 'react-magma-dom';
 export function Example() {
 const [inputVal, setInputVal] = React.useState('');
 const [hasError, setHasError] = React.useState(false);
-const phonePattern = '^[0-9]{3}-[0-9]{2}-[0-9]{3}$';
+const phonePattern = '^[0-9]{3}-[0-9]{3}-[0-9]{4}$';
 
 function handleChange(event) {
   setInputVal(event.target.value);
@@ -108,10 +108,9 @@ return (
     pattern={phonePattern}
     labelText={
       <>
-        Phone <br /> Format: 123-45-678
+        Phone <br /> Format: 123-456-7890
       </>
     }
-    helperMessage={'Enter a phone number'}
     type={InputType.tel}
     errorMessage={hasError ? 'Please enter a phone number' : null}
     value={inputVal}
@@ -129,34 +128,33 @@ import React from 'react';
 import { Input, InputType } from 'react-magma-dom';
 
 export function Example() {
-const [inputVal, setInputVal] = React.useState('');
-const [hasError, setHasError] = React.useState(false);
-const urlPattern =
-  '^(https?:\\/\\/)?([a-zA-Z0-9.-]+)\\.([a-zA-Z]{2,})(:[0-9]+)?(\\/.*)?$';
+  const [inputVal, setInputVal] = React.useState('');
+  const [hasError, setHasError] = React.useState(false);
+  const urlPattern =
+    '^(https?:\\/\\/)?([a-zA-Z0-9.-]+)\\.([a-zA-Z]{2,})(:[0-9]+)?(\\/.*)?$';
 
-function handleChange(event) {
-  setInputVal(event.target.value);
-}
-
-React.useEffect(() => {
-  if (inputVal === '' || inputVal.match(urlPattern)) {
-    setHasError(false);
-  } else {
-    setHasError(true);
+  function handleChange(event) {
+    setInputVal(event.target.value);
   }
-}, [hasError, inputVal]);
 
-return (
-  <Input
-    helperMessage={'Enter an url'}
-    pattern={urlPattern}
-    labelText="Url"
-    type={InputType.url}
-    errorMessage={hasError ? 'Please enter an url' : null}
-    value={inputVal}
-    onChange={handleChange}
-  />
-);
+  React.useEffect(() => {
+    if (inputVal === '' || inputVal.match(urlPattern)) {
+      setHasError(false);
+    } else {
+      setHasError(true);
+    }
+  }, [hasError, inputVal]);
+
+  return (
+    <Input
+      pattern={urlPattern}
+      labelText="Url"
+      type={InputType.url}
+      errorMessage={hasError ? 'Please enter a url' : null}
+      value={inputVal}
+      onChange={handleChange}
+    />
+  );
 }
 ```
 

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -79,6 +79,87 @@ export function Example() {
 }
 ```
 
+## Phone
+
+```tsx
+import React from 'react';
+
+import { Input, InputType } from 'react-magma-dom';
+
+export function Example() {
+const [inputVal, setInputVal] = React.useState('');
+const [hasError, setHasError] = React.useState(false);
+const phonePattern = '^[0-9]{3}-[0-9]{2}-[0-9]{3}$';
+
+function handleChange(event) {
+  setInputVal(event.target.value);
+}
+
+React.useEffect(() => {
+  if (inputVal === '' || inputVal.match(phonePattern)) {
+    setHasError(false);
+  } else {
+    setHasError(true);
+  }
+}, [inputVal]);
+
+return (
+  <Input
+    pattern={phonePattern}
+    labelText={
+      <>
+        Phone <br /> Format: 123-45-678
+      </>
+    }
+    helperMessage={'Enter a phone number'}
+    type={InputType.tel}
+    errorMessage={hasError ? 'Please enter a phone number' : null}
+    value={inputVal}
+    onChange={handleChange}
+  />
+);
+}
+```
+
+## Url
+
+```tsx
+import React from 'react';
+
+import { Input, InputType } from 'react-magma-dom';
+
+export function Example() {
+const [inputVal, setInputVal] = React.useState('');
+const [hasError, setHasError] = React.useState(false);
+const urlPattern =
+  '^(https?:\\/\\/)?([a-zA-Z0-9.-]+)\\.([a-zA-Z]{2,})(:[0-9]+)?(\\/.*)?$';
+
+function handleChange(event) {
+  setInputVal(event.target.value);
+}
+
+React.useEffect(() => {
+  if (inputVal === '' || inputVal.match(urlPattern)) {
+    setHasError(false);
+  } else {
+    setHasError(true);
+  }
+}, [hasError, inputVal]);
+
+return (
+  <Input
+    helperMessage={'Enter an url'}
+    pattern={urlPattern}
+    labelText="Url"
+    type={InputType.url}
+    errorMessage={hasError ? 'Please enter an url' : null}
+    value={inputVal}
+    onChange={handleChange}
+  />
+);
+}
+```
+
 ## Disabled
 
 ```tsx
@@ -796,10 +877,13 @@ All of the [standard input attributes](https://developer.mozilla.org/en-US/docs/
         name: 'enum',
         options: [
           'InputType.email',
+          'InputType.file',
           'InputType.number',
           'InputType.password',
           'InputType.search',
           'InputType.text',
+          'InputType.url',
+          'InputType.tel',
         ],
       },
       required: false,


### PR DESCRIPTION
Closes: #1689
## What I did
- Added new types `tel` and `url` for Input component.
- Updated storybook and react-magma-docs.

## Screenshots
![Screenshot from 2025-03-12 12-16-38](https://github.com/user-attachments/assets/367c4102-d18f-4905-b7f5-64d528ec7319)
![Screenshot from 2025-03-12 12-17-07](https://github.com/user-attachments/assets/5831ced9-6f2b-454d-a819-95be6609691b)
![Screenshot from 2025-03-12 12-16-53](https://github.com/user-attachments/assets/5c985080-4151-4dbb-beab-71f5fb38562f)
![Screenshot from 2025-03-12 12-17-17](https://github.com/user-attachments/assets/507ef005-91e3-4722-8f63-fea00657ccaa)
![Screenshot from 2025-03-12 12-17-34](https://github.com/user-attachments/assets/cd742d85-b824-4c6c-b3fc-2d232a8dacd0)

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Open Storybook
- Go to Input -> Phone Input or Url Input
- Fill out the Input related a pattern for a phone number or Url
