### PR TITLE
fix(password input): fix webkit styles when using the password manager

### DIFF
--- a/.changeset/fix-Password-input-password-manager.md
+++ b/.changeset/fix-Password-input-password-manager.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(PasswordInput): Fix webkit styles when using the password manager.

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -415,7 +415,7 @@ describe('Input', () => {
         'font-size',
         magma.typeScale.size03.fontSize
       );
-      expect(input).toHaveStyleRule('height', magma.spaceScale.spacing09);
+      expect(input).toHaveStyleRule('height', '100%');
       expect(input).toHaveStyleRule('padding-left', magma.spaceScale.spacing09);
 
       expect(iconWrapper).toHaveStyleRule('left', magma.spaceScale.spacing03);
@@ -442,7 +442,7 @@ describe('Input', () => {
         'font-size',
         magma.typeScale.size04.fontSize
       );
-      expect(input).toHaveStyleRule('height', magma.spaceScale.spacing11);
+      expect(input).toHaveStyleRule('height', '100%');
       expect(input).toHaveStyleRule('padding', `${magma.spaceScale.spacing04}`);
     });
 

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -298,7 +298,7 @@ export const inputBaseStyles = (props: InputBaseStylesProps) => css`
   font-size: ${props.theme.typeScale.size03.fontSize};
   line-height: ${props.theme.typeScale.size03.lineHeight};
   font-family: ${props.theme.bodyFont};
-  height: ${props.theme.spaceScale.spacing09};
+  height: 100%;
   padding: ${props.theme.spaceScale.spacing03};
   -webkit-appearance: none;
   width: 100%;
@@ -307,7 +307,6 @@ export const inputBaseStyles = (props: InputBaseStylesProps) => css`
   css`
     font-size: ${props.theme.typeScale.size04.fontSize};
     line-height: ${props.theme.typeScale.size04.lineHeight};
-    height: ${props.theme.spaceScale.spacing11};
     padding: ${props.theme.spaceScale.spacing04};
   `}
 
@@ -347,6 +346,20 @@ export const inputBaseStyles = (props: InputBaseStylesProps) => css`
       opacity: ${props.isInverse ? 0.4 : 0.6};
     }
   `}
+
+  &:-webkit-autofill,
+  &:-webkit-autofill:focus,
+  &:-webkit-autofill:hover,
+  &:-webkit-autofill:active {
+    box-shadow: none !important;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: ${props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral700} !important;
+    caret-color: ${props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral700} !important;
+  }
 `;
 
 const InputContainer = styled.div<InputWrapperStylesProps>`

--- a/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.test.js
+++ b/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.test.js
@@ -186,7 +186,7 @@ describe('sizes', () => {
       magma.typeScale.size02.letterSpacing
     );
     expect(input).toHaveStyleRule('font-size', magma.typeScale.size03.fontSize);
-    expect(input).toHaveStyleRule('height', magma.spaceScale.spacing09);
+    expect(input).toHaveStyleRule('height', '100%');
   });
 
   it('should render a large input with correct styles', () => {
@@ -201,7 +201,7 @@ describe('sizes', () => {
     expect(label).toHaveStyleRule('font-size', magma.typeScale.size03.fontSize);
 
     expect(input).toHaveStyleRule('font-size', magma.typeScale.size04.fontSize);
-    expect(input).toHaveStyleRule('height', magma.spaceScale.spacing11);
+    expect(input).toHaveStyleRule('height', '100%');
     expect(input).toHaveStyleRule('padding', `${magma.spaceScale.spacing04}`);
   });
 


### PR DESCRIPTION
Closes: #1165

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix webkit styles for the `PasswordInput` when using the password manager

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook/Docs -> PasswordInput -> Select password from the password manager -> Check styles.