### PR TITLE
fix(Dropdown): Expandable Menu Items > Icon missing at parent level

### DIFF
--- a/.changeset/fix-Dropdown-add-icon-parent-level.md
+++ b/.changeset/fix-Dropdown-add-icon-parent-level.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Added icon prop for DropdownExpandableMenuListItem

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -700,8 +700,10 @@ export const DropdownExpandableMenuListItemWithIcons = args => {
         </DropdownExpandableMenuListItem>
         <DropdownDivider />
         <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
-          Pizza seafood (no icon)
-          <p style={{ marginLeft: '10px' }}>children</p>
+          Pizza seafood
+          <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
+            Child (no icon)
+          </DropdownExpandableMenuListItem>
         </DropdownExpandableMenuListItem>
       </DropdownContent>
     </Dropdown>

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -673,3 +673,37 @@ export const CustomRef = CustomRefTemplate.bind({});
 CustomRef.args = {
   ...Default.args,
 };
+
+export const DropdownExpandableMenuListItemWithIcons = args => {
+  return (
+    <Dropdown {...args} width={300}>
+      <DropdownButton>Dropdown Expandable Menu List Item</DropdownButton>
+      <DropdownContent>
+        <DropdownExpandableMenuGroup isMulti={false} defaultIndex={0}>
+          <DropdownExpandableMenuItem>
+            <DropdownExpandableMenuButton icon={<LocalPizzaIcon />}>
+              Pizza
+            </DropdownExpandableMenuButton>
+            <DropdownExpandableMenuPanel>
+              <DropdownExpandableMenuListItem>
+                Margherita
+              </DropdownExpandableMenuListItem>
+              <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
+                Capricciosa (no icon)
+              </DropdownExpandableMenuListItem>
+            </DropdownExpandableMenuPanel>
+          </DropdownExpandableMenuItem>
+        </DropdownExpandableMenuGroup>
+        <DropdownDivider />
+        <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
+          Pizza marinara (with icon)
+        </DropdownExpandableMenuListItem>
+        <DropdownDivider />
+        <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
+          Pizza seafood (no icon)
+          <p style={{ marginLeft: '10px' }}>children</p>
+        </DropdownExpandableMenuListItem>
+      </DropdownContent>
+    </Dropdown>
+  );
+};

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -682,28 +682,21 @@ export const DropdownExpandableMenuListItemWithIcons = args => {
         <DropdownExpandableMenuGroup isMulti={false} defaultIndex={0}>
           <DropdownExpandableMenuItem>
             <DropdownExpandableMenuButton icon={<LocalPizzaIcon />}>
-              Pizza
+              Specialty Pizza
             </DropdownExpandableMenuButton>
             <DropdownExpandableMenuPanel>
               <DropdownExpandableMenuListItem>
                 Margherita
               </DropdownExpandableMenuListItem>
               <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
-                Capricciosa (no icon)
+                Capricciosa
               </DropdownExpandableMenuListItem>
             </DropdownExpandableMenuPanel>
           </DropdownExpandableMenuItem>
         </DropdownExpandableMenuGroup>
         <DropdownDivider />
         <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
-          Pizza marinara (with icon)
-        </DropdownExpandableMenuListItem>
-        <DropdownDivider />
-        <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
-          Pizza seafood
-          <DropdownExpandableMenuListItem icon={<LocalPizzaIcon />}>
-            Child (no icon)
-          </DropdownExpandableMenuListItem>
+          Cheese Pizza
         </DropdownExpandableMenuListItem>
       </DropdownContent>
     </Dropdown>

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
@@ -48,6 +48,7 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
   );
 
   const ref = useForkedRef(forwardedRef, ownRef);
+  const hasChildren = React.Children.count(children) > 1;
 
   React.useEffect(() => {
     if (!expandableMenuItemContext.disabled)
@@ -59,7 +60,7 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
       {...other}
       disabled={disabled}
       expandableMenuButtonHasIcon={menuGroupContext.expandableMenuButtonHasIcon}
-      icon={icon}
+      icon={hasChildren ? null : icon}
       isExpandablePanel={menuGroupContext.isExpandablePanel}
       ref={expandableMenuItemContext.disabled ? null : ref}
       theme={theme}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
@@ -48,7 +48,6 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
   );
 
   const ref = useForkedRef(forwardedRef, ownRef);
-  const hasChildren = React.Children.count(children) > 1;
 
   React.useEffect(() => {
     if (!expandableMenuItemContext.disabled)
@@ -60,13 +59,19 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
       {...other}
       disabled={disabled}
       expandableMenuButtonHasIcon={menuGroupContext.expandableMenuButtonHasIcon}
-      icon={hasChildren ? null : icon}
+      icon={
+        menuGroupContext && !menuGroupContext.isExpandablePanel ? icon : null
+      }
       isExpandablePanel={menuGroupContext.isExpandablePanel}
       ref={expandableMenuItemContext.disabled ? null : ref}
       theme={theme}
       role="menuitem"
     >
-      {children}
+      {React.Children.map(children, child =>
+        React.isValidElement(child)
+          ? React.cloneElement(child, { icon: undefined })
+          : child
+      )}
     </StyledDropdownMenuItem>
   );
 });

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
@@ -59,19 +59,13 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
       {...other}
       disabled={disabled}
       expandableMenuButtonHasIcon={menuGroupContext.expandableMenuButtonHasIcon}
-      icon={
-        menuGroupContext && !menuGroupContext.isExpandablePanel ? icon : null
-      }
+      icon={!menuGroupContext.isExpandablePanel ? icon : null}
       isExpandablePanel={menuGroupContext.isExpandablePanel}
       ref={expandableMenuItemContext.disabled ? null : ref}
       theme={theme}
       role="menuitem"
     >
-      {React.Children.map(children, child =>
-        React.isValidElement(child)
-          ? React.cloneElement(child, { icon: undefined })
-          : child
-      )}
+      {children}
     </StyledDropdownMenuItem>
   );
 });

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
@@ -7,10 +7,10 @@ import { DropdownExpandableMenuGroupContext } from './DropdownExpandableMenuGrou
 import { DropdownExpandableMenuItemContext } from './DropdownExpandableMenuItem';
 import { DropdownMenuItem, DropdownMenuItemProps } from './DropdownMenuItem';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { Omit, useForkedRef } from '../../utils';
+import { useForkedRef } from '../../utils';
 
 export interface DropdownExpandableMenuListItemProps
-  extends Omit<DropdownMenuItemProps, 'icon'> {
+  extends DropdownMenuItemProps {
   disabled?: boolean;
   testId?: string;
 }
@@ -35,7 +35,7 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
   HTMLDivElement,
   DropdownExpandableMenuListItemProps
 >((props, forwardedRef) => {
-  const { children, disabled, ...other } = props;
+  const { children, disabled, icon, ...other } = props;
 
   const ownRef = React.useRef<HTMLDivElement>();
   const theme = React.useContext(ThemeContext);
@@ -59,6 +59,7 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
       {...other}
       disabled={disabled}
       expandableMenuButtonHasIcon={menuGroupContext.expandableMenuButtonHasIcon}
+      icon={icon}
       isExpandablePanel={menuGroupContext.isExpandablePanel}
       ref={expandableMenuItemContext.disabled ? null : ref}
       theme={theme}


### PR DESCRIPTION
Closes: #1573

## What I did
- Added the `icon` prop for `DropdownExpandableMenuListItem` component.

## Screenshots
React Magma Docs

![Screenshot from 2025-03-19 17-23-43](https://github.com/user-attachments/assets/c86f1210-c5f3-4861-b793-bcaafa3ba55a)

Storybook
![Screenshot from 2025-03-25 16-29-47](https://github.com/user-attachments/assets/57e4acad-3b2b-4d3e-a0ce-bdcadfc06cc8)



## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Go to `Storybook`
- Open Dropdown -> Dropdown Expandable Menu List Item With Icons :
- for Specialty Pizza -> Capricciossa -> should be invisible icon (because is inside list of items)
- for Cheese Pizza -> should be visible icon
