### PR TITLE
fix(Search): Style issues with clear and search icons

### DIFF
--- a/.changeset/fix-Search-Update-icon-styles.md
+++ b/.changeset/fix-Search-Update-icon-styles.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Search): Update `clear` and `search` icon styles

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -538,9 +538,9 @@ const PasswordButtonContainer = styled.span<{
 function getClearablePosition(props) {
   if (props.iconPosition === 'right' && props.icon) {
     if (props.inputSize === 'large') {
-      return '88px';
+      return props.theme.spaceScale.spacing13;
     }
-    return props.theme.spaceScale.spacing12;
+    return '72px';
   }
   if (props.inputSize === 'large') {
     return props.theme.spaceScale.spacing10;
@@ -564,7 +564,7 @@ const IsClearableContainer = styled.span<{
     ${props =>
       props.inputSize === InputSize.large
         ? props.theme.spaceScale.spacing03
-        : '7px'}
+        : '6px'}
   );
 `;
 

--- a/packages/react-magma-dom/src/components/Search/Search.stories.tsx
+++ b/packages/react-magma-dom/src/components/Search/Search.stories.tsx
@@ -20,35 +20,6 @@ const Template: Story<SearchProps> = args => (
   </Card>
 );
 
-const ClearableTemplate: Story<SearchProps> = args => (
-  <Card isInverse={args.isInverse}>
-    <CardBody>
-      <Search
-        {...args}
-        onSearch={term => {
-          alert(term);
-        }}
-        isClearable
-      />
-    </CardBody>
-  </Card>
-);
-
-const LargeTemplate: Story<SearchProps> = args => (
-  <Card isInverse={args.isInverse}>
-    <CardBody>
-      <Search
-        {...args}
-        onSearch={term => {
-          alert(term);
-        }}
-        isClearable
-        inputSize={InputSize.large}
-      />
-    </CardBody>
-  </Card>
-);
-
 export default {
   title: 'Search',
   component: Search,
@@ -87,16 +58,6 @@ export default {
 } as Meta;
 
 export const Default = Template.bind({});
-Default.args = {
-  placeholder: 'Search',
-};
-
-export const Clearable = ClearableTemplate.bind({});
-Default.args = {
-  placeholder: 'Search',
-};
-
-export const Large = LargeTemplate.bind({});
 Default.args = {
   placeholder: 'Search',
 };

--- a/packages/react-magma-dom/src/components/Search/Search.stories.tsx
+++ b/packages/react-magma-dom/src/components/Search/Search.stories.tsx
@@ -20,6 +20,35 @@ const Template: Story<SearchProps> = args => (
   </Card>
 );
 
+const ClearableTemplate: Story<SearchProps> = args => (
+  <Card isInverse={args.isInverse}>
+    <CardBody>
+      <Search
+        {...args}
+        onSearch={term => {
+          alert(term);
+        }}
+        isClearable
+      />
+    </CardBody>
+  </Card>
+);
+
+const LargeTemplate: Story<SearchProps> = args => (
+  <Card isInverse={args.isInverse}>
+    <CardBody>
+      <Search
+        {...args}
+        onSearch={term => {
+          alert(term);
+        }}
+        isClearable
+        inputSize={InputSize.large}
+      />
+    </CardBody>
+  </Card>
+);
+
 export default {
   title: 'Search',
   component: Search,
@@ -58,6 +87,16 @@ export default {
 } as Meta;
 
 export const Default = Template.bind({});
+Default.args = {
+  placeholder: 'Search',
+};
+
+export const Clearable = ClearableTemplate.bind({});
+Default.args = {
+  placeholder: 'Search',
+};
+
+export const Large = LargeTemplate.bind({});
 Default.args = {
   placeholder: 'Search',
 };


### PR DESCRIPTION
Closes: #1575 

## What I did
- Updated `clear` button styles for `Search` component 
- Add some examples in Storybook

## Screenshots
Storybook
![Screenshot from 2025-03-21 15-22-09](https://github.com/user-attachments/assets/234220bb-ba32-45db-917a-0c1c1bb10a00)
![Screenshot from 2025-03-21 15-20-58](https://github.com/user-attachments/assets/2c28e4c1-d77e-45a3-bb5c-60f8cbec52d6)
![Screenshot from 2025-03-21 15-20-50](https://github.com/user-attachments/assets/c4f10f76-ddd4-46c4-9aea-94d91ac69959)


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Open Storybook
- Go to Search -> Clearable -> type some text in input -> the focus border of `clear` button shouldn't be on the `search icon`
- Go to Search -> Large -> type some text in input -> the focus border of `clear` button shouldn't be on the `search icon`
