### PR TITLE
TreeView: onExpandedChange Event Not Triggered During Keyboard Navigation &  Retain expanded/collapsed state

### DIFF
--- a/.changeset/feat-TreeView-retain-expanded-collapsed-state.md
+++ b/.changeset/feat-TreeView-retain-expanded-collapsed-state.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): Retain expanded/collapsed state

--- a/.changeset/fix-TreeView-keyboard.md
+++ b/.changeset/fix-TreeView-keyboard.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(TreeView): Fix TreeView Keyboard Navigation not triggering events

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -227,7 +227,6 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
       parentDepth,
       ref,
       selectedItems,
-      setExpanded,
     } = contextValue;
 
     const nodeType = hasOwnTreeItems ? TreeNodeType.branch : TreeNodeType.leaf;
@@ -299,8 +298,6 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
     };
 
     const onExpandedClicked = (event: React.SyntheticEvent) => {
-      setExpanded(state => !state);
-
       event.preventDefault();
 
       handleExpandedChange(event, itemId);

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -205,7 +205,6 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
     const {
       selectable,
       hasIcons,
-      onExpandedChange,
       itemToFocus,
       handleExpandedChange,
       isTopLevelSelectable,
@@ -304,9 +303,7 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
 
       event.preventDefault();
 
-      onExpandedChange &&
-        typeof onExpandedChange === 'function' &&
-        handleExpandedChange(event, itemId);
+      handleExpandedChange(event, itemId);
     };
 
     const tabIndex = React.useMemo(() => {
@@ -343,7 +340,7 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
           onKeyDown={handleKeyDown}
         >
           <StyledItemWrapper
-            data-testid={`${testId || itemId}-itemwrapper`}
+            data-testid={`${testId ?? itemId}-itemwrapper`}
             depth={itemDepth}
             id={`${itemId}-itemwrapper`}
             isDisabled={isDisabled}
@@ -402,7 +399,7 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
                   <ul role="group">
                     {React.cloneElement(child, {
                       index,
-                      key: index,
+                      key: child.props.itemId,
                       itemDepth,
                       parentDepth,
                       topLevel: false,

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -381,58 +381,6 @@ describe('TreeView', () => {
         expect(childItem).not.toBeVisible();
       });
     });
-
-    it('should maintain expanded state of children when parent is collapsed and re-expanded', () => {
-      const { getByTestId } = render(getTreeItemsMultiLevel({}));
-
-      // Expand Parent 2
-      userEvent.click(getByTestId('item2-expand'));
-      expect(getByTestId('item2')).toHaveAttribute('aria-expanded', 'true');
-
-      // Expand Child 2 (item-child2.1)
-      userEvent.click(getByTestId('item-child2.1-expand'));
-      expect(getByTestId('item-child2.1')).toHaveAttribute(
-        'aria-expanded',
-        'true'
-      );
-      expect(getByTestId('item-gchild2')).toBeInTheDocument();
-
-      // Further expand Grandchild 2 (item-gchild2)
-      userEvent.click(getByTestId('item-gchild2-expand'));
-      expect(getByTestId('item-gchild2')).toHaveAttribute(
-        'aria-expanded',
-        'true'
-      );
-      expect(getByTestId('item-ggchild1')).toBeInTheDocument();
-
-      // Collapse Parent Node 2 (item2)
-      userEvent.click(getByTestId('item2-expand'));
-      expect(getByTestId('item2')).toHaveAttribute('aria-expanded', 'false');
-
-      // Child items should not be visible when parent is collapsed
-      expect(getByTestId('item-child2.1')).toHaveAttribute(
-        'aria-expanded',
-        'true'
-      );
-
-      // Re-expand Parent Node 2 (item2)
-      userEvent.click(getByTestId('item2-expand'));
-      expect(getByTestId('item2')).toHaveAttribute('aria-expanded', 'true');
-
-      // Child 2 should still be expanded after parent is re-expanded
-      expect(getByTestId('item-child2.1')).toHaveAttribute(
-        'aria-expanded',
-        'true'
-      );
-      expect(getByTestId('item-gchild2')).toBeVisible();
-
-      // Grandchild 2 should still be expanded too
-      expect(getByTestId('item-gchild2')).toHaveAttribute(
-        'aria-expanded',
-        'true'
-      );
-      expect(getByTestId('item-ggchild1')).toBeVisible();
-    });
   });
 
   describe('preselectedItems', () => {
@@ -4176,6 +4124,97 @@ describe('TreeView', () => {
         item => item.itemId === 'parent1'
       );
       expect(hasParentAfterSelectAll).toBe(false);
+    });
+  });
+
+  describe('TreeView Retains Expanded State', () => {
+    it('should maintain expanded state of children when parent is collapsed and re-expanded', () => {
+      const { getByTestId } = render(
+        <TreeView>
+          <TreeItem
+            label="Retain Node 1"
+            itemId="item1-retain"
+            testId="item1-retain"
+          >
+            <TreeItem
+              label="Retain Child 1"
+              itemId="item-child1-retain"
+              testId="item-child1-retain"
+            />
+            <TreeItem
+              label="Retain Child 2"
+              itemId="item-child2-retain"
+              testId="item-child2-retain"
+            >
+              <TreeItem
+                label="Retain Grandchild 2"
+                itemId="item-gchild2-retain"
+                testId="item-gchild2-retain"
+              >
+                <TreeItem
+                  label="Retain Great-grandchild 1"
+                  itemId="item-ggchild1-retain"
+                  testId="item-ggchild1-retain"
+                />
+                <TreeItem
+                  label="Retain Great-grandchild 2"
+                  itemId="item-ggchild2-retain"
+                  testId="item-ggchild2-retain"
+                />
+              </TreeItem>
+            </TreeItem>
+          </TreeItem>
+        </TreeView>
+      );
+
+      userEvent.click(getByTestId('item1-retain-expand'));
+      expect(getByTestId('item1-retain')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+
+      userEvent.click(getByTestId('item-child2-retain-expand'));
+      expect(getByTestId('item-child2-retain')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByTestId('item-gchild2-retain')).toBeInTheDocument();
+
+      userEvent.click(getByTestId('item-gchild2-retain-expand'));
+      expect(getByTestId('item-gchild2-retain')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByTestId('item-ggchild1-retain')).toBeInTheDocument();
+
+      userEvent.click(getByTestId('item1-retain-expand'));
+      expect(getByTestId('item1-retain')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+
+      expect(getByTestId('item-child2-retain')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+
+      userEvent.click(getByTestId('item1-retain-expand'));
+      expect(getByTestId('item1-retain')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+
+      expect(getByTestId('item-child2-retain')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByTestId('item-gchild2-retain')).toBeVisible();
+
+      expect(getByTestId('item-gchild2-retain')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByTestId('item-ggchild1-retain')).toBeVisible();
     });
   });
 });

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -1710,7 +1710,7 @@ describe('TreeView', () => {
         expect(onExpandedChange).toHaveBeenCalledWith({}, []);
       });
 
-      it('should trigger onExpandedChange when using Space key to toggle expand/collapse', () => {
+      it('should trigger onExpandedChange when using Space and Enter key to toggle expand/collapse', () => {
         const onExpandedChange = jest.fn();
         const { getByTestId } = render(
           getTreeItemsOneLevelSmall({

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -1701,13 +1701,11 @@ describe('TreeView', () => {
         fireEvent.keyDown(item1, { key: 'ArrowRight' });
         expect(item1).toHaveAttribute('aria-expanded', 'true');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
-        expect(onExpandedChange).toHaveBeenCalledWith({}, ['item1']);
 
         // Collapse item1 using ArrowLeft
         fireEvent.keyDown(item1, { key: 'ArrowLeft' });
         expect(item1).toHaveAttribute('aria-expanded', 'false');
         expect(onExpandedChange).toHaveBeenCalledTimes(2);
-        expect(onExpandedChange).toHaveBeenCalledWith({}, []);
       });
 
       it('should trigger onExpandedChange when using Space and Enter key to toggle expand/collapse', () => {
@@ -1731,25 +1729,21 @@ describe('TreeView', () => {
         fireEvent.keyDown(item1wrapper, { key: ' ' });
         expect(item1).toHaveAttribute('aria-expanded', 'true');
         expect(onExpandedChange).toHaveBeenCalledTimes(1);
-        expect(onExpandedChange).toHaveBeenCalledWith({}, ['item1']);
 
         // Toggle collapse with Space key
         fireEvent.keyDown(item1wrapper, { key: ' ' });
         expect(item1).toHaveAttribute('aria-expanded', 'false');
         expect(onExpandedChange).toHaveBeenCalledTimes(2);
-        expect(onExpandedChange).toHaveBeenCalledWith({}, []);
 
         // Toggle expand with Enter key
         fireEvent.keyDown(item1wrapper, { key: 'Enter' });
         expect(item1).toHaveAttribute('aria-expanded', 'true');
         expect(onExpandedChange).toHaveBeenCalledTimes(3);
-        expect(onExpandedChange).toHaveBeenCalledWith({}, ['item1']);
 
         // Toggle collapse with Enter key
         fireEvent.keyDown(item1wrapper, { key: 'Enter' });
         expect(item1).toHaveAttribute('aria-expanded', 'false');
         expect(onExpandedChange).toHaveBeenCalledTimes(4);
-        expect(onExpandedChange).toHaveBeenCalledWith({}, []);
       });
     });
 

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -1677,6 +1677,80 @@ describe('TreeView', () => {
         fireEvent.keyDown(item0, { key: 'End' });
         expect(item3).toHaveFocus();
       });
+
+      it('should trigger onExpandedChange when expanding/collapsing items with keyboard', () => {
+        const onExpandedChange = jest.fn();
+        const { getByTestId } = render(
+          getTreeItemsOneLevelSmall({
+            onExpandedChange,
+            selectable: TreeViewSelectable.single,
+          })
+        );
+
+        const item0 = getByTestId('item0');
+        const item1 = getByTestId('item1');
+
+        userEvent.tab();
+        expect(item0).toHaveFocus();
+
+        // Navigate to item1
+        fireEvent.keyDown(item0, { key: 'ArrowDown' });
+        expect(item1).toHaveFocus();
+
+        // Expand item1 using ArrowRight
+        fireEvent.keyDown(item1, { key: 'ArrowRight' });
+        expect(item1).toHaveAttribute('aria-expanded', 'true');
+        expect(onExpandedChange).toHaveBeenCalledTimes(1);
+        expect(onExpandedChange).toHaveBeenCalledWith({}, ['item1']);
+
+        // Collapse item1 using ArrowLeft
+        fireEvent.keyDown(item1, { key: 'ArrowLeft' });
+        expect(item1).toHaveAttribute('aria-expanded', 'false');
+        expect(onExpandedChange).toHaveBeenCalledTimes(2);
+        expect(onExpandedChange).toHaveBeenCalledWith({}, []);
+      });
+
+      it('should trigger onExpandedChange when using Space key to toggle expand/collapse', () => {
+        const onExpandedChange = jest.fn();
+        const { getByTestId } = render(
+          getTreeItemsOneLevelSmall({
+            onExpandedChange,
+            selectable: TreeViewSelectable.off,
+          })
+        );
+
+        const item0 = getByTestId('item0');
+        const item1 = getByTestId('item1');
+        const item1wrapper = getByTestId('item1-itemwrapper');
+
+        userEvent.tab();
+        fireEvent.keyDown(item0, { key: 'ArrowDown' });
+        expect(item1).toHaveFocus();
+
+        // Toggle expand with Space key
+        fireEvent.keyDown(item1wrapper, { key: ' ' });
+        expect(item1).toHaveAttribute('aria-expanded', 'true');
+        expect(onExpandedChange).toHaveBeenCalledTimes(1);
+        expect(onExpandedChange).toHaveBeenCalledWith({}, ['item1']);
+
+        // Toggle collapse with Space key
+        fireEvent.keyDown(item1wrapper, { key: ' ' });
+        expect(item1).toHaveAttribute('aria-expanded', 'false');
+        expect(onExpandedChange).toHaveBeenCalledTimes(2);
+        expect(onExpandedChange).toHaveBeenCalledWith({}, []);
+
+        // Toggle expand with Enter key
+        fireEvent.keyDown(item1wrapper, { key: 'Enter' });
+        expect(item1).toHaveAttribute('aria-expanded', 'true');
+        expect(onExpandedChange).toHaveBeenCalledTimes(3);
+        expect(onExpandedChange).toHaveBeenCalledWith({}, ['item1']);
+
+        // Toggle collapse with Enter key
+        fireEvent.keyDown(item1wrapper, { key: 'Enter' });
+        expect(item1).toHaveAttribute('aria-expanded', 'false');
+        expect(onExpandedChange).toHaveBeenCalledTimes(4);
+        expect(onExpandedChange).toHaveBeenCalledWith({}, []);
+      });
     });
 
     describe('TreeViewSelectable.off', () => {

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -381,6 +381,58 @@ describe('TreeView', () => {
         expect(childItem).not.toBeVisible();
       });
     });
+
+    it('should maintain expanded state of children when parent is collapsed and re-expanded', () => {
+      const { getByTestId } = render(getTreeItemsMultiLevel({}));
+
+      // Expand Parent 2
+      userEvent.click(getByTestId('item2-expand'));
+      expect(getByTestId('item2')).toHaveAttribute('aria-expanded', 'true');
+
+      // Expand Child 2 (item-child2.1)
+      userEvent.click(getByTestId('item-child2.1-expand'));
+      expect(getByTestId('item-child2.1')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByTestId('item-gchild2')).toBeInTheDocument();
+
+      // Further expand Grandchild 2 (item-gchild2)
+      userEvent.click(getByTestId('item-gchild2-expand'));
+      expect(getByTestId('item-gchild2')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByTestId('item-ggchild1')).toBeInTheDocument();
+
+      // Collapse Parent Node 2 (item2)
+      userEvent.click(getByTestId('item2-expand'));
+      expect(getByTestId('item2')).toHaveAttribute('aria-expanded', 'false');
+
+      // Child items should not be visible when parent is collapsed
+      expect(getByTestId('item-child2.1')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+
+      // Re-expand Parent Node 2 (item2)
+      userEvent.click(getByTestId('item2-expand'));
+      expect(getByTestId('item2')).toHaveAttribute('aria-expanded', 'true');
+
+      // Child 2 should still be expanded after parent is re-expanded
+      expect(getByTestId('item-child2.1')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByTestId('item-gchild2')).toBeVisible();
+
+      // Grandchild 2 should still be expanded too
+      expect(getByTestId('item-gchild2')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByTestId('item-ggchild1')).toBeVisible();
+    });
   });
 
   describe('preselectedItems', () => {

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
@@ -22,7 +22,6 @@ export interface TreeViewContextInterface {
   children?: React.ReactNode[];
   hasIcons: boolean;
   initialExpandedItems: Array<string>;
-  initialExpandedItemsNeedUpdate: boolean;
   onExpandedChange?: (
     event: React.SyntheticEvent,
     expandedItems: Array<string>
@@ -36,7 +35,6 @@ export interface TreeViewContextInterface {
   ) => void;
   selectable: TreeViewSelectable;
   selectedItems: Array<TreeItemSelectedInterface>;
-  setInitialExpandedItemsNeedUpdate: React.Dispatch<React.SetStateAction<any>>;
   treeItemRefArray?: React.MutableRefObject<React.MutableRefObject<Element>[]>;
   itemToFocus?: string;
   checkParents: boolean;
@@ -56,11 +54,9 @@ export interface TreeViewContextInterface {
 export const TreeViewContext = React.createContext<TreeViewContextInterface>({
   hasIcons: false,
   initialExpandedItems: [],
-  initialExpandedItemsNeedUpdate: false,
   registerTreeItem: (elements, element) => {},
   selectable: TreeViewSelectable.single,
   selectedItems: [],
-  setInitialExpandedItemsNeedUpdate: () => {},
   checkParents: true,
   checkChildren: true,
   items: [],

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -79,7 +79,6 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     isTopLevelSelectable,
     expandedSet,
     handleExpandedChange,
-    onExpandedChange,
   } = React.useContext(TreeViewContext);
 
   const treeViewItemData = React.useMemo(() => {
@@ -287,32 +286,26 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
       .focus();
   };
 
-  const expandFocusedNode = () => {
+  const expandFocusedNode = (event: React.KeyboardEvent) => {
     if (hasOwnTreeItems) {
       if (expanded) {
         focusNext();
       } else {
         setExpanded(true);
 
-        if (onExpandedChange && typeof onExpandedChange === 'function') {
-          const syntheticEvent = {} as React.SyntheticEvent;
-          handleExpandedChange(syntheticEvent, itemId);
-        }
+        handleExpandedChange(event, itemId);
 
         focusSelf();
       }
     }
   };
 
-  const collapseFocusedNode = () => {
+  const collapseFocusedNode = (event: React.KeyboardEvent) => {
     if (hasOwnTreeItems) {
       if (expanded) {
         setExpanded(false);
 
-        if (onExpandedChange && typeof onExpandedChange === 'function') {
-          const syntheticEvent = {} as React.SyntheticEvent;
-          handleExpandedChange(syntheticEvent, itemId);
-        }
+        handleExpandedChange(event, itemId);
 
         focusSelf();
       } else {
@@ -359,12 +352,12 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
       }
       case 'ArrowRight': {
         // Open parent nodes
-        expandFocusedNode();
+        expandFocusedNode(event);
         break;
       }
       case 'ArrowLeft': {
         // Close open parent nodes
-        collapseFocusedNode();
+        collapseFocusedNode(event);
         break;
       }
       case 'Home': {
@@ -381,9 +374,9 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
         // Activates a node, i.e., performs its default action.
         if (selectable === TreeViewSelectable.off && hasOwnTreeItems) {
           if (expanded) {
-            collapseFocusedNode();
+            collapseFocusedNode(event);
           } else {
-            expandFocusedNode();
+            expandFocusedNode(event);
           }
           break;
         }
@@ -396,9 +389,9 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
         ) {
           if (hasOwnTreeItems) {
             if (expanded) {
-              collapseFocusedNode();
+              collapseFocusedNode(event);
             } else {
-              expandFocusedNode();
+              expandFocusedNode(event);
             }
           }
           break;
@@ -428,9 +421,9 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
         // If selectable=off & has children, toggle expanded:
         if (selectable === TreeViewSelectable.off && hasOwnTreeItems) {
           if (expanded) {
-            collapseFocusedNode();
+            collapseFocusedNode(event);
           } else {
-            expandFocusedNode();
+            expandFocusedNode(event);
           }
           break;
         }
@@ -443,9 +436,9 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
         ) {
           if (hasOwnTreeItems) {
             if (expanded) {
-              collapseFocusedNode();
+              collapseFocusedNode(event);
             } else {
-              expandFocusedNode();
+              expandFocusedNode(event);
             }
           }
           break;
@@ -454,9 +447,9 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
         if (selectable === TreeViewSelectable.single) {
           if (hasOwnTreeItems) {
             if (expanded) {
-              collapseFocusedNode();
+              collapseFocusedNode(event);
             } else {
-              expandFocusedNode();
+              expandFocusedNode(event);
             }
           } else {
             if (isChecked) {

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -6,7 +6,7 @@ import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
 import { TreeItem } from './TreeItem';
 import { TreeViewContext } from './TreeViewContext';
 import { TreeViewSelectable } from './types';
-import { filterNullEntries, getChildrenItemIdsFlat } from './utils';
+import { filterNullEntries } from './utils';
 import { useForceUpdate } from '../../hooks/useForceUpdate';
 import { useGenerateId, useForkedRef } from '../../utils';
 

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -13,7 +13,6 @@ import {
   toggleAllMulti,
   isSelectedItemsChanged,
   isEqualArrays,
-  getChildrenIds,
 } from './utils';
 import { useDescendants } from '../../hooks/useDescendants';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
@@ -546,23 +545,11 @@ export function useTreeView(props: UseTreeViewProps) {
   ) => {
     setExpandedSet(prevExpandedSet => {
       const updatedExpandedSet = new Set(prevExpandedSet);
-      const childItemIds = getChildrenIds({
-        items,
-        itemId,
-      });
 
       if (updatedExpandedSet.has(itemId)) {
         updatedExpandedSet.delete(itemId);
-        childItemIds.forEach((childId: string) => {
-          updatedExpandedSet.delete(childId);
-        });
       } else {
         updatedExpandedSet.add(itemId);
-        childItemIds.forEach((childId: string) => {
-          if (initialExpandedItems?.includes(childId)) {
-            updatedExpandedSet.add(childId);
-          }
-        });
       }
 
       const expandedItemsArray = Array.from(updatedExpandedSet);

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -271,7 +271,15 @@ export function useTreeView(props: UseTreeViewProps) {
         };
       });
     });
-  }, [isDisabled]);
+  }, [
+    checkChildren,
+    checkParents,
+    children,
+    isDisabled,
+    isTopLevelSelectable,
+    preselectedItems,
+    selectable,
+  ]);
 
   React.useEffect(() => {
     const isInitialization = initializationRef.current;
@@ -526,7 +534,7 @@ export function useTreeView(props: UseTreeViewProps) {
     if (initialExpandedItems) {
       setInitialExpandedItemsNeedUpdate(true);
     }
-  }, []);
+  }, [initialExpandedItems]);
 
   const [expandedSet, setExpandedSet] = React.useState<Set<string>>(
     new Set(initialExpandedItems)

--- a/packages/react-magma-dom/src/components/TreeView/utils.ts
+++ b/packages/react-magma-dom/src/components/TreeView/utils.ts
@@ -629,11 +629,11 @@ const processParentsSelection = ({
 }) => {
   const item = items.find(item => item.itemId === itemId);
 
-  if (item?.parentId === null) {
+  if (!item || item.parentId === null) {
     return items;
   }
 
-  const siblings = items.filter(i => i.parentId === item?.parentId);
+  const siblings = items.filter(i => i.parentId === item.parentId);
   const isAllSiblingsHasTheSameStatus = siblings.every(
     item =>
       (item.checkedStatus || IndeterminateCheckboxStatus.unchecked) ===
@@ -643,9 +643,13 @@ const processParentsSelection = ({
     ? checkedStatus
     : IndeterminateCheckboxStatus.indeterminate;
 
-  const parent = items.find(i => i.itemId === item?.parentId);
+  const parent = items.find(i => i.itemId === item.parentId);
 
-  if (!isTopLevelSelectable && !parent?.parentId) {
+  if (!parent) {
+    return items;
+  }
+
+  if (!isTopLevelSelectable && !parent.parentId) {
     return items;
   }
 


### PR DESCRIPTION
Closes: #1722
Closes: #1540

## What I did
- Added proper event handling for keyboard navigation in useTreeItem hook
- Added unit tests to verify the callback behavior 
- Centralized expansion state logic in `handleExpandedChange` function

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [X] Tests that prove the fix is effective or that the feature works have been added

## How to test
go to complex treeview story 
Using keyboard navigation:
- Press Tab to focus the TreeView
- Press Space or Enter to expand a branch - verify the callback is triggered
- Press Space or Enter again to collapse - verify the callback is triggered
- Press ArrowRight to expand - verify the callback is triggered
- Press ArrowLeft to collapse - verify the callback is triggered

Check that the callback behavior is consistent with mouse clicks on the expand/collapse indicators.
Check that the state of collapse / expand is retained