### PR TITLE
fix(tabs): improve scroll functionality for smaller screens

### DIFF
--- a/.changeset/fix-Tabs-Improve-functionality-small-screen.md
+++ b/.changeset/fix-Tabs-Improve-functionality-small-screen.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tabs/Scroll Spy): Improve scroll functionality for smaller screens.

--- a/packages/react-magma-dom/src/components/Tabs/TabsScrollSpyContainer.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/TabsScrollSpyContainer.tsx
@@ -44,7 +44,7 @@ export const TabsScrollSpyContainer = React.forwardRef<
 
   const [isActive, setIsActive] = React.useState(0);
 
-  const [activeIndex, setActiveIndex] = React.useState();
+  const [activeIndex, setActiveIndex] = React.useState<number>();
 
   //Window scroll override
   React.useEffect(() => {
@@ -56,8 +56,10 @@ export const TabsScrollSpyContainer = React.forwardRef<
   React.useEffect(() => {
     options.map((option: any) => {
       /*
-      TODO: Get the last item in the array and set it to active when the user scrolls to the bottom of the page. This helps in cases where more than just the last section is visible, yet the conveyance of the active state should still remain the last item.
-
+       * Get the last item in the array and set it to active when the user scrolls to the bottom of the page.
+       * This helps in cases where more than just the last section is visible,
+       * yet the conveyance of the active state should still remain the last item.
+       * */
       const lastIndex = options.length - 1;
 
       window.onscroll = function (ev) {
@@ -68,7 +70,6 @@ export const TabsScrollSpyContainer = React.forwardRef<
           setActiveIndex(lastIndex);
         }
       };
-      */
 
       if (option.hash === isActive) {
         setActiveIndex(option.index);

--- a/packages/react-magma-dom/src/components/Tabs/utils.ts
+++ b/packages/react-magma-dom/src/components/Tabs/utils.ts
@@ -4,8 +4,8 @@ import { TabsOrientation } from './shared';
 import {
   animate,
   debounce,
-  getNormalizedScrollLeft,
   detectScrollType,
+  getNormalizedScrollLeft,
 } from '../../utils';
 
 export function useTabsMeta(theme, orientation, backgroundColor, isInverse) {
@@ -122,7 +122,7 @@ export function useTabsMeta(theme, orientation, backgroundColor, isInverse) {
 export const ScrollSpy = ({ handleScroll }) => {
   const isInViewPort = (entry, offset = 0) => {
     const rect = entry.boundingClientRect;
-    return rect.top <= 0 + offset && rect.bottom >= 0 + offset;
+    return rect.top <= offset && rect.bottom >= offset;
   };
 
   useLayoutEffect(() => {
@@ -141,7 +141,7 @@ export const ScrollSpy = ({ handleScroll }) => {
         {
           root: null,
           rootMargin: '0px',
-          threshold: [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+          threshold: Array.from({ length: 1000 }, (_, i) => (i + 1) * 0.001),
         }
       );
       observer.observe(scrollable);


### PR DESCRIPTION
Closes: #1562

## What I did
- Improved scrolling functionality for small screens
- Fixed selecting last tab the user scrolls to the bottom of the page

## Screenshots
[Screencast from 27.03.25 14:35:06.webm](https://github.com/user-attachments/assets/8e7242d8-a806-480b-a5f6-eaa055a2038d)
[Screencast from 27.03.25 14:30:36.webm](https://github.com/user-attachments/assets/c5d8ff0b-380b-45ea-bb82-65b6c954cca8)
[Screencast from 27.03.25 12:37:31.webm](https://github.com/user-attachments/assets/5262023c-bd26-4153-bacd-3f5a320fc035)


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Open Storybook
- Go to Tabs -> ScrollSpy/Scroll Spy Icons -> zoom to 300% -> scroll down -> the tabs on the left side should update as soon as you start scrolling into a new section.
- Compress your browser window and scroll down ->  the tabs on the left side should update as soon as you start scrolling into a new section.
