### PR TITLE
chore: Update preview workflow

### DIFF
--- a/.changeset/chore-previewworkflow.md
+++ b/.changeset/chore-previewworkflow.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+chore: update preview workflow (removes edited and reopened)

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,7 +6,7 @@ on:
       - main
       - 'dev-patch'
       - 'patch-*'
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize]
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Closes: n/a

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Updating our preview workflow to get lets netlify previews.

`edited: The title or body of a pull request was edited, or the base branch of a pull request was changed.`
-- any time a PR description, title or even labels got added our preview workflow got triggered
`reopened: A previously closed pull request was reopened.`
-- we don't really reopen PRs

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [X] changeset has been added
- [X] Pull request is assigned, labels have been added and ticket is linked
- [X] Pull request description is descriptive and testing steps are listed
- [-] Corresponding changes to the documentation have been made
- [-] New and existing unit tests pass locally with the proposed changes
- [-] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Next time a PR is opened, we should see if previews still get triggered a lot
