### PR TITLE
fix(Character Counter): Fixed screenreader properly conveying the remainder in a character counter on user input.

### DIFF
--- a/.changeset/fix-character-counter-accessibility.md
+++ b/.changeset/fix-character-counter-accessibility.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(CharacterCounter): Fixed screenreader properly conveying the remainder in a character counter on user input.

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import { I18nContext } from '../../i18n';
 import { magma } from '../../theme/magma';
+import { HiddenLabelText } from '../Checkbox';
 import { InputMessage } from '../Input/InputMessage';
 
 export interface CharacterCounterProps
@@ -97,6 +98,13 @@ export const CharacterCounter = React.forwardRef<
     return 'off';
   }
 
+  function getAriaLiveScreenReaderState() {
+    if (getPercentage > 100) {
+      return 'assertive';
+    }
+    return 'polite';
+  }
+
   // As the user types, this calculates the remaining characters set by maxCount which counts down to zero then counts up if over the limit.
   const characterLimit =
     maxCharacters > inputLength
@@ -139,6 +147,7 @@ export const CharacterCounter = React.forwardRef<
     <div data-testid={testId} id={id} ref={ref} {...rest}>
       <StyledInputMessage
         aria-live={getAriaLiveState()}
+        aria-hidden="true"
         hasCharacterCounter={hasCharacterCounter}
         hasError={isOverMaxCount}
         isInverse={isInverse}
@@ -148,6 +157,11 @@ export const CharacterCounter = React.forwardRef<
       >
         {characterTitle()}
       </StyledInputMessage>
+      {onkeydown && (
+        <HiddenLabelText id={id} aria-live={getAriaLiveScreenReaderState()}>
+          {characterTitle()}
+        </HiddenLabelText>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
Closes: #1682 

## What I did
- Added ability for screenreaders to give proper feedback to the remaining characters as the user types.

## Screenshots
https://github.com/user-attachments/assets/038ed3fb-9a9a-4c85-a10d-9ba5916f90a7

## Checklist 
- [X] changeset has been added
- [X] Pull request is assigned, labels have been added and ticket is linked
- [X] Pull request description is descriptive and testing steps are listed
- [N/A] Corresponding changes to the documentation have been made
- [X] New and existing unit tests pass locally with the proposed changes
- [N/A] Tests that prove the fix is effective or that the feature works have been added

## How to test
- With your favorite screenreader open, go to Storybook
- Character Counter > Start typing
- Verify the screenreader dictates the proper remaining count as you type
- Rejoice 
