### PR TITLE
fix(Drawer): Props not visible on docs site

### DIFF
--- a/.changeset/fix-Drawer-props-not-visible.md
+++ b/.changeset/fix-Drawer-props-not-visible.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Drawer): Fix visibility of Modal props in docs.

--- a/website/react-magma-docs/src/pages/api/drawer.mdx
+++ b/website/react-magma-docs/src/pages/api/drawer.mdx
@@ -3,6 +3,7 @@ pageTitle: Drawer API
 title: Drawer
 props:
   - DrawerProps
+  - ModalProps
 ---
 
 <PageContent componentName="drawer" type="api">
@@ -203,5 +204,6 @@ export function Example() {
 **Any other props supplied will be provided to the wrapping `div` element.**
 
 <DrawerProps />
+<ModalProps />
 
 </PageContent>


### PR DESCRIPTION
Closes: #1564 

## What I did
Updated docs for the `Drawer` component. Added visibility of ModalProps.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Open React Magma Docs
- Go to Components -> Drawer -> Drawer Props
- You should see DrawerProps and ModalProps included as well.. 
