### PR TITLE
feat(Treeview): Support additionalContent prop.

### DIFF
--- a/.changeset/feat-TreeView-support-additionlContent-prop.md
+++ b/.changeset/feat-TreeView-support-additionlContent-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): Add additionalContent prop.

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
@@ -4,7 +4,6 @@ import { render, getByTestId } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
 
-import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
 
 import { TreeItem, TreeView } from '.';
@@ -71,6 +70,37 @@ describe('TreeItem', () => {
 
       expect(getByTestId(`${testId}-itemwrapper`)).toHaveStyle(
         `backgroundColor: ${backgroundColor}`
+      );
+    });
+  });
+
+  describe('additional content styles', () => {
+    it('should apply default styles', () => {
+      const { getByTestId } = render(
+        <TreeItem label={labelText} testId={testId} itemId={itemId} />
+      );
+
+      expect(getByTestId(`${testId}-itemwrapper`)).toHaveStyle(
+        `flexDirection: row`
+      );
+    });
+
+    it('should apply custom styles when additional contens is provided', () => {
+      const { getByTestId, getByText } = render(
+        <TreeItem
+          additionalContent={<>Content</>}
+          label={labelText}
+          testId={testId}
+          itemId={itemId}
+        />
+      );
+
+      expect(getByText('Content')).toBeInTheDocument();
+      expect(getByTestId(`${testId}-itemwrapper`)).toHaveStyle(
+        `flexDirection: column`
+      );
+      expect(getByTestId(`${testId}-additionalcontentrapper`)).toHaveStyle(
+        `marginBottom: 16px`
       );
     });
   });

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -4,19 +4,19 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { transparentize } from 'polished';
 import {
-  FolderIcon,
   ArticleIcon,
-  ExpandMoreIcon,
   ChevronRightIcon,
+  ExpandMoreIcon,
+  FolderIcon,
 } from 'react-magma-icons';
 
 import { TreeItemContext } from './TreeItemContext';
 import { TreeViewContext } from './TreeViewContext';
 import { TreeViewSelectable } from './types';
 import {
-  UseTreeItemProps,
-  useTreeItem,
   checkedStatusToBoolean,
+  useTreeItem,
+  UseTreeItemProps,
 } from './useTreeItem';
 import { useIsInverse } from '../../inverse';
 import { ThemeInterface } from '../../theme/magma';
@@ -29,12 +29,12 @@ import {
 import { Transition } from '../Transition';
 import {
   calculateOffset,
-  TreeNodeType,
   getTreeItemLabelColor,
   getTreeItemWrapperCursor,
+  TreeNodeType,
 } from './utils';
 
-export type TreeItemProps = UseTreeItemProps;
+export interface TreeItemProps extends UseTreeItemProps {}
 
 const StyledTreeItem = styled.li<{
   theme?: ThemeInterface;
@@ -107,7 +107,6 @@ const StyledTreeItem = styled.li<{
           inset-inline-start: 0;
         }
       `}
-
     &:hover {
       background: ${props =>
         !props.isDisabled
@@ -127,7 +126,8 @@ const IconWrapper = styled.span<{
   color: ${props =>
     getTreeItemLabelColor(props.isInverse, props.isDisabled, props.theme)};
   margin-right: ${props => props.theme.spaceScale.spacing03};
-  margin-left: 0px;
+  margin-left: 0;
+
   svg {
     height: ${props => props.theme.iconSizes.medium}px;
     width: ${props => props.theme.iconSizes.medium}px;
@@ -169,6 +169,7 @@ const StyledCheckboxWrapper = styled.div<{ theme?: ThemeInterface }>`
 `;
 
 const StyledItemWrapper = styled.div<{
+  additionalContent?: React.ReactNode;
   theme?: ThemeInterface;
   selectable?: TreeViewSelectable;
   nodeType: TreeNodeType;
@@ -177,6 +178,7 @@ const StyledItemWrapper = styled.div<{
   isDisabled: boolean;
 }>`
   display: flex;
+  flex-direction: ${props => (props.additionalContent ? 'column' : 'row')};
   align-items: flex-start;
   cursor: ${props =>
     getTreeItemWrapperCursor(
@@ -186,9 +188,14 @@ const StyledItemWrapper = styled.div<{
     )};
 `;
 
+const AdditionalContentWrapper = styled.div<{ theme?: ThemeInterface }>`
+  margin-bottom: ${props => props.theme.spaceScale.spacing05};
+`;
+
 export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
   (props, forwardedRef) => {
     const {
+      additionalContent,
       children,
       icon,
       index,
@@ -315,6 +322,24 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
       selectable === TreeViewSelectable.multi &&
       (isTopLevelSelectable !== false || !topLevel);
 
+    const handleAdditionalContentKeyDown = e => {
+      if (['Enter', ' '].includes(e.key)) {
+        const interactiveElement =
+          e.target instanceof HTMLElement &&
+          e.target.closest('button, [role="button"], input, select, textarea');
+
+        if (interactiveElement) {
+          e.stopPropagation();
+
+          if (e.key === ' ' && interactiveElement.tagName !== 'BUTTON') {
+            e.preventDefault();
+          }
+
+          interactiveElement.click();
+        }
+      }
+    };
+
     return (
       <TreeItemContext.Provider value={contextValue}>
         <StyledTreeItem
@@ -337,6 +362,7 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
           onKeyDown={handleKeyDown}
         >
           <StyledItemWrapper
+            additionalContent={additionalContent}
             data-testid={`${testId ?? itemId}-itemwrapper`}
             depth={itemDepth}
             id={`${itemId}-itemwrapper`}
@@ -384,7 +410,18 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
                 )}
               </StyledCheckboxWrapper>
             ) : (
-              <>{labelText}</>
+              <>
+                {labelText}
+                {additionalContent && (
+                  <AdditionalContentWrapper
+                    theme={theme}
+                    data-testid={`${testId ?? itemId}-additionalcontentrapper`}
+                    onKeyDown={handleAdditionalContentKeyDown}
+                  >
+                    {additionalContent}
+                  </AdditionalContentWrapper>
+                )}
+              </>
             )}
           </StyledItemWrapper>
 

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -3,41 +3,62 @@ import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 import {
   ArticleIcon,
-  FolderIcon,
-  FavoriteIcon,
-  StarIcon,
+  BookIcon,
+  EditIcon,
   EmergencyIcon,
+  FavoriteIcon,
+  FolderIcon,
   KeyboardArrowDownIcon,
   KeyboardArrowUpIcon,
+  LockIcon,
+  MoreHorizIcon,
+  QueuePlayNextIcon,
+  QuizIcon,
+  SpaceDashboardIcon,
+  StarIcon,
+  VerifiedIcon,
 } from 'react-magma-icons';
 
 import {
-  Tag,
-  TagSize,
+  Accordion,
+  AccordionButton,
+  AccordionItem,
+  AccordionPanel,
   Button,
+  ButtonGroup,
+  ButtonVariant,
   Flex,
   FlexBehavior,
+  IconButton,
   IndeterminateCheckboxStatus,
-  TreeItemSelectedInterface,
-  TreeViewProps,
-  ButtonVariant,
-  ButtonGroup,
   Spacer,
   SpacerAxis,
-  Accordion,
-  AccordionItem,
-  AccordionButton,
-  AccordionPanel,
-  IconButton,
+  Tag,
+  TagSize,
+  TreeItemSelectedInterface,
+  TreeViewProps,
 } from '../..';
 import { magma } from '../../theme/magma';
-import { ButtonColor, ButtonSize } from '../Button';
+import { ButtonColor, ButtonShape, ButtonSize } from '../Button';
 import { Card } from '../Card';
-import { FlexAlignContent, FlexAlignItems } from '../Flex';
+import {
+  Dropdown,
+  DropdownButton,
+  DropdownContent,
+  DropdownMenuItem,
+} from '../Dropdown';
+import {
+  FlexAlignContent,
+  FlexAlignItems,
+  FlexJustify,
+  FlexWrap,
+} from '../Flex';
+import { Hyperlink } from '../Hyperlink';
 import { Paragraph } from '../Paragraph';
 import { TagColor } from '../Tag';
+import { TypographyColor, TypographyVisualStyle } from '../Typography';
 
-import { TreeView, TreeItem, TreeViewSelectable, TreeViewApi } from '.';
+import { TreeItem, TreeView, TreeViewApi, TreeViewSelectable } from '.';
 
 export default {
   component: TreeView,
@@ -2383,4 +2404,306 @@ ComplexWithTopLevelNotSelectable.args = {
   checkChildren: true,
   isDisabled: false,
   testId: 'complex-example',
+};
+
+export const ComplexWithAdditionalContent = (args: Partial<TreeViewProps>) => {
+  const treeLabel = () => {
+    return (
+      <Flex
+        behavior={FlexBehavior.container}
+        justify={FlexJustify.spaceBetween}
+        wrap={FlexWrap.wrap}
+      >
+        <Flex behavior={FlexBehavior.item}>
+          <Hyperlink to="google.com" target="_blank" hasUnderline={false}>
+            Most common activity length is 39 chars but what if longer
+          </Hyperlink>
+        </Flex>
+        <Flex
+          behavior={FlexBehavior.item}
+          style={{ marginLeft: '40px' }}
+          justify={FlexJustify.flexEnd}
+          alignContent={FlexAlignContent.flexEnd}
+        >
+          <Flex
+            behavior={FlexBehavior.container}
+            style={{ gap: '8px' }}
+            wrap={FlexWrap.nowrap}
+          >
+            <Flex behavior={FlexBehavior.item}>
+              <Tag size={TagSize.small} icon={<LockIcon />}>
+                Hidden from Students
+              </Tag>
+            </Flex>
+            <Flex behavior={FlexBehavior.item}>
+              <Dropdown>
+                <DropdownButton
+                  aria-label="Extra icon example"
+                  color={ButtonColor.secondary}
+                  size={ButtonSize.small}
+                  icon={<MoreHorizIcon />}
+                  shape={ButtonShape.fill}
+                />
+                <DropdownContent>
+                  <DropdownMenuItem icon={<EditIcon aria-hidden />}>
+                    Rename
+                  </DropdownMenuItem>
+                </DropdownContent>
+              </Dropdown>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    );
+  };
+
+  const folderLabel = (label: any) => {
+    return (
+      <Flex
+        behavior={FlexBehavior.container}
+        justify={FlexJustify.spaceBetween}
+        wrap={FlexWrap.nowrap}
+      >
+        <Flex behavior={FlexBehavior.item}>{label}</Flex>
+        <Flex
+          behavior={FlexBehavior.item}
+          style={{ display: 'inline-flex', marginLeft: '40px' }}
+        >
+          <Paragraph
+            visualStyle={TypographyVisualStyle.bodySmall}
+            noMargins
+            color={TypographyColor.subdued}
+            style={{ marginRight: magma.spaceScale.spacing03 }}
+          />
+          <Dropdown>
+            <DropdownButton
+              aria-label="Extra icon example"
+              color={ButtonColor.secondary}
+              size={ButtonSize.small}
+              icon={<MoreHorizIcon />}
+              shape={ButtonShape.fill}
+            />
+            <DropdownContent>
+              <DropdownMenuItem icon={<EditIcon aria-hidden />}>
+                Rename
+              </DropdownMenuItem>
+            </DropdownContent>
+          </Dropdown>
+        </Flex>
+      </Flex>
+    );
+  };
+
+  const additionalContent = () => {
+    return (
+      <div style={{ width: '100%' }}>
+        <Paragraph noTopMargin visualStyle={TypographyVisualStyle.bodyXSmall}>
+          Due: xx/xx/xxx · Submitted: 12 · Missing: 3
+        </Paragraph>
+        <ButtonGroup style={{ marginBottom: '16px' }}>
+          <Dropdown>
+            <DropdownButton size={ButtonSize.small} color={ButtonColor.subtle}>
+              <div style={{ display: 'flex' }}>
+                <SpaceDashboardIcon
+                  size={16}
+                  style={{
+                    flex: '0 0 auto',
+                    marginRight: magma.spaceScale.spacing02,
+                  }}
+                />{' '}
+                <span style={{ flex: '1 1 auto' }}>10 Resources</span>
+              </div>
+            </DropdownButton>
+            <DropdownContent>
+              <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+              <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+            </DropdownContent>
+          </Dropdown>
+          <Dropdown>
+            <DropdownButton size={ButtonSize.small} color={ButtonColor.subtle}>
+              <div style={{ display: 'flex' }}>
+                <VerifiedIcon
+                  size={16}
+                  style={{
+                    flex: '0 0 auto',
+                    marginRight: magma.spaceScale.spacing02,
+                  }}
+                />{' '}
+                <span style={{ flex: '1 1 auto' }}>24 Standards</span>
+              </div>
+            </DropdownButton>
+            <DropdownContent>
+              <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+              <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+            </DropdownContent>
+          </Dropdown>
+        </ButtonGroup>
+      </div>
+    );
+  };
+
+  return (
+    <Card isInverse={args.isInverse}>
+      <TreeView
+        {...args}
+        ariaLabelledBy={'ah-textbook'}
+        selectable={TreeViewSelectable.off}
+        initialExpandedItems={['ch5water', 'sample9']}
+      >
+        <TreeItem
+          label={folderLabel(
+            <Paragraph
+              visualStyle={TypographyVisualStyle.headingSmall}
+              noMargins
+            >
+              English Edition
+            </Paragraph>
+          )}
+          itemId="english"
+        >
+          <TreeItem
+            label={folderLabel(
+              <Paragraph
+                visualStyle={TypographyVisualStyle.headingXSmall}
+                noMargins
+              >
+                Unit 1 Relationships in Ecosystems (Chapters 2-4)
+              </Paragraph>
+            )}
+            itemId="unit1"
+          >
+            <TreeItem label="Chapter 1" itemId="unit1ch1" />
+          </TreeItem>
+          <TreeItem
+            label={folderLabel(
+              <Paragraph
+                visualStyle={TypographyVisualStyle.headingXSmall}
+                noMargins
+              >
+                Unit 2 Cell Systems (Chapters 5-7)
+              </Paragraph>
+            )}
+            itemId="unit2"
+          >
+            <TreeItem
+              label={folderLabel(
+                <span style={{ fontWeight: '600' }}>
+                  Chapter 5 Molecules in Living Systems (pp. 128-163)
+                </span>
+              )}
+              itemId="ch5"
+            >
+              <TreeItem
+                label={folderLabel(
+                  <span style={{ fontWeight: '600' }}>
+                    Chapter 5 Introductory Materials
+                  </span>
+                )}
+                itemId="ch5intro"
+              >
+                <TreeItem
+                  additionalContent={additionalContent()}
+                  label={treeLabel()}
+                  itemId="sample1"
+                  icon={<BookIcon />}
+                />
+              </TreeItem>
+              <TreeItem
+                label={folderLabel(
+                  <span style={{ fontWeight: '600' }}>
+                    5.1 Elements and Compounds (pp. 130-136)
+                  </span>
+                )}
+                itemId="ch5el"
+              >
+                <TreeItem
+                  additionalContent={additionalContent()}
+                  label={treeLabel()}
+                  itemId="sample2"
+                  icon={<BookIcon />}
+                />
+              </TreeItem>
+              <TreeItem
+                additionalContent={additionalContent()}
+                label={treeLabel()}
+                itemId="sample3"
+                icon={<BookIcon />}
+              />
+              <TreeItem
+                label={folderLabel(
+                  <span style={{ fontWeight: '600' }}>
+                    5.2 Water (pp. 137-141)
+                  </span>
+                )}
+                itemId="ch5water"
+              >
+                <TreeItem
+                  additionalContent={additionalContent()}
+                  label={treeLabel()}
+                  itemId="sample6"
+                  icon={<BookIcon />}
+                />
+
+                <TreeItem
+                  additionalContent={additionalContent()}
+                  label={treeLabel()}
+                  itemId="sample7"
+                  icon={<QuizIcon />}
+                />
+
+                <TreeItem
+                  label={<>Expanded Tree Item with Button</>}
+                  itemId="sample8"
+                  icon={<QueuePlayNextIcon />}
+                >
+                  <TreeItem
+                    additionalContent={
+                      <Button
+                        style={{ marginTop: '12px' }}
+                        onClick={() => console.log('Click button!')}
+                      >
+                        Click
+                      </Button>
+                    }
+                    label={<>Button Label</>}
+                    itemId="sample9"
+                  />
+                </TreeItem>
+              </TreeItem>
+            </TreeItem>
+          </TreeItem>
+          <TreeItem
+            label={folderLabel(
+              <Paragraph
+                visualStyle={TypographyVisualStyle.headingXSmall}
+                noMargins
+              >
+                Unit 3 Interactions in Living Systems (Chapters 8-10)
+              </Paragraph>
+            )}
+            itemId="unit3"
+          >
+            <TreeItem
+              additionalContent={additionalContent()}
+              label={treeLabel()}
+              itemId="sample10"
+              icon={<BookIcon />}
+            />
+          </TreeItem>
+        </TreeItem>
+      </TreeView>
+    </Card>
+  );
+};
+
+ComplexWithAdditionalContent.args = {
+  ariaLabel: 'Textbook tree',
+  initialExpandedItems: [
+    'Unit 2 Cell Systems (Chapters 5-7)',
+    '5.2 Water (pp. 137-141)',
+  ],
+  checkParents: true,
+  checkChildren: true,
+  isDisabled: false,
+  testId: 'complex-additional-content-example',
 };

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -277,6 +277,9 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -463,6 +466,9 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -968,6 +974,9 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -1154,6 +1163,9 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -2153,6 +2165,9 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -2339,6 +2354,9 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -2959,6 +2977,9 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -3145,6 +3166,9 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -4320,6 +4344,9 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -4506,6 +4533,9 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -5051,6 +5081,9 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -5237,6 +5270,9 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -6336,6 +6372,9 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -6522,6 +6561,9 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -7067,6 +7109,9 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -7253,6 +7298,9 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -8352,6 +8400,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -8538,6 +8589,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -9158,6 +9212,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -9344,6 +9401,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -10519,6 +10579,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -10705,6 +10768,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -11325,6 +11391,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -11511,6 +11580,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -12686,6 +12758,9 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -12872,6 +12947,9 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -13417,6 +13495,9 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -13603,6 +13684,9 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -12,6 +12,10 @@ import { useGenerateId, useForkedRef } from '../../utils';
 
 export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
   /**
+   * Enables additional content within the TreeItem.
+   */
+  additionalContent?: React.ReactNode;
+  /**
    * Index number
    * private
    */

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -1397,6 +1397,120 @@ export function Example() {
 }
 ```
 
+## additionalContent
+
+The `additionalContent` prop allows the adopter to render additional custom content below the label.
+This can include any valid React node, such as text, icons, buttons, tooltips, or other components.
+
+```tsx
+import React from 'react';
+
+import {
+  Button,
+  ButtonGroup,
+  ButtonSize,
+  ButtonColor,
+  Dropdown,
+  DropdownButton,
+  DropdownContent,
+  DropdownMenuItem,
+  TreeItem,
+  TreeView,
+  TreeViewSelectable,
+} from 'react-magma-dom';
+import { FolderIcon, SpaceDashboardIcon } from 'react-magma-icons';
+
+export function Example() {
+  const parrotsAdditionalContent = () => {
+    return (
+      <div style={{ width: '100%', marginTop: '12px' }}>
+        <ButtonGroup style={{ marginBottom: '16px' }}>
+          <Dropdown>
+            <DropdownButton size={ButtonSize.small} color={ButtonColor.subtle}>
+              <div style={{ display: 'flex' }}>
+                <SpaceDashboardIcon
+                  size={16}
+                  style={{
+                    flex: '0 0 auto',
+                    marginRight: '4px',
+                  }}
+                />{' '}
+                <span style={{ flex: '1 1 auto' }}>Parrots</span>
+              </div>
+            </DropdownButton>
+            <DropdownContent>
+              <DropdownMenuItem>African Grey</DropdownMenuItem>
+              <DropdownMenuItem>Cockatiel</DropdownMenuItem>
+              <DropdownMenuItem>Budgerigar</DropdownMenuItem>
+            </DropdownContent>
+          </Dropdown>
+        </ButtonGroup>
+      </div>
+    );
+  };
+
+  const birdsOfPrey = () => {
+    return (
+      <div style={{ marginTop: '12px' }}>
+        <Button
+          style={{ marginRight: '12px' }}
+          onClick={() => console.log('Eagles')}
+        >
+          Eagles
+        </Button>
+        <Button
+          style={{ marginRight: '12px' }}
+          onClick={() => console.log('Hawks')}
+        >
+          Hawks
+        </Button>
+        <Button onClick={() => console.log('Falcons')}>Falcons</Button>
+      </div>
+    );
+  };
+
+  return (
+    <TreeView
+      selectable={TreeViewSelectable.off}
+      initialExpandedItems={['parrots-AdditionalContent', 'birdsOfPrey']}
+    >
+      <TreeItem
+        icon={<FolderIcon aria-hidden />}
+        label={<>Birds</>}
+        itemId="birds"
+      >
+        <TreeItem label={<>Parrots</>} itemId="parrots-folder">
+          <TreeItem
+            additionalContent={parrotsAdditionalContent()}
+            label={<>Additional content</>}
+            itemId="parrots-AdditionalContent"
+          />
+        </TreeItem>
+        <TreeItem label={<>Birds of Prey</>} itemId="birdsOfPrey-folder">
+          <TreeItem
+            additionalContent={birdsOfPrey()}
+            label={<>Additional content</>}
+            itemId="birdsOfPrey"
+          />
+        </TreeItem>
+      </TreeItem>
+      <TreeItem label="Aquatic Animals" itemId="selectable-Aquatic Animals">
+        <TreeItem label="Fish" itemId="selectable-Fish">
+          <TreeItem label="Goldfish" itemId="selectable-Goldfish" />
+          <TreeItem label="Betta Fish" itemId="selectable-Betta Fish" />
+          <TreeItem label="Guppies" itemId="selectable-Guppies" />
+        </TreeItem>
+        <TreeItem label="Marine Mammals" itemId="selectable-Marine Mammals">
+          <TreeItem label="Dolphins" itemId="selectable-Dolphins" />
+          <TreeItem label="Whales" itemId="selectable-Whales" />
+          <TreeItem label="Seals" itemId="selectable-Seals" />
+        </TreeItem>
+      </TreeItem>
+    </TreeView>
+  );
+}
+```
+
 ## Inverse
 
 ```tsx


### PR DESCRIPTION
Closes: #1637

## What I did
- Added the new `additionalContent` prop for `TreeItem` component
- Fixed a bug causing `TreeItemProps` not to display correctly in `React Magma Docs`.

## Screenshots
React Magma Docs

![Screenshot from 2025-04-04 12-55-12](https://github.com/user-attachments/assets/abaea53a-aff8-4835-9fe1-481a7ac87ba1)
![Screenshot from 2025-04-04 13-45-29](https://github.com/user-attachments/assets/d7ee9ea1-267c-40ea-9f04-1c300e634ddc)

Storybook

![Screenshot from 2025-04-04 15-48-44](https://github.com/user-attachments/assets/cfddd150-374c-4a2a-a712-bf0625fec4ea)


## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Go to Storybook
- Open Treeview -> Complex with Additional Content -> inside some TreeItem components should be showed content

- Go to React Magma Docs
- Open Components -> Treeview -> additionalComponent
- Take a look at the TreeItemProps section as well.
