### PR TITLE
fix(Dropdown): Displaying dropdown content under other elements.

### DIFF
--- a/.changeset/fix-Dropdown-not-displayed-above-elements.md
+++ b/.changeset/fix-Dropdown-not-displayed-above-elements.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Make to display Dropdown content above other elements.

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1395,7 +1395,8 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
         </button>
       </div>
       <div
-        style="position: absolute; left: 0px; top: 0px; z-index: 2; transform: translate(0px, 0px);"
+        data-testid="dropdownContentWrapper"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996; transform: translate(0px, 0px);"
       >
         <div
           class="emotion-15 emotion-16 emotion-17"
@@ -1458,7 +1459,8 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
         </button>
       </div>
       <div
-        style="position: absolute; left: 0px; top: 0px; z-index: 2; transform: translate(0px, 0px);"
+        data-testid="dropdownContentWrapper"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996; transform: translate(0px, 0px);"
       >
         <div
           class="emotion-15 emotion-16 emotion-17"
@@ -2146,7 +2148,8 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
         </button>
       </div>
       <div
-        style="position: absolute; left: 0px; top: 0px; z-index: 2; transform: translate(0px, 0px);"
+        data-testid="dropdownContentWrapper"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996; transform: translate(0px, 0px);"
       >
         <div
           class="emotion-15 emotion-16 emotion-17"
@@ -2209,7 +2212,8 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
         </button>
       </div>
       <div
-        style="position: absolute; left: 0px; top: 0px; z-index: 2; transform: translate(0px, 0px);"
+        data-testid="dropdownContentWrapper"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996; transform: translate(0px, 0px);"
       >
         <div
           class="emotion-15 emotion-16 emotion-17"
@@ -2975,7 +2979,8 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
         </button>
       </div>
       <div
-        style="position: absolute; left: 0px; top: 0px; z-index: 2; transform: translate(0px, 0px);"
+        data-testid="dropdownContentWrapper"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996; transform: translate(0px, 0px);"
       >
         <div
           class="emotion-15 emotion-16 emotion-17"
@@ -3038,7 +3043,8 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
         </button>
       </div>
       <div
-        style="position: absolute; left: 0px; top: 0px; z-index: 2; transform: translate(0px, 0px);"
+        data-testid="dropdownContentWrapper"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996; transform: translate(0px, 0px);"
       >
         <div
           class="emotion-15 emotion-16 emotion-17"

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -49,6 +49,11 @@ describe('Dropdown', () => {
     expect(getByTestId(testId)).toBeInTheDocument();
     expect(getByTestId('dropdownContent')).toBeInTheDocument();
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+
+    expect(getByTestId('dropdownContentWrapper')).toBeInTheDocument();
+    expect(getByTestId('dropdownContentWrapper')).toHaveStyle({
+      zIndex: '996',
+    });
   });
 
   it('should render a custom wrapped dropdown item', () => {

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -91,9 +91,11 @@ export const DropdownContent = React.forwardRef<
 
   return (
     <div
+      data-testid={'dropdownContentWrapper'}
       ref={context.setFloating}
-      // z-index 2 is used to make the content appear above docs elements (code blocks)
-      style={{ ...context.floatingStyles, zIndex: '2' }}
+      // z-index 996 is used to make the content appear above docs elements (code blocks)
+      // and below the Modal component (z-index 997)
+      style={{ ...context.floatingStyles, zIndex: '996' }}
     >
       <StyledCard
         {...other}


### PR DESCRIPTION
Closes: #1737

## What I did
- Updated the z-index value for `DropdownContent` to ensure it is displayed above all other elements.
- Added test and updated snapshot.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
- To verify it, you need to add some content for Dropdown into storybook.
- Go to storybook -> Dropdown -> get your updated example ->  DropdownContent should be displayed above all suggested components.
