### PR TITLE
chore(docs): update landing page

### DIFF
--- a/.changeset/update-ladning-page.md
+++ b/.changeset/update-ladning-page.md
@@ -1,0 +1,7 @@
+---
+'react-magma-landing': patch
+---
+
+Updated landing page:
+- Added proxy redirect for version 2.6.0 to serve content from https://soft-elf-84cb2b.netlify.app/
+- Modified build script to only support specified legacy versions [2.6.0, 3.10.0, 3.11.0] and all v4.x versions

--- a/website/react-magma-landing/scripts/build.js
+++ b/website/react-magma-landing/scripts/build.js
@@ -1,18 +1,25 @@
 const axios = require('axios');
-const semver = require('semver');
 const copy = require('copy');
 const ejs = require('ejs');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
+const path = require('path');
+const semver = require('semver');
 
 const english = new Intl.DateTimeFormat('en');
-const path = require('path');
+
+const SUPPORTED_LEGACY_VERSIONS = ['2.6.0', '3.11.0', '3.10.0'];
 
 const cleanVersions = ({ versions, time, tags }) => {
   return semver
     .sort(Object.keys(versions))
     .filter(a => a.match(/^\d+\.\d+\.\d+$/))
-    .filter(a => semver.gte(a, '2.3.2'))
+    .filter(a => {
+      if (semver.major(a) === 4) {
+        return true;
+      }
+      return SUPPORTED_LEGACY_VERSIONS.includes(a);
+    })
     .map(version => {
       return {
         version,
@@ -43,7 +50,7 @@ const versionsByReactDependency = ({ versions, time, tags }) => {
   });
 
   const latestVersions = [];
-  for (let [, value] of versionsByReactDep) {
+  for (const [, value] of versionsByReactDep) {
     const latest = value.reverse()[0];
     latestVersions.push(latest);
   }
@@ -81,8 +88,15 @@ const getAllVersions = () => {
     .then(({ data }) => filterNPM(data));
 };
 
+const prepareVersionsWithRedirects = versions => {
+  versions.v2Redirect = 'https://soft-elf-84cb2b.netlify.app/';
+  return versions;
+};
+
 mkdirp(path.resolve(__dirname, '../dist'));
 getAllVersions().then(versions => {
+  const versionsWithRedirects = prepareVersionsWithRedirects(versions);
+
   return Promise.all([
     copy(
       path.resolve(__dirname, '../static/**'),
@@ -94,7 +108,7 @@ getAllVersions().then(versions => {
     ),
     fs.writeFile(
       path.resolve(__dirname, '../dist/versions'),
-      JSON.stringify(versions, null, 2),
+      JSON.stringify(versionsWithRedirects, null, 2),
       err => {
         if (err) throw err;
         console.log('- dist/versions has been saved!');
@@ -106,7 +120,7 @@ getAllVersions().then(versions => {
         fs
           .readFileSync(path.resolve(__dirname, '../templates/index.html'))
           .toString(),
-        versions
+        versionsWithRedirects
       ),
       err => {
         if (err) throw err;
@@ -119,7 +133,7 @@ getAllVersions().then(versions => {
         fs
           .readFileSync(path.resolve(__dirname, '../templates/_redirects'))
           .toString(),
-        versions
+        versionsWithRedirects
       ),
       err => {
         if (err) throw err;

--- a/website/react-magma-landing/templates/_redirects
+++ b/website/react-magma-landing/templates/_redirects
@@ -1,6 +1,11 @@
 /version/latest  /version/<%= tags.latest.version %> 302
 
 /version/next/*    https://next--upbeat-sinoussi-f675aa.netlify.app/:splat   200
+
+/version/2.6.0/*   https://soft-elf-84cb2b.netlify.app/:splat   200
+
 <% versions.reverse().forEach(function(version){ %>
+<% if(version.version !== '2.6.0') { %>
 /version/<%= version.version %>/*   https://<%= version.alias %>--upbeat-sinoussi-f675aa.netlify.app/:splat   200
+<% } %>
 <% }); %>


### PR DESCRIPTION
Closes: #1716 

## What I did

- Added proxy redirect for version 2.6.0 to serve content from https://soft-elf-84cb2b.netlify.app/
- Updated the landing page build script to only support specific legacy versions [2.6.0, 3.10.0, 3.11.0] and all v4.x 

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [X] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. Build the landing page locally: 
   ```
   cd website/react-magma-landing && npm run build
   ```
2. Verify that the generated `_redirects` file in the `dist` directory contains the proper redirect for version 2.6.0:
   ```
   /version/2.6.0/* https://soft-elf-84cb2b.netlify.app/:splat 200
   ```
3. Verify that the version list only includes v4.x versions and the specified legacy versions [2.6.0, 3.10.0, 3.11.0]:
   ```
   cat dist/versions
   ```
4. After deployment, verify that navigating to `https://react-magma.cengage.com/version/2.6.0/` displays content from the legacy site while maintaining the original RM URL in the browser