### PR TITLE
 chore(Playwright): Set up new testing tools

### DIFF
--- a/.changeset/chore-Playwright-initial-configuration.md
+++ b/.changeset/chore-Playwright-initial-configuration.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+chore: Add Playwright initial configuration and some example tests.

--- a/README.md
+++ b/README.md
@@ -348,3 +348,22 @@ If the `pre-commit` scripts prevent your commit due to a test or linting failure
 
 
 </details>
+
+#### Playwright
+To install the required browsers (Chromium, Firefox, WebKit) used by Playwright: (should be run from the root of the project)
+
+```
+npx playwright install
+```
+
+To execute all Playwright tests, use the following command:
+
+```sh
+npm run playwright:test
+```
+
+To generate and view the test report after running the tests:
+
+```sh
+npm run playwright:report
+```

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "getAlias": "node ./packages/react-magma-dom/scripts/getAlias.js",
     "getVersion": "node ./packages/react-magma-dom/scripts/getVersion.js",
     "postinstall": "npm run build:lite",
+    "playwright:test": "cd playwright && npx playwright test",
+    "playwright:report": "cd playwright && npx playwright show-report",
     "lint": "eslint \"**/src/**/*.{js,jsx,ts,tsx,mdx}\"",
     "lint:ci": "eslint --max-warnings 0 \"**/src/**/*.{js,jsx,ts,tsx,mdx}\"",
     "lint:fix": "eslint --fix \"**/src/**/*.{js,jsx,ts,tsx,mdx}\"",

--- a/packages/react-magma-dom/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/Accordion.stories.tsx
@@ -95,6 +95,7 @@ Controlled.args = {
 export const ControlledNoMulti = Template.bind({});
 ControlledNoMulti.args = {
   index: 0,
+  isMulti: false,
 };
 
 export const ExpandCollapseAll = args => {
@@ -141,7 +142,7 @@ export const ExpandCollapseAll = args => {
         </AccordionItem>
         <AccordionItem>
           <AccordionButton>Section 3</AccordionButton>
-          <AccordionPanel>Content for section two lorem ipsum</AccordionPanel>
+          <AccordionPanel>Content for section three lorem ipsum</AccordionPanel>
         </AccordionItem>
       </Accordion>
     </>
@@ -150,6 +151,7 @@ export const ExpandCollapseAll = args => {
 
 export const Inverse = Template.bind({});
 Inverse.args = {
+  defaultIndex: [0],
   isInverse: true,
 };
 

--- a/playwright/.github/workflows/playwright.yml
+++ b/playwright/.github/workflows/playwright.yml
@@ -1,0 +1,29 @@
+#Do we need run playwright tests during merging into master?
+
+#name: Playwright Tests
+#on:
+#  push:
+#    branches: [ main, master ]
+#  pull_request:
+#    branches: [ main, master ]
+#jobs:
+#  test:
+#    timeout-minutes: 60
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v4
+#    - uses: actions/setup-node@v4
+#      with:
+#        node-version: lts/*
+#    - name: Install dependencies
+#      run: npm ci
+#    - name: Install Playwright Browsers
+#      run: npx playwright install --with-deps
+#    - name: Run Playwright tests
+#      run: npx playwright test
+#    - uses: actions/upload-artifact@v4
+#      if: ${{ !cancelled() }}
+#      with:
+#        name: playwright-report
+#        path: playwright-report/
+#        retention-days: 30

--- a/playwright/.gitignore
+++ b/playwright/.gitignore
@@ -1,0 +1,7 @@
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -1,0 +1,91 @@
+{
+  "name": "playwright",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "playwright",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.51.1",
+        "@types/node": "^22.14.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.51.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+      "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.51.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    }
+  }
+}

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "playwright-tests",
+  "version": "1.0.0",
+  "description": "Playwright tests for React Magma",
+  "scripts": {},
+  "keywords": [],
+  "license": "ISC",
+  "devDependencies": {
+    "@playwright/test": "^1.51.1",
+    "@types/node": "^22.14.0"
+  }
+}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:6006/',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+    // {
+    //   name: 'edge',
+    //   use: { ...devices['Desktop Edge'] },
+    // },
+  ],
+
+  webServer: [
+    {
+      command: 'cd .. && npm run storybook',
+      url: 'http://localhost:6006/',
+      reuseExistingServer: !process.env.CI,
+    },
+    // Will be used for the React Magma documentation
+    // {
+    //   command: 'cd .. && npm run docs',
+    //   url: 'http://localhost:8000/',
+    //   reuseExistingServer: !process.env.CI,
+    // },
+  ],
+});

--- a/playwright/tests/storybook/accordion/accordion.spec.ts
+++ b/playwright/tests/storybook/accordion/accordion.spec.ts
@@ -1,0 +1,355 @@
+import { expect, FrameLocator, Locator, test } from '@playwright/test';
+
+const section1Text = 'Content for section one lorem ipsum';
+const section2Text = 'Content for section two lorem ipsum';
+const section3Text = 'Content for section three lorem ipsum';
+
+async function verifySectionVisibilityAndState(
+  storyBookIframe: FrameLocator,
+  section1Button: Locator,
+  section2Button: Locator,
+  section3Button: Locator,
+  section4Button: Locator
+) {
+  await expect(section1Button).toBeVisible();
+  await expect(storyBookIframe.getByText(section1Text)).toBeVisible();
+
+  await expect(section2Button).toBeVisible();
+  await expect(storyBookIframe.getByText(section2Text)).toBeHidden();
+
+  await expect(section3Button).toBeVisible();
+  await expect(storyBookIframe.getByText(section3Text)).toBeHidden();
+
+  await expect(section4Button).toBeVisible();
+  await expect(section4Button).toBeDisabled();
+}
+
+async function verifyDefaultBehaviour(
+  storyBookIframe: FrameLocator,
+  section1Button: Locator,
+  section2Button: Locator,
+  section3Button: Locator
+) {
+  await section1Button.click();
+  await expect(storyBookIframe.getByText(section1Text)).toBeHidden();
+
+  await section2Button.click();
+  await expect(storyBookIframe.getByText(section2Text)).toBeVisible();
+
+  await section2Button.click();
+  await expect(storyBookIframe.getByText(section2Text)).toBeHidden();
+
+  await section3Button.click();
+  await expect(storyBookIframe.getByText(section3Text)).toBeVisible();
+
+  await section3Button.click();
+  await expect(storyBookIframe.getByText(section3Text)).toBeHidden();
+}
+
+test.describe('Accordion', () => {
+  let storyBookIframe: FrameLocator;
+  let section1Button: Locator;
+  let section2Button: Locator;
+  let section3Button: Locator;
+  let section4Button: Locator;
+
+  test.beforeEach(async ({ page }) => {
+    // Uses the baseURL
+    await page.goto('/');
+
+    storyBookIframe = page.frameLocator(
+      'iframe[title="storybook-preview-iframe"]'
+    );
+
+    section1Button = storyBookIframe.getByRole('button', {
+      name: 'Section 1',
+    });
+    section2Button = storyBookIframe.getByRole('button', {
+      name: 'Section 2',
+    });
+    section3Button = storyBookIframe.getByRole('button', {
+      name: 'Section 3',
+    });
+    section4Button = storyBookIframe.getByRole('button', {
+      name: 'Section 4',
+    });
+  });
+
+  test('Default', async ({ page }) => {
+    await page.getByRole('link', { name: 'Default' }).click();
+
+    await expect(page).toHaveTitle('Accordion - Default ⋅ Storybook');
+
+    await verifySectionVisibilityAndState(
+      storyBookIframe,
+      section1Button,
+      section2Button,
+      section3Button,
+      section4Button
+    );
+
+    await verifyDefaultBehaviour(
+      storyBookIframe,
+      section1Button,
+      section2Button,
+      section3Button
+    );
+
+    await section1Button.click();
+    const inverseContainer = storyBookIframe
+      .locator('#root > div > div')
+      .first();
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeVisible();
+    await expect(inverseContainer).toHaveCSS(
+      'background-color',
+      'rgba(0, 0, 0, 0)'
+    );
+    await expect(section1Button).toHaveCSS('color', 'rgb(69, 69, 69)');
+    await expect(storyBookIframe.getByText(section1Text)).toHaveCSS(
+      'color',
+      'rgb(69, 69, 69)'
+    );
+  });
+
+  test('No Multi', async ({ page }) => {
+    await page.getByRole('link', { name: 'No Multi', exact: true }).click();
+
+    await expect(page).toHaveTitle('Accordion - No Multi ⋅ Storybook');
+
+    await verifySectionVisibilityAndState(
+      storyBookIframe,
+      section1Button,
+      section2Button,
+      section3Button,
+      section4Button
+    );
+
+    await section2Button.click();
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section2Text)).toBeVisible();
+    await expect(storyBookIframe.getByText(section3Text)).toBeHidden();
+
+    await section3Button.click();
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section2Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section3Text)).toBeVisible();
+  });
+
+  test('Controlled', async ({ page }) => {
+    await page.getByRole('link', { name: 'Controlled', exact: true }).click();
+
+    await expect(page).toHaveTitle('Accordion - Controlled ⋅ Storybook');
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeVisible();
+
+    await section2Button.click();
+    await section3Button.click();
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeVisible();
+    await expect(storyBookIframe.getByText(section2Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section3Text)).toBeHidden();
+
+    await page.getByRole('tab', { name: 'Controls (4)' }).click();
+
+    await page.getByText('0', { exact: true }).click();
+    await page.getByRole('textbox').fill('1');
+    await page.getByRole('textbox').press('Enter');
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section2Text)).toBeVisible();
+    await expect(storyBookIframe.getByText(section3Text)).toBeHidden();
+  });
+
+  test('Controlled No Multi', async ({ page }) => {
+    await page.getByRole('link', { name: 'Controlled No Multi' }).click();
+
+    await expect(page).toHaveTitle(
+      'Accordion - Controlled No Multi ⋅ Storybook'
+    );
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeVisible();
+
+    await section2Button.click();
+    await section3Button.click();
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeVisible();
+    await expect(storyBookIframe.getByText(section2Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section3Text)).toBeHidden();
+
+    await page.getByRole('tab', { name: 'Controls (4)' }).click();
+
+    const indexValue = page.getByPlaceholder('Edit number...');
+    await indexValue.click();
+    await indexValue.fill('1');
+    await indexValue.press('Enter');
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section2Text)).toBeVisible();
+    await expect(storyBookIframe.getByText(section3Text)).toBeHidden();
+  });
+
+  test('Expand Collapse all', async ({ page }) => {
+    await page.getByRole('link', { name: 'Expand Collapse All' }).click();
+
+    await expect(page).toHaveTitle(
+      'Accordion - Expand Collapse All ⋅ Storybook'
+    );
+    await expect(
+      storyBookIframe.getByRole('button', { name: 'Expand All' })
+    ).toBeVisible();
+
+    await expect(section1Button).toBeVisible();
+    await expect(section2Button).toBeVisible();
+    await expect(section3Button).toBeVisible();
+
+    await section1Button.click();
+    await section2Button.click();
+    await section3Button.click();
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeVisible();
+    await expect(storyBookIframe.getByText(section2Text)).toBeVisible();
+    await expect(storyBookIframe.getByText(section3Text)).toBeVisible();
+
+    await expect(
+      storyBookIframe.getByRole('button', { name: 'Collapse All' })
+    ).toBeVisible();
+    await storyBookIframe.getByRole('button', { name: 'Collapse All' }).click();
+
+    await expect(
+      storyBookIframe.getByRole('button', { name: 'Expand All' })
+    ).toBeVisible();
+    await expect(storyBookIframe.getByText(section1Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section2Text)).toBeHidden();
+    await expect(storyBookIframe.getByText(section3Text)).toBeHidden();
+
+    await storyBookIframe.getByRole('button', { name: 'Expand All' }).click();
+
+    await expect(section1Button).toBeVisible();
+    await expect(section2Button).toBeVisible();
+    await expect(section3Button).toBeVisible();
+  });
+
+  test('Inverse', async ({ page }) => {
+    await page.getByRole('link', { name: 'Inverse' }).click();
+
+    await expect(page).toHaveTitle('Accordion - Inverse ⋅ Storybook');
+
+    await verifySectionVisibilityAndState(
+      storyBookIframe,
+      section1Button,
+      section2Button,
+      section3Button,
+      section4Button
+    );
+
+    await verifyDefaultBehaviour(
+      storyBookIframe,
+      section1Button,
+      section2Button,
+      section3Button
+    );
+
+    await section1Button.click();
+    const inverseContainer = storyBookIframe
+      .locator('#root > div > div')
+      .first();
+
+    await expect(storyBookIframe.getByText(section1Text)).toBeVisible();
+    await expect(inverseContainer).toHaveCSS(
+      'background-color',
+      'rgb(41, 47, 124)'
+    );
+    await expect(section1Button).toHaveCSS('color', 'rgb(255, 255, 255)');
+    await expect(storyBookIframe.getByText(section1Text)).toHaveCSS(
+      'color',
+      'rgb(255, 255, 255)'
+    );
+  });
+
+  test('With Dropdown', async ({ page }) => {
+    await page.getByRole('link', { name: 'With Dropdown' }).click();
+
+    const personalInfoButton = storyBookIframe.getByRole('button', {
+      name: 'Personal Information',
+    });
+
+    const shippingAddressButton = storyBookIframe.getByRole('button', {
+      name: 'Shipping Address',
+    });
+
+    const randomButton = storyBookIframe.getByRole('button', {
+      name: 'Random',
+    });
+
+    async function verifyPersonalInformationContentHidden() {
+      await expect(storyBookIframe.getByText('Email')).toBeHidden();
+      await expect(storyBookIframe.getByText('Full Name')).toBeHidden();
+      await expect(storyBookIframe.getByText('Message')).toBeHidden();
+      await expect(storyBookIframe.getByText('Comments')).toBeHidden();
+      await expect(storyBookIframe.getByText('Questions')).toBeHidden();
+      await expect(storyBookIframe.getByText('Jokes')).toBeHidden();
+    }
+
+    async function verifyShippingAddressContentHidden() {
+      await expect(storyBookIframe.getByText('City')).toBeHidden();
+      await expect(storyBookIframe.getByText('State')).toBeHidden();
+      await expect(
+        storyBookIframe.getByText('Additional Information')
+      ).toBeHidden();
+    }
+
+    await expect(page).toHaveTitle('Accordion - With Dropdown ⋅ Storybook');
+    await expect(personalInfoButton).toBeVisible();
+    await expect(shippingAddressButton).toBeVisible();
+    await expect(randomButton).toBeVisible();
+
+    async function verifyRandomContentHidden() {
+      await expect(storyBookIframe.getByText('ComboBox Example')).toBeHidden();
+      await expect(
+        storyBookIframe.getByRole('button', { name: 'Basic Dropdown' })
+      ).toBeHidden();
+      await expect(
+        storyBookIframe.getByRole('button', { name: 'Show Modal' })
+      ).toBeHidden();
+    }
+
+    await personalInfoButton.click();
+
+    await expect(storyBookIframe.getByText('Email')).toBeVisible();
+    await expect(storyBookIframe.getByText('Full Name')).toBeVisible();
+    await expect(storyBookIframe.getByText('Message')).toBeVisible();
+    await expect(storyBookIframe.getByText('Comments')).toBeVisible();
+    await expect(storyBookIframe.getByText('Questions')).toBeVisible();
+    await expect(storyBookIframe.getByText('Jokes')).toBeVisible();
+
+    await verifyShippingAddressContentHidden();
+    await verifyRandomContentHidden();
+
+    await shippingAddressButton.click();
+
+    await verifyPersonalInformationContentHidden();
+    await verifyRandomContentHidden();
+
+    await expect(storyBookIframe.getByText('City')).toBeVisible();
+    await expect(storyBookIframe.getByText('State')).toBeVisible();
+    await expect(
+      storyBookIframe.getByText('Additional Information')
+    ).toBeVisible();
+
+    await randomButton.click();
+
+    await verifyPersonalInformationContentHidden();
+    await verifyShippingAddressContentHidden();
+
+    await expect(storyBookIframe.getByText('ComboBox Example')).toBeVisible();
+    await expect(
+      storyBookIframe.getByRole('button', { name: 'Basic Dropdown' })
+    ).toBeVisible();
+    await expect(
+      storyBookIframe.getByRole('button', { name: 'Show Modal' })
+    ).toBeVisible();
+  });
+});

--- a/playwright/tests/storybook/alert/alert.spec.ts
+++ b/playwright/tests/storybook/alert/alert.spec.ts
@@ -1,0 +1,216 @@
+import { expect, FrameLocator, Locator, test } from '@playwright/test';
+
+test.describe('Alert', () => {
+  let storyBookIframe: FrameLocator;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+
+    storyBookIframe = page.frameLocator(
+      'iframe[title="storybook-preview-iframe"]'
+    );
+  });
+
+  function getAlertByName(name: string): Locator {
+    return storyBookIframe
+      .locator('#root > div > div > div')
+      .filter({ hasText: name })
+      .first();
+  }
+
+  function getAlertByNameInversePage(name: string): Locator {
+    return storyBookIframe
+      .locator('#root > div > div > div > div > div')
+      .filter({ hasText: name })
+      .first();
+  }
+
+  async function verifyCloseButtons(storyBookIframe: FrameLocator) {
+    for (let i = 0; i < 4; i++) {
+      await expect(
+        storyBookIframe
+          .getByRole('button', { name: 'Close this message' })
+          .nth(i)
+      ).toBeVisible();
+    }
+  }
+
+  test('Default', async ({ page }) => {
+    await page.getByRole('button', { name: 'Alert' }).click();
+
+    await expect(page).toHaveTitle('Alert - Default ⋅ Storybook');
+
+    // Default alert
+    const defaultAlert = getAlertByName('Default');
+    await expect(defaultAlert).toBeVisible();
+    await expect(defaultAlert).toHaveCSS(
+      'background-color',
+      'rgb(232, 245, 252)'
+    );
+    await expect(defaultAlert).toHaveCSS(
+      'border',
+      '1px solid rgb(0, 116, 183)'
+    );
+    await expect(defaultAlert).toHaveCSS('border-radius', '8px');
+    await expect(defaultAlert).toHaveCSS('color', 'rgb(0, 116, 183)');
+
+    // Success alert
+    const successAlert = getAlertByName('Success hyperlink');
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toHaveCSS(
+      'background-color',
+      'rgb(227, 250, 234)'
+    );
+    await expect(successAlert).toHaveCSS(
+      'border',
+      '1px solid rgb(23, 128, 55)'
+    );
+    await expect(successAlert).toHaveCSS('border-radius', '8px');
+    await expect(successAlert).toHaveCSS('color', 'rgb(23, 128, 55)');
+    await expect(storyBookIframe.getByText('Badgery').first()).toBeVisible();
+    await expect(
+      storyBookIframe.getByText('More Badgery').first()
+    ).toBeVisible();
+
+    // Warning alert
+    const warningAlert = getAlertByName('Warning hyperlink');
+    await expect(warningAlert).toBeVisible();
+    await expect(
+      storyBookIframe.getByRole('button', { name: 'Button it up' }).first()
+    ).toBeVisible();
+    await expect(warningAlert).toHaveCSS(
+      'background-color',
+      'rgb(252, 238, 229)'
+    );
+    await expect(warningAlert).toHaveCSS(
+      'border',
+      '1px solid rgb(173, 81, 21)'
+    );
+    await expect(warningAlert).toHaveCSS('border-radius', '8px');
+    await expect(warningAlert).toHaveCSS('color', 'rgb(173, 81, 21)');
+
+    // Danger alert
+    const dangerAlert = getAlertByName('Danger hyperlink');
+    await expect(dangerAlert).toBeVisible();
+    await expect(dangerAlert).toHaveCSS(
+      'background-color',
+      'rgb(253, 239, 238)'
+    );
+    await expect(dangerAlert).toHaveCSS('border', '1px solid rgb(211, 40, 33)');
+    await expect(dangerAlert).toHaveCSS('border-radius', '8px');
+    await expect(dangerAlert).toHaveCSS('color', 'rgb(211, 40, 33)');
+
+    // Default dismissible alert
+    const defaultDismissibleAlert = getAlertByName('Default dismissible with');
+    await expect(defaultDismissibleAlert).toBeVisible();
+
+    // Success dismissible alert
+    const successDismissibleAlert = getAlertByName('Success dismissible with');
+    await expect(successDismissibleAlert).toBeVisible();
+    await expect(storyBookIframe.getByText('Badgery').nth(2)).toBeVisible();
+    await expect(
+      storyBookIframe.getByText('More Badgery').nth(1)
+    ).toBeVisible();
+
+    // Warning dismissible alert
+    const warningDismissibleAlert = getAlertByName('Warning dismissible with');
+    await expect(warningDismissibleAlert).toBeVisible();
+    await expect(
+      storyBookIframe.getByRole('button', { name: 'Button it up' }).nth(1)
+    ).toBeVisible();
+
+    // Danger dismissible alert
+    const dangerDismissibleAlert = getAlertByName('Danger dismissible with');
+    await expect(dangerDismissibleAlert).toBeVisible();
+
+    // Verify close buttons
+    await verifyCloseButtons(storyBookIframe);
+  });
+
+  test('Inverse', async ({ page }) => {
+    const inverseWrapper = storyBookIframe.locator('#root > div > div');
+    await page.getByRole('button', { name: 'Alert' }).click();
+    await page.locator('#alert--inverse').click();
+
+    await expect(page).toHaveTitle('Alert - Inverse ⋅ Storybook');
+    await expect(inverseWrapper).toHaveCSS(
+      'background-color',
+      'rgb(41, 47, 124)'
+    );
+    await expect(inverseWrapper).toHaveCSS('color', 'rgb(255, 255, 255)');
+
+    // Default alert
+    const defaultAlert = getAlertByNameInversePage('Default');
+    await expect(defaultAlert).toBeVisible();
+    await expect(defaultAlert).toHaveCSS('background-color', 'rgb(0, 74, 117)');
+    await expect(defaultAlert).toHaveCSS(
+      'border',
+      '1px solid rgb(47, 179, 255)'
+    );
+    await expect(defaultAlert).toHaveCSS('border-radius', '8px');
+    await expect(defaultAlert).toHaveCSS('color', 'rgb(255, 255, 255)');
+
+    // Success alert
+    const successAlert = getAlertByNameInversePage('Success');
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toHaveCSS('background-color', 'rgb(15, 83, 35)');
+    await expect(successAlert).toHaveCSS(
+      'border',
+      '1px solid rgb(62, 221, 110)'
+    );
+    await expect(successAlert).toHaveCSS('border-radius', '8px');
+    await expect(successAlert).toHaveCSS('color', 'rgb(255, 255, 255)');
+
+    // Warning alert
+    const warningAlert = getAlertByNameInversePage('Warning');
+    await expect(warningAlert).toBeVisible();
+    await expect(warningAlert).toHaveCSS(
+      'background-color',
+      'rgb(110, 52, 14)'
+    );
+    await expect(warningAlert).toHaveCSS(
+      'border',
+      '1px solid rgb(233, 139, 76)'
+    );
+    await expect(warningAlert).toHaveCSS('border-radius', '8px');
+    await expect(warningAlert).toHaveCSS('color', 'rgb(255, 255, 255)');
+
+    // Danger alert
+    const dangerAlert = getAlertByNameInversePage('Danger');
+    await expect(dangerAlert).toBeVisible();
+    await expect(dangerAlert).toHaveCSS('background-color', 'rgb(127, 23, 20)');
+    await expect(dangerAlert).toHaveCSS(
+      'border',
+      '1px solid rgb(250, 174, 176)'
+    );
+    await expect(dangerAlert).toHaveCSS('border-radius', '8px');
+    await expect(dangerAlert).toHaveCSS('color', 'rgb(255, 255, 255)');
+
+    // Default dismissible alert
+    const defaultDismissibleAlert = getAlertByNameInversePage(
+      'Default dismissible with'
+    );
+    await expect(defaultDismissibleAlert).toBeVisible();
+
+    // Success dismissible alert
+    const successDismissibleAlert = getAlertByNameInversePage(
+      'Success dismissible with'
+    );
+    await expect(successDismissibleAlert).toBeVisible();
+
+    // Warning dismissible alert
+    const warningDismissibleAlert = getAlertByNameInversePage(
+      'Warning dismissible with'
+    );
+    await expect(warningDismissibleAlert).toBeVisible();
+
+    // Danger dismissible alert
+    const dangerDismissibleAlert = getAlertByNameInversePage(
+      'Danger dismissible with'
+    );
+    await expect(dangerDismissibleAlert).toBeVisible();
+
+    // Verify close buttons
+    await verifyCloseButtons(storyBookIframe);
+  });
+});

--- a/playwright/tests/storybook/announce/announce.spec.ts
+++ b/playwright/tests/storybook/announce/announce.spec.ts
@@ -1,0 +1,34 @@
+import { expect, FrameLocator, test } from '@playwright/test';
+
+test.describe('Alert', () => {
+  let storyBookIframe: FrameLocator;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+
+    storyBookIframe = page.frameLocator(
+      'iframe[title="storybook-preview-iframe"]'
+    );
+  });
+
+  test('Default', async ({ page }) => {
+    await page.getByRole('button', { name: 'Announce' }).click();
+    await page.locator('#announce--default').click();
+
+    await expect(page).toHaveTitle('Announce - Default ⋅ Storybook');
+
+    await expect(
+      storyBookIframe.getByText('This content will be read by')
+    ).toBeVisible();
+    await expect(
+      storyBookIframe.getByRole('button', { name: 'Update content' })
+    ).toBeVisible();
+    await expect(storyBookIframe.getByText('Initial content')).toBeVisible();
+    await storyBookIframe
+      .getByRole('button', { name: 'Update content' })
+      .click();
+    await expect(
+      storyBookIframe.getByText('New content replacing the initial content')
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes: #[1726](https://github.com/cengage/react-magma/issues/1726)

## What I did
- Integrated the `Playwright `testing tool into React Magma.
- Added some test examples for Accordion, Alert, Announce components.

## Screenshots
Test report
![Screenshot from 2025-04-15 15-24-32](https://github.com/user-attachments/assets/e11bfce6-41ba-4703-9cc4-8fa6163500b6)


## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- React Magma app
- in root folder run `npm run playwright:test` to run tests
- - in root folder run `npm run playwright:report` to show reports
