### PR TITLE
fix(SkipLink): Deprecate `to` prop.

### DIFF
--- a/.changeset/fix-SkipLink-deprecate-to-prop.md
+++ b/.changeset/fix-SkipLink-deprecate-to-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(SkipLink): Deprecate `to` prop.

--- a/packages/react-magma-dom/src/components/SkipLink/index.tsx
+++ b/packages/react-magma-dom/src/components/SkipLink/index.tsx
@@ -29,6 +29,12 @@ export interface SkipLinkProps extends Omit<HyperlinkProps, 'children' | 'to'> {
    * @internal
    */
   testId?: string;
+
+  /**
+   * The `to` prop will be removed from the SkipLink component in the next major release.
+   * @deprecated = true
+   */
+  to?: string;
 }
 
 const handleClick = e => {


### PR DESCRIPTION
Closes: #1744

## What I did
- Add `to` prop as an option for the `SkipLink`  component.
- Added comment that this prop is deprecated and will be removed in the next major release.

## Screenshots
![Screenshot from 2025-04-16 16-21-25](https://github.com/user-attachments/assets/39ba2a1b-fb08-4936-9c0f-5aca0e75bed9)


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Go to React Magma Dom
- Open SkipLink component
- The prop `to` should be available for use as an optional
- In comments should be marked as deprecated and informed about being fully deleted in the next major release.
