### PR TITLE
fix(dropdown): Added aria-current to DropdownMenuNavItem component for fix with NVDA screen reader.

### DIFF
--- a/.changeset/fix-Dropdown-Firefox-Screenreader.md
+++ b/.changeset/fix-Dropdown-Firefox-Screenreader.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Added `aria-current` to `DropdownMenuNavItem` component for fix with NVDA screen reader.

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownMenuNavItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownMenuNavItem.tsx
@@ -42,6 +42,18 @@ export const DropdownMenuNavItem = React.forwardRef<
 
   const ref = useForkedRef(forwardedRef, ownRef);
 
+  const index = context.itemRefArray.current.findIndex(({ current: item }) => {
+    if (!item || !ownRef.current) return false;
+
+    return item === ownRef.current;
+  });
+
+  const isActive =
+    context.activeItemIndex >= 0 && context.activeItemIndex === index;
+
+  const isInactive =
+    context.activeItemIndex >= 0 && context.activeItemIndex !== index;
+
   React.useEffect(() => {
     context.registerDropdownMenuItem(context.itemRefArray, ownRef);
   }, []);
@@ -49,7 +61,9 @@ export const DropdownMenuNavItem = React.forwardRef<
   return (
     <StyledItem
       {...other}
+      aria-current={isActive ? 'true' : null}
       href={to}
+      isInactive={isInactive}
       isFixedWidth={context.isFixedWidth}
       isInverse={context.isInverse}
       ref={ref}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownMenuNavItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownMenuNavItem.tsx
@@ -42,18 +42,6 @@ export const DropdownMenuNavItem = React.forwardRef<
 
   const ref = useForkedRef(forwardedRef, ownRef);
 
-  const index = context.itemRefArray.current.findIndex(({ current: item }) => {
-    if (!item || !ownRef.current) return false;
-
-    return item === ownRef.current;
-  });
-
-  const isActive =
-    context.activeItemIndex >= 0 && context.activeItemIndex === index;
-
-  const isInactive =
-    context.activeItemIndex >= 0 && context.activeItemIndex !== index;
-
   React.useEffect(() => {
     context.registerDropdownMenuItem(context.itemRefArray, ownRef);
   }, []);
@@ -61,9 +49,7 @@ export const DropdownMenuNavItem = React.forwardRef<
   return (
     <StyledItem
       {...other}
-      aria-current={isActive ? 'true' : null}
       href={to}
-      isInactive={isInactive}
       isFixedWidth={context.isFixedWidth}
       isInverse={context.isInverse}
       ref={ref}
@@ -71,7 +57,11 @@ export const DropdownMenuNavItem = React.forwardRef<
       tabIndex={-1}
       theme={theme}
     >
-      {icon && <IconWrapper theme={theme}>{icon}</IconWrapper>}
+      {icon && (
+        <IconWrapper aria-hidden theme={theme}>
+          {icon}
+        </IconWrapper>
+      )}
       {children}
     </StyledItem>
   );


### PR DESCRIPTION
Closes: #1612 

## What I did
- Added `aria-current` to `DropdownMenuNavItem` component for fix with NVDA screen reader.

## Screenshots


## Checklist 
- [X] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- In Windows native or VM Windows > open Firefox with NVDA screenreader.
- Go to Storybook > Dropdown > Link menu.
- Verify keyboard navigation up and down goes through the Dropdown items properly.
