### PR TITLE
chore: Update React Magma Versions page to remove old docs link.

### DIFF
--- a/.changeset/chore-Remove-old-doc-links.md
+++ b/.changeset/chore-Remove-old-doc-links.md
@@ -1,5 +1,5 @@
 ---
-"@react-magma/dropzone": patch
+'react-magma-docs': patch
 ---
 
 chore: Remove all old documentation links.

--- a/.changeset/chore-Remove-old-doc-links.md
+++ b/.changeset/chore-Remove-old-doc-links.md
@@ -1,0 +1,5 @@
+---
+"@react-magma/dropzone": patch
+---
+
+chore: Remove all old documentation links.

--- a/website/react-magma-docs/src/pages/api-intro/versions.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/versions.mdx
@@ -186,9 +186,8 @@ export const IconsTable = () => {
 <PageContent componentName="react_magma_versions" type="api_intro">
 
 <LeadParagraph>
-  On an older version? Want to see the newest unreleased updates? Switch to a
-  different version of the docs at any time to access all available
-  documentation starting from version 4.0.0.
+  On an older version? Want to see the newest unreleased updates? Switch to
+  different versions of the docs any time.
 </LeadParagraph>
 
 ## Next Version

--- a/website/react-magma-docs/src/pages/api-intro/versions.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/versions.mdx
@@ -13,6 +13,7 @@ import {
   Tag,
   TagSize,
 } from 'react-magma-dom';
+import semver from 'semver';
 
 import { getVersions } from '../../utils';
 
@@ -84,11 +85,15 @@ export const ReleasedVersionsTable = () => {
             </TableCell>
             <TableCell key={`row${i}-date`}>{row.date}</TableCell>
             <TableCell key={`row${i}-docs`}>
-              <a
-                href={`https://react-magma.cengage.com/version/${row.version}`}
-              >
-                Docs
-              </a>
+              {semver.gte(row.version, '4.0.0') ? (
+                <a
+                  href={`https://react-magma.cengage.com/version/${row.version}`}
+                >
+                  Docs
+                </a>
+              ) : (
+                <></>
+              )}
             </TableCell>
             <TableCell key={`row${i}-react`}>
               {row.peerDependencies?.react}
@@ -180,7 +185,8 @@ export const IconsTable = () => {
 
 <LeadParagraph>
   On an older version? Want to see the newest unreleased updates? Switch to a
-  different version of the docs at anytime.
+  different version of the docs at any time to access all available
+  documentation starting from version 4.0.0.
 </LeadParagraph>
 
 ## Next Version

--- a/website/react-magma-docs/src/pages/api-intro/versions.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/versions.mdx
@@ -85,7 +85,9 @@ export const ReleasedVersionsTable = () => {
             </TableCell>
             <TableCell key={`row${i}-date`}>{row.date}</TableCell>
             <TableCell key={`row${i}-docs`}>
-              {semver.gte(row.version, '4.0.0') ? (
+              {semver.gte(row.version, '4.0.0') ||
+              row.version === '3.11.0' ||
+              row.version === '2.6.0' ? (
                 <a
                   href={`https://react-magma.cengage.com/version/${row.version}`}
                 >


### PR DESCRIPTION
Closes: #1750

## What I did
Removed all old docs links less than 4.0.0.
Updated description of React Magma Versions page.

## Screenshots
![Screenshot from 2025-05-06 17-37-10](https://github.com/user-attachments/assets/a0380615-790f-4ed9-bd77-266a6e34a86b)

[Screencast from 06.05.25 17:37:41.webm](https://github.com/user-attachments/assets/4e13db2a-ae1f-4025-99d0-b27a4bd9f517)



## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
-> Go to React Magma Docs
-> Components -> Intro -> React Magma Versions
-> Released Versions -> Doc links should be unavailable for versions earlier than 4.0.0
-> Released Versions -> Doc links should be available for versions older than 4.0.0
