### PR TITLE
fix(Input): Does not update value as expected

### DIFF
--- a/.changeset/fix-Input-not-properly-update-value.md
+++ b/.changeset/fix-Input-not-properly-update-value.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Input): Improve the logic for updating the value in the handleChange function.

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -796,3 +796,151 @@ export function TimeInput() {
     </>
   );
 }
+
+export const CustomTopicsRow = ({
+  topicList,
+  isRemoveButtonDisabled,
+  shouldValidate,
+  topicTitle,
+  testTopic,
+  studyMaterialsTopic,
+  order,
+  setTopicTitle,
+  setTestTopic,
+  setStudyMaterialsTopic,
+  removeTopicRow,
+}: {
+  topicList: { reference: string; title: string }[];
+  isRemoveButtonDisabled: boolean;
+  shouldValidate?: boolean;
+  topicTitle: string;
+  testTopic?: string;
+  studyMaterialsTopic?: string;
+  order: number;
+  setTopicTitle: (title: string) => void;
+  setTestTopic: (reference: string) => void;
+  setStudyMaterialsTopic: (reference: string) => void;
+  removeTopicRow: () => void;
+}) => {
+  const getTopicTitleError = (): string | undefined => {
+    if (!topicTitle.length) return 'Enter a topic title';
+    if (topicTitle.length >= 100) return 'Title is too long';
+    return undefined;
+  };
+
+  const normalizeTopicItems = (): { label: string; value: string }[] =>
+    topicList.map((topic: { reference: string; title: string }) => ({
+      label: topic.title,
+      value: topic.reference,
+    }));
+
+  const getSelectedTopic = (
+    reference?: string
+  ): { label: string; value: string } | undefined => {
+    if (!reference) return;
+    const selectedTopic = topicList.find(
+      (topic: { reference: string }) => topic.reference === reference
+    );
+    return selectedTopic
+      ? {
+          label: selectedTopic.title,
+          value: selectedTopic.reference,
+        }
+      : undefined;
+  };
+
+  const onTopicTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setTopicTitle(event.target.value.trim());
+  };
+
+  const onTestTopicChange = (
+    changes: Partial<{ selectedItem: { label: string; value: string } }>
+  ) => {
+    if (changes.selectedItem) {
+      setTestTopic(changes.selectedItem.value);
+    }
+  };
+
+  const onStudyMaterialsTopicChange = (
+    changes: Partial<{ selectedItem: { label: string; value: string } }>
+  ) => {
+    if (changes.selectedItem) {
+      setStudyMaterialsTopic(changes.selectedItem.value);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <Input
+        errorMessage={shouldValidate && getTopicTitleError()}
+        id={`topicTitle-${order}`}
+        labelText={`Topic ${order} Title *`}
+        onChange={onTopicTitleChange}
+        required
+        testId={`topicTitle-${order}`}
+        value={topicTitle}
+      />
+      <Combobox
+        items={normalizeTopicItems()}
+        labelText={`Topic ${order} Test *`}
+        onSelectedItemChange={onTestTopicChange}
+        placeholder="Select a test topic"
+        selectedItem={getSelectedTopic(testTopic)}
+        testId={`testTopic-${order}`}
+      />
+      <Combobox
+        items={normalizeTopicItems()}
+        labelText={`Topic ${order} Study Materials *`}
+        onSelectedItemChange={onStudyMaterialsTopicChange}
+        placeholder="Select study materials"
+        selectedItem={getSelectedTopic(studyMaterialsTopic)}
+        testId={`studyMaterialsTopic-${order}`}
+      />
+      <IconButton
+        aria-label="Remove"
+        color={
+          isRemoveButtonDisabled ? ButtonColor.secondary : ButtonColor.primary
+        }
+        disabled={isRemoveButtonDisabled}
+        icon={<WorkIcon />}
+        onClick={removeTopicRow}
+        testId={`removeRowButton-${order}`}
+        variant={ButtonVariant.link}
+      />
+    </div>
+  );
+};
+
+export const CustomTopicsRowStory = () => {
+  const topicList = [
+    { reference: 'topic1', title: 'Topic 1' },
+    { reference: 'topic2', title: 'Topic 2' },
+    { reference: 'topic3', title: 'Topic 3' },
+  ];
+
+  const [topicTitle, setTopicTitle] = React.useState('');
+  const [testTopic, setTestTopic] = React.useState<string | undefined>();
+  const [studyMaterialsTopic, setStudyMaterialsTopic] = React.useState<
+    string | undefined
+  >();
+
+  const removeTopicRow = () => {
+    alert('Row removed');
+  };
+
+  return (
+    <CustomTopicsRow
+      topicList={topicList}
+      isRemoveButtonDisabled={false}
+      shouldValidate
+      topicTitle={topicTitle}
+      testTopic={testTopic}
+      studyMaterialsTopic={studyMaterialsTopic}
+      order={1}
+      setTopicTitle={setTopicTitle}
+      setTestTopic={setTestTopic}
+      setStudyMaterialsTopic={setStudyMaterialsTopic}
+      removeTopicRow={removeTopicRow}
+    />
+  );
+};

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -396,7 +396,7 @@ export const URLInput = () => {
       pattern={urlPattern}
       labelText="URL"
       type={InputType.url}
-      errorMessage={hasError ? 'Please enter a url' : null}
+      errorMessage={hasError ? 'Enter a valid URL.' : null}
       value={inputVal}
       onChange={handleChange}
     />
@@ -736,10 +736,14 @@ export function TimeInput() {
     const numericValue = inputValue ? Number(inputValue) : NaN;
     const currentUnitValue =
       numericValue && numericValue >= 0 ? numericValue : 0;
-    const totalDurationMilliseconds =
-      unit === 'hours'
-        ? (currentUnitValue * 60 + oppositeUnitValue) * 60 * 1000
-        : (oppositeUnitValue * 60 + currentUnitValue) * 60 * 1000;
+    const isHours = unit === 'hours';
+
+    // Immediate sync for Magma Input
+    isHours ? setHours(currentUnitValue) : setMinutes(currentUnitValue);
+
+    const totalDurationMilliseconds = isHours
+      ? (currentUnitValue * 60 + oppositeUnitValue) * 60 * 1000
+      : (oppositeUnitValue * 60 + currentUnitValue) * 60 * 1000;
 
     setTotalDurationMilliseconds(totalDurationMilliseconds);
   };
@@ -796,151 +800,3 @@ export function TimeInput() {
     </>
   );
 }
-
-export const CustomTopicsRow = ({
-  topicList,
-  isRemoveButtonDisabled,
-  shouldValidate,
-  topicTitle,
-  testTopic,
-  studyMaterialsTopic,
-  order,
-  setTopicTitle,
-  setTestTopic,
-  setStudyMaterialsTopic,
-  removeTopicRow,
-}: {
-  topicList: { reference: string; title: string }[];
-  isRemoveButtonDisabled: boolean;
-  shouldValidate?: boolean;
-  topicTitle: string;
-  testTopic?: string;
-  studyMaterialsTopic?: string;
-  order: number;
-  setTopicTitle: (title: string) => void;
-  setTestTopic: (reference: string) => void;
-  setStudyMaterialsTopic: (reference: string) => void;
-  removeTopicRow: () => void;
-}) => {
-  const getTopicTitleError = (): string | undefined => {
-    if (!topicTitle.length) return 'Enter a topic title';
-    if (topicTitle.length >= 100) return 'Title is too long';
-    return undefined;
-  };
-
-  const normalizeTopicItems = (): { label: string; value: string }[] =>
-    topicList.map((topic: { reference: string; title: string }) => ({
-      label: topic.title,
-      value: topic.reference,
-    }));
-
-  const getSelectedTopic = (
-    reference?: string
-  ): { label: string; value: string } | undefined => {
-    if (!reference) return;
-    const selectedTopic = topicList.find(
-      (topic: { reference: string }) => topic.reference === reference
-    );
-    return selectedTopic
-      ? {
-          label: selectedTopic.title,
-          value: selectedTopic.reference,
-        }
-      : undefined;
-  };
-
-  const onTopicTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setTopicTitle(event.target.value.trim());
-  };
-
-  const onTestTopicChange = (
-    changes: Partial<{ selectedItem: { label: string; value: string } }>
-  ) => {
-    if (changes.selectedItem) {
-      setTestTopic(changes.selectedItem.value);
-    }
-  };
-
-  const onStudyMaterialsTopicChange = (
-    changes: Partial<{ selectedItem: { label: string; value: string } }>
-  ) => {
-    if (changes.selectedItem) {
-      setStudyMaterialsTopic(changes.selectedItem.value);
-    }
-  };
-
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-      <Input
-        errorMessage={shouldValidate && getTopicTitleError()}
-        id={`topicTitle-${order}`}
-        labelText={`Topic ${order} Title *`}
-        onChange={onTopicTitleChange}
-        required
-        testId={`topicTitle-${order}`}
-        value={topicTitle}
-      />
-      <Combobox
-        items={normalizeTopicItems()}
-        labelText={`Topic ${order} Test *`}
-        onSelectedItemChange={onTestTopicChange}
-        placeholder="Select a test topic"
-        selectedItem={getSelectedTopic(testTopic)}
-        testId={`testTopic-${order}`}
-      />
-      <Combobox
-        items={normalizeTopicItems()}
-        labelText={`Topic ${order} Study Materials *`}
-        onSelectedItemChange={onStudyMaterialsTopicChange}
-        placeholder="Select study materials"
-        selectedItem={getSelectedTopic(studyMaterialsTopic)}
-        testId={`studyMaterialsTopic-${order}`}
-      />
-      <IconButton
-        aria-label="Remove"
-        color={
-          isRemoveButtonDisabled ? ButtonColor.secondary : ButtonColor.primary
-        }
-        disabled={isRemoveButtonDisabled}
-        icon={<WorkIcon />}
-        onClick={removeTopicRow}
-        testId={`removeRowButton-${order}`}
-        variant={ButtonVariant.link}
-      />
-    </div>
-  );
-};
-
-export const CustomTopicsRowStory = () => {
-  const topicList = [
-    { reference: 'topic1', title: 'Topic 1' },
-    { reference: 'topic2', title: 'Topic 2' },
-    { reference: 'topic3', title: 'Topic 3' },
-  ];
-
-  const [topicTitle, setTopicTitle] = React.useState('');
-  const [testTopic, setTestTopic] = React.useState<string | undefined>();
-  const [studyMaterialsTopic, setStudyMaterialsTopic] = React.useState<
-    string | undefined
-  >();
-
-  const removeTopicRow = () => {
-    alert('Row removed');
-  };
-
-  return (
-    <CustomTopicsRow
-      topicList={topicList}
-      isRemoveButtonDisabled={false}
-      shouldValidate
-      topicTitle={topicTitle}
-      testTopic={testTopic}
-      studyMaterialsTopic={studyMaterialsTopic}
-      order={1}
-      setTopicTitle={setTopicTitle}
-      setTestTopic={setTestTopic}
-      setStudyMaterialsTopic={setStudyMaterialsTopic}
-      removeTopicRow={removeTopicRow}
-    />
-  );
-};

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { HelpIcon, NotificationsIcon, WorkIcon } from 'react-magma-icons';
@@ -18,6 +18,7 @@ import { IconButton } from '../IconButton';
 import { InputIconPosition, InputSize, InputType } from '../InputBase';
 import { LabelPosition } from '../Label';
 import { NativeSelect } from '../NativeSelect';
+import { Paragraph } from '../Paragraph';
 import { PasswordInput } from '../PasswordInput';
 import { Search } from '../Search';
 import { Spacer, SpacerAxis } from '../Spacer';
@@ -706,3 +707,92 @@ export const AllInputs = () => {
     </>
   );
 };
+
+export function TimeInput() {
+  const [hours, setHours] = React.useState(0);
+  const [minutes, setMinutes] = React.useState(0);
+  const [totalDurationMilliseconds, setTotalDurationMilliseconds] =
+    React.useState(0);
+
+  const makeHoursAndMinutesFromMilliseconds = (
+    milliseconds = 0
+  ): { hours: number; minutes: number } => {
+    const hours = Math.floor(milliseconds / (60 * 60 * 1000));
+    const remainingMilliseconds = milliseconds % (60 * 60 * 1000);
+    const minutes = Math.floor(remainingMilliseconds / (60 * 1000));
+
+    return {
+      hours,
+      minutes,
+    };
+  };
+
+  const onChangeTimedDuration = (
+    event: ChangeEvent<HTMLInputElement>,
+    unit: 'hours' | 'minutes',
+    oppositeUnitValue: number
+  ) => {
+    const inputValue = event.target.value.replace(/\D/g, '');
+    const numericValue = inputValue ? Number(inputValue) : NaN;
+    const currentUnitValue =
+      numericValue && numericValue >= 0 ? numericValue : 0;
+    const totalDurationMilliseconds =
+      unit === 'hours'
+        ? (currentUnitValue * 60 + oppositeUnitValue) * 60 * 1000
+        : (oppositeUnitValue * 60 + currentUnitValue) * 60 * 1000;
+
+    setTotalDurationMilliseconds(totalDurationMilliseconds);
+  };
+
+  React.useEffect(() => {
+    const { hours, minutes } = makeHoursAndMinutesFromMilliseconds(
+      totalDurationMilliseconds
+    );
+    setHours(hours);
+    setMinutes(minutes);
+  }, [totalDurationMilliseconds]);
+
+  return (
+    <>
+      <Paragraph>React Magma inputs:</Paragraph>
+      <Input
+        type={InputType.number}
+        labelText="Hours"
+        inputWrapperStyle={{ width: '264px' }}
+        min={1}
+        max={60}
+        value={hours}
+        onChange={event => onChangeTimedDuration(event, 'hours', minutes)}
+      />
+      <Input
+        type={InputType.number}
+        labelText="Minutes"
+        inputWrapperStyle={{ width: '264px' }}
+        min={1}
+        max={60}
+        value={minutes}
+        onChange={event => onChangeTimedDuration(event, 'minutes', hours)}
+      />
+      <Spacer size={32} />
+      <Paragraph>Native inputs:</Paragraph>
+      <Paragraph style={{ marginBottom: '8px' }}>Hours</Paragraph>
+      <div style={{ display: 'flex', flexDirection: 'column', width: '264px' }}>
+        <input
+          type={InputType.number}
+          min={1}
+          max={60}
+          value={hours}
+          onChange={event => onChangeTimedDuration(event, 'hours', minutes)}
+        />
+        <Paragraph style={{ marginBottom: '8px' }}>Minutes</Paragraph>
+        <input
+          type={InputType.number}
+          min={1}
+          max={60}
+          value={minutes}
+          onChange={event => onChangeTimedDuration(event, 'minutes', hours)}
+        />
+      </div>
+    </>
+  );
+}

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -24,6 +24,7 @@ import { Search } from '../Search';
 import { Spacer, SpacerAxis } from '../Spacer';
 import { TimePicker } from '../TimePicker';
 import { Tooltip } from '../Tooltip';
+import { CustomTopicsRow } from './testUtils';
 
 import { Input, InputProps } from '.';
 
@@ -800,3 +801,37 @@ export function TimeInput() {
     </>
   );
 }
+
+export const CustomTopicsRowStory = () => {
+  const topicList = [
+    { reference: 'topic1', title: 'Topic 1' },
+    { reference: 'topic2', title: 'Topic 2' },
+    { reference: 'topic3', title: 'Topic 3' },
+  ];
+
+  const [topicTitle, setTopicTitle] = React.useState('');
+  const [testTopic, setTestTopic] = React.useState<string | undefined>();
+  const [studyMaterialsTopic, setStudyMaterialsTopic] = React.useState<
+    string | undefined
+  >();
+
+  const removeTopicRow = () => {
+    alert('Row removed');
+  };
+
+  return (
+    <CustomTopicsRow
+      topicList={topicList}
+      isRemoveButtonDisabled={false}
+      shouldValidate
+      topicTitle={topicTitle}
+      testTopic={testTopic}
+      studyMaterialsTopic={studyMaterialsTopic}
+      order={1}
+      setTopicTitle={setTopicTitle}
+      setTestTopic={setTestTopic}
+      setStudyMaterialsTopic={setStudyMaterialsTopic}
+      removeTopicRow={removeTopicRow}
+    />
+  );
+};

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
 import { CheckIcon } from 'react-magma-icons';
 
@@ -704,6 +705,38 @@ describe('Input', () => {
 
       const inputElement = getByLabelText('Url');
       expect(inputElement).toHaveAttribute('type', 'url');
+    });
+  });
+
+  describe('Value state', () => {
+    const inputLabel = 'Input Label';
+
+    it('should not update value when is controlled component by props', () => {
+      const value = 0;
+      const { getByLabelText } = render(
+        <Input type={InputType.number} labelText={inputLabel} value={value} />
+      );
+
+      const labelInput = getByLabelText(inputLabel);
+      expect(labelInput).toBeInTheDocument();
+
+      userEvent.type(labelInput, `123`);
+      expect(labelInput).toHaveValue(value);
+    });
+
+    it('should update value when is uncontrolled component', () => {
+      const { getByLabelText } = render(
+        <Input type={InputType.number} labelText={inputLabel} />
+      );
+
+      const labelInput = getByLabelText(inputLabel);
+      expect(labelInput).toBeInTheDocument();
+
+      userEvent.type(labelInput, `123`);
+      expect(labelInput).toHaveValue(123);
+
+      userEvent.type(labelInput, `456`);
+      expect(labelInput).toHaveValue(123456);
     });
   });
 });

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -1,15 +1,28 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
+import PropTypes from 'prop-types';
 import { CheckIcon } from 'react-magma-icons';
 
 import { axe } from '../../../axe-helper';
 import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
 import { InputType } from '../InputBase';
+import { CustomTopicsRow } from './testUtils';
 
 import { Input } from '.';
+
+const renderWithProviders = (ui, renderOptions = {}) => {
+  const Wrapper = ({ children }) => <>{children}</>;
+
+  Wrapper.propTypes = {
+    children: PropTypes.node,
+  };
+
+  return render(ui, { wrapper: Wrapper, ...renderOptions });
+};
 
 const label = 'test label';
 
@@ -704,6 +717,73 @@ describe('Input', () => {
 
       const inputElement = getByLabelText('Url');
       expect(inputElement).toHaveAttribute('type', 'url');
+    });
+  });
+
+  describe('Custom Topics Row', () => {
+    const properties = {
+      topicList: [
+        {
+          reference: 'custom sub activity reference',
+          title: 'custom sub activity title',
+        },
+      ],
+      isRemoveButtonDisabled: false,
+      shouldValidate: true,
+      topicTitle: '',
+      testTopic: undefined,
+      studyMaterialsTopic: undefined,
+      order: 1,
+      setTopicTitle: jest.fn(),
+      setTestTopic: jest.fn(),
+      setStudyMaterialsTopic: jest.fn(),
+      removeTopicRow: jest.fn(),
+    };
+
+    it('should insert title topic', async () => {
+      renderWithProviders(<CustomTopicsRow {...properties} />);
+
+      await userEvent.type(screen.getByTestId('topicTitle-1'), 'topicTitle');
+
+      expect(properties.setTopicTitle).toHaveBeenCalledWith('topicTitle');
+    });
+
+    it('should select test topic', async () => {
+      renderWithProviders(<CustomTopicsRow {...properties} />);
+
+      await userEvent.click(
+        screen.getByRole('combobox', { name: 'Topic 1 Test *' })
+      );
+      await userEvent.click(
+        screen.getByRole('option', { name: 'custom sub activity title' })
+      );
+
+      expect(properties.setTestTopic).toHaveBeenCalledWith(
+        'custom sub activity reference'
+      );
+    });
+
+    it('should select study materials topic', async () => {
+      renderWithProviders(<CustomTopicsRow {...properties} />);
+
+      await userEvent.click(
+        screen.getByRole('combobox', { name: 'Topic 1 Study Materials *' })
+      );
+      await userEvent.click(
+        screen.getByRole('option', { name: 'custom sub activity title' })
+      );
+
+      expect(properties.setStudyMaterialsTopic).toHaveBeenCalledWith(
+        'custom sub activity reference'
+      );
+    });
+
+    it('should remove custom topics row', async () => {
+      renderWithProviders(<CustomTopicsRow {...properties} />);
+
+      await userEvent.click(screen.getByTestId('removeRowButton-1'));
+
+      expect(properties.removeTopicRow).toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -1,16 +1,28 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
+import PropTypes from 'prop-types';
 import { CheckIcon } from 'react-magma-icons';
 
 import { axe } from '../../../axe-helper';
 import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
 import { InputType } from '../InputBase';
+import { CustomTopicsRow } from './Input.stories';
 
 import { Input } from '.';
+
+const renderWithProviders = (ui, renderOptions = {}) => {
+  const Wrapper = ({ children }) => <>{children}</>;
+
+  Wrapper.propTypes = {
+    children: PropTypes.node,
+  };
+
+  return render(ui, { wrapper: Wrapper, ...renderOptions });
+};
 
 const label = 'test label';
 
@@ -738,5 +750,72 @@ describe('Input', () => {
       userEvent.type(labelInput, `456`);
       expect(labelInput).toHaveValue(123456);
     });
+  });
+});
+
+describe('Custom Topics Row', () => {
+  const properties = {
+    topicList: [
+      {
+        reference: 'custom sub activity reference',
+        title: 'custom sub activity title',
+      },
+    ],
+    isRemoveButtonDisabled: false,
+    shouldValidate: true,
+    topicTitle: '',
+    testTopic: undefined,
+    studyMaterialsTopic: undefined,
+    order: 1,
+    setTopicTitle: jest.fn(),
+    setTestTopic: jest.fn(),
+    setStudyMaterialsTopic: jest.fn(),
+    removeTopicRow: jest.fn(),
+  };
+
+  it('should insert title topic', async () => {
+    renderWithProviders(<CustomTopicsRow {...properties} />);
+
+    await userEvent.type(screen.getByTestId('topicTitle-1'), 'topicTitle');
+
+    expect(properties.setTopicTitle).toHaveBeenCalledWith('topicTitle');
+  });
+
+  it('should select test topic', async () => {
+    renderWithProviders(<CustomTopicsRow {...properties} />);
+
+    await userEvent.click(
+      screen.getByRole('combobox', { name: 'Topic 1 Test *' })
+    );
+    await userEvent.click(
+      screen.getByRole('option', { name: 'custom sub activity title' })
+    );
+
+    expect(properties.setTestTopic).toHaveBeenCalledWith(
+      'custom sub activity reference'
+    );
+  });
+
+  it('should select study materials topic', async () => {
+    renderWithProviders(<CustomTopicsRow {...properties} />);
+
+    await userEvent.click(
+      screen.getByRole('combobox', { name: 'Topic 1 Study Materials *' })
+    );
+    await userEvent.click(
+      screen.getByRole('option', { name: 'custom sub activity title' })
+    );
+
+    expect(properties.setStudyMaterialsTopic).toHaveBeenCalledWith(
+      'custom sub activity reference'
+    );
+  });
+
+  it('should remove custom topics row', async () => {
+    renderWithProviders(<CustomTopicsRow {...properties} />);
+
+    await userEvent.click(screen.getByTestId('removeRowButton-1'));
+
+    expect(properties.removeTopicRow).toHaveBeenCalled();
   });
 });

--- a/packages/react-magma-dom/src/components/Input/Input.test.js
+++ b/packages/react-magma-dom/src/components/Input/Input.test.js
@@ -1,28 +1,15 @@
 import React from 'react';
 
-import { render, fireEvent, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, fireEvent } from '@testing-library/react';
 import { transparentize } from 'polished';
-import PropTypes from 'prop-types';
 import { CheckIcon } from 'react-magma-icons';
 
 import { axe } from '../../../axe-helper';
 import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
 import { InputType } from '../InputBase';
-import { CustomTopicsRow } from './Input.stories';
 
 import { Input } from '.';
-
-const renderWithProviders = (ui, renderOptions = {}) => {
-  const Wrapper = ({ children }) => <>{children}</>;
-
-  Wrapper.propTypes = {
-    children: PropTypes.node,
-  };
-
-  return render(ui, { wrapper: Wrapper, ...renderOptions });
-};
 
 const label = 'test label';
 
@@ -718,104 +705,5 @@ describe('Input', () => {
       const inputElement = getByLabelText('Url');
       expect(inputElement).toHaveAttribute('type', 'url');
     });
-  });
-
-  describe('Value state', () => {
-    const inputLabel = 'Input Label';
-
-    it('should not update value when is controlled component by props', () => {
-      const value = 0;
-      const { getByLabelText } = render(
-        <Input type={InputType.number} labelText={inputLabel} value={value} />
-      );
-
-      const labelInput = getByLabelText(inputLabel);
-      expect(labelInput).toBeInTheDocument();
-
-      userEvent.type(labelInput, `123`);
-      expect(labelInput).toHaveValue(value);
-    });
-
-    it('should update value when is uncontrolled component', () => {
-      const { getByLabelText } = render(
-        <Input type={InputType.number} labelText={inputLabel} />
-      );
-
-      const labelInput = getByLabelText(inputLabel);
-      expect(labelInput).toBeInTheDocument();
-
-      userEvent.type(labelInput, `123`);
-      expect(labelInput).toHaveValue(123);
-
-      userEvent.type(labelInput, `456`);
-      expect(labelInput).toHaveValue(123456);
-    });
-  });
-});
-
-describe('Custom Topics Row', () => {
-  const properties = {
-    topicList: [
-      {
-        reference: 'custom sub activity reference',
-        title: 'custom sub activity title',
-      },
-    ],
-    isRemoveButtonDisabled: false,
-    shouldValidate: true,
-    topicTitle: '',
-    testTopic: undefined,
-    studyMaterialsTopic: undefined,
-    order: 1,
-    setTopicTitle: jest.fn(),
-    setTestTopic: jest.fn(),
-    setStudyMaterialsTopic: jest.fn(),
-    removeTopicRow: jest.fn(),
-  };
-
-  it('should insert title topic', async () => {
-    renderWithProviders(<CustomTopicsRow {...properties} />);
-
-    await userEvent.type(screen.getByTestId('topicTitle-1'), 'topicTitle');
-
-    expect(properties.setTopicTitle).toHaveBeenCalledWith('topicTitle');
-  });
-
-  it('should select test topic', async () => {
-    renderWithProviders(<CustomTopicsRow {...properties} />);
-
-    await userEvent.click(
-      screen.getByRole('combobox', { name: 'Topic 1 Test *' })
-    );
-    await userEvent.click(
-      screen.getByRole('option', { name: 'custom sub activity title' })
-    );
-
-    expect(properties.setTestTopic).toHaveBeenCalledWith(
-      'custom sub activity reference'
-    );
-  });
-
-  it('should select study materials topic', async () => {
-    renderWithProviders(<CustomTopicsRow {...properties} />);
-
-    await userEvent.click(
-      screen.getByRole('combobox', { name: 'Topic 1 Study Materials *' })
-    );
-    await userEvent.click(
-      screen.getByRole('option', { name: 'custom sub activity title' })
-    );
-
-    expect(properties.setStudyMaterialsTopic).toHaveBeenCalledWith(
-      'custom sub activity reference'
-    );
-  });
-
-  it('should remove custom topics row', async () => {
-    renderWithProviders(<CustomTopicsRow {...properties} />);
-
-    await userEvent.click(screen.getByTestId('removeRowButton-1'));
-
-    expect(properties.removeTopicRow).toHaveBeenCalled();
   });
 });

--- a/packages/react-magma-dom/src/components/Input/testUtils.tsx
+++ b/packages/react-magma-dom/src/components/Input/testUtils.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+
+import { WorkIcon } from 'react-magma-icons';
+
+import { ButtonColor, ButtonVariant } from '../Button';
+import { Combobox } from '../Combobox';
+import { IconButton } from '../IconButton';
+
+import { Input } from './index';
+
+// This component is used to render the Input usage for testing purposes.
+export const CustomTopicsRow = ({
+  topicList,
+  isRemoveButtonDisabled,
+  shouldValidate,
+  topicTitle,
+  testTopic,
+  studyMaterialsTopic,
+  order,
+  setTopicTitle,
+  setTestTopic,
+  setStudyMaterialsTopic,
+  removeTopicRow,
+}: {
+  topicList: { reference: string; title: string }[];
+  isRemoveButtonDisabled: boolean;
+  shouldValidate?: boolean;
+  topicTitle: string;
+  testTopic?: string;
+  studyMaterialsTopic?: string;
+  order: number;
+  setTopicTitle: (title: string) => void;
+  setTestTopic: (reference: string) => void;
+  setStudyMaterialsTopic: (reference: string) => void;
+  removeTopicRow: () => void;
+}) => {
+  const getTopicTitleError = (): string | undefined => {
+    if (!topicTitle.length) return 'Enter a topic title';
+    if (topicTitle.length >= 100) return 'Title is too long';
+    return undefined;
+  };
+
+  const normalizeTopicItems = (): { label: string; value: string }[] =>
+    topicList.map((topic: { reference: string; title: string }) => ({
+      label: topic.title,
+      value: topic.reference,
+    }));
+
+  const getSelectedTopic = (
+    reference?: string
+  ): { label: string; value: string } | undefined => {
+    if (!reference) return;
+    const selectedTopic = topicList.find(
+      (topic: { reference: string }) => topic.reference === reference
+    );
+    return selectedTopic
+      ? {
+          label: selectedTopic.title,
+          value: selectedTopic.reference,
+        }
+      : undefined;
+  };
+
+  const onTopicTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setTopicTitle(event.target.value.trim());
+  };
+
+  const onTestTopicChange = (
+    changes: Partial<{ selectedItem: { label: string; value: string } }>
+  ) => {
+    if (changes.selectedItem) {
+      setTestTopic(changes.selectedItem.value);
+    }
+  };
+
+  const onStudyMaterialsTopicChange = (
+    changes: Partial<{ selectedItem: { label: string; value: string } }>
+  ) => {
+    if (changes.selectedItem) {
+      setStudyMaterialsTopic(changes.selectedItem.value);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <Input
+        errorMessage={shouldValidate && getTopicTitleError()}
+        id={`topicTitle-${order}`}
+        labelText={`Topic ${order} Title *`}
+        onChange={onTopicTitleChange}
+        required
+        testId={`topicTitle-${order}`}
+        value={topicTitle}
+      />
+      <Combobox
+        items={normalizeTopicItems()}
+        labelText={`Topic ${order} Test *`}
+        onSelectedItemChange={onTestTopicChange}
+        placeholder="Select a test topic"
+        selectedItem={getSelectedTopic(testTopic)}
+        testId={`testTopic-${order}`}
+      />
+      <Combobox
+        items={normalizeTopicItems()}
+        labelText={`Topic ${order} Study Materials *`}
+        onSelectedItemChange={onStudyMaterialsTopicChange}
+        placeholder="Select study materials"
+        selectedItem={getSelectedTopic(studyMaterialsTopic)}
+        testId={`studyMaterialsTopic-${order}`}
+      />
+      <IconButton
+        aria-label="Remove"
+        color={
+          isRemoveButtonDisabled ? ButtonColor.secondary : ButtonColor.primary
+        }
+        disabled={isRemoveButtonDisabled}
+        icon={<WorkIcon />}
+        onClick={removeTopicRow}
+        testId={`removeRowButton-${order}`}
+        variant={ButtonVariant.link}
+      />
+    </div>
+  );
+};

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -701,14 +701,15 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       props.onChange &&
         typeof props.onChange === 'function' &&
         props.onChange(event);
+      const isOnDateChange = onDateChange && typeof onDateChange === 'function';
+      const { value } = event.target;
 
-      setValue(event.target.value);
-      if (
-        !event.target.value &&
-        onDateChange &&
-        typeof onDateChange === 'function'
-      )
-        onDateChange(null);
+      setValue(props.value ?? value);
+
+      if (isOnDateChange) {
+        setValue(value);
+        if (!value) onDateChange(null);
+      }
     }
 
     const passwordBtnWidth = () => {

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -704,11 +704,10 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       const isOnDateChange = onDateChange && typeof onDateChange === 'function';
       const { value } = event.target;
 
-      setValue(props.value ?? value);
+      setValue(isOnDateChange ? value : (props.value ?? value));
 
-      if (isOnDateChange) {
-        setValue(value);
-        if (!value) onDateChange(null);
+      if (isOnDateChange && !value) {
+        onDateChange(null);
       }
     }
 

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -701,14 +701,14 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
       props.onChange &&
         typeof props.onChange === 'function' &&
         props.onChange(event);
-      const isOnDateChange = onDateChange && typeof onDateChange === 'function';
-      const { value } = event.target;
 
-      setValue(isOnDateChange ? value : (props.value ?? value));
-
-      if (isOnDateChange && !value) {
+      setValue(event.target.value);
+      if (
+        !event.target.value &&
+        onDateChange &&
+        typeof onDateChange === 'function'
+      )
         onDateChange(null);
-      }
     }
 
     const passwordBtnWidth = () => {


### PR DESCRIPTION
Closes: #[1721](https://github.com/cengage/react-magma/issues/1721)

## What I did
- Provided a fix for this issue on the customer side.
- Added example in Storybook.
- Added additional tests of using `Input` on the customer side to track break changes.

## Screenshots
[Screencast from 11.04.25 10:50:08.webm](https://github.com/user-attachments/assets/e12404ca-caea-41db-9014-60a3f96b502c)


Storybook:
![image](https://github.com/user-attachments/assets/fca1720c-0df6-445b-a0d6-2b769c8060e7)
![Screenshot from 2025-05-20 11-03-25](https://github.com/user-attachments/assets/d09509ae-72f5-42e9-a946-6ecae34e10a7)

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Go to Storybook
- Input -> Time Input
- Type 133, 66 or 333 into the `Minutes` field (RM input)
- In case of 66, in **Hours** field should be `1` hour and in **Minutes** should be `6`
- The values of minutes and hours have to be the same for the native input component.

**On the customer side need add this line to fix this issue:**

`isHours ? setHours(currentUnitValue) : setMinutes(currentUnitValue);`

You can take a look at the [implementation](https://github.com/cengage/react-magma/pull/1782/files#diff-96fd9e1b6321b5f876d0e6926e79651a7c8f7dfa8f510e5eeda0c985ed3c6fe2R730) `onChangeTimedDuration` function 

**Why should the customer update the current Implementation?**

The main issue lies in this line: `const currentUnitValue = numericValue && numericValue >= 0 ? numericValue : 0;`

Let’s say `numericValue === 66`. Based on totalDurationMilliseconds, the parsed minutes become 6, so we call setMinutes(6). However, if the current state minutes is already 6, React sees no change and skips the re-render.

**As a result:**
1) Even though the user typed 66, the internal minutes state is 6
2) React skips the update as a no-op (minutes didn’t change)
3) The input still shows 66, but logically the time is 1h 6m, causing a mismatch.

**Why This Works Differently in Native Inputs vs. React Magma Input**

Native inputs update their displayed value immediately, independent of React state — they're "uncontrolled" in that sense. In contrast, `InputBase` and `Input` components in React Magma are state-driven and semi-controlled. Their displayed value is tied to React state and props.

If the parent component fails to re-set the value explicitly, or if React optimizes away a no-op update, the visual value may fall out of sync with the actual state — especially when parsing alters the value (like converting 66 to 6).