### PR TITLE
feat(DropdownButton): Add leading icon capability

### DIFF
--- a/.changeset/feat-Dropdown-Add-leading-icon.md
+++ b/.changeset/feat-Dropdown-Add-leading-icon.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Dropdown & IconButton): Add leading icon capability.

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -971,6 +971,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
 }
 
 .emotion-13 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -1265,6 +1266,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
 }
 
 .emotion-13 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -1717,6 +1719,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
 }
 
 .emotion-13 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2018,6 +2021,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
 }
 
 .emotion-13 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2509,6 +2513,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
 }
 
 .emotion-13 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2849,6 +2854,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
 }
 
 .emotion-13 {
+  padding-left: 0;
   padding-right: 8px;
 }
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -5,6 +5,7 @@ import {
   LocalPizzaIcon,
   LunchDiningIcon,
   MenuIcon,
+  ReorderIcon,
   RestaurantMenuIcon,
   SettingsIcon,
 } from 'react-magma-icons';
@@ -21,9 +22,13 @@ import { DropdownMenuGroup } from './DropdownMenuGroup';
 import { DropdownMenuItem } from './DropdownMenuItem';
 import { DropdownMenuNavItem } from './DropdownMenuNavItem';
 import { DropdownSplitButton } from './DropdownSplitButton';
-import { Paragraph, Spacer, SpacerAxis } from '../..';
+import { ButtonIconPosition, Paragraph, Spacer, SpacerAxis } from '../..';
 import { Button, ButtonColor, ButtonSize, ButtonVariant } from '../Button';
-import { ButtonGroup } from '../ButtonGroup';
+import {
+  ButtonGroup,
+  ButtonGroupAlignment,
+  ButtonGroupOrientation,
+} from '../ButtonGroup';
 import { Card, CardBody } from '../Card';
 
 import {
@@ -702,3 +707,75 @@ export const DropdownExpandableMenuListItemWithIcons = args => {
     </Dropdown>
   );
 };
+
+const LeadingIconTemplate: Story<DropdownProps> = args => (
+  <div
+    style={{
+      margin: '150px auto',
+      textAlign: 'center',
+      display: 'flex',
+      justifyContent: 'space-evenly',
+    }}
+  >
+    <ButtonGroup
+      orientation={ButtonGroupOrientation.vertical}
+      alignment={ButtonGroupAlignment.left}
+    >
+      <Dropdown {...args}>
+        <DropdownButton
+          size={ButtonSize.small}
+          leadingIcon={<SettingsIcon />}
+          iconPosition={ButtonIconPosition.right}
+        >
+          Small leading icon
+        </DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <Dropdown {...args}>
+        <DropdownButton
+          size={ButtonSize.medium}
+          leadingIcon={<SettingsIcon />}
+          iconPosition={ButtonIconPosition.right}
+        >
+          Medium leading icon
+        </DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <Dropdown {...args}>
+        <DropdownButton
+          size={ButtonSize.large}
+          leadingIcon={<SettingsIcon />}
+          iconPosition={ButtonIconPosition.right}
+        >
+          Large leading icon
+        </DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    </ButtonGroup>
+    <Dropdown {...args} style={{ marginLeft: '20px' }}>
+      <DropdownButton
+        icon={<ReorderIcon />}
+        leadingIcon={<SettingsIcon />}
+        iconPosition={ButtonIconPosition.left}
+      >
+        Icon left suppresses leading icon
+      </DropdownButton>
+      <DropdownContent>
+        <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+        <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+      </DropdownContent>
+    </Dropdown>
+  </div>
+);
+
+export const LeadingIcon = LeadingIconTemplate.bind({});
+LeadingIcon.args = { ...Default.args };

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -9,9 +9,15 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
-import { AsteriskIcon, RestaurantMenuIcon } from 'react-magma-icons';
+import {
+  AsteriskIcon,
+  ReorderIcon,
+  RestaurantMenuIcon,
+  SettingsIcon,
+} from 'react-magma-icons';
 
 import { magma } from '../../theme/magma';
+import { ButtonIconPosition } from '../IconButton';
 import { Modal } from '../Modal';
 
 import {
@@ -1452,6 +1458,57 @@ describe('Dropdown', () => {
           magma.colors.neutral100
         );
       });
+    });
+  });
+
+  describe('leading icon', () => {
+    it('should be shown when icon position is right', () => {
+      const { container, getByText } = render(
+        <Dropdown>
+          <DropdownButton
+            icon={<ReorderIcon />}
+            iconPosition={ButtonIconPosition.right}
+            leadingIcon={<SettingsIcon />}
+          >
+            Toggle me
+          </DropdownButton>
+          <DropdownContent>
+            <DropdownMenuItem onClick={() => {}}>Menu item 1</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => {}}>
+              Menu item number two
+            </DropdownMenuItem>
+          </DropdownContent>
+        </Dropdown>
+      );
+
+      expect(getByText('Toggle me')).toHaveStyleRule(
+        'padding-left',
+        magma.spaceScale.spacing03
+      );
+
+      expect(container.querySelectorAll('svg').length).toBe(2);
+    });
+
+    it('should not be shown when icon position is left', () => {
+      const { container } = render(
+        <Dropdown>
+          <DropdownButton
+            icon={<ReorderIcon />}
+            iconPosition={ButtonIconPosition.left}
+            leadingIcon={<SettingsIcon />}
+          >
+            Toggle me
+          </DropdownButton>
+          <DropdownContent>
+            <DropdownMenuItem onClick={() => {}}>Menu item 1</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => {}}>
+              Menu item number two
+            </DropdownMenuItem>
+          </DropdownContent>
+        </Dropdown>
+      );
+
+      expect(container.querySelectorAll('svg').length).toBe(1);
     });
   });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -55,7 +55,6 @@ export interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
    * Max-height of dropdown content
    * @default 250px
    */
-
   maxHeight?: string | number;
   /**
    * Function called when closing the dropdown menu

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
@@ -40,6 +40,10 @@ export interface IconTextDropdownButtonProps extends ButtonProps {
    */
   iconPosition?: ButtonIconPosition;
   /**
+   * Leading icon to display on the left side within the component
+   */
+  leadingIcon?: React.ReactElement<IconProps>;
+  /**
    * The content of the component
    */
   children: React.ReactChild | React.ReactChild[];
@@ -110,7 +114,7 @@ export const DropdownButton = React.forwardRef<
   const buttonIcon = getButtonIcon(context.dropDirection);
 
   let children;
-  const { icon = buttonIcon, iconPosition, ...other } = props;
+  const { icon = buttonIcon, iconPosition, leadingIcon, ...other } = props;
 
   if (!instanceOfIconOnlyDropdownButton(props)) {
     children = props.children;
@@ -145,6 +149,7 @@ export const DropdownButton = React.forwardRef<
         iconPosition={iconPositionToUse}
         id={context.dropdownButtonId.current}
         isInverse={context.isInverse}
+        leadingIcon={leadingIcon}
         onClick={handleClick}
         ref={ref}
         theme={theme}

--- a/packages/react-magma-dom/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/react-magma-dom/src/components/IconButton/IconButton.stories.tsx
@@ -19,7 +19,7 @@ import {
 import { Card } from '../Card';
 import { CardBody } from '../Card/CardBody';
 
-import { IconButton, IconButtonProps } from '.';
+import { ButtonIconPosition, IconButton, IconButtonProps } from '.';
 
 const Template: Story<IconButtonProps> = args => (
   <IconButton icon={<SettingsIcon />} {...args}>
@@ -156,3 +156,17 @@ AnimatedIcon.args = {
   isInverse: false,
   disabled: false,
 };
+
+const LeadingIconTemplate: Story<IconButtonProps> = args => (
+  <IconButton
+    iconPosition={ButtonIconPosition.right}
+    icon={<SettingsIcon />}
+    leadingIcon={<NotificationsIcon />}
+    aria-label="Button"
+    {...args}
+  >
+    Leading Icon
+  </IconButton>
+);
+
+export const LeadingIcon = LeadingIconTemplate.bind({});

--- a/packages/react-magma-dom/src/components/IconButton/IconButton.test.js
+++ b/packages/react-magma-dom/src/components/IconButton/IconButton.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
-import { CheckIcon } from 'react-magma-icons';
+import { CheckIcon, ReorderIcon, SettingsIcon } from 'react-magma-icons';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
@@ -13,7 +13,7 @@ import {
   ButtonVariant,
 } from '../Button';
 
-import { IconButton, ButtonIconPosition } from '.';
+import { ButtonIconPosition, IconButton } from '.';
 
 describe('IconButton', () => {
   it('An icon-only button does not violate detectible accessibility standards', () => {
@@ -485,6 +485,46 @@ describe('IconButton', () => {
       const svg = container.querySelector('svg');
       expect(svg).toHaveAttribute('height', '5');
       expect(svg).toHaveAttribute('width', '5');
+    });
+  });
+
+  describe('leading icon', () => {
+    it('should be shown when icon position is right', () => {
+      const { container, getByText } = render(
+        <IconButton
+          icon={<ReorderIcon />}
+          iconPosition={ButtonIconPosition.right}
+          leadingIcon={<SettingsIcon />}
+        >
+          Click me
+        </IconButton>
+      );
+
+      expect(getByText('Click me')).toHaveStyleRule(
+        'padding-left',
+        magma.spaceScale.spacing03
+      );
+
+      expect(getByText('Click me')).toHaveStyleRule(
+        'padding-right',
+        magma.spaceScale.spacing03
+      );
+
+      expect(container.querySelectorAll('svg').length).toBe(2);
+    });
+
+    it('should not be shown when icon position is left', () => {
+      const { container } = render(
+        <IconButton
+          icon={<ReorderIcon />}
+          iconPosition={ButtonIconPosition.left}
+          leadingIcon={<SettingsIcon />}
+        >
+          Click me
+        </IconButton>
+      );
+
+      expect(container.querySelectorAll('svg').length).toBe(1);
     });
   });
 });

--- a/packages/react-magma-dom/src/components/IconButton/__snapshots__/IconButton.test.js.snap
+++ b/packages/react-magma-dom/src/components/IconButton/__snapshots__/IconButton.test.js.snap
@@ -1262,6 +1262,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 16px;
 }
 
@@ -1356,6 +1357,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 16px;
 }
 
@@ -1487,6 +1489,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -1581,6 +1584,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -1712,6 +1716,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 4px;
 }
 
@@ -1806,6 +1811,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 4px;
 }
 
@@ -1937,6 +1943,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2031,6 +2038,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2162,6 +2170,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2256,6 +2265,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2387,6 +2397,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2481,6 +2492,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2612,6 +2624,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 
@@ -2706,6 +2719,7 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
 }
 
 .emotion-4 {
+  padding-left: 0;
   padding-right: 8px;
 }
 

--- a/packages/react-magma-dom/src/components/IconButton/index.tsx
+++ b/packages/react-magma-dom/src/components/IconButton/index.tsx
@@ -7,12 +7,12 @@ import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { omit, Omit, resolveProps, XOR } from '../../utils';
 import {
-  ButtonProps,
   ButtonColor,
+  ButtonProps,
   ButtonShape,
   ButtonSize,
-  ButtonVariant,
   ButtonTextTransform,
+  ButtonVariant,
 } from '../Button';
 import { ButtonGroupContext } from '../ButtonGroup';
 import { StyledButton } from '../StyledButton';
@@ -38,22 +38,36 @@ export interface IconTextButtonProps extends ButtonProps {
    * Icon to display within the component
    */
   icon: React.ReactElement<IconProps>;
-  children: React.ReactChild | React.ReactChild[];
   /**
    * Position within the button for the icon to appear
    * @default ButtonIconPosition.right
    */
   iconPosition?: ButtonIconPosition;
+  /**
+   * Leading icon to display on the left side of the button
+   */
+  leadingIcon?: React.ReactElement<IconProps>;
+  /**
+   * The content of the component
+   */
+  children: React.ReactChild | React.ReactChild[];
 }
 
 export type IconButtonProps = XOR<IconOnlyButtonProps, IconTextButtonProps>;
 
 export interface SpanProps {
+  hasIconLeading?: boolean;
   size?: ButtonSize;
 }
 
 const SpanTextLeft = styled.span<SpanProps>`
-  padding-right: ${props => getIconPadding(props)};
+  ${props => {
+    const padding = getIconPadding(props);
+    return `
+      padding-left: ${props.hasIconLeading ? padding : 0};
+      padding-right: ${padding};
+    `;
+  }}
 `;
 
 const SpanTextRight = styled.span<SpanProps>`
@@ -91,6 +105,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     let icon;
     let iconPosition;
     let children;
+    let leadingIcon;
 
     const contextProps = React.useContext(ButtonGroupContext);
     const theme = React.useContext(ThemeContext);
@@ -104,6 +119,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       icon = resolvedProps.icon;
       iconPosition = resolvedProps.iconPosition;
       children = resolvedProps.children;
+      leadingIcon = resolvedProps.leadingIcon;
     }
 
     const other = omit(['iconPosition', 'textPosition'], rest);
@@ -147,9 +163,23 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         variant={variant || ButtonVariant.solid}
       >
         {iconPosition === ButtonIconPosition.right && (
-          <SpanTextLeft size={size} theme={theme}>
-            {children}
-          </SpanTextLeft>
+          <>
+            {leadingIcon &&
+              React.Children.only(
+                React.cloneElement(leadingIcon, {
+                  size: leadingIcon.props.size || getIconSize(size, theme),
+                  'data-testid': `${testId}-leading-icon`,
+                  'aria-hidden': 'true',
+                })
+              )}
+            <SpanTextLeft
+              hasIconLeading={!!leadingIcon}
+              size={size}
+              theme={theme}
+            >
+              {children}
+            </SpanTextLeft>
+          </>
         )}
         {React.Children.only(
           React.cloneElement(icon, {

--- a/website/react-magma-docs/src/components/IconButtonProps/index.js
+++ b/website/react-magma-docs/src/components/IconButtonProps/index.js
@@ -80,6 +80,13 @@ export function IconButtonProps() {
             'If true, the component will have inverse styling to better appear on a dark background',
           defaultValue: 'false',
         },
+        leadingIcon: {
+          type: {
+            name: 'React Element',
+          },
+          required: false,
+          description: 'Leading icon to display on the left side of the button',
+        },
         shape: {
           type: {
             name: 'enum',

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -713,7 +713,7 @@ export function Example() {
 
 ## Custom Icon Button
 
-Similarly, the `DropdownButton` can be customized by using any of the props that the <Link to="/api/icon-button">Icon Button</Link> component accepts, to create a button with an icon.
+Similarly, the `DropdownButton` can be customized by using any of the props that the <Link to="/api/icon-button">Icon Button</Link> component accepts to customize the dropdown open arrow icon.
 
 ```tsx
 import React from 'react';
@@ -789,6 +789,80 @@ export function Example() {
         </Dropdown>
       </ButtonGroup>
     </>
+  );
+}
+```
+
+## Leading Icon
+
+The `DropdownButton` can be customized using the `leadingIcon` prop, which allows an icon to be placed to the left of the button text.
+
+Note: The `leadingIcon` prop will be ignored when `iconPosition` is set
+to `ButtonIconPosition.left`, as it is only intended for using on the left side
+of the button.
+
+```tsx
+import React from 'react';
+
+import {
+  ButtonGroupOrientation,
+  ButtonGroupAlignment,
+  ButtonIconPosition,
+  ButtonSize,
+  ButtonGroup,
+  Dropdown,
+  DropdownButton,
+  DropdownContent,
+  DropdownMenuItem,
+} from 'react-magma-dom';
+import { SettingsIcon } from 'react-magma-icons';
+
+export function Example() {
+  return (
+    <ButtonGroup
+      orientation={ButtonGroupOrientation.vertical}
+      alignment={ButtonGroupAlignment.left}
+    >
+      <Dropdown>
+        <DropdownButton
+          size={ButtonSize.small}
+          leadingIcon={<SettingsIcon />}
+          iconPosition={ButtonIconPosition.right}
+        >
+          Small leading icon
+        </DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <Dropdown>
+        <DropdownButton
+          size={ButtonSize.medium}
+          leadingIcon={<SettingsIcon />}
+          iconPosition={ButtonIconPosition.right}
+        >
+          Medium leading icon
+        </DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <Dropdown>
+        <DropdownButton
+          size={ButtonSize.large}
+          leadingIcon={<SettingsIcon />}
+          iconPosition={ButtonIconPosition.right}
+        >
+          Large leading icon
+        </DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    </ButtonGroup>
   );
 }
 ```
@@ -986,7 +1060,7 @@ Examples may include an id, a title, event handlers or various aria attributes. 
 
 <ButtonProps />
 
-The DropdownButton can also accept an `icon` property, as in the <Link to="/api/icon-button">Icon Button</Link> component.
+The DropdownButton can also accept `icon` and `leadingIcon` properties, as in the <Link to="/api/icon-button">Icon Button</Link> component.
 
 <IconButtonProps />
 

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -627,7 +627,7 @@ export function Example() {
 }
 ```
 
-### Leading Icons
+## DropdownMenuItem Leading Icons
 
 The `icon` prop can be used to specify an icon for the `DropdownMenuItem` elements.
 

--- a/website/react-magma-docs/src/pages/api/icon-button.mdx
+++ b/website/react-magma-docs/src/pages/api/icon-button.mdx
@@ -244,6 +244,34 @@ export function Example() {
 }
 ```
 
+## Leading Icon
+
+The `Icon Button` can be customized using the `leadingIcon` prop, which allows an icon to be placed to the left of the button text.
+
+Note: The `leadingIcon` prop will be ignored when `iconPosition` is set
+to `ButtonIconPosition.left`, as it is only intended for using on the left side
+of the button.
+
+```tsx
+import React from 'react';
+
+import { ButtonIconPosition, IconButton } from 'react-magma-dom';
+import { NotificationsIcon, SettingsIcon } from 'react-magma-icons';
+
+export function Example() {
+  return (
+    <IconButton
+      aria-label="Button"
+      iconPosition={ButtonIconPosition.right}
+      icon={<SettingsIcon />}
+      leadingIcon={<NotificationsIcon />}
+    >
+      Leading Icon
+    </IconButton>
+  );
+}
+```
+
 ## Sizes
 
 Sizes for `IconButtons` include `small`, `medium`, and `large`, with `medium` being the default value.


### PR DESCRIPTION
Closes: #1745 

## What I did
- Added the new `leadingIcon` prop for `DropdownButton` and `IconButton`
- Updated React Magma docs for these components
- Added some new unit tests
- Added examples in docs and storybook

## Screenshots
**Storybook:**
![Screenshot from 2025-05-13 11-35-55](https://github.com/user-attachments/assets/e63f21d3-a279-4fdb-a58a-ea2bf89f9da9)
![Screenshot from 2025-05-13 11-36-13](https://github.com/user-attachments/assets/df76ff7e-15bc-4aa3-8c9e-bb4d2833bd35)

**React Magma Docs:**

![Screenshot from 2025-05-13 11-37-12](https://github.com/user-attachments/assets/0021e983-8595-4fdf-b9b5-44dda97e2f2d)
![Screenshot from 2025-05-13 11-42-14](https://github.com/user-attachments/assets/f2602044-9e4f-4932-9a2c-f2b2bb54b28b)
![Screenshot from 2025-05-13 12-21-33](https://github.com/user-attachments/assets/ad32e712-e966-4e6e-8ef1-3641945d429c)
![Screenshot from 2025-05-13 13-50-38](https://github.com/user-attachments/assets/2b74a97e-f6c0-4bab-92ef-bd1e62081485)
![Screenshot from 2025-05-13 14-35-17](https://github.com/user-attachments/assets/b857f31a-2660-4a00-874c-de5a407dfba0)
![Screenshot from 2025-05-19 11-21-04](https://github.com/user-attachments/assets/7316f8e8-4979-4996-b0b6-bb71a24f8f50)




## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
**Dropdown Button:**

- Go to Storybook
- DropDown -> Leading Icon
- All styles should be the same as in these [mock-ups](https://www.figma.com/design/VoWYiiOKKppcYm5QLgPyDC/Components---Inputs?m=auto&node-id=2506-3713&t=ibAT74oQ5OxMb9zC-1)

- Go to React Magma Docs
- Components -> Dropdown -> Leading Icon
- The description and an example of this new prop should be provided
- The documentation of `Dropdown button props` should be updated

**Icon Button:**
- Go to Storybook
- Icon Button -> Leading Icon
- All styles should be the same as in these [mock-ups](https://www.figma.com/design/VoWYiiOKKppcYm5QLgPyDC/Components---Inputs?m=auto&node-id=2506-3713&t=ibAT74oQ5OxMb9zC-1)

- Go to React Magma Docs
- Components -> Icon Button -> Leading Icon
- The description and an example of this new prop should be provided
- The documentation of `Icon button props` should be updated

