### PR TITLE
feat(MultiSelect): Make selected items disabled when MultiSelect is disabled

### DIFF
--- a/.changeset/feat-multiselect-new-option-disabled.md
+++ b/.changeset/feat-multiselect-new-option-disabled.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(MultiSelect): Make selected items disabled when MultiSelect is disabled.

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
@@ -445,6 +445,43 @@ describe('Select', () => {
     expect(renderedSelect).toHaveAttribute('disabled');
   });
 
+  it('should disable selected items in the disabled multi-select and disabled items should not be removable', () => {
+    const { getByLabelText, getByText } = render(
+      <MultiSelect
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={items}
+        disabled
+      />
+    );
+
+    const renderedSelect = getByLabelText(labelText, { selector: 'div' });
+
+    expect(renderedSelect).toHaveAttribute('disabled');
+
+    expect(getByText(items[0], { selector: 'button' })).toBeInTheDocument();
+    expect(getByText(items[0], { selector: 'button' })).toBeDisabled();
+    expect(getByText(items[0], { selector: 'button' })).toHaveAttribute(
+      'disabled'
+    );
+    expect(getByText(items[1], { selector: 'button' })).toBeInTheDocument();
+    expect(getByText(items[1], { selector: 'button' })).toBeDisabled();
+    expect(getByText(items[1], { selector: 'button' })).toHaveAttribute(
+      'disabled'
+    );
+    expect(getByText(items[2], { selector: 'button' })).toBeInTheDocument();
+    expect(getByText(items[2], { selector: 'button' })).toBeDisabled();
+    expect(getByText(items[2], { selector: 'button' })).toHaveAttribute(
+      'disabled'
+    );
+
+    const selectedItem = getByText(items[0], { selector: 'button' });
+    fireEvent.click(selectedItem);
+
+    expect(selectedItem).toBeInTheDocument();
+  });
+
   it('should open select when clicking the enter key', () => {
     const { getByLabelText, getByText } = render(
       <MultiSelect isMulti labelText={labelText} items={items} />

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -316,6 +316,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
                 onFocus={() => setActiveIndex(index)}
                 theme={theme}
                 isInverse={isInverse}
+                disabled={disabled}
               >
                 {multiSelectedItemString}
                 <IconWrapper>

--- a/packages/react-magma-dom/src/components/Select/Select.stories.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.stories.tsx
@@ -94,15 +94,20 @@ Disabled.args = {
 
 export const Multi = (props: MultiSelectProps<SelectOptions>) => (
   <Select
-    isMulti
     {...props}
+    isMulti
     items={[
       { label: 'Red', value: 'red' },
       { label: 'Blue', value: 'blue' },
       { label: 'Green', value: 'green' },
     ]}
+    initialSelectedItems={[{ label: 'Red', value: 'red' }]}
   />
 );
+Multi.args = {
+  ...Default.args,
+  disabled: false,
+};
 
 const helpLinkLabel = 'Learn more';
 const onHelpLinkClick = () => {


### PR DESCRIPTION
Closes: #1202

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Make selected items disabled when MultiSelect is disabled

## Screenshots
<!-- Include screenshot of your change, when applicable -->
![image](https://github.com/user-attachments/assets/2f399859-308b-473b-83e1-2224c48a2d06)

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open StoryBook -> MultiSelect -> Select a few items -> Turn on the `disabled` option.