### PR TITLE
fix(dropdown): add `aria-label` to navitem for windows + firefox for nvda announce

### DIFF
--- a/.changeset/fix-Dropdown-nav-item-accessibility-issue.md
+++ b/.changeset/fix-Dropdown-nav-item-accessibility-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Add `aria-label` to NavItem for Windows + Firefox for NVDA announce.

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -8,6 +8,7 @@ import {
   ReorderIcon,
   RestaurantMenuIcon,
   SettingsIcon,
+  GooglePlusIcon,
 } from 'react-magma-icons';
 
 import { DropdownButton } from './DropdownButton';
@@ -316,6 +317,18 @@ const LinkMenuTemplate: Story<DropdownProps> = args => (
           target="_blank"
         >
           Cengage
+        </DropdownMenuNavItem>
+        <DropdownMenuNavItem
+          icon={<GooglePlusIcon />}
+          to="http://www.google.com"
+          target="_blank"
+        >
+          <div>
+            <p style={{ margin: 0 }}>Google</p>
+            <p style={{ margin: 0 }}>With</p>
+            <p style={{ margin: 0 }}>Some</p>
+            <p style={{ margin: 0 }}>Text</p>
+          </div>
         </DropdownMenuNavItem>
       </DropdownContent>
     </Dropdown>

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownMenuNavItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownMenuNavItem.tsx
@@ -6,7 +6,7 @@ import { IconProps } from 'react-magma-icons';
 import { DropdownContext } from './Dropdown';
 import { MenuItemStyles, IconWrapper } from './DropdownMenuItem';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { Omit, useForkedRef } from '../../utils';
+import { Omit, useForkedRef, collectTextFromReactNode } from '../../utils';
 
 export interface DropdownMenuNavItemProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
@@ -46,6 +46,21 @@ export const DropdownMenuNavItem = React.forwardRef<
     context.registerDropdownMenuItem(context.itemRefArray, ownRef);
   }, []);
 
+  const ariaLabel = React.useMemo(() => {
+    const isWindows = navigator.platform.startsWith('Win');
+    const isFireFox = /^((?!chrome|android).)*firefox/i.test(
+      navigator.userAgent
+    );
+
+    if (isWindows && isFireFox) {
+      const collectedText = collectTextFromReactNode(children);
+
+      return collectedText.length > 0 ? collectedText : undefined;
+    }
+
+    return undefined;
+  }, []);
+
   return (
     <StyledItem
       {...other}
@@ -56,6 +71,7 @@ export const DropdownMenuNavItem = React.forwardRef<
       role="menuitem"
       tabIndex={-1}
       theme={theme}
+      aria-label={ariaLabel}
     >
       {icon && <IconWrapper theme={theme}>{icon}</IconWrapper>}
       {children}

--- a/packages/react-magma-dom/src/utils/index.ts
+++ b/packages/react-magma-dom/src/utils/index.ts
@@ -315,3 +315,21 @@ export const reactNodeToString = (node: React.ReactNode): string => {
 
   return '';
 };
+
+export function collectTextFromReactNode(node: React.ReactNode) {
+  const result = [];
+
+  React.Children.forEach(node, child => {
+    if (child === null || typeof child === 'boolean') {
+      return;
+    }
+
+    if (typeof child === 'string' || typeof child === 'number') {
+      result.push(child);
+    } else if (React.isValidElement(child)) {
+      result.push(collectTextFromReactNode(child.props.children));
+    }
+  });
+
+  return result.join(' ');
+}


### PR DESCRIPTION
Closes: #1612 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add `aria-label` to NavItem for Windows + Firefox for NVDA announce

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Windows + NVDA + Firefox -> Storybook -> Dropdown -> Link Menu -> Try to navigate using a keyboard.

## Notes:
- If you can't navigate through elements - Press `Insert + Space` -> This will change the Focus mode, then try again;
- Need to test all other components using all OS, Browsers and Screenreaders to make sure everything else is working fine;