### PR TITLE
fix(Indeterminate Checkbox): Screenreader reads "unticked" on indeterminate state.

### DIFF
--- a/.changeset/fix-Intermediate-Checkbox-screenreader-reads-unticked.md
+++ b/.changeset/fix-Intermediate-Checkbox-screenreader-reads-unticked.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Intermediate Checkbox): Fix screen reading 'unticked' on indeterminate state.

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.stories.tsx
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.stories.tsx
@@ -82,48 +82,74 @@ export const Behavior = () => {
   const [checkedItems, setCheckedItems] = React.useState<Array<boolean>>([
     true,
     false,
+    false,
+    false,
   ]);
 
-  const status: IndeterminateCheckboxStatus = checkedItems.every(Boolean)
-    ? IndeterminateCheckboxStatus.checked
-    : checkedItems.some(Boolean)
-      ? IndeterminateCheckboxStatus.indeterminate
-      : IndeterminateCheckboxStatus.unchecked;
+  const [status, setStatus] = React.useState<IndeterminateCheckboxStatus>(
+    IndeterminateCheckboxStatus.indeterminate
+  );
+
+  function getStatus(items: Array<boolean>) {
+    return items.every(Boolean)
+      ? IndeterminateCheckboxStatus.checked
+      : items.some(Boolean)
+        ? IndeterminateCheckboxStatus.indeterminate
+        : IndeterminateCheckboxStatus.unchecked;
+  }
 
   function handleUpdateIndeterminateChecked(
     event: React.ChangeEvent<HTMLInputElement>
   ) {
-    setCheckedItems([event.target.checked, event.target.checked]);
+    const updatedCheckedItems = Array(4).fill(event.target.checked);
+    setCheckedItems(updatedCheckedItems);
+    setStatus(getStatus(updatedCheckedItems));
   }
 
-  function handleUpdateRedChecked(event: React.ChangeEvent<HTMLInputElement>) {
-    setCheckedItems([event.target.checked, checkedItems[1]]);
-  }
-
-  function handleUpdateBlueChecked(event: React.ChangeEvent<HTMLInputElement>) {
-    setCheckedItems([checkedItems[0], event.target.checked]);
+  function handleColorChecked(
+    index: number,
+    event: React.ChangeEvent<HTMLInputElement>
+  ) {
+    const updatedCheckedItems = [...checkedItems];
+    updatedCheckedItems[index] = event.target.checked;
+    setCheckedItems(updatedCheckedItems);
+    setStatus(getStatus(updatedCheckedItems));
   }
 
   return (
-    <>
+    <FormGroup labelText="Colors group" isTextVisuallyHidden>
       <IndeterminateCheckbox
         onChange={handleUpdateIndeterminateChecked}
         status={status}
         labelText="Colors"
-        id="5"
+        id="indeterminateCheckbox"
       />
       <div style={{ marginLeft: magma.spaceScale.spacing08 }}>
         <Checkbox
           checked={checkedItems[0]}
-          onChange={handleUpdateRedChecked}
+          onChange={e => handleColorChecked(0, e)}
           labelText="Red"
+          id="Red"
         />
         <Checkbox
           checked={checkedItems[1]}
-          onChange={handleUpdateBlueChecked}
+          onChange={e => handleColorChecked(1, e)}
           labelText="Blue"
+          id="Blue"
+        />
+        <Checkbox
+          checked={checkedItems[2]}
+          onChange={e => handleColorChecked(2, e)}
+          labelText="Green"
+          id="Green"
+        />
+        <Checkbox
+          checked={checkedItems[3]}
+          onChange={e => handleColorChecked(3, e)}
+          labelText="Yellow"
+          id="Yellow"
         />
       </div>
-    </>
+    </FormGroup>
   );
 };

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
@@ -158,7 +158,11 @@ export const IndeterminateCheckbox = React.forwardRef<
           data-testid={testId}
           disabled={disabled}
           id={id}
-          ref={ref}
+          ref={el => {
+            if (el) el.indeterminate = isIndeterminate;
+            if (typeof ref === 'function') ref(el);
+            else if (ref) ref.current = el;
+          }}
           type="checkbox"
           onChange={handleChange}
         />


### PR DESCRIPTION
Closes: #1566 

## What I did
- Fixed reading by Screen Reader Indeterminate Checkbox.

## Screenshots
![Screenshot from 2025-05-28 16-38-21](https://github.com/user-attachments/assets/568498eb-49b7-493e-b1d3-69a225e3e39d)


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Go to Storybook -> Indeterminate Checkbox -> Default
- Turn on Screen Reader
-  Indeterminate Checkbox is read as `mixed`.