### PR TITLE
chore(docs): Add warning for `Tooltip` that the child element must be able to accept a ref.

### DIFF
--- a/.changeset/chore-docs-add-warning-for-tooltip.md
+++ b/.changeset/chore-docs-add-warning-for-tooltip.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+chore: Add warning for `Tooltip` that the child element must be able to accept a ref.

--- a/website/react-magma-docs/src/pages/api/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/api/tooltip.mdx
@@ -16,13 +16,6 @@ props:
 
 The Tooltip component should wrap the triggerring element. This trigger should be a focusable element for accessibility, such as a button.
 
-<Alert variant="warning">
-  The child element must be able to accept a React <inlineCode>ref</inlineCode>{' '}
-  (for example, a native DOM element like <inlineCode>{'<button>'}</inlineCode>{' '}
-  or a component created with <inlineCode>React.forwardRef</inlineCode>). If the
-  child cannot accept a ref, the tooltip may not position correctly.
-</Alert>
-
 ```tsx
 import React from 'react';
 
@@ -116,6 +109,57 @@ export function Example() {
           icon={<KeyboardArrowUpIcon />}
           variant={ButtonVariant.solid}
         />
+      </Tooltip>
+    </Flex>
+  );
+}
+```
+
+## On non-interactive element
+
+The child element must be able to accept a React `ref`
+(for example, a native DOM element like `<button>`
+or a component created with `React.forwardRef`). If the
+child cannot accept a ref, the tooltip may not position correctly.
+
+<Alert variant="info">
+  You can get around this by adding a wrapping element.
+</Alert>
+
+```tsx
+import React from 'react';
+
+import { Tooltip, Flex, FlexBehavior, FlexAlignItems } from 'react-magma-dom';
+import { HelpOutlineIcon } from 'react-magma-icons';
+
+export function Example() {
+  const tooltipContentShort = (
+    <>
+      Tooltip wrapped in <b>div</b>
+    </>
+  );
+  const tooltipContentLong = (
+    <>
+      Tooltip wrapped in <b>span</b>
+    </>
+  );
+
+  return (
+    <Flex
+      behavior={FlexBehavior.container}
+      alignItems={FlexAlignItems.center}
+      spacing={2}
+    >
+      <Tooltip content={tooltipContentShort}>
+        <div style={{ width: 'fit-content', height: 'fit-content' }}>
+          <HelpOutlineIcon tabIndex="0" size={40} />
+        </div>
+      </Tooltip>
+
+      <Tooltip content={tooltipContentLong}>
+        <span>
+          <HelpOutlineIcon tabIndex="0" />
+        </span>
       </Tooltip>
     </Flex>
   );

--- a/website/react-magma-docs/src/pages/api/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/api/tooltip.mdx
@@ -16,6 +16,13 @@ props:
 
 The Tooltip component should wrap the triggerring element. This trigger should be a focusable element for accessibility, such as a button.
 
+<Alert variant="warning">
+  The child element must be able to accept a React <inlineCode>ref</inlineCode>{' '}
+  (for example, a native DOM element like <inlineCode>{'<button>'}</inlineCode>{' '}
+  or a component created with <inlineCode>React.forwardRef</inlineCode>). If the
+  child cannot accept a ref, the tooltip may not position correctly.
+</Alert>
+
 ```tsx
 import React from 'react';
 


### PR DESCRIPTION
Closes: #1802 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add warning for `Tooltip` that the child element must be able to accept a ref.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open docs -> Tooltip -> Basic Usage -> Check Warning