### PR TITLE
feat(Drawer):  Add prop to show/hide background overlay

### DIFF
--- a/.changeset/feat-Drawer-Add-Show-Background-Overlay-prop.md
+++ b/.changeset/feat-Drawer-Add-Show-Background-Overlay-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat (Drawer): Add `showBackgroundOverlay` prop.

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
@@ -18,6 +18,16 @@ const info = {
         options: DrawerPosition,
       },
     },
+    isInverse: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    showBackgroundOverlay: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 };
 
@@ -67,8 +77,12 @@ export const SiteNavigation = args => {
         position={DrawerPosition.right}
         ariaLabel="Site Navigation Drawer"
         closeAriaLabel="Close Navigation Drawer"
+        {...args}
       >
-        <NavTabs orientation={TabsOrientation.vertical}>
+        <NavTabs
+          orientation={TabsOrientation.vertical}
+          isInverse={args.isInverse}
+        >
           <NavTab to="#">One</NavTab>
           <NavTab to="#">Two</NavTab>
           <NavTab to="#">Three</NavTab>

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import { axe } from '../../../axe-helper';
+import { magma } from '../../theme/magma';
 
 import { Drawer } from '.';
 
@@ -98,5 +99,49 @@ describe('Drawer', () => {
     const results = await axe(baseElement);
 
     return expect(results).toHaveNoViolations();
+  });
+
+  describe('showBackgroundOverlay prop', () => {
+    const drawerContent = 'Drawer content';
+    const modalBackDropTestId = 'modal-backdrop';
+    const modalContentTestId = 'modal-content';
+
+    it('should show background overlay when showBackgroundOverlay is true', async () => {
+      const { getByTestId } = render(
+        <Drawer position="bottom" header="Hello" isOpen testId={TEST_ID}>
+          {drawerContent}
+        </Drawer>
+      );
+
+      const modalContent = getByTestId(modalContentTestId);
+
+      expect(modalContent).toBeInTheDocument();
+      expect(getByTestId(modalBackDropTestId)).toBeInTheDocument();
+      expect(modalContent).toHaveStyle(`border: none`);
+    });
+
+    it('should hide background overlay when showBackgroundOverlay is false', async () => {
+      const { queryByTestId } = render(
+        <Drawer
+          position="bottom"
+          header="Hello"
+          isOpen
+          testId={TEST_ID}
+          showBackgroundOverlay={false}
+          isInverse
+        >
+          {drawerContent}
+        </Drawer>
+      );
+
+      const modalContent = queryByTestId(modalContentTestId);
+
+      expect(modalContent).toBeInTheDocument();
+      expect(queryByTestId(modalBackDropTestId)).not.toBeInTheDocument();
+      expect(modalContent).toHaveStyleRule(
+        `border`,
+        `1px solid ${magma.colors.primary400}`
+      );
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
@@ -41,6 +41,11 @@ export interface DrawerProps extends Omit<ModalProps, 'size'> {
    * @default DrawerPosition.top
    */
   position?: DrawerPosition;
+  /**
+   * Shows a background overlay when the drawer is open.
+   * @default true
+   */
+  showBackgroundOverlay?: boolean;
   isInverse?: boolean;
 }
 

--- a/website/react-magma-docs/src/pages/api/drawer.mdx
+++ b/website/react-magma-docs/src/pages/api/drawer.mdx
@@ -100,6 +100,56 @@ export function Example() {
 }
 ```
 
+## Show background overlay
+
+The `showBackgroundOverlay` can be set to `false` to hide a background overlay when the drawer is open.
+
+```tsx
+import React from 'react';
+
+import {
+  Button,
+  Drawer,
+  DrawerPosition,
+  NavTab,
+  NavTabs,
+  TabsOrientation,
+  VisuallyHidden,
+} from 'react-magma-dom';
+
+export function Example() {
+  const [showDrawer, setShowDrawer] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
+
+  return (
+    <>
+      <Drawer
+        onClose={() => {
+          setShowDrawer(false);
+          buttonRef.current.focus();
+        }}
+        isOpen={showDrawer}
+        position={DrawerPosition.right}
+        ariaLabel="Site Navigation Drawer"
+        closeAriaLabel="Close Navigation Drawer"
+        showBackgroundOverlay={false}
+      >
+        <NavTabs orientation={TabsOrientation.vertical}>
+          <NavTab to="#">One</NavTab>
+          <NavTab to="#">Two</NavTab>
+          <NavTab to="#">Three</NavTab>
+          <NavTab to="#">Four</NavTab>
+        </NavTabs>
+      </Drawer>
+      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
+        Show Drawer
+        <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
+      </Button>
+    </>
+  );
+}
+```
+
 ## Inverse
 
 ```tsx


### PR DESCRIPTION
Closes: #1703 

## What I did
- Added new `showBackgroundOverlay` prop.
- Updated React Magma docs

## Screenshots
**Storybook
![Screenshot from 2025-06-03 12-03-18](https://github.com/user-attachments/assets/f733c702-dc8c-4ae4-ae51-75928b2087f0)
**
![Screenshot from 2025-06-03 16-05-57](https://github.com/user-attachments/assets/309912ac-e212-48eb-9d2b-42aa8adbcd24)
![Screenshot from 2025-06-03 16-06-03](https://github.com/user-attachments/assets/2502f530-f8dd-49ff-8f9e-ddaeaa0fd615)

**React Magma Docs**
![Screenshot from 2025-06-03 16-34-46](https://github.com/user-attachments/assets/06cf9857-3d75-438a-a56b-77c9e321866e)
![Screenshot from 2025-06-03 16-34-11](https://github.com/user-attachments/assets/71f45c9d-5f79-493a-8134-01599a6cccc9)


## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test

Go to **Storybook** -> Drawer -> Site Navigation -> in controls update shouldBackgroundOverlay to `false` -> background overlay should not be visible

Go to **Docs** -> Components -> Drawer -> Show background overlay - example of new prop
Go to **Docs** -> Components -> Drawer -> Drawer props - a new prop should be added.

