### PR TITLE
feat(Table, Datagrid): Added new tableTitle, hasOutsideBorder, hasTablePagination props

### DIFF
--- a/.changeset/feat-Table-DataGrid-Caption-as-title-of-table.md
+++ b/.changeset/feat-Table-DataGrid-Caption-as-title-of-table.md
@@ -2,4 +2,4 @@
 'react-magma-dom': minor
 ---
 
-feat(Table & Datagrid): Added new prop `tableTitle` to `Table` and `Datagrid` which supports a captioned title above each Table and Datagrid. Added new prop `hasOutsideBorder` to `Table`.
+feat(Table & Datagrid): Added new prop `tableTitle` to `Table` and `Datagrid` which supports a captioned title above each Table and Datagrid. Added new props `hasOutsideBorder`, `hasTablePagination` to `Table`.

--- a/.changeset/feat-Table-DataGrid-Caption-as-title-of-table.md
+++ b/.changeset/feat-Table-DataGrid-Caption-as-title-of-table.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Table & Datagrid): Added new prop `tableTitle` to `Table` and `Datagrid` which supports a captioned title above each Table and Datagrid. Added new prop `hasOutsideBorder` to `Table`.

--- a/.changeset/fix-Table-DataGrid-Caption-as-title-of-table.md
+++ b/.changeset/fix-Table-DataGrid-Caption-as-title-of-table.md
@@ -2,4 +2,4 @@
 'react-magma-dom': patch
 ---
 
-fix(Table & Datagrid): Added new prop `tableTitle` to `Table` and `Datagrid` which supports a captioned title above each Table and Datagrid.
+fix(Table & Datagrid): Added new prop `tableTitle` to `Table` and `Datagrid` which supports a captioned title above each Table and Datagrid. Added new prop `hasOutsideBorder` to `Table`.

--- a/.changeset/fix-Table-DataGrid-Caption-as-title-of-table.md
+++ b/.changeset/fix-Table-DataGrid-Caption-as-title-of-table.md
@@ -1,5 +1,0 @@
----
-'react-magma-dom': patch
----
-
-fix(Table & Datagrid): Added new prop `tableTitle` to `Table` and `Datagrid` which supports a captioned title above each Table and Datagrid. Added new prop `hasOutsideBorder` to `Table`.

--- a/.changeset/fix-Table-DataGrid-Caption-as-title-of-table.md
+++ b/.changeset/fix-Table-DataGrid-Caption-as-title-of-table.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Table & Datagrid): Added new prop `tableTitle` to `Table` and `Datagrid` which supports a captioned title above each Table and Datagrid.

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -322,6 +322,11 @@ export default {
         type: 'text',
       },
     },
+    hasOutsideBorder: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { Meta, Story } from '@storybook/react/types-6-0';
 
 import { DatagridProps } from './Datagrid';
 import { magma } from '../../theme/magma';
 import { Announce } from '../Announce';
 import { Button } from '../Button';
 import { ButtonGroup } from '../ButtonGroup';
-import { Card } from '../Card';
+import { Card, CardBody } from '../Card';
 import { usePagination } from '../Pagination/usePagination';
 import { Spacer, SpacerAxis } from '../Spacer';
 import {
+  TableDensity,
   TablePaginationProps,
   TableRowColor,
   TableSortDirection,
-  TableDensity,
 } from '../Table';
 import { VisuallyHidden } from '../VisuallyHidden';
 
@@ -224,13 +224,12 @@ const rowsForPagination = [
 ];
 
 const Template: Story<Omit<DatagridProps, 'selectedRows'>> = args => (
-  <Card
-    isInverse={args.isInverse}
-    style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-  >
-    <Datagrid tableTitle="Basic usage table" {...args}>
-      Sample Text
-    </Datagrid>
+  <Card isInverse={args.isInverse}>
+    <CardBody>
+      <Datagrid tableTitle="Basic usage table" {...args}>
+        Sample Text
+      </Datagrid>
+    </CardBody>
   </Card>
 );
 
@@ -242,17 +241,16 @@ const ControlledTemplate: Story<
   >([1]);
 
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Datagrid
-        {...args}
-        selectedRows={selectedRows}
-        onSelectedRowsChange={updatedSelectedRows}
-      >
-        Sample Text
-      </Datagrid>
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Datagrid
+          {...args}
+          selectedRows={selectedRows}
+          onSelectedRowsChange={updatedSelectedRows}
+        >
+          Sample Text
+        </Datagrid>
+      </CardBody>
     </Card>
   );
 };
@@ -287,11 +285,10 @@ const ControlledPaginatedTemplate: Story<DatagridProps> = ({
   };
 
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Datagrid {...args} paginationProps={passedInPaginationProps} />
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Datagrid {...args} paginationProps={passedInPaginationProps} />
+      </CardBody>
     </Card>
   );
 };
@@ -552,24 +549,23 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
   }
 
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Datagrid
-        {...args}
-        rows={sortedItems}
-        columns={productColumns}
-        onSortBySelected={() => {
-          requestSort('name');
-        }}
-        onRowSelect={handleRowSelect}
-        onHeaderSelect={handleHeaderSelect}
-        sortDirection={selectedDirection}
-      />
-      <Announce>
-        <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
-      </Announce>
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Datagrid
+          {...args}
+          rows={sortedItems}
+          columns={productColumns}
+          onSortBySelected={() => {
+            requestSort('name');
+          }}
+          onRowSelect={handleRowSelect}
+          onHeaderSelect={handleHeaderSelect}
+          sortDirection={selectedDirection}
+        />
+        <Announce>
+          <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
+        </Announce>
+      </CardBody>
     </Card>
   );
 };

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -7,6 +7,7 @@ import { magma } from '../../theme/magma';
 import { Announce } from '../Announce';
 import { Button } from '../Button';
 import { ButtonGroup } from '../ButtonGroup';
+import { Card } from '../Card';
 import { usePagination } from '../Pagination/usePagination';
 import { Spacer, SpacerAxis } from '../Spacer';
 import {
@@ -223,7 +224,18 @@ const rowsForPagination = [
 ];
 
 const Template: Story<Omit<DatagridProps, 'selectedRows'>> = args => (
-  <Datagrid {...args}>Sample Text</Datagrid>
+  <Card
+    isInverse={args.isInverse}
+    style={
+      args.hasSquareCorners
+        ? { borderRadius: '0', padding: '16px' }
+        : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
+    }
+  >
+    <Datagrid tableTitle="Basic usage table" {...args}>
+      Sample Text
+    </Datagrid>
+  </Card>
 );
 
 const ControlledTemplate: Story<
@@ -234,13 +246,22 @@ const ControlledTemplate: Story<
   >([1]);
 
   return (
-    <Datagrid
-      {...args}
-      selectedRows={selectedRows}
-      onSelectedRowsChange={updatedSelectedRows}
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
+      }
     >
-      Sample Text
-    </Datagrid>
+      <Datagrid
+        {...args}
+        selectedRows={selectedRows}
+        onSelectedRowsChange={updatedSelectedRows}
+      >
+        Sample Text
+      </Datagrid>
+    </Card>
   );
 };
 
@@ -273,7 +294,18 @@ const ControlledPaginatedTemplate: Story<DatagridProps> = ({
     onRowsPerPageChange: handleRowsPerPageChange,
   };
 
-  return <Datagrid {...args} paginationProps={passedInPaginationProps} />;
+  return (
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
+      }
+    >
+      <Datagrid {...args} paginationProps={passedInPaginationProps} />
+    </Card>
+  );
 };
 
 export default {
@@ -283,6 +315,11 @@ export default {
     isInverse: {
       control: {
         type: 'boolean',
+      },
+    },
+    tableTitle: {
+      control: {
+        type: 'text',
       },
     },
   },
@@ -340,18 +377,23 @@ const defaultArgs = {
 };
 
 export const Default = Template.bind({});
-Default.args = defaultArgs;
+Default.args = {
+  ...defaultArgs,
+  tableTitle: 'Default',
+};
 
 export const ColoredRows = Template.bind({});
 ColoredRows.args = {
   ...defaultArgs,
   rows: coloredRows,
+  tableTitle: 'Colored rows',
 };
 
 export const Selectable = Template.bind({});
 Selectable.args = {
   ...defaultArgs,
   isSelectable: true,
+  tableTitle: 'Selectable',
 };
 
 export const SelectableAndSortable: Story<DatagridProps> = ({
@@ -517,7 +559,14 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
   }
 
   return (
-    <>
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
+      }
+    >
       <Datagrid
         {...args}
         rows={sortedItems}
@@ -532,25 +581,28 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
       <Announce>
         <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
       </Announce>
-    </>
+    </Card>
   );
 };
 
 SelectableAndSortable.args = {
   isSelectable: true,
   isSortableBySelected: true,
+  tableTitle: 'Selectable and sortable',
 };
 
 export const ControlledSelectable = ControlledTemplate.bind({});
 ControlledSelectable.args = {
   ...defaultArgs,
   isSelectable: true,
+  tableTitle: 'Controlled selectable',
 };
 
 export const DisabledSelectableRow = Template.bind({});
 DisabledSelectableRow.args = {
   ...defaultArgs,
   isSelectable: true,
+  tableTitle: 'Disabled selectable row',
   rows: [
     ...defaultArgs.rows,
     {
@@ -567,6 +619,7 @@ DisabledSelectableRow.args = {
 export const PaginationChangedDefaults = Template.bind({});
 PaginationChangedDefaults.args = {
   ...defaultArgs,
+  tableTitle: 'Pagination changed defaults',
   paginationProps: {
     defaultPage: 2,
     defaultRowsPerPage: 5,
@@ -577,6 +630,7 @@ PaginationChangedDefaults.args = {
 export const ControlledPagination = ControlledPaginatedTemplate.bind({});
 ControlledPagination.args = {
   ...defaultArgs,
+  tableTitle: 'Controlled pagination',
   paginationProps: {
     rowsPerPageValues: [5, 10, 20],
   },
@@ -586,6 +640,7 @@ export const WithoutPagination = Template.bind({});
 WithoutPagination.args = {
   ...defaultArgs,
   hasPagination: false,
+  tableTitle: 'Without pagination',
 };
 
 const CustomPaginationComponent: React.FunctionComponent<
@@ -630,7 +685,14 @@ const CustomPaginationComponent: React.FunctionComponent<
 export const PaginationWithCustomComponent = Template.bind({});
 PaginationWithCustomComponent.args = {
   ...defaultArgs,
+  tableTitle: 'Pagination with custom component',
   components: {
     Pagination: CustomPaginationComponent,
   },
+};
+
+export const TitleTable = Template.bind({});
+TitleTable.args = {
+  ...defaultArgs,
+  tableTitle: <h1>Title table</h1>,
 };

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.stories.tsx
@@ -226,11 +226,7 @@ const rowsForPagination = [
 const Template: Story<Omit<DatagridProps, 'selectedRows'>> = args => (
   <Card
     isInverse={args.isInverse}
-    style={
-      args.hasSquareCorners
-        ? { borderRadius: '0', padding: '16px' }
-        : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-    }
+    style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
   >
     <Datagrid tableTitle="Basic usage table" {...args}>
       Sample Text
@@ -248,11 +244,7 @@ const ControlledTemplate: Story<
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Datagrid
         {...args}
@@ -297,11 +289,7 @@ const ControlledPaginatedTemplate: Story<DatagridProps> = ({
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Datagrid {...args} paginationProps={passedInPaginationProps} />
     </Card>
@@ -566,11 +554,7 @@ export const SelectableAndSortable: Story<DatagridProps> = ({
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Datagrid
         {...args}
@@ -699,5 +683,7 @@ PaginationWithCustomComponent.args = {
 export const TitleTable = Template.bind({});
 TitleTable.args = {
   ...defaultArgs,
+  hasOutsideBorder: true,
+  hasSquareCorners: false,
   tableTitle: <h1>Title table</h1>,
 };

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
@@ -845,5 +845,20 @@ describe('Datagrid', () => {
     return axe(container.innerHTML).then(result => {
       return expect(result).toHaveNoViolations();
     });
+  });
+
+  it('should display the title table', () => {
+    const { getByText } = render(
+      <Datagrid
+        columns={columns}
+        rows={rowsForPagination}
+        tableTitle="Datagrid title"
+      />
+    );
+
+    const titleTable = getByText('Datagrid title');
+
+    expect(titleTable).toBeInTheDocument();
+    expect(titleTable).toHaveStyle(`margin: ${magma.spaceScale.spacing04}`);
   });
 });

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -864,4 +864,21 @@ describe('Datagrid', () => {
       `margin-bottom: ${magma.spaceScale.spacing04}`
     );
   });
+
+  it('should display the outer border when hasOutsideBorder is true and hasSquareCorners is false', () => {
+    const testId = 'table-test';
+
+    const { getByTestId } = render(
+      <Datagrid
+        hasOutsideBorder
+        testId={testId}
+        columns={columns}
+        rows={rowsForPagination}
+      />
+    );
+
+    expect(getByTestId(testId)).toHaveStyle(
+      `border-radius: ${magma.borderRadius} ${magma.borderRadius} 0 0`
+    );
+  });
 });

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -859,6 +859,9 @@ describe('Datagrid', () => {
     const titleTable = getByText('Datagrid title');
 
     expect(titleTable).toBeInTheDocument();
-    expect(titleTable).toHaveStyle(`margin: ${magma.spaceScale.spacing04}`);
+    expect(titleTable).toHaveStyle(`margin-top: ${magma.spaceScale.spacing04}`);
+    expect(titleTable).toHaveStyle(
+      `margin-bottom: ${magma.spaceScale.spacing04}`
+    );
   });
 });

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.test.js
@@ -878,6 +878,9 @@ describe('Datagrid', () => {
     );
 
     expect(getByTestId(testId)).toHaveStyle(
+      `border: 1px solid ${magma.colors.neutral300}`
+    );
+    expect(getByTestId(testId)).toHaveStyle(
       `border-radius: ${magma.borderRadius} ${magma.borderRadius} 0 0`
     );
   });

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -160,6 +160,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       rows,
       selectedRows: selectedRowsProp,
       hasPagination = true,
+      isDataGrid = true,
       onSortBySelected,
       sortDirection,
       ...other
@@ -279,7 +280,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
 
     return (
       <>
-        <Table {...other} ref={ref} aria-live="polite">
+        <Table isDataGrid={isDataGrid} {...other} ref={ref} aria-live="polite">
           <TableHead>
             <TableRow
               headerRowStatus={headerRowStatus}

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -170,7 +170,7 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       default: defaultSelectedRows,
     });
 
-    const isControlled = selectedRowsProp ? true : false;
+    const isControlled = !!selectedRowsProp;
 
     const {
       getPageItems,

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -162,7 +162,6 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       hasSquareCorners,
       hasOutsideBorder,
       hasPagination = true,
-      isDataGrid = true,
       onSortBySelected,
       sortDirection,
       ...other
@@ -283,9 +282,9 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
     return (
       <>
         <Table
-          isDataGrid={isDataGrid}
           hasOutsideBorder={hasOutsideBorder}
           hasSquareCorners={hasSquareCorners}
+          hasTablePagination={hasPagination}
           {...other}
           ref={ref}
           aria-live="polite"

--- a/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
+++ b/packages/react-magma-dom/src/components/Datagrid/Datagrid.tsx
@@ -159,6 +159,8 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
       paginationProps = {},
       rows,
       selectedRows: selectedRowsProp,
+      hasSquareCorners,
+      hasOutsideBorder,
       hasPagination = true,
       isDataGrid = true,
       onSortBySelected,
@@ -280,7 +282,14 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
 
     return (
       <>
-        <Table isDataGrid={isDataGrid} {...other} ref={ref} aria-live="polite">
+        <Table
+          isDataGrid={isDataGrid}
+          hasOutsideBorder={hasOutsideBorder}
+          hasSquareCorners={hasSquareCorners}
+          {...other}
+          ref={ref}
+          aria-live="polite"
+        >
           <TableHead>
             <TableRow
               headerRowStatus={headerRowStatus}
@@ -332,6 +341,8 @@ export const Datagrid = React.forwardRef<HTMLTableElement, DatagridProps>(
           <Pagination
             isInverse={props.isInverse}
             itemCount={rows.length}
+            hasOutsideBorder={hasOutsideBorder}
+            hasSquareCorners={hasSquareCorners}
             {...passedOnPaginationProps}
             {...componentsProps.pagination}
           />

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -348,6 +348,7 @@ export const ControlledPagination = args => {
           page={pageIndex}
           rowsPerPage={rowsPerPage}
           isInverse={args.isInverse}
+          hasOutsideBorder={args.hasOutsideBorder}
           hasSquareCorners={args.hasSquareCorners}
           rowsPerPageValues={args.rowsPerPageValues}
         />
@@ -360,6 +361,7 @@ ControlledPagination.args = {
   tableTitle: 'Controlled Pagination',
   rowsPerPage: 10,
   rowsPerPageValues: [10, 20, 50, 100],
+  hasTablePagination: true,
 };
 
 export const UncontrolledPagination = args => {
@@ -404,10 +406,13 @@ export const UncontrolledPagination = args => {
           </TableBody>
         </Table>
         <TablePagination
+          isInverse={args.isInverse}
           itemCount={rowsLong.length}
           onPageChange={handlePageChange}
           onRowsPerPageChange={handleRowsPerPageChange}
           defaultRowsPerPage={rowsPerPage}
+          hasOutsideBorder={args.hasOutsideBorder}
+          hasSquareCorners={args.hasSquareCorners}
           rowsPerPageValues={args.rowsPerPageValues}
         />
       </CardBody>
@@ -419,6 +424,7 @@ UncontrolledPagination.args = {
   tableTitle: 'Uncontrolled Pagination',
   defaultRowsPerPage: 10,
   rowsPerPageValues: [10, 20, 50, 100],
+  hasTablePagination: true,
 };
 
 export const PaginationWithSquareCorners = args => {
@@ -466,12 +472,14 @@ export const PaginationWithSquareCorners = args => {
         page={pageIndex}
         rowsPerPage={rowsPerPage}
         isInverse={args.isInverse}
+        hasOutsideBorder={args.hasOutsideBorder}
         hasSquareCorners={args.hasSquareCorners}
       />
     </div>
   );
 };
 PaginationWithSquareCorners.args = {
+  hasTablePagination: true,
   hasSquareCorners: true,
   hasOutsideBorder: false,
   hasHoverStyles: false,
@@ -524,6 +532,8 @@ export const PaginationInverse = args => {
           isInverse
           onPageChange={handlePageChange}
           onRowsPerPageChange={handleRowsPerPageChange}
+          hasOutsideBorder={args.hasOutsideBorder}
+          hasSquareCorners={args.hasSquareCorners}
         />
       </CardBody>
     </Card>
@@ -533,6 +543,7 @@ PaginationInverse.args = {
   ...Default.args,
   isInverse: true,
   tableTitle: 'Pagination inverse',
+  hasTablePagination: true,
 };
 
 export const RowColors = args => {
@@ -932,6 +943,7 @@ export const NoRowsPerPageControl = args => {
           page={pageIndex}
           rowsPerPage={rowsPerPage}
           isInverse={args.isInverse}
+          hasOutsideBorder={args.hasOutsideBorder}
           hasSquareCorners={args.hasSquareCorners}
         />
       </CardBody>
@@ -942,6 +954,7 @@ NoRowsPerPageControl.args = {
   ...Default.args,
   numberRows: 300,
   tableTitle: 'No Rows Per Page Control Table',
+  hasTablePagination: true,
 };
 
 export const TitleTableAndOutsideBorder = Template.bind({});

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -102,12 +102,18 @@ export default {
         type: 'text',
       },
     },
+    hasOutsideBorder: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 } as Meta;
 
 export const Default = Template.bind({});
 Default.args = {
   hasHoverStyles: false,
+  hasOutsideBorder: false,
   hasSquareCorners: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,
@@ -150,6 +156,7 @@ export const SquareCorners = args => {
 };
 SquareCorners.args = {
   hasSquareCorners: true,
+  hasOutsideBorder: false,
   hasHoverStyles: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,
@@ -481,6 +488,7 @@ export const PaginationWithSquareCorners = args => {
 };
 PaginationWithSquareCorners.args = {
   hasSquareCorners: true,
+  hasOutsideBorder: false,
   hasHoverStyles: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 
 import { magma } from '../../theme/magma';
 import { Announce } from '../Announce';
-import { Card } from '../Card';
+import { Card, CardBody } from '../Card';
 import { Combobox } from '../Combobox';
 import {
   Dropdown,
@@ -52,29 +52,28 @@ const rows = [
 ];
 
 const Template: Story<TableProps> = args => (
-  <Card
-    style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    isInverse={args.isInverse}
-  >
-    <Table tableTitle="Basic Usage Table" {...args}>
-      <TableHead>
-        <TableRow>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {rows.map((row, i) => (
-          <TableRow key={`row${i}`}>
-            {row.map((cell, j) => (
-              <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
-            ))}
+  <Card isInverse={args.isInverse}>
+    <CardBody>
+      <Table tableTitle="Basic Usage Table" {...args}>
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, i) => (
+            <TableRow key={`row${i}`}>
+              {row.map((cell, j) => (
+                <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </CardBody>
   </Card>
 );
 
@@ -321,39 +320,38 @@ export const ControlledPagination = args => {
   );
 
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table {...args}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rowsToShow.map((row, i) => (
-            <TableRow key={`row${i}`}>
-              {row.map((cell, j) => (
-                <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
-              ))}
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Table {...args}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      <TablePagination
-        itemCount={rowsLong.length}
-        onRowsPerPageChange={handleRowsPerPageChange}
-        onPageChange={handlePageChange}
-        page={pageIndex}
-        rowsPerPage={rowsPerPage}
-        isInverse={args.isInverse}
-        hasSquareCorners={args.hasSquareCorners}
-        rowsPerPageValues={args.rowsPerPageValues}
-      />
+          </TableHead>
+          <TableBody>
+            {rowsToShow.map((row, i) => (
+              <TableRow key={`row${i}`}>
+                {row.map((cell, j) => (
+                  <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <TablePagination
+          itemCount={rowsLong.length}
+          onRowsPerPageChange={handleRowsPerPageChange}
+          onPageChange={handlePageChange}
+          page={pageIndex}
+          rowsPerPage={rowsPerPage}
+          isInverse={args.isInverse}
+          hasSquareCorners={args.hasSquareCorners}
+          rowsPerPageValues={args.rowsPerPageValues}
+        />
+      </CardBody>
     </Card>
   );
 };
@@ -384,36 +382,35 @@ export const UncontrolledPagination = args => {
   );
 
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table {...args}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rowsToShow.map((row, i) => (
-            <TableRow key={`row${i}`}>
-              {row.map((cell, j) => (
-                <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
-              ))}
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Table {...args}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      <TablePagination
-        itemCount={rowsLong.length}
-        onPageChange={handlePageChange}
-        onRowsPerPageChange={handleRowsPerPageChange}
-        defaultRowsPerPage={rowsPerPage}
-        rowsPerPageValues={args.rowsPerPageValues}
-      />
+          </TableHead>
+          <TableBody>
+            {rowsToShow.map((row, i) => (
+              <TableRow key={`row${i}`}>
+                {row.map((cell, j) => (
+                  <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <TablePagination
+          itemCount={rowsLong.length}
+          onPageChange={handlePageChange}
+          onRowsPerPageChange={handleRowsPerPageChange}
+          defaultRowsPerPage={rowsPerPage}
+          rowsPerPageValues={args.rowsPerPageValues}
+        />
+      </CardBody>
     </Card>
   );
 };
@@ -501,35 +498,34 @@ export const PaginationInverse = args => {
   );
 
   return (
-    <Card
-      isInverse
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table {...args} isInverse>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rowsToShow.map((row, i) => (
-            <TableRow key={`row${i}`}>
-              {row.map((cell, j) => (
-                <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
-              ))}
+    <Card isInverse>
+      <CardBody>
+        <Table {...args} isInverse>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      <TablePagination
-        itemCount={rowsLong.length}
-        isInverse
-        onPageChange={handlePageChange}
-        onRowsPerPageChange={handleRowsPerPageChange}
-      />
+          </TableHead>
+          <TableBody>
+            {rowsToShow.map((row, i) => (
+              <TableRow key={`row${i}`}>
+                {row.map((cell, j) => (
+                  <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <TablePagination
+          itemCount={rowsLong.length}
+          isInverse
+          onPageChange={handlePageChange}
+          onRowsPerPageChange={handleRowsPerPageChange}
+        />
+      </CardBody>
     </Card>
   );
 };
@@ -541,51 +537,50 @@ PaginationInverse.args = {
 
 export const RowColors = args => {
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table {...args}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow color={TableRowColor.success}>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow color={TableRowColor.danger}>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow color={TableRowColor.info}>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow color={TableRowColor.warning}>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Table {...args}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow color={TableRowColor.success}>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow color={TableRowColor.danger}>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow color={TableRowColor.info}>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow color={TableRowColor.warning}>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardBody>
     </Card>
   );
 };
@@ -598,56 +593,55 @@ RowColors.args = {
 
 export const RowColorsInverse = args => {
   return (
-    <Card
-      isInverse
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table {...args}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow color={TableRowColor.success}>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow color={TableRowColor.danger}>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow color={TableRowColor.info}>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow color={TableRowColor.warning}>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Lorem ipsum</TableCell>
-            <TableCell>dolar sit</TableCell>
-            <TableCell>amet</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
+    <Card isInverse>
+      <CardBody>
+        <Table {...args}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow color={TableRowColor.success}>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow color={TableRowColor.danger}>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow color={TableRowColor.info}>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow color={TableRowColor.warning}>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Lorem ipsum</TableCell>
+              <TableCell>dolar sit</TableCell>
+              <TableCell>amet</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardBody>
     </Card>
   );
 };
@@ -703,70 +697,71 @@ export const Sortable = args => {
   };
 
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table {...args}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell
-              onSort={() => {
-                requestSort('name');
-              }}
-              isSortable
-              sortDirection={
-                sortConfig.key === 'name'
-                  ? sortConfig.direction
-                  : TableSortDirection.none
-              }
-            >
-              Name
-            </TableHeaderCell>
-            <TableHeaderCell
-              onSort={() => {
-                requestSort('price');
-              }}
-              isSortable
-              align={TableCellAlign.right}
-              sortDirection={
-                sortConfig.key === 'price'
-                  ? sortConfig.direction
-                  : TableSortDirection.none
-              }
-            >
-              Price
-            </TableHeaderCell>
-            <TableHeaderCell
-              onSort={() => {
-                requestSort('stock');
-              }}
-              isSortable
-              align={TableCellAlign.right}
-              sortDirection={
-                sortConfig.key === 'stock'
-                  ? sortConfig.direction
-                  : TableSortDirection.none
-              }
-            >
-              In Stock
-            </TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {sortedItems.map(item => (
-            <TableRow key={item.id}>
-              <TableCell>{item.name}</TableCell>
-              <TableCell align={TableCellAlign.right}>${item.price}</TableCell>
-              <TableCell align={TableCellAlign.right}>{item.stock}</TableCell>
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Table {...args}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell
+                onSort={() => {
+                  requestSort('name');
+                }}
+                isSortable
+                sortDirection={
+                  sortConfig.key === 'name'
+                    ? sortConfig.direction
+                    : TableSortDirection.none
+                }
+              >
+                Name
+              </TableHeaderCell>
+              <TableHeaderCell
+                onSort={() => {
+                  requestSort('price');
+                }}
+                isSortable
+                align={TableCellAlign.right}
+                sortDirection={
+                  sortConfig.key === 'price'
+                    ? sortConfig.direction
+                    : TableSortDirection.none
+                }
+              >
+                Price
+              </TableHeaderCell>
+              <TableHeaderCell
+                onSort={() => {
+                  requestSort('stock');
+                }}
+                isSortable
+                align={TableCellAlign.right}
+                sortDirection={
+                  sortConfig.key === 'stock'
+                    ? sortConfig.direction
+                    : TableSortDirection.none
+                }
+              >
+                In Stock
+              </TableHeaderCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {sortedItems.map(item => (
+              <TableRow key={item.id}>
+                <TableCell>{item.name}</TableCell>
+                <TableCell align={TableCellAlign.right}>
+                  ${item.price}
+                </TableCell>
+                <TableCell align={TableCellAlign.right}>{item.stock}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
 
-      <Announce>
-        <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
-      </Announce>
+        <Announce>
+          <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
+        </Announce>
+      </CardBody>
     </Card>
   );
 };
@@ -778,75 +773,74 @@ Sortable.args = {
 
 export const WithDropdown = args => {
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table maxWidth={500} {...args}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>
-              <Dropdown isInverse={args.isInverse}>
-                <DropdownButton>Basic Dropdown</DropdownButton>
-                <DropdownContent>
-                  <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-                  <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-                  <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-                  <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-                  <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-                  <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-                  <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-                </DropdownContent>
-              </Dropdown>
-            </TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>
-              <Select
-                labelText="Select Example"
-                items={[
-                  { label: 'Red', value: 'red' },
-                  { label: 'Blue', value: 'blue' },
-                  { label: 'Green', value: 'green' },
-                  { label: 'Yellow', value: 'yellow' },
-                ]}
-                isInverse={args.isInverse}
-              />
-            </TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>
-              <Combobox
-                isMulti
-                labelText="ComboBox Example"
-                defaultItems={[
-                  { label: 'Pink', value: 'pink' },
-                  { label: 'Orange', value: 'orange' },
-                  { label: 'Purple', value: 'purple' },
-                ]}
-                isInverse={args.isInverse}
-              />
-            </TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Table maxWidth={500} {...args}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>
+                <Dropdown isInverse={args.isInverse}>
+                  <DropdownButton>Basic Dropdown</DropdownButton>
+                  <DropdownContent>
+                    <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+                    <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+                    <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+                    <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+                    <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+                    <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+                    <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+                  </DropdownContent>
+                </Dropdown>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>
+                <Select
+                  labelText="Select Example"
+                  items={[
+                    { label: 'Red', value: 'red' },
+                    { label: 'Blue', value: 'blue' },
+                    { label: 'Green', value: 'green' },
+                    { label: 'Yellow', value: 'yellow' },
+                  ]}
+                  isInverse={args.isInverse}
+                />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>
+                <Combobox
+                  isMulti
+                  labelText="ComboBox Example"
+                  defaultItems={[
+                    { label: 'Pink', value: 'pink' },
+                    { label: 'Orange', value: 'orange' },
+                    { label: 'Purple', value: 'purple' },
+                  ]}
+                  isInverse={args.isInverse}
+                />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardBody>
     </Card>
   );
 };
@@ -875,20 +869,19 @@ export const AdjustableRowNumber = args => {
   }
 
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table {...args}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Number</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>{getTableRows()}</TableBody>
-      </Table>
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Table {...args}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Number</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>{getTableRows()}</TableBody>
+        </Table>
+      </CardBody>
     </Card>
   );
 };
@@ -912,37 +905,36 @@ export const NoRowsPerPageControl = args => {
   );
 
   return (
-    <Card
-      isInverse={args.isInverse}
-      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
-    >
-      <Table {...args}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rowsToShow.map((row, i) => (
-            <TableRow key={`row${i}`}>
-              {row.map((cell, j) => (
-                <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
-              ))}
+    <Card isInverse={args.isInverse}>
+      <CardBody>
+        <Table {...args}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      <TablePagination
-        itemCount={rowsLong.length}
-        onPageChange={handlePageChange}
-        page={pageIndex}
-        rowsPerPage={rowsPerPage}
-        isInverse={args.isInverse}
-        hasSquareCorners={args.hasSquareCorners}
-      />
+          </TableHead>
+          <TableBody>
+            {rowsToShow.map((row, i) => (
+              <TableRow key={`row${i}`}>
+                {row.map((cell, j) => (
+                  <TableCell key={`cell${i}_${j}`}>{cell}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+        <TablePagination
+          itemCount={rowsLong.length}
+          onPageChange={handlePageChange}
+          page={pageIndex}
+          rowsPerPage={rowsPerPage}
+          isInverse={args.isInverse}
+          hasSquareCorners={args.hasSquareCorners}
+        />
+      </CardBody>
     </Card>
   );
 };

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { Meta, Story } from '@storybook/react/types-6-0';
 
 import { magma } from '../../theme/magma';
 import { Announce } from '../Announce';
@@ -17,17 +17,17 @@ import { VisuallyHidden } from '../VisuallyHidden';
 
 import {
   Table,
-  TableCell,
-  TableHead,
-  TableRow,
-  TableHeaderCell,
   TableBody,
+  TableCell,
+  TableCellAlign,
+  TableDensity,
+  TableHead,
+  TableHeaderCell,
   TablePagination,
   TableProps,
-  TableDensity,
+  TableRow,
   TableRowColor,
   TableSortDirection,
-  TableCellAlign,
 } from './';
 
 const rows = [
@@ -55,12 +55,12 @@ const Template: Story<TableProps> = args => (
   <Card
     style={
       args.hasSquareCorners
-        ? { borderRadius: '0' }
-        : { borderRadius: `${magma.borderRadius}` }
+        ? { borderRadius: '0', padding: '16px' }
+        : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
     }
     isInverse={args.isInverse}
   >
-    <Table {...args}>
+    <Table tableTitle="Basic Usage Table" {...args}>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -97,6 +97,11 @@ export default {
         type: 'number',
       },
     },
+    tableTitle: {
+      control: {
+        type: 'text',
+      },
+    },
   },
 } as Meta;
 
@@ -107,6 +112,7 @@ Default.args = {
   hasVerticalBorders: false,
   hasZebraStripes: false,
   isInverse: false,
+  tableTitle: 'Basic usage table',
 };
 
 export const SquareCorners = args => {
@@ -119,7 +125,7 @@ export const SquareCorners = args => {
   );
 
   return (
-    <div style={{ background: magma.colors.primary600, padding: '20px' }}>
+    <div style={{ background: magma.colors.neutral300, padding: '16px' }}>
       <Table style={{ background: magma.colors.neutral100 }} {...args}>
         <TableHead>
           <TableRow>
@@ -147,6 +153,7 @@ SquareCorners.args = {
   hasHoverStyles: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,
+  tableTitle: 'Square corners',
 };
 
 const rowsLong = [
@@ -315,8 +322,8 @@ export const ControlledPagination = args => {
       isInverse={args.isInverse}
       style={
         args.hasSquareCorners
-          ? { borderRadius: '0' }
-          : { borderRadius: `${magma.borderRadius}` }
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
       }
     >
       <Table {...args}>
@@ -353,6 +360,7 @@ export const ControlledPagination = args => {
 };
 ControlledPagination.args = {
   ...Default.args,
+  tableTitle: 'Controlled Pagination',
   rowsPerPage: 10,
   rowsPerPageValues: [10, 20, 50, 100],
 };
@@ -377,8 +385,15 @@ export const UncontrolledPagination = args => {
   );
 
   return (
-    <>
-      <Table>
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
+      }
+    >
+      <Table {...args}>
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -404,10 +419,12 @@ export const UncontrolledPagination = args => {
         defaultRowsPerPage={rowsPerPage}
         rowsPerPageValues={args.rowsPerPageValues}
       />
-    </>
+    </Card>
   );
 };
 UncontrolledPagination.args = {
+  ...Default.args,
+  tableTitle: 'Uncontrolled Pagination',
   defaultRowsPerPage: 10,
   rowsPerPageValues: [10, 20, 50, 100],
 };
@@ -430,7 +447,7 @@ export const PaginationWithSquareCorners = args => {
   );
 
   return (
-    <div style={{ background: magma.colors.primary600, padding: '20px' }}>
+    <div style={{ background: magma.colors.neutral300, padding: '16px' }}>
       <Table style={{ background: magma.colors.neutral100 }} {...args}>
         <TableHead>
           <TableRow>
@@ -467,6 +484,7 @@ PaginationWithSquareCorners.args = {
   hasHoverStyles: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,
+  tableTitle: 'Pagination with square corners',
 };
 
 export const PaginationInverse = args => {
@@ -491,8 +509,8 @@ export const PaginationInverse = args => {
       isInverse
       style={
         args.hasSquareCorners
-          ? { borderRadius: '0' }
-          : { borderRadius: `${magma.borderRadius}` }
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
       }
     >
       <Table {...args} isInverse>
@@ -526,57 +544,68 @@ export const PaginationInverse = args => {
 PaginationInverse.args = {
   ...Default.args,
   isInverse: true,
+  tableTitle: 'Pagination inverse',
 };
 
 export const RowColors = args => {
   return (
-    <Table {...args}>
-      <TableHead>
-        <TableRow>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        <TableRow>
-          <TableCell>Lorem ipsum</TableCell>
-          <TableCell>dolar sit</TableCell>
-          <TableCell>amet</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell>Lorem ipsum</TableCell>
-          <TableCell>dolar sit</TableCell>
-          <TableCell>amet</TableCell>
-        </TableRow>
-        <TableRow color={TableRowColor.success}>
-          <TableCell>Lorem ipsum</TableCell>
-          <TableCell>dolar sit</TableCell>
-          <TableCell>amet</TableCell>
-        </TableRow>
-        <TableRow color={TableRowColor.danger}>
-          <TableCell>Lorem ipsum</TableCell>
-          <TableCell>dolar sit</TableCell>
-          <TableCell>amet</TableCell>
-        </TableRow>
-        <TableRow color={TableRowColor.info}>
-          <TableCell>Lorem ipsum</TableCell>
-          <TableCell>dolar sit</TableCell>
-          <TableCell>amet</TableCell>
-        </TableRow>
-        <TableRow color={TableRowColor.warning}>
-          <TableCell>Lorem ipsum</TableCell>
-          <TableCell>dolar sit</TableCell>
-          <TableCell>amet</TableCell>
-        </TableRow>
-      </TableBody>
-    </Table>
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
+      }
+    >
+      <Table {...args}>
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>Lorem ipsum</TableCell>
+            <TableCell>dolar sit</TableCell>
+            <TableCell>amet</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Lorem ipsum</TableCell>
+            <TableCell>dolar sit</TableCell>
+            <TableCell>amet</TableCell>
+          </TableRow>
+          <TableRow color={TableRowColor.success}>
+            <TableCell>Lorem ipsum</TableCell>
+            <TableCell>dolar sit</TableCell>
+            <TableCell>amet</TableCell>
+          </TableRow>
+          <TableRow color={TableRowColor.danger}>
+            <TableCell>Lorem ipsum</TableCell>
+            <TableCell>dolar sit</TableCell>
+            <TableCell>amet</TableCell>
+          </TableRow>
+          <TableRow color={TableRowColor.info}>
+            <TableCell>Lorem ipsum</TableCell>
+            <TableCell>dolar sit</TableCell>
+            <TableCell>amet</TableCell>
+          </TableRow>
+          <TableRow color={TableRowColor.warning}>
+            <TableCell>Lorem ipsum</TableCell>
+            <TableCell>dolar sit</TableCell>
+            <TableCell>amet</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Card>
   );
 };
 RowColors.args = {
   ...Default.args,
   hasHoverStyles: true,
   hasZebraStripe: true,
+  tableTitle: 'Row colors',
 };
 
 export const RowColorsInverse = args => {
@@ -585,8 +614,8 @@ export const RowColorsInverse = args => {
       isInverse
       style={
         args.hasSquareCorners
-          ? { borderRadius: '0' }
-          : { borderRadius: `${magma.borderRadius}` }
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
       }
     >
       <Table {...args}>
@@ -641,6 +670,7 @@ export const RowColorsInverse = args => {
 RowColorsInverse.args = {
   ...Default.args,
   isInverse: true,
+  tableTitle: 'Row colors Inverse',
 };
 
 export const Sortable = args => {
@@ -693,8 +723,8 @@ export const Sortable = args => {
       isInverse={args.isInverse}
       style={
         args.hasSquareCorners
-          ? { borderRadius: '0' }
-          : { borderRadius: `${magma.borderRadius}` }
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
       }
     >
       <Table {...args}>
@@ -763,6 +793,7 @@ export const Sortable = args => {
 
 Sortable.args = {
   ...Default.args,
+  tableTitle: 'Sortable Table',
 };
 
 export const WithDropdown = args => {
@@ -771,8 +802,8 @@ export const WithDropdown = args => {
       isInverse={args.isInverse}
       style={
         args.hasSquareCorners
-          ? { borderRadius: '0' }
-          : { borderRadius: `${magma.borderRadius}` }
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
       }
     >
       <Table maxWidth={500} {...args}>
@@ -845,6 +876,7 @@ export const WithDropdown = args => {
 };
 WithDropdown.args = {
   ...Default.args,
+  tableTitle: 'With dropdown',
 };
 
 export const AdjustableRowNumber = args => {
@@ -867,20 +899,31 @@ export const AdjustableRowNumber = args => {
   }
 
   return (
-    <Table {...args}>
-      <TableHead>
-        <TableRow>
-          <TableHeaderCell>Number</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-          <TableHeaderCell>Column</TableHeaderCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>{getTableRows()}</TableBody>
-    </Table>
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
+      }
+    >
+      <Table {...args}>
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>Number</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+            <TableHeaderCell>Column</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>{getTableRows()}</TableBody>
+      </Table>
+    </Card>
   );
 };
 AdjustableRowNumber.args = {
+  ...Default.args,
   numberRows: 300,
+  tableTitle: 'Adjustable Row Number Table',
 };
 
 export const NoRowsPerPageControl = args => {
@@ -897,7 +940,14 @@ export const NoRowsPerPageControl = args => {
   );
 
   return (
-    <Card isInverse={args.isInverse}>
+    <Card
+      isInverse={args.isInverse}
+      style={
+        args.hasSquareCorners
+          ? { borderRadius: '0', padding: '16px' }
+          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
+      }
+    >
       <Table {...args}>
         <TableHead>
           <TableRow>
@@ -927,4 +977,19 @@ export const NoRowsPerPageControl = args => {
       />
     </Card>
   );
+};
+NoRowsPerPageControl.args = {
+  ...Default.args,
+  numberRows: 300,
+  tableTitle: 'No Rows Per Page Control Table',
+};
+
+export const TitleTable = Template.bind({});
+TitleTable.args = {
+  hasHoverStyles: false,
+  hasSquareCorners: false,
+  hasVerticalBorders: false,
+  hasZebraStripes: false,
+  isInverse: false,
+  tableTitle: <h2>Title table</h2>,
 };

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -53,11 +53,7 @@ const rows = [
 
 const Template: Story<TableProps> = args => (
   <Card
-    style={
-      args.hasSquareCorners
-        ? { borderRadius: '0', padding: '16px' }
-        : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-    }
+    style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     isInverse={args.isInverse}
   >
     <Table tableTitle="Basic Usage Table" {...args}>
@@ -327,11 +323,7 @@ export const ControlledPagination = args => {
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table {...args}>
         <TableHead>
@@ -394,11 +386,7 @@ export const UncontrolledPagination = args => {
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table {...args}>
         <TableHead>
@@ -515,11 +503,7 @@ export const PaginationInverse = args => {
   return (
     <Card
       isInverse
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table {...args} isInverse>
         <TableHead>
@@ -559,11 +543,7 @@ export const RowColors = args => {
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table {...args}>
         <TableHead>
@@ -620,11 +600,7 @@ export const RowColorsInverse = args => {
   return (
     <Card
       isInverse
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table {...args}>
         <TableHead>
@@ -729,11 +705,7 @@ export const Sortable = args => {
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table {...args}>
         <TableHead>
@@ -808,11 +780,7 @@ export const WithDropdown = args => {
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table maxWidth={500} {...args}>
         <TableHead>
@@ -909,11 +877,7 @@ export const AdjustableRowNumber = args => {
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table {...args}>
         <TableHead>
@@ -950,11 +914,7 @@ export const NoRowsPerPageControl = args => {
   return (
     <Card
       isInverse={args.isInverse}
-      style={
-        args.hasSquareCorners
-          ? { borderRadius: '0', padding: '16px' }
-          : { borderRadius: `${magma.borderRadius}`, padding: '16px' }
-      }
+      style={{ borderRadius: `${magma.borderRadius}`, padding: '16px' }}
     >
       <Table {...args}>
         <TableHead>
@@ -992,9 +952,10 @@ NoRowsPerPageControl.args = {
   tableTitle: 'No Rows Per Page Control Table',
 };
 
-export const TitleTable = Template.bind({});
-TitleTable.args = {
+export const TitleTableAndOutsideBorder = Template.bind({});
+TitleTableAndOutsideBorder.args = {
   hasHoverStyles: false,
+  hasOutsideBorder: true,
   hasSquareCorners: false,
   hasVerticalBorders: false,
   hasZebraStripes: false,

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -322,7 +322,7 @@ export const ControlledPagination = args => {
   return (
     <Card isInverse={args.isInverse}>
       <CardBody>
-        <Table {...args}>
+        <Table {...args} hasTablePagination>
           <TableHead>
             <TableRow>
               <TableHeaderCell>Column</TableHeaderCell>
@@ -361,7 +361,6 @@ ControlledPagination.args = {
   tableTitle: 'Controlled Pagination',
   rowsPerPage: 10,
   rowsPerPageValues: [10, 20, 50, 100],
-  hasTablePagination: true,
 };
 
 export const UncontrolledPagination = args => {
@@ -386,7 +385,7 @@ export const UncontrolledPagination = args => {
   return (
     <Card isInverse={args.isInverse}>
       <CardBody>
-        <Table {...args}>
+        <Table {...args} hasTablePagination>
           <TableHead>
             <TableRow>
               <TableHeaderCell>Column</TableHeaderCell>
@@ -424,7 +423,6 @@ UncontrolledPagination.args = {
   tableTitle: 'Uncontrolled Pagination',
   defaultRowsPerPage: 10,
   rowsPerPageValues: [10, 20, 50, 100],
-  hasTablePagination: true,
 };
 
 export const PaginationWithSquareCorners = args => {
@@ -446,7 +444,11 @@ export const PaginationWithSquareCorners = args => {
 
   return (
     <div style={{ background: magma.colors.neutral300, padding: '16px' }}>
-      <Table style={{ background: magma.colors.neutral100 }} {...args}>
+      <Table
+        style={{ background: magma.colors.neutral100 }}
+        {...args}
+        hasTablePagination
+      >
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -479,7 +481,6 @@ export const PaginationWithSquareCorners = args => {
   );
 };
 PaginationWithSquareCorners.args = {
-  hasTablePagination: true,
   hasSquareCorners: true,
   hasOutsideBorder: false,
   hasHoverStyles: false,
@@ -508,7 +509,7 @@ export const PaginationInverse = args => {
   return (
     <Card isInverse>
       <CardBody>
-        <Table {...args} isInverse>
+        <Table {...args} isInverse hasTablePagination>
           <TableHead>
             <TableRow>
               <TableHeaderCell>Column</TableHeaderCell>
@@ -543,7 +544,6 @@ PaginationInverse.args = {
   ...Default.args,
   isInverse: true,
   tableTitle: 'Pagination inverse',
-  hasTablePagination: true,
 };
 
 export const RowColors = args => {
@@ -918,7 +918,7 @@ export const NoRowsPerPageControl = args => {
   return (
     <Card isInverse={args.isInverse}>
       <CardBody>
-        <Table {...args}>
+        <Table {...args} hasTablePagination>
           <TableHead>
             <TableRow>
               <TableHeaderCell>Column</TableHeaderCell>
@@ -954,7 +954,6 @@ NoRowsPerPageControl.args = {
   ...Default.args,
   numberRows: 300,
   tableTitle: 'No Rows Per Page Control Table',
-  hasTablePagination: true,
 };
 
 export const TitleTableAndOutsideBorder = Template.bind({});

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { act, render, fireEvent, getByTestId } from '@testing-library/react';
+import { act, fireEvent, getByTestId, render } from '@testing-library/react';
 import { transparentize } from 'polished';
 
 import { magma } from '../../theme/magma';
@@ -413,6 +413,60 @@ describe('Table', () => {
     expect(titleTable).toHaveStyle(
       `margin-bottom: ${magma.spaceScale.spacing04}`
     );
+  });
+
+  it('should display the outer border when hasOutsideBorder is true and hasSquareCorners is false', () => {
+    const testId = 'table-test';
+
+    const { getByTestId } = render(
+      <Table hasOutsideBorder testId={testId}>
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>heading 1</TableHeaderCell>
+            <TableHeaderCell>heading 2</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>cell 1</TableCell>
+            <TableCell>cell 2</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByTestId(testId)).toHaveStyle('border-collapse: separate');
+    expect(getByTestId(testId)).toHaveStyle(
+      `border: 1px solid ${magma.colors.neutral300}`
+    );
+    expect(getByTestId(testId)).toHaveStyle(
+      `border-radius: ${magma.borderRadius}`
+    );
+  });
+
+  it('should not display the outer border when hasOutsideBorder is false and hasSquareCorners is true', () => {
+    const testId = 'table-test';
+
+    const { getByTestId } = render(
+      <Table hasOutsideBorder={false} hasSquareCorners testId={testId}>
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>heading 1</TableHeaderCell>
+            <TableHeaderCell>heading 2</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>cell 1</TableCell>
+            <TableCell>cell 2</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByTestId(testId)).toHaveStyle('border-collapse: collapse');
+    expect(getByTestId(testId)).toHaveStyle(`border: none`);
+    expect(getByTestId(testId)).toHaveStyle(`border-radius: 0`);
   });
 
   it('should render sortable table header cells with inverse styles', () => {

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -409,7 +409,10 @@ describe('Table', () => {
     const titleTable = getByText('Title table');
 
     expect(titleTable).toBeInTheDocument();
-    expect(titleTable).toHaveStyle(`margin: ${magma.spaceScale.spacing04}`);
+    expect(titleTable).toHaveStyle(`margin-top: ${magma.spaceScale.spacing04}`);
+    expect(titleTable).toHaveStyle(
+      `margin-bottom: ${magma.spaceScale.spacing04}`
+    );
   });
 
   it('should render sortable table header cells with inverse styles', () => {

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -388,6 +388,30 @@ describe('Table', () => {
     });
   });
 
+  it('should display the title table', () => {
+    const { getByText } = render(
+      <Table tableTitle="Title table">
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>heading 1</TableHeaderCell>
+            <TableHeaderCell>heading 2</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>cell 1</TableCell>
+            <TableCell>cell 2</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    const titleTable = getByText('Title table');
+
+    expect(titleTable).toBeInTheDocument();
+    expect(titleTable).toHaveStyle(`margin: ${magma.spaceScale.spacing04}`);
+  });
+
   it('should render sortable table header cells with inverse styles', () => {
     const { getByTestId } = render(
       <Table isInverse>

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -444,6 +444,37 @@ describe('Table', () => {
     );
   });
 
+  it('should display the outer border when hasOutsideBorder is true and isInverse is true', () => {
+    const testId = 'table-test';
+
+    const { getByTestId } = render(
+      <Table hasOutsideBorder isInverse testId={testId}>
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>heading 1</TableHeaderCell>
+            <TableHeaderCell>heading 2</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>cell 1</TableCell>
+            <TableCell>cell 2</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByTestId(testId)).toHaveStyleRule('border-collapse', 'separate');
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border',
+      `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
+    );
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border-radius',
+      `${magma.borderRadius}`
+    );
+  });
+
   it('should not display the outer border when hasOutsideBorder is false and hasSquareCorners is true', () => {
     const testId = 'table-test';
 

--- a/packages/react-magma-dom/src/components/Table/Table.test.js
+++ b/packages/react-magma-dom/src/components/Table/Table.test.js
@@ -415,91 +415,6 @@ describe('Table', () => {
     );
   });
 
-  it('should display the outer border when hasOutsideBorder is true and hasSquareCorners is false', () => {
-    const testId = 'table-test';
-
-    const { getByTestId } = render(
-      <Table hasOutsideBorder testId={testId}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>heading 1</TableHeaderCell>
-            <TableHeaderCell>heading 2</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>cell 1</TableCell>
-            <TableCell>cell 2</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    );
-
-    expect(getByTestId(testId)).toHaveStyle('border-collapse: separate');
-    expect(getByTestId(testId)).toHaveStyle(
-      `border: 1px solid ${magma.colors.neutral300}`
-    );
-    expect(getByTestId(testId)).toHaveStyle(
-      `border-radius: ${magma.borderRadius}`
-    );
-  });
-
-  it('should display the outer border when hasOutsideBorder is true and isInverse is true', () => {
-    const testId = 'table-test';
-
-    const { getByTestId } = render(
-      <Table hasOutsideBorder isInverse testId={testId}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>heading 1</TableHeaderCell>
-            <TableHeaderCell>heading 2</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>cell 1</TableCell>
-            <TableCell>cell 2</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    );
-
-    expect(getByTestId(testId)).toHaveStyleRule('border-collapse', 'separate');
-    expect(getByTestId(testId)).toHaveStyleRule(
-      'border',
-      `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
-    );
-    expect(getByTestId(testId)).toHaveStyleRule(
-      'border-radius',
-      `${magma.borderRadius}`
-    );
-  });
-
-  it('should not display the outer border when hasOutsideBorder is false and hasSquareCorners is true', () => {
-    const testId = 'table-test';
-
-    const { getByTestId } = render(
-      <Table hasOutsideBorder={false} hasSquareCorners testId={testId}>
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>heading 1</TableHeaderCell>
-            <TableHeaderCell>heading 2</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>cell 1</TableCell>
-            <TableCell>cell 2</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    );
-
-    expect(getByTestId(testId)).toHaveStyle('border-collapse: collapse');
-    expect(getByTestId(testId)).toHaveStyle(`border: none`);
-    expect(getByTestId(testId)).toHaveStyle(`border-radius: 0`);
-  });
-
   it('should render sortable table header cells with inverse styles', () => {
     const { getByTestId } = render(
       <Table isInverse>
@@ -536,5 +451,95 @@ describe('Table', () => {
         target: ':hover',
       }
     );
+  });
+
+  describe('Outer border', () => {
+    it('should display the outer border when hasOutsideBorder is true and hasSquareCorners is false', () => {
+      const testId = 'table-test';
+
+      const { getByTestId } = render(
+        <Table hasOutsideBorder testId={testId}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>heading 1</TableHeaderCell>
+              <TableHeaderCell>heading 2</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>cell 1</TableCell>
+              <TableCell>cell 2</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      );
+
+      expect(getByTestId(testId)).toHaveStyle('border-collapse: separate');
+      expect(getByTestId(testId)).toHaveStyle(
+        `border: 1px solid ${magma.colors.neutral300}`
+      );
+      expect(getByTestId(testId)).toHaveStyle(
+        `border-radius: ${magma.borderRadius}`
+      );
+    });
+
+    it('should display the outer border when hasOutsideBorder is true and isInverse is true', () => {
+      const testId = 'table-test';
+
+      const { getByTestId } = render(
+        <Table hasOutsideBorder isInverse testId={testId}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>heading 1</TableHeaderCell>
+              <TableHeaderCell>heading 2</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>cell 1</TableCell>
+              <TableCell>cell 2</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      );
+
+      expect(getByTestId(testId)).toHaveStyleRule(
+        'border-collapse',
+        'separate'
+      );
+      expect(getByTestId(testId)).toHaveStyleRule(
+        'border',
+        `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
+      );
+      expect(getByTestId(testId)).toHaveStyleRule(
+        'border-radius',
+        `${magma.borderRadius}`
+      );
+    });
+
+    it('should not display the outer border when hasOutsideBorder is false and hasSquareCorners is true', () => {
+      const testId = 'table-test';
+
+      const { getByTestId } = render(
+        <Table hasOutsideBorder={false} hasSquareCorners testId={testId}>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>heading 1</TableHeaderCell>
+              <TableHeaderCell>heading 2</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>cell 1</TableCell>
+              <TableCell>cell 2</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      );
+
+      expect(getByTestId(testId)).toHaveStyle('border-collapse: collapse');
+      expect(getByTestId(testId)).toHaveStyle(`border: none`);
+      expect(getByTestId(testId)).toHaveStyle(`border-radius: 0`);
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -145,7 +145,9 @@ export const StyledTableTitle = styled.caption<{
   isTitleNode: boolean;
 }>`
   ${headingMediumStyles};
-  margin: ${props => props.isTitleNode || props.theme.spaceScale.spacing04};
+  margin-bottom: ${props =>
+    props.isTitleNode || props.theme.spaceScale.spacing04};
+  margin-top: ${props => props.isTitleNode || props.theme.spaceScale.spacing04};
   text-align: left;
 `;
 

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -104,6 +104,7 @@ interface TableContextInterface {
   hasSquareCorners?: boolean;
   hasVerticalBorders?: boolean;
   hasZebraStripes?: boolean;
+  isDataGrid?: boolean;
   isInverse?: boolean;
   isSelectable?: boolean;
   rowCount?: number;
@@ -117,6 +118,7 @@ export const TableContext = React.createContext<TableContextInterface>({
   hasSquareCorners: false,
   hasZebraStripes: false,
   hasVerticalBorders: false,
+  isDataGrid: false,
   isInverse: false,
   isSelectable: false,
   isSortableBySelected: false,
@@ -182,7 +184,7 @@ export const StyledTable = styled.table<{
         }`
       : 'none'};
   border-radius: ${props => {
-    if (props.hasOutsideBorder && !props.hasSquareCorners) {
+    if (!props.hasSquareCorners) {
       if (props.isDataGrid) {
         return `${props.theme.borderRadius} ${props.theme.borderRadius} 0 0`;
       }
@@ -238,6 +240,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           hasZebraStripes,
           hasVerticalBorders,
           isInverse: isInverse,
+          isDataGrid: isDataGrid,
           isSelectable,
           isSortableBySelected,
           rowCount,

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
+import { headingMediumStyles } from '../Typography';
 
 /**
  * @children required
@@ -48,6 +49,12 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
   minWidth?: number;
   rowCount?: number;
   selectedItems?: Array<number>;
+  /**
+   * The title or caption of a table inside a <caption> HTML element that provides the table an accessible
+   * description.
+   * It can be a simple string or a React node, such as a heading element (e.g., <h1>, <h2>).
+   */
+  tableTitle?: React.ReactNode | string;
   /**
    * @internal
    */
@@ -133,6 +140,15 @@ export const TableWrapper = styled.div<{ minWidth: number }>`
   }
 `;
 
+export const StyledTableTitle = styled.caption<{
+  isInverse: boolean;
+  isTitleNode: boolean;
+}>`
+  ${headingMediumStyles};
+  margin: ${props => props.isTitleNode || props.theme.spaceScale.spacing04};
+  text-align: left;
+`;
+
 export const StyledTable = styled.table<{
   hasSquareCorners?: boolean;
   isInverse?: boolean;
@@ -167,6 +183,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       minWidth = 600,
       rowCount,
       selectedItems,
+      tableTitle,
       testId,
       isSortableBySelected,
       ...other
@@ -209,6 +226,16 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
               ref={ref}
               theme={theme}
             >
+              {tableTitle && (
+                <StyledTableTitle
+                  data-testid={`${testId}-table-title`}
+                  isInverse={isInverse}
+                  isTitleNode={typeof tableTitle !== 'string'}
+                  theme={theme}
+                >
+                  {tableTitle}
+                </StyledTableTitle>
+              )}
               {children}
             </StyledTable>
           </TableWrapper>

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -22,6 +22,11 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    */
   hasHoverStyles?: boolean;
   /**
+   *  If true, the table will have additional styles for table.
+   *  @default false
+   */
+  hasTablePagination?: boolean;
+  /**
    * If true, the table will have square edges
    * @default false
    */
@@ -65,10 +70,6 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    * @internal
    */
   testId?: string;
-  /**
-   * @internal - used within DataGrid to handle data-grid styles
-   */
-  isDataGrid?: boolean;
 }
 
 export enum TableDensity {
@@ -102,9 +103,9 @@ interface TableContextInterface {
   density?: TableDensity;
   hasHoverStyles?: boolean;
   hasSquareCorners?: boolean;
+  hasTablePagination?: boolean;
   hasVerticalBorders?: boolean;
   hasZebraStripes?: boolean;
-  isDataGrid?: boolean;
   isInverse?: boolean;
   isSelectable?: boolean;
   rowCount?: number;
@@ -116,9 +117,9 @@ export const TableContext = React.createContext<TableContextInterface>({
   density: TableDensity.normal,
   hasHoverStyles: false,
   hasSquareCorners: false,
+  hasTablePagination: false,
   hasZebraStripes: false,
   hasVerticalBorders: false,
-  isDataGrid: false,
   isInverse: false,
   isSelectable: false,
   isSortableBySelected: false,
@@ -166,7 +167,7 @@ export const StyledTableTitle = styled.caption<{
 export const StyledTable = styled.table<{
   hasOutsideBorder?: boolean;
   hasSquareCorners?: boolean;
-  isDataGrid?: boolean;
+  hasTablePagination?: boolean;
   isInverse?: boolean;
   minWidth: number;
 }>`
@@ -185,7 +186,7 @@ export const StyledTable = styled.table<{
       : 'none'};
   border-radius: ${props => {
     if (!props.hasSquareCorners) {
-      if (props.isDataGrid) {
+      if (props.hasTablePagination) {
         return `${props.theme.borderRadius} ${props.theme.borderRadius} 0 0`;
       }
       return props.theme.borderRadius;
@@ -212,6 +213,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       hasHoverStyles,
       hasOutsideBorder,
       hasSquareCorners,
+      hasTablePagination,
       hasVerticalBorders,
       hasZebraStripes,
       isSelectable,
@@ -221,7 +223,6 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       tableTitle,
       testId,
       isSortableBySelected,
-      isDataGrid,
       ...other
     } = props;
 
@@ -237,10 +238,10 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
           density,
           hasHoverStyles,
           hasSquareCorners,
+          hasTablePagination: hasTablePagination,
           hasZebraStripes,
           hasVerticalBorders,
           isInverse: isInverse,
-          isDataGrid: isDataGrid,
           isSelectable,
           isSortableBySelected,
           rowCount,
@@ -259,8 +260,8 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
               data-testid={testId}
               hasOutsideBorder={hasOutsideBorder}
               hasSquareCorners={hasSquareCorners}
+              hasTablePagination={hasTablePagination}
               isInverse={isInverse}
-              isDataGrid={isDataGrid}
               minWidth={minWidth || theme.breakpoints.small}
               ref={ref}
               theme={theme}

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import styled from '@emotion/styled';
+import { transparentize } from 'polished';
 
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
@@ -174,7 +175,11 @@ export const StyledTable = styled.table<{
   border-spacing: 0;
   border: ${props =>
     props.hasOutsideBorder
-      ? `1px solid ${props.theme.colors.neutral300}`
+      ? `1px solid ${
+          props.isInverse
+            ? transparentize(0.6, props.theme.colors.neutral100)
+            : props.theme.colors.neutral300
+        }`
       : 'none'};
   border-radius: ${props => {
     if (props.hasOutsideBorder && !props.hasSquareCorners) {

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -64,6 +64,10 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    * @internal
    */
   testId?: string;
+  /**
+   * @internal - used within DataGrid to handle data-grid styles
+   */
+  isDataGrid?: boolean;
 }
 
 export enum TableDensity {
@@ -96,7 +100,6 @@ export enum TableRowColor {
 interface TableContextInterface {
   density?: TableDensity;
   hasHoverStyles?: boolean;
-  hasOutsideBorder: boolean;
   hasSquareCorners?: boolean;
   hasVerticalBorders?: boolean;
   hasZebraStripes?: boolean;
@@ -110,7 +113,6 @@ interface TableContextInterface {
 export const TableContext = React.createContext<TableContextInterface>({
   density: TableDensity.normal,
   hasHoverStyles: false,
-  hasOutsideBorder: false,
   hasSquareCorners: false,
   hasZebraStripes: false,
   hasVerticalBorders: false,
@@ -161,17 +163,28 @@ export const StyledTableTitle = styled.caption<{
 export const StyledTable = styled.table<{
   hasOutsideBorder?: boolean;
   hasSquareCorners?: boolean;
+  isDataGrid?: boolean;
   isInverse?: boolean;
   minWidth: number;
 }>`
-  border-collapse: collapse;
+  border-collapse: ${props =>
+    props.hasOutsideBorder && !props.hasSquareCorners
+      ? 'separate'
+      : 'collapse'};
   border-spacing: 0;
   border: ${props =>
     props.hasOutsideBorder
       ? `1px solid ${props.theme.colors.neutral300}`
       : 'none'};
-  border-radius: ${props =>
-    props.hasSquareCorners ? '0' : props.theme.borderRadius};
+  border-radius: ${props => {
+    if (props.hasOutsideBorder && !props.hasSquareCorners) {
+      if (props.isDataGrid) {
+        return `${props.theme.borderRadius} ${props.theme.borderRadius} 0 0`;
+      }
+      return props.theme.borderRadius;
+    }
+    return '0';
+  }};
   color: ${props =>
     props.isInverse
       ? props.theme.colors.neutral100
@@ -201,6 +214,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       tableTitle,
       testId,
       isSortableBySelected,
+      isDataGrid,
       ...other
     } = props;
 
@@ -215,7 +229,6 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
         value={{
           density,
           hasHoverStyles,
-          hasOutsideBorder,
           hasSquareCorners,
           hasZebraStripes,
           hasVerticalBorders,
@@ -239,6 +252,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
               hasOutsideBorder={hasOutsideBorder}
               hasSquareCorners={hasSquareCorners}
               isInverse={isInverse}
+              isDataGrid={isDataGrid}
               minWidth={minWidth || theme.breakpoints.small}
               ref={ref}
               theme={theme}

--- a/packages/react-magma-dom/src/components/Table/Table.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.tsx
@@ -26,6 +26,11 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
    */
   hasSquareCorners?: boolean;
   /**
+   * If true, the table will have outer border
+   * @default false
+   */
+  hasOutsideBorder?: boolean;
+  /**
    * If true, columns will have vertical borders
    */
   hasVerticalBorders?: boolean;
@@ -91,6 +96,7 @@ export enum TableRowColor {
 interface TableContextInterface {
   density?: TableDensity;
   hasHoverStyles?: boolean;
+  hasOutsideBorder: boolean;
   hasSquareCorners?: boolean;
   hasVerticalBorders?: boolean;
   hasZebraStripes?: boolean;
@@ -104,6 +110,7 @@ interface TableContextInterface {
 export const TableContext = React.createContext<TableContextInterface>({
   density: TableDensity.normal,
   hasHoverStyles: false,
+  hasOutsideBorder: false,
   hasSquareCorners: false,
   hasZebraStripes: false,
   hasVerticalBorders: false,
@@ -152,12 +159,17 @@ export const StyledTableTitle = styled.caption<{
 `;
 
 export const StyledTable = styled.table<{
+  hasOutsideBorder?: boolean;
   hasSquareCorners?: boolean;
   isInverse?: boolean;
   minWidth: number;
 }>`
   border-collapse: collapse;
   border-spacing: 0;
+  border: ${props =>
+    props.hasOutsideBorder
+      ? `1px solid ${props.theme.colors.neutral300}`
+      : 'none'};
   border-radius: ${props =>
     props.hasSquareCorners ? '0' : props.theme.borderRadius};
   color: ${props =>
@@ -178,6 +190,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
       children,
       density = TableDensity.normal,
       hasHoverStyles,
+      hasOutsideBorder,
       hasSquareCorners,
       hasVerticalBorders,
       hasZebraStripes,
@@ -202,6 +215,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
         value={{
           density,
           hasHoverStyles,
+          hasOutsideBorder,
           hasSquareCorners,
           hasZebraStripes,
           hasVerticalBorders,
@@ -222,6 +236,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
             <StyledTable
               {...other}
               data-testid={testId}
+              hasOutsideBorder={hasOutsideBorder}
               hasSquareCorners={hasSquareCorners}
               isInverse={isInverse}
               minWidth={minWidth || theme.breakpoints.small}

--- a/packages/react-magma-dom/src/components/Table/TablePagination.test.js
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.test.js
@@ -30,6 +30,25 @@ describe('Table Pagination', () => {
     );
   });
 
+  it('should use inverse styles when hasOutsideBorder is true', () => {
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <TablePagination
+        itemCount={20}
+        isInverse
+        hasOutsideBorder
+        testId={testId}
+      />
+    );
+
+    expect(getByTestId(testId)).toHaveStyleRule('border-top', `none`);
+
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border',
+      `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
+    );
+  });
+
   describe('uncontrolled', () => {
     it('should change page when clicking next', () => {
       const handlePageChange = jest.fn();

--- a/packages/react-magma-dom/src/components/Table/TablePagination.test.js
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { act, render, fireEvent, getAllByRole } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { transparentize } from 'polished';
 
 import { axe } from '../../../axe-helper';
@@ -18,34 +18,75 @@ describe('Table Pagination', () => {
     expect(getByTestId(testId)).toBeInTheDocument();
   });
 
-  it('should use inverse styles', () => {
+  it('should use styles when hasOutsideBorder is true and hasSquareCorners is true', () => {
     const testId = 'test-id';
     const { getByTestId } = render(
-      <TablePagination itemCount={20} isInverse testId={testId} />
+      <TablePagination
+        itemCount={20}
+        hasOutsideBorder
+        hasSquareCorners
+        testId={testId}
+      />
     );
 
     expect(getByTestId(testId)).toHaveStyleRule(
-      'border-top',
-      `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
+      'border-left',
+      `1px solid ${magma.colors.neutral300}`
     );
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border-right',
+      `1px solid ${magma.colors.neutral300}`
+    );
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border-bottom',
+      `1px solid ${magma.colors.neutral300}`
+    );
+    expect(getByTestId(testId)).toHaveStyle('border-radius: 0');
   });
 
-  it('should use inverse styles when hasOutsideBorder is true', () => {
+  it('should use inverse styles when hasOutsideBorder is true and hasSquareCorners is true', () => {
     const testId = 'test-id';
     const { getByTestId } = render(
       <TablePagination
         itemCount={20}
         isInverse
         hasOutsideBorder
+        hasSquareCorners
         testId={testId}
       />
     );
 
-    expect(getByTestId(testId)).toHaveStyleRule('border-top', `none`);
-
     expect(getByTestId(testId)).toHaveStyleRule(
-      'border',
+      'border-left',
       `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
+    );
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border-right',
+      `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
+    );
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border-bottom',
+      `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
+    );
+    expect(getByTestId(testId)).toHaveStyle('border-radius: 0');
+  });
+
+  it('should use styles when hasOutsideBorder is false and hasSquareCorners is false', () => {
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <TablePagination
+        hasSquareCorners={false}
+        itemCount={20}
+        isInverse
+        testId={testId}
+      />
+    );
+
+    expect(getByTestId(testId)).toHaveStyle('border-left : none');
+    expect(getByTestId(testId)).toHaveStyle('border-right : none');
+    expect(getByTestId(testId)).toHaveStyle('border-bottom : none');
+    expect(getByTestId(testId)).toHaveStyle(
+      `border-radius: 0 0 ${magma.borderRadius} ${magma.borderRadius}`
     );
   });
 

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -7,7 +7,7 @@ import { EastIcon, WestIcon } from 'react-magma-icons';
 import { useControlled } from '../../hooks/useControlled';
 import { I18nContext } from '../../i18n';
 import { useIsInverse } from '../../inverse';
-import { ThemeInterface } from '../../theme/magma';
+import { magma, ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { XOR } from '../../utils';
 import { ButtonColor, ButtonVariant } from '../Button';
@@ -104,6 +104,16 @@ export type TablePaginationProps = BaseTablePaginationProps &
   PagePaginationProps &
   RowsPaginationProps;
 
+function getBorder(hasOutsideBorder: boolean, isInverse: boolean) {
+  return hasOutsideBorder
+    ? `1px solid ${
+        isInverse
+          ? transparentize(0.6, magma.colors.neutral100)
+          : magma.colors.neutral300
+      }`
+    : 'none';
+}
+
 const StyledContainer = styled.div<{
   isInverse?: boolean;
   theme: ThemeInterface;
@@ -115,21 +125,12 @@ const StyledContainer = styled.div<{
     props.isInverse
       ? transparentize(0.9, props.theme.colors.neutral100)
       : props.theme.colors.neutral200};
-  border-top: ${props =>
-    props.hasOutsideBorder
-      ? 'none'
-      : `1px solid ${props.isInverse ? transparentize(0.6, props.theme.colors.neutral100) : props.theme.colors.neutral300}`};
   display: flex;
   justify-content: flex-end;
   padding: ${props => props.theme.spaceScale.spacing02};
-  border: ${props =>
-    props.hasOutsideBorder
-      ? `1px solid ${
-          props.isInverse
-            ? transparentize(0.6, props.theme.colors.neutral100)
-            : props.theme.colors.neutral300
-        }`
-      : 'none'};
+  border-left: ${props => getBorder(props.hasOutsideBorder, props.isInverse)};
+  border-right: ${props => getBorder(props.hasOutsideBorder, props.isInverse)};
+  border-bottom: ${props => getBorder(props.hasOutsideBorder, props.isInverse)};
   border-radius: ${props =>
     props.hasSquareCorners
       ? '0'

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -53,6 +53,11 @@ export interface BaseTablePaginationProps
    * @default true
    */
   hasSquareCorners?: boolean;
+  /**
+   * If true, the table paginator will have outer border
+   * @default false
+   */
+  hasOutsideBorder?: boolean;
 }
 
 export interface ControlledPageProps {
@@ -102,6 +107,7 @@ export type TablePaginationProps = BaseTablePaginationProps &
 const StyledContainer = styled.div<{
   isInverse?: boolean;
   theme: ThemeInterface;
+  hasOutsideBorder?: boolean;
   hasSquareCorners?: boolean;
 }>`
   align-items: center;
@@ -109,14 +115,21 @@ const StyledContainer = styled.div<{
     props.isInverse
       ? transparentize(0.9, props.theme.colors.neutral100)
       : props.theme.colors.neutral200};
-  border-top: 1px solid
-    ${props =>
-      props.isInverse
-        ? transparentize(0.6, props.theme.colors.neutral100)
-        : props.theme.colors.neutral300};
+  border-top: ${props =>
+    props.hasOutsideBorder
+      ? 'none'
+      : `1px solid ${props.isInverse ? transparentize(0.6, props.theme.colors.neutral100) : props.theme.colors.neutral300}`};
   display: flex;
   justify-content: flex-end;
   padding: ${props => props.theme.spaceScale.spacing02};
+  border: ${props =>
+    props.hasOutsideBorder
+      ? `1px solid ${
+          props.isInverse
+            ? transparentize(0.6, props.theme.colors.neutral100)
+            : props.theme.colors.neutral300
+        }`
+      : 'none'};
   border-radius: ${props =>
     props.hasSquareCorners
       ? '0'
@@ -202,6 +215,7 @@ export const TablePagination = React.forwardRef<
     page: pageProp,
     rowsPerPage: rowsPerPageProp,
     rowsPerPageValues = [10, 20, 50, 100],
+    hasOutsideBorder,
     hasSquareCorners = true,
     ...other
   } = props;
@@ -268,6 +282,7 @@ export const TablePagination = React.forwardRef<
       {...other}
       data-testid={testId}
       isInverse={isInverse}
+      hasOutsideBorder={hasOutsideBorder}
       hasSquareCorners={hasSquareCorners}
       ref={ref}
       theme={theme}

--- a/packages/react-magma-dom/src/components/Table/TableRow.test.js
+++ b/packages/react-magma-dom/src/components/Table/TableRow.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
+import { transparentize } from 'polished';
 
 import { magma } from '../../theme/magma';
 
@@ -29,6 +30,72 @@ describe('Table Row', () => {
     );
 
     expect(getByTestId(testId)).toBeInTheDocument();
+  });
+
+  it('should have border bottom', () => {
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <Table>
+        <TableBody>
+          <TableRow testId={testId}>
+            <TableCell />
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border-bottom',
+      `1px solid ${magma.colors.neutral300}`
+    );
+  });
+
+  it('should have border bottom when table row is inverse', () => {
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <Table isInverse>
+        <TableBody>
+          <TableRow testId={testId}>
+            <TableCell />
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByTestId(testId)).toHaveStyleRule(
+      'border-bottom',
+      `1px solid ${transparentize(0.6, magma.colors.neutral100)}`
+    );
+  });
+
+  it('should not have border bottom when table row has color', () => {
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <Table>
+        <TableBody>
+          <TableRow testId={testId} color={TableRowColor.info}>
+            <TableCell />
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByTestId(testId)).toHaveStyle('border-bottom: 0');
+  });
+
+  it('should not have border bottom when table row has zebra stripe and does not have pagination', () => {
+    const testId = 'test-id';
+    const { getByTestId } = render(
+      <Table hasZebraStripes hasTablePagination={false}>
+        <TableBody>
+          <TableRow testId={testId}>
+            <TableCell />
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(getByTestId(testId)).toHaveStyle('border-bottom: 0');
   });
 
   describe('colors', () => {

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -6,6 +6,7 @@ import { transparentize } from 'polished';
 import { NorthIcon, SortDoubleArrowIcon, SouthIcon } from 'react-magma-icons';
 
 import { I18nContext } from '../../i18n';
+import { magma } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { Checkbox } from '../Checkbox';
 import {
@@ -48,7 +49,7 @@ export interface TableRowProps
   onTableRowSelect?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   rowIndex?: number;
   /**
-   * Unique name to be used to identify row for screenreaders
+   * Unique name to be used to identify row for screen readers
    */
   rowName?: string;
   /**
@@ -98,19 +99,23 @@ function buildTableRowColor(props) {
   return 'inherit';
 }
 
+function getBorderBottom(isInverse: boolean) {
+  return `1px solid ${
+    isInverse
+      ? transparentize(0.6, magma.colors.neutral100)
+      : magma.colors.neutral300
+  }`;
+}
+
 const StyledTableRow = styled.tr<{
   color?: string;
-  hasSquareCorners?: boolean;
   hasHoverStyles?: boolean;
+  hasSquareCorners?: boolean;
+  hasTablePagination?: boolean;
   hasZebraStripes?: boolean;
-  isDataGrid?: boolean;
   isInverse?: boolean;
 }>`
-  border-bottom: 1px solid
-    ${props =>
-      props.isInverse
-        ? transparentize(0.6, props.theme.colors.neutral100)
-        : props.theme.colors.neutral300};
+  border-bottom: ${props => getBorderBottom(props.isInverse)};
   color: inherit;
   display: table-row;
   outline: 0;
@@ -118,28 +123,28 @@ const StyledTableRow = styled.tr<{
 
   // Compensates border bottom for all rows (except last one) when table has outside border
   td {
-    border-bottom: 1px solid
-      ${props =>
-        props.isInverse
-          ? transparentize(0.6, props.theme.colors.neutral100)
-          : props.theme.colors.neutral300};
+    border-bottom: ${props => getBorderBottom(props.isInverse)};
   }
 
   &:last-child {
-    border-bottom: 0;
+    // Removes border bottom for last row if it's colored
+    border-bottom: ${props =>
+      props.color || (props.hasZebraStripes && !props.hasTablePagination)
+        ? 0
+        : `${getBorderBottom(props.isInverse)}`};
 
     td {
       border-bottom: 0;
     }
     td:first-child {
       border-radius: ${props =>
-        props.hasSquareCorners || props.isDataGrid
+        props.hasSquareCorners || props.hasTablePagination
           ? '0'
           : `0 0 0 ${props.theme.borderRadius}`};
     }
     td:last-child {
       border-radius: ${props =>
-        props.hasSquareCorners || props.isDataGrid
+        props.hasSquareCorners || props.hasTablePagination
           ? '0'
           : `0 0 ${props.theme.borderRadius} 0`};
     }
@@ -311,11 +316,11 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
       <StyledTableRow
         {...other}
         data-testid={testId}
-        hasSquareCorners={tableContext.hasSquareCorners}
         hasHoverStyles={tableContext.hasHoverStyles && !isHeaderRow}
+        hasSquareCorners={tableContext.hasSquareCorners}
+        hasTablePagination={tableContext.hasTablePagination}
         hasZebraStripes={tableContext.hasZebraStripes}
         isInverse={tableContext.isInverse}
-        isDataGrid={tableContext.isDataGrid}
         ref={ref}
         theme={theme}
       >

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -103,6 +103,7 @@ const StyledTableRow = styled.tr<{
   hasSquareCorners?: boolean;
   hasHoverStyles?: boolean;
   hasZebraStripes?: boolean;
+  isDataGrid?: boolean;
   isInverse?: boolean;
 }>`
   border-bottom: 1px solid
@@ -115,7 +116,7 @@ const StyledTableRow = styled.tr<{
   outline: 0;
   vertical-align: top;
 
-  // Compensates border bottom for all rows when table has outside border
+  // Compensates border bottom for all rows (except last one) when table has outside border
   td {
     border-bottom: 1px solid
       ${props =>
@@ -125,16 +126,22 @@ const StyledTableRow = styled.tr<{
   }
 
   &:last-child {
+    border-bottom: 0;
+
     td {
       border-bottom: 0;
     }
     td:first-child {
       border-radius: ${props =>
-        props.hasSquareCorners ? '0' : `0 0 0 ${props.theme.borderRadius}`};
+        props.hasSquareCorners || props.isDataGrid
+          ? '0'
+          : `0 0 0 ${props.theme.borderRadius}`};
     }
     td:last-child {
       border-radius: ${props =>
-        props.hasSquareCorners ? '0' : `0 0 ${props.theme.borderRadius} 0`};
+        props.hasSquareCorners || props.isDataGrid
+          ? '0'
+          : `0 0 ${props.theme.borderRadius} 0`};
     }
   }
 
@@ -308,6 +315,7 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
         hasHoverStyles={tableContext.hasHoverStyles && !isHeaderRow}
         hasZebraStripes={tableContext.hasZebraStripes}
         isInverse={tableContext.isInverse}
+        isDataGrid={tableContext.isDataGrid}
         ref={ref}
         theme={theme}
       >

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -115,8 +115,19 @@ const StyledTableRow = styled.tr<{
   outline: 0;
   vertical-align: top;
 
+  // Compensates border bottom for all rows when table has outside border
+  td {
+    border-bottom: 1px solid
+      ${props =>
+        props.isInverse
+          ? transparentize(0.6, props.theme.colors.neutral100)
+          : props.theme.colors.neutral300};
+  }
+
   &:last-child {
-    border-bottom: 0;
+    td {
+      border-bottom: 0;
+    }
     td:first-child {
       border-radius: ${props =>
         props.hasSquareCorners ? '0' : `0 0 0 ${props.theme.borderRadius}`};

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -23,7 +23,7 @@ props:
 ```tsx
 import React from 'react';
 
-import { Datagrid, Card } from 'react-magma-dom';
+import { Datagrid } from 'react-magma-dom';
 
 export function Example() {
   const columns = [
@@ -212,9 +212,13 @@ export function Example() {
   ];
 
   return (
-    <Card style={{ padding: '16px' }}>
-      <Datagrid columns={columns} rows={rows} tableTitle="Basic usage" />
-    </Card>
+    <Datagrid
+      columns={columns}
+      rows={rows}
+      tableTitle="Basic usage"
+      hasOutsideBorder
+      hasSquareCorners={false}
+    />
   );
 }
 ```
@@ -282,7 +286,7 @@ Use `rowName` when using Selectable so that the aria labels on the checkboxes ca
 ```tsx
 import React from 'react';
 
-import { Datagrid, Card } from 'react-magma-dom';
+import { Datagrid } from 'react-magma-dom';
 
 export function Example() {
   const columns = [
@@ -496,14 +500,13 @@ export function Example() {
   ];
 
   return (
-    <Card style={{ padding: '16px' }}>
-      <Datagrid
-        columns={columns}
-        rows={rows}
-        isSelectable
-        tableTitle="Selectable table"
-      />
-    </Card>
+    <Datagrid
+      columns={columns}
+      rows={rows}
+      isSelectable
+      tableTitle="Selectable table"
+      hasSquareCorners={false}
+    />
   );
 }
 ```
@@ -513,7 +516,7 @@ export function Example() {
 ```tsx
 import React from 'react';
 
-import { Datagrid, Card } from 'react-magma-dom';
+import { Datagrid } from 'react-magma-dom';
 
 export function Example() {
   const columns = [
@@ -728,14 +731,13 @@ export function Example() {
   ];
 
   return (
-    <Card style={{ padding: '16px' }}>
-      <Datagrid
-        columns={columns}
-        rows={rows}
-        isSelectable
-        tableTitle="Disabled Selectable Row table"
-      />
-    </Card>
+    <Datagrid
+      columns={columns}
+      rows={rows}
+      isSelectable
+      tableTitle="Disabled Selectable Row table"
+      hasSquareCorners={false}
+    />
   );
 }
 ```
@@ -925,6 +927,7 @@ export function Example() {
         onHeaderSelect={handleHeaderSelect}
         sortDirection={selectedDirection}
         tableTitle="Selectable and Sortable table"
+        hasSquareCorners
       />
       <Announce>
         <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
@@ -939,7 +942,7 @@ export function Example() {
 ```tsx
 import React from 'react';
 
-import { Button, ButtonColor, Datagrid, Card } from 'react-magma-dom';
+import { Button, ButtonColor, Datagrid } from 'react-magma-dom';
 
 export function Example() {
   const [selectedRows, updatedSelectedRows] = React.useState<
@@ -1157,7 +1160,7 @@ export function Example() {
   ];
 
   return (
-    <Card style={{ padding: '16px' }}>
+    <>
       <strong>Selected Rows: </strong>
       <pre>{JSON.stringify(selectedRows, null, 2)}</pre>
       <Button
@@ -1174,8 +1177,9 @@ export function Example() {
         selectedRows={selectedRows}
         onSelectedRowsChange={updatedSelectedRows}
         tableTitle="Controlled Selectable Column table"
+        hasSquareCorners
       />
-    </Card>
+    </>
   );
 }
 ```
@@ -1385,6 +1389,7 @@ export function Example() {
       rows={rows}
       paginationProps={paginationProps}
       tableTitle="Pagination Defaults table"
+      hasSquareCorners={false}
     />
   );
 }
@@ -1614,6 +1619,7 @@ export function Example() {
       rows={rows}
       paginationProps={paginationProps}
       tableTitle="Pagination Controlled table"
+      hasSquareCorners={false}
     />
   );
 }
@@ -2072,6 +2078,62 @@ export function Example() {
       rows={rows}
       hasPagination={false}
       tableTitle="Without Pagination table"
+    />
+  );
+}
+```
+
+## Outside Border
+
+The `hasOutsideBorder` boolean prop may be used to give table outer border.
+
+```tsx
+import React from 'react';
+
+import { Datagrid } from 'react-magma-dom';
+
+export function Example() {
+  const columns = [
+    { field: 'col1', header: 'Col 1' },
+    { field: 'col2', header: 'Col 2' },
+    { field: 'col3', header: 'Col 3' },
+    { field: 'col4', header: 'Col 4' },
+  ];
+
+  const rows = [
+    {
+      id: 1,
+      col1: 'Lorem ipsum dolor sit amet consectetur',
+      col2: 'Lorem ipsum dolor',
+      col3: 'Lorem ipsum dolor',
+      col4: 'Lorem ipsum',
+      rowName: 'Row danger',
+    },
+    {
+      id: 2,
+      col1: 'Lorem ipsum dolor sit amet',
+      col2: 'Lorem ipsum dolor',
+      col3: 'Lorem ipsum dolor',
+      col4: 'Lorem ipsum',
+      rowName: 'Row info',
+    },
+    {
+      id: 3,
+      col1: 'Lorem ipsum dolor',
+      col2: 'Lorem ipsum dolor',
+      col3: 'Lorem ipsum dolor',
+      col4: 'Lorem ipsum',
+      rowName: 'Row success',
+    },
+  ];
+
+  return (
+    <Datagrid
+      columns={columns}
+      rows={rows}
+      hasSquareCorners={false}
+      hasOutsideBorder
+      tableTitle="Row color table"
     />
   );
 }

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -2184,6 +2184,8 @@ export function Example() {
   return (
     <Card isInverse style={{ padding: '16px' }}>
       <Datagrid
+        hasSquareCorners={false}
+        hasOutsideBorder
         columns={columns}
         isInverse
         rows={rows}

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -212,8 +212,8 @@ export function Example() {
   ];
 
   return (
-    <Card>
-      <Datagrid columns={columns} rows={rows} />
+    <Card style={{ padding: '16px' }}>
+      <Datagrid columns={columns} rows={rows} tableTitle="Basic usage" />
     </Card>
   );
 }
@@ -264,7 +264,14 @@ export function Example() {
     },
   ];
 
-  return <Datagrid columns={columns} rows={coloredRows} hasSquareCorners />;
+  return (
+    <Datagrid
+      columns={columns}
+      rows={coloredRows}
+      hasSquareCorners
+      tableTitle="Row color table"
+    />
+  );
 }
 ```
 
@@ -489,8 +496,13 @@ export function Example() {
   ];
 
   return (
-    <Card>
-      <Datagrid columns={columns} rows={rows} isSelectable />
+    <Card style={{ padding: '16px' }}>
+      <Datagrid
+        columns={columns}
+        rows={rows}
+        isSelectable
+        tableTitle="Selectable table"
+      />
     </Card>
   );
 }
@@ -716,8 +728,13 @@ export function Example() {
   ];
 
   return (
-    <Card>
-      <Datagrid columns={columns} rows={rows} isSelectable />
+    <Card style={{ padding: '16px' }}>
+      <Datagrid
+        columns={columns}
+        rows={rows}
+        isSelectable
+        tableTitle="Disabled Selectable Row table"
+      />
     </Card>
   );
 }
@@ -907,6 +924,7 @@ export function Example() {
         onRowSelect={handleSelectedItems}
         onHeaderSelect={handleHeaderSelect}
         sortDirection={selectedDirection}
+        tableTitle="Selectable and Sortable table"
       />
       <Announce>
         <VisuallyHidden>{sortConfig.message}</VisuallyHidden>
@@ -1139,7 +1157,7 @@ export function Example() {
   ];
 
   return (
-    <Card>
+    <Card style={{ padding: '16px' }}>
       <strong>Selected Rows: </strong>
       <pre>{JSON.stringify(selectedRows, null, 2)}</pre>
       <Button
@@ -1155,6 +1173,7 @@ export function Example() {
         isSelectable
         selectedRows={selectedRows}
         onSelectedRowsChange={updatedSelectedRows}
+        tableTitle="Controlled Selectable Column table"
       />
     </Card>
   );
@@ -1361,7 +1380,12 @@ export function Example() {
   };
 
   return (
-    <Datagrid columns={columns} rows={rows} paginationProps={paginationProps} />
+    <Datagrid
+      columns={columns}
+      rows={rows}
+      paginationProps={paginationProps}
+      tableTitle="Pagination Defaults table"
+    />
   );
 }
 ```
@@ -1585,7 +1609,12 @@ export function Example() {
   };
 
   return (
-    <Datagrid columns={columns} rows={rows} paginationProps={paginationProps} />
+    <Datagrid
+      columns={columns}
+      rows={rows}
+      paginationProps={paginationProps}
+      tableTitle="Pagination Controlled table"
+    />
   );
 }
 ```
@@ -1836,6 +1865,7 @@ export function Example() {
       columns={columns}
       rows={rows}
       components={{ Pagination: CustomPaginationComponent }}
+      tableTitle="Custom Pagination Components table"
     />
   );
 }
@@ -2036,7 +2066,14 @@ export function Example() {
     },
   ];
 
-  return <Datagrid columns={columns} rows={rows} hasPagination={false} />;
+  return (
+    <Datagrid
+      columns={columns}
+      rows={rows}
+      hasPagination={false}
+      tableTitle="Without Pagination table"
+    />
+  );
 }
 ```
 
@@ -2083,8 +2120,13 @@ export function Example() {
   ];
 
   return (
-    <Card isInverse>
-      <Datagrid columns={columns} isInverse rows={rows} />
+    <Card isInverse style={{ padding: '16px' }}>
+      <Datagrid
+        columns={columns}
+        isInverse
+        rows={rows}
+        tableTitle="Inverse table"
+      />
     </Card>
   );
 }

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -78,7 +78,7 @@ export function Example() {
   ];
 
   return (
-    <Table tableTitle="Basic Usage table">
+    <Table tableTitle="Basic Usage table" hasOutsideBorder>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -119,7 +119,11 @@ import {
 
 export function Example() {
   return (
-    <Table tableTitle="Vertical borders table" hasVerticalBorders>
+    <Table
+      tableTitle="Vertical borders table"
+      hasVerticalBorders
+      hasOutsideBorder
+    >
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -211,7 +215,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasHoverStyles tableTitle="Hover style table">
+    <Table hasHoverStyles tableTitle="Hover style table" hasOutsideBorder>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -257,7 +261,12 @@ import {
 
 export function Example() {
   return (
-    <Table hasZebraStripes hasHoverStyles tableTitle="Zebra Stripes table">
+    <Table
+      hasZebraStripes
+      hasHoverStyles
+      hasOutsideBorder
+      tableTitle="Zebra Stripes table"
+    >
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -317,7 +326,11 @@ import {
 export function Example() {
   return (
     <>
-      <Table density={TableDensity.compact} tableTitle="Density table compact">
+      <Table
+        density={TableDensity.compact}
+        tableTitle="Density table compact"
+        hasOutsideBorder
+      >
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -342,7 +355,11 @@ export function Example() {
         </TableBody>
       </Table>
       <br /> <br />
-      <Table density={TableDensity.loose} tableTitle="Density table loose">
+      <Table
+        density={TableDensity.loose}
+        tableTitle="Density table loose"
+        hasOutsideBorder
+      >
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -441,7 +458,7 @@ export function Example() {
 
   return (
     <>
-      <Table tableTitle="Sortable table">
+      <Table tableTitle="Sortable table" hasOutsideBorder>
         <TableHead>
           <TableRow>
             <TableHeaderCell
@@ -579,6 +596,7 @@ export function Example() {
       <CardBody>
         <Table
           isInverse
+          hasOutsideBorder
           hasZebraStripes
           hasVerticalBorders
           hasHoverStyles
@@ -638,7 +656,7 @@ import {
 
 export function Example() {
   return (
-    <Table tableTitle="Cell alignment table">
+    <Table tableTitle="Cell alignment table" hasOutsideBorder>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -683,7 +701,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table tableTitle="Cell Width table in percentage">
+      <Table tableTitle="Cell Width table in percentage" hasOutsideBorder>
         <TableHead>
           <TableRow>
             <TableHeaderCell width="25%">Column 25%</TableHeaderCell>
@@ -706,7 +724,7 @@ export function Example() {
 
       <br />
 
-      <Table tableTitle="Cell Width table in pixels">
+      <Table tableTitle="Cell Width table in pixels" hasOutsideBorder>
         <TableHead>
           <TableRow>
             <TableHeaderCell width={200}>Column 200px</TableHeaderCell>
@@ -750,7 +768,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table minWidth={920} tableTitle="Min-width table">
+      <Table minWidth={920} tableTitle="Min-width table" hasOutsideBorder>
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column 1</TableHeaderCell>
@@ -809,7 +827,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasVerticalBorders tableTitle="Other content table">
+    <Table hasVerticalBorders tableTitle="Other content table" hasOutsideBorder>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column 1</TableHeaderCell>
@@ -1085,7 +1103,7 @@ import {
 
 export function Example() {
   return (
-    <Table tableTitle="Table row color table">
+    <Table tableTitle="Table row color table" hasOutsideBorder>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -78,7 +78,7 @@ export function Example() {
   ];
 
   return (
-    <Table>
+    <Table tableTitle="Basic Usage table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -119,7 +119,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasVerticalBorders>
+    <Table tableTitle="Vertical borders table" hasVerticalBorders>
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -165,7 +165,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasHoverStyles>
+    <Table hasHoverStyles tableTitle="Hover style table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -211,7 +211,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasZebraStripes hasHoverStyles>
+    <Table hasZebraStripes hasHoverStyles tableTitle="Zebra Stripes table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -271,7 +271,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table density={TableDensity.compact}>
+      <Table density={TableDensity.compact} tableTitle="Density table compact">
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -296,7 +296,7 @@ export function Example() {
         </TableBody>
       </Table>
       <br /> <br />
-      <Table density={TableDensity.loose}>
+      <Table density={TableDensity.loose} tableTitle="Density table loose">
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -395,7 +395,7 @@ export function Example() {
 
   return (
     <>
-      <Table>
+      <Table tableTitle="Sortable table">
         <TableHead>
           <TableRow>
             <TableHeaderCell
@@ -480,8 +480,14 @@ import {
 
 export function Example() {
   return (
-    <Card isInverse>
-      <Table isInverse hasZebraStripes hasVerticalBorders hasHoverStyles>
+    <Card isInverse style={{ padding: '16px' }}>
+      <Table
+        isInverse
+        hasZebraStripes
+        hasVerticalBorders
+        hasHoverStyles
+        tableTitle="Inverse table"
+      >
         <TableHead>
           <TableRow>
             <TableHeaderCell sortDirection={TableSortDirection.descending}>
@@ -535,7 +541,7 @@ import {
 
 export function Example() {
   return (
-    <Table>
+    <Table tableTitle="Cell alignment table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>
@@ -580,7 +586,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table>
+      <Table tableTitle="Cell Width table in percentage">
         <TableHead>
           <TableRow>
             <TableHeaderCell width="25%">Column 25%</TableHeaderCell>
@@ -603,7 +609,7 @@ export function Example() {
 
       <br />
 
-      <Table>
+      <Table tableTitle="Cell Width table in pixels">
         <TableHead>
           <TableRow>
             <TableHeaderCell width={200}>Column 200px</TableHeaderCell>
@@ -647,7 +653,7 @@ import {
 export function Example() {
   return (
     <>
-      <Table minWidth={920}>
+      <Table minWidth={920} tableTitle="Min-width table">
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column 1</TableHeaderCell>
@@ -706,7 +712,7 @@ import {
 
 export function Example() {
   return (
-    <Table hasVerticalBorders>
+    <Table hasVerticalBorders tableTitle="Other content table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column 1</TableHeaderCell>
@@ -923,7 +929,7 @@ export function Example() {
 
   return (
     <>
-      <Table>
+      <Table tableTitle="Pagination table">
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -973,7 +979,7 @@ import {
 
 export function Example() {
   return (
-    <Table>
+    <Table tableTitle="Table row color table">
       <TableHead>
         <TableRow>
           <TableHeaderCell>Column</TableHeaderCell>

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -506,6 +506,54 @@ export function Example() {
 }
 ```
 
+## Table title
+
+The `tableTitle` defines the title or caption of the table using the native `<caption>` HTML element for improved accessibility.
+
+Accepts either a plain string or a React node (e.g., a heading like `<h2>`) to allow flexible formatting.
+
+```tsx
+import React from 'react';
+
+import {
+  Table,
+  TableHead,
+  TableRow,
+  TableHeaderCell,
+  TableBody,
+  TableCell,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Table tableTitle="Table title" hasVerticalBorders hasOutsideBorder>
+      <TableHead>
+        <TableRow>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+          <TableCell>Lorem ipsum dolor</TableCell>
+          <TableCell>Lorem ipsum dolor</TableCell>
+          <TableCell>Lorem ipsum</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Lorem ipsum dolor sit amet</TableCell>
+          <TableCell>Lorem ipsum dolor</TableCell>
+          <TableCell>Lorem ipsum dolor</TableCell>
+          <TableCell>Lorem ipsum</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}
+```
+
 ## Inverse
 
 `IsInverse` is an optional boolean prop, that may be used when a table is displayed on a dark background.
@@ -515,6 +563,7 @@ import React from 'react';
 
 import {
   Card,
+  CardBody,
   Table,
   TableHead,
   TableRow,
@@ -526,45 +575,47 @@ import {
 
 export function Example() {
   return (
-    <Card isInverse style={{ padding: '16px' }}>
-      <Table
-        isInverse
-        hasZebraStripes
-        hasVerticalBorders
-        hasHoverStyles
-        tableTitle="Inverse table"
-      >
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell sortDirection={TableSortDirection.descending}>
-              Column
-            </TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-            <TableHeaderCell>Column</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
-            <TableCell>Lorem ipsum dolor</TableCell>
-            <TableCell>Lorem ipsum dolor</TableCell>
-            <TableCell>Lorem ipsum</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Lorem ipsum dolor sit amet</TableCell>
-            <TableCell>Lorem ipsum dolor</TableCell>
-            <TableCell>Lorem ipsum dolor</TableCell>
-            <TableCell>Lorem ipsum</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Lorem ipsum dolor sit amet</TableCell>
-            <TableCell>Lorem ipsum dolor</TableCell>
-            <TableCell>Lorem ipsum dolor</TableCell>
-            <TableCell>Lorem ipsum</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
+    <Card isInverse>
+      <CardBody>
+        <Table
+          isInverse
+          hasZebraStripes
+          hasVerticalBorders
+          hasHoverStyles
+          tableTitle="Inverse table"
+        >
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell sortDirection={TableSortDirection.descending}>
+                Column
+              </TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+              <TableHeaderCell>Column</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+              <TableCell>Lorem ipsum dolor</TableCell>
+              <TableCell>Lorem ipsum dolor</TableCell>
+              <TableCell>Lorem ipsum</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Lorem ipsum dolor sit amet</TableCell>
+              <TableCell>Lorem ipsum dolor</TableCell>
+              <TableCell>Lorem ipsum dolor</TableCell>
+              <TableCell>Lorem ipsum</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Lorem ipsum dolor sit amet</TableCell>
+              <TableCell>Lorem ipsum dolor</TableCell>
+              <TableCell>Lorem ipsum dolor</TableCell>
+              <TableCell>Lorem ipsum</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardBody>
     </Card>
   );
 }

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -853,6 +853,8 @@ It also takes the function `onRowsPerPageChange`.
 
 This component does not handle the actual pagination of the table itself, it simply provides the UI and allows for the consumer to do the sorting.
 
+**NOTE:** When using the `TablePagination`, it is recommended to set the `Table` component's `hasOutsideBorder` and `hasSquareCorners` props for proper styling, and also add the `hasTablePagination` to the `Table` component.
+
 ```tsx codesandbox=magma
 import React from 'react';
 
@@ -1026,7 +1028,12 @@ export function Example() {
 
   return (
     <>
-      <Table tableTitle="Pagination table">
+      <Table
+        tableTitle="Pagination table"
+        hasTablePagination
+        hasOutsideBorder={false}
+        hasSquareCorners={false}
+      >
         <TableHead>
           <TableRow>
             <TableHeaderCell>Column</TableHeaderCell>
@@ -1051,6 +1058,8 @@ export function Example() {
         onPageChange={handlePageChange}
         page={pageIndex}
         rowsPerPage={rowsPerPage}
+        hasOutsideBorder={false}
+        hasSquareCorners={false}
       />
     </>
   );

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -147,6 +147,52 @@ export function Example() {
 }
 ```
 
+## Outside Border
+
+The `hasOutsideBorder` boolean prop may be used to give table outer border.
+
+```tsx
+import React from 'react';
+
+import {
+  Table,
+  TableHead,
+  TableRow,
+  TableHeaderCell,
+  TableBody,
+  TableCell,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Table tableTitle="Outer border table" hasVerticalBorders hasOutsideBorder>
+      <TableHead>
+        <TableRow>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+          <TableHeaderCell>Column</TableHeaderCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
+          <TableCell>Lorem ipsum dolor</TableCell>
+          <TableCell>Lorem ipsum dolor</TableCell>
+          <TableCell>Lorem ipsum</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Lorem ipsum dolor sit amet</TableCell>
+          <TableCell>Lorem ipsum dolor</TableCell>
+          <TableCell>Lorem ipsum dolor</TableCell>
+          <TableCell>Lorem ipsum</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}
+```
+
 ## Hover Styles
 
 The `hasHoverStyles` boolean prop may be used to visually highlight a row when hovered over.


### PR DESCRIPTION
Closes: #1395 

## What I did
- Added the new  `tableTitle` prop for both Table and Datagrid to enable the use of captions and further improve accessibility across both components.
- Added the new `hasOutsideBorder` prop.
- Fixed all storybook examples for both Table and DataGrid when `isInverse=true` value
- Updated React Magma docs

## Screenshots
**Storybook**

**Datagrid**
![Screenshot from 2025-06-16 10-33-03](https://github.com/user-attachments/assets/b6e046e7-ce87-49b0-b3d3-1dc64080a62d)
![Screenshot from 2025-06-16 10-32-56](https://github.com/user-attachments/assets/cdfa80f9-b3f2-4dd2-9ad2-a7b13c7a0632)


**Table**
![Screenshot from 2025-06-10 14-01-11](https://github.com/user-attachments/assets/3ce15e60-e971-4997-83a4-3342d133cc51)
![Screenshot from 2025-06-10 14-01-16](https://github.com/user-attachments/assets/5122f545-dc18-4bef-97ea-a291961e6712)


**React Magma Docs**
**Datagrid**
![Screenshot from 2025-06-10 13-48-51](https://github.com/user-attachments/assets/1d519b9d-fb4e-43ed-ab9b-28003d2ea02d)
![Screenshot from 2025-06-16 11-39-36](https://github.com/user-attachments/assets/48baddf6-e5b7-42af-83b7-9f63b990dc6d)




**Table**
![Screenshot from 2025-06-10 13-46-20](https://github.com/user-attachments/assets/214495f8-8349-41d1-ad6d-745802380305)
![Screenshot from 2025-06-12 14-37-51](https://github.com/user-attachments/assets/79c76b68-6edb-41ae-b8e7-781fb2d9ff60)
![Screenshot from 2025-06-12 14-05-25](https://github.com/user-attachments/assets/d0d000cf-6336-48a5-8590-820c6da9dce6)
![Screenshot from 2025-06-17 14-54-13](https://github.com/user-attachments/assets/194456c0-b483-4910-a4b1-2002d87c91b3)
![Screenshot from 2025-06-18 19-20-28](https://github.com/user-attachments/assets/46edc46c-99b9-4e65-8606-c792de94d074)








## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
**Datagrid**
Go to `Storybook` -> Open `Datagrid`  -> all examples should consist of `tableTitle` above the table.
Go to `Storybook` -> Open `Datagrid`  -> `Default`, select `hasOuterBorder` in true -> the example should have the outer border.
Go to `React Magma Docs` -> Open `Components` -> `Datagrid` -> all examples should consist of `tableTitle` above the table -> Table Props should show description `tableTitle` property.

**Table**
Go to `Storybook` -> Open `Table`  -> all examples should consist of `tableTitle` above the table.
Go to `Storybook` -> Open `Table`  -> `Title Table And Outside Border`, should have outer border.
Go to `React Magma Docs` -> Open `Components` -> `Table`->all examples should consist of `tableTitle` above the table -> Table Props should show description `tableTitle` property.
