### PR TITLE
feat(Toggle): Remove part of the animation

### DIFF
--- a/.changeset/feat-Toogle-remove-animation.md
+++ b/.changeset/feat-Toogle-remove-animation.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Toggle): Removed animation from Toggle component.

--- a/packages/react-magma-dom/src/components/Toggle/Toggle.test.js
+++ b/packages/react-magma-dom/src/components/Toggle/Toggle.test.js
@@ -104,7 +104,10 @@ describe('Toggle', () => {
     const track = getByTestId('toggle-track');
 
     expect(toggle).toHaveAttribute('checked');
-    expect(track).toHaveStyleRule('border-color', magma.colors.success);
+    expect(track).toHaveStyleRule(
+      'border',
+      `2px solid ${magma.colors.success}`
+    );
   });
 
   it('should render a toggle with an error message', () => {
@@ -119,7 +122,7 @@ describe('Toggle', () => {
     const error = getByText(errorMessage);
 
     expect(toggle).toHaveAttribute('aria-describedby', 'testId__desc');
-    expect(track).toHaveStyleRule('border-color', magma.colors.danger);
+    expect(track).toHaveStyleRule('border', `2px solid ${magma.colors.danger}`);
 
     expect(error).toBeInTheDocument();
     expect(error.parentElement).toHaveAttribute('id', 'testId__desc');
@@ -138,7 +141,7 @@ describe('Toggle', () => {
       />
     );
     const track = getByTestId('toggle-track');
-    expect(track).toHaveStyleRule('border-color', magma.colors.danger);
+    expect(track).toHaveStyleRule('border', `2px solid ${magma.colors.danger}`);
   });
 
   it('should render an inverse toggle with error styling', () => {
@@ -150,7 +153,10 @@ describe('Toggle', () => {
     );
     const track = getByTestId('toggle-track');
 
-    expect(track).toHaveStyleRule('border-color', magma.colors.danger200);
+    expect(track).toHaveStyleRule(
+      'border',
+      `2px solid ${magma.colors.danger200}`
+    );
     expect(track).toHaveStyleRule(
       'box-shadow',
       `0 0 0 1px ${magma.colors.neutral100}`
@@ -171,7 +177,7 @@ describe('Toggle', () => {
     const error = getByText(errorMessage);
 
     expect(toggle).toHaveAttribute('aria-describedby', 'testId__desc');
-    expect(track).toHaveStyleRule('border-color', magma.colors.danger);
+    expect(track).toHaveStyleRule('border', `2px solid ${magma.colors.danger}`);
   });
 
   it('should render a toggle with a value passed through', () => {

--- a/packages/react-magma-dom/src/components/Toggle/index.tsx
+++ b/packages/react-magma-dom/src/components/Toggle/index.tsx
@@ -25,7 +25,7 @@ export enum ToggleTextPosition {
 export interface ToggleProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   /**
-   * If true, element is checked (i.e. selected)
+   * If true, an element is checked (i.e., selected)
    * @default false
    */
   checked?: boolean;
@@ -48,7 +48,7 @@ export interface ToggleProps
   hasError?: boolean;
   isInverse?: boolean;
   /**
-   * If true, label text will be hidden visually, but will still be read by assistive technology
+   * If true, a label text will be hidden visually, but will still be read by assistive technology
    * @default false
    */
   isTextVisuallyHidden?: boolean;
@@ -135,8 +135,7 @@ const Track = styled.span<{
     props.isInverse
       ? transparentize(0.8, props.theme.colors.neutral900)
       : props.theme.colors.neutral};
-  border: 2px solid;
-  border-color: ${props => buildToggleBorderColor(props)};
+  border: 2px solid ${props => buildToggleBorderColor(props)};
   border-radius: 12px;
   box-shadow: ${props =>
     props.isInverse && props.hasError
@@ -175,41 +174,6 @@ const Track = styled.span<{
           ? props.theme.colors.focusInverse
           : props.theme.colors.focus};
     outline-offset: 2px;
-  }
-
-  &:before {
-    // active state
-    background: ${props => props.theme.colors.neutral};
-    border-radius: 50%;
-    content: '';
-    display: block;
-    height: 40px;
-    left: -12px;
-    opacity: 0;
-    margin-top: -22px;
-    padding: 50%;
-    position: absolute;
-    top: 50%;
-    transform: scale(1);
-    transition:
-      opacity 1s,
-      transform 0.25s;
-    width: 40px;
-
-    ${props =>
-      props.isChecked &&
-      css`
-        background: ${props.theme.colors.success};
-        left: 12px;
-      `}
-  }
-
-  ${HiddenInput}:not(:disabled):active + label & {
-    &:before {
-      opacity: 0.4;
-      transform: scale(0);
-      transition: transform 0s;
-    }
   }
 `;
 


### PR DESCRIPTION
Closes: #1552 

## What I did
- Removed animation for Toggle.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Toggle -> Default -> Click on `Toggle label off` -> the animation is not shown
