### PR TITLE
fix(Radio Button): Hide decorative icons from assistive technology.

### DIFF
--- a/.changeset/fix-RadioButton-hide-decorative-icons-from-assistive-technology.md
+++ b/.changeset/fix-RadioButton-hide-decorative-icons-from-assistive-technology.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(RadioButton): Add `aria-hidden` to decorative icons in RadioButton component to hide them from assistive technology.

--- a/packages/react-magma-dom/src/components/Radio/index.tsx
+++ b/packages/react-magma-dom/src/components/Radio/index.tsx
@@ -204,9 +204,9 @@ export const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
             theme={theme}
           >
             {context.selectedValue === value ? (
-              <RadioButtonCheckedIcon />
+              <RadioButtonCheckedIcon aria-hidden />
             ) : (
-              <RadioButtonUncheckedIcon />
+              <RadioButtonUncheckedIcon aria-hidden />
             )}
           </StyledFakeInput>
           {isTextVisuallyHidden ? (


### PR DESCRIPTION
Closes: #1765 

## What I did
- Added `aria-hidden` for decorative icon

## Screenshots

## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open Storybook -> Radio -> Default -> Turn on Voice Over -> Voice Over should not announce the word `image` during interaction.
