### PR TITLE
fix(Popover, Tooltip): Fix an issue when pressing `Escape` doesn't stop bubbling (Focus issue)

### DIFF
--- a/.changeset/fix-Popover-and-Tooltip-focus-issue.md
+++ b/.changeset/fix-Popover-and-Tooltip-focus-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Popover, Tooltip): Fix an issue when pressing `Escape` doesn't stop bubbling (Focus issue).

--- a/packages/react-magma-dom/src/components/Popover/Popover.tsx
+++ b/packages/react-magma-dom/src/components/Popover/Popover.tsx
@@ -250,7 +250,9 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
 
     function handleKeyDown(event: React.KeyboardEvent) {
       if (event.key === 'Escape') {
-        event.nativeEvent.stopImmediatePropagation();
+        if (isOpen) {
+          event.stopPropagation();
+        }
         closePopover(event);
       }
     }

--- a/packages/react-magma-dom/src/components/Tooltip/index.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/index.tsx
@@ -193,6 +193,9 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
 
   function handleKeyDown(event: React.KeyboardEvent) {
     if (event.key === 'Escape') {
+      if (isVisible) {
+        event.stopPropagation();
+      }
       hideTooltip();
     }
   }

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -13,6 +13,7 @@ import {
   MoreHorizIcon,
   QueuePlayNextIcon,
   QuizIcon,
+  SpaceDashboardIcon,
   StarIcon,
 } from 'react-magma-icons';
 
@@ -28,10 +29,15 @@ import {
   FlexBehavior,
   IconButton,
   IndeterminateCheckboxStatus,
+  Popover,
+  PopoverApi,
+  PopoverContent,
+  PopoverTrigger,
   Spacer,
   SpacerAxis,
   Tag,
   TagSize,
+  Tooltip,
   TreeItemSelectedInterface,
   TreeViewProps,
 } from '../..';
@@ -3098,3 +3104,128 @@ ComplexWithAdditionalContent.args = {
   isDisabled: false,
   testId: 'complex-additional-content-example',
 };
+
+export function TreeViewWithDifferentElements() {
+  const parrotsInDropdown = () => {
+    return (
+      <div style={{ width: '100%', marginTop: '12px' }}>
+        <ButtonGroup style={{ marginBottom: '16px' }}>
+          <Dropdown>
+            <DropdownButton size={ButtonSize.small} color={ButtonColor.subtle}>
+              <div style={{ display: 'flex' }}>
+                <SpaceDashboardIcon
+                  size={16}
+                  style={{
+                    flex: '0 0 auto',
+                    marginRight: '4px',
+                  }}
+                />{' '}
+                <span style={{ flex: '1 1 auto' }}>Parrots</span>
+              </div>
+            </DropdownButton>
+            <DropdownContent>
+              <DropdownMenuItem>African Grey</DropdownMenuItem>
+              <DropdownMenuItem>Cockatiel</DropdownMenuItem>
+              <DropdownMenuItem>Budgerigar</DropdownMenuItem>
+            </DropdownContent>
+          </Dropdown>
+        </ButtonGroup>
+      </div>
+    );
+  };
+
+  const popoverApiRef = React.useRef<PopoverApi>();
+
+  const birdsOfPreyInPopover = () => {
+    return (
+      <>
+        <Popover hasPointer={false} focusTrap={false} apiRef={popoverApiRef}>
+          <PopoverTrigger aria-label="Open popover">Eagles</PopoverTrigger>
+          <PopoverContent>
+            <div>Large, powerful birds known for their soaring flight.</div>
+          </PopoverContent>
+        </Popover>
+        <Popover hasPointer={false} focusTrap>
+          <PopoverTrigger
+            aria-label="Open popover"
+            color={ButtonColor.secondary}
+          >
+            Owls
+          </PopoverTrigger>
+          <PopoverContent>
+            <div>
+              Nocturnal birds with distinctive facial discs and silent flight.{' '}
+              <Button
+                onClick={event => apiRef.current?.closePopoverManually(event)}
+              >
+                Ok
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
+      </>
+    );
+  };
+
+  const pinguinsInTooltip = () => {
+    return (
+      <Tooltip content="Pinguins are flightless birds that live in the Southern Hemisphere.">
+        <Button size={ButtonSize.small}>Pinguins description</Button>
+      </Tooltip>
+    );
+  };
+
+  return (
+    <TreeView
+      selectable={TreeViewSelectable.off}
+      initialExpandedItems={[
+        'parrots-AdditionalContent',
+        'birdsOfPrey',
+        'pinguins',
+      ]}
+    >
+      <TreeItem
+        icon={<FolderIcon aria-hidden />}
+        label={<>Birds</>}
+        itemId="birds"
+      >
+        <TreeItem label={<>Parrots (Dropdown)</>} itemId="parrots-folder">
+          <TreeItem
+            additionalContent={parrotsInDropdown()}
+            label={<>Additional content</>}
+            itemId="parrots-AdditionalContent"
+          />
+        </TreeItem>
+        <TreeItem
+          label={<>Birds of Prey (Popover)</>}
+          itemId="birdsOfPrey-folder"
+        >
+          <TreeItem
+            additionalContent={birdsOfPreyInPopover()}
+            label={<>Additional content</>}
+            itemId="birdsOfPrey"
+          />
+        </TreeItem>
+        <TreeItem label={<>Pinguins (Tooltip)</>} itemId="pinguins-folder">
+          <TreeItem
+            additionalContent={pinguinsInTooltip()}
+            label={<>Additional content</>}
+            itemId="pinguins"
+          />
+        </TreeItem>
+      </TreeItem>
+      <TreeItem label="Aquatic Animals" itemId="selectable-Aquatic Animals">
+        <TreeItem label="Fish" itemId="selectable-Fish">
+          <TreeItem label="Goldfish" itemId="selectable-Goldfish" />
+          <TreeItem label="Betta Fish" itemId="selectable-Betta Fish" />
+          <TreeItem label="Guppies" itemId="selectable-Guppies" />
+        </TreeItem>
+        <TreeItem label="Marine Mammals" itemId="selectable-Marine Mammals">
+          <TreeItem label="Dolphins" itemId="selectable-Dolphins" />
+          <TreeItem label="Whales" itemId="selectable-Whales" />
+          <TreeItem label="Seals" itemId="selectable-Seals" />
+        </TreeItem>
+      </TreeItem>
+    </TreeView>
+  );
+}


### PR DESCRIPTION
Closes: #1828

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix the bug when when pressing `Escape` doesn't stop bubbling for Popover and Tooltip

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook -> TreeView -> TreeView With Different Elements -> Focus on buttons -> Press `Esc` -> Focus should be on trigger button -> Press `Esc` -> Focus should be on the TreeItem.