### PR TITLE
feat(ButtonGroup, IconButton, ToogleButton): Update icon size on all button and button-based componets.

### DIFF
--- a/.changeset/feat-Button-update-icon-size.md
+++ b/.changeset/feat-Button-update-icon-size.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat (Button): Update icon size for `Button`, `Icon button`, `Dropdown button`, `Button group` and `Toggle button`.

--- a/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.test.js
+++ b/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
+import { CheckIcon } from 'react-magma-icons';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
@@ -11,8 +12,9 @@ import {
   DropdownContent,
   DropdownMenuItem,
 } from '../Dropdown';
+import { IconButton } from '../IconButton';
 
-import { ButtonGroup, ButtonGroupOrientation, ButtonGroupAlignment } from '.';
+import { ButtonGroup, ButtonGroupAlignment, ButtonGroupOrientation } from '.';
 
 const testId = 'test-id';
 
@@ -480,5 +482,52 @@ describe('ButtonGroup', () => {
 
       expect(container).toMatchSnapshot();
     });
+  });
+});
+
+describe('Size', () => {
+  const icon = <CheckIcon />;
+
+  it('Large', () => {
+    const { container } = render(
+      <ButtonGroup>
+        <IconButton icon={icon} size={ButtonSize.large}>
+          Large
+        </IconButton>
+      </ButtonGroup>
+    );
+
+    const svg = container.querySelector('svg');
+
+    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('width', '24');
+  });
+
+  it('Medium', () => {
+    const { container } = render(
+      <ButtonGroup>
+        <IconButton icon={icon} size={ButtonSize.medium}>
+          Medium
+        </IconButton>
+      </ButtonGroup>
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('height', '20');
+    expect(svg).toHaveAttribute('width', '20');
+  });
+
+  it('Small', () => {
+    const { container } = render(
+      <ButtonGroup>
+        <IconButton icon={icon} size={ButtonSize.small}>
+          Small
+        </IconButton>
+      </ButtonGroup>
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('height', '16');
+    expect(svg).toHaveAttribute('width', '16');
   });
 });

--- a/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.test.js
+++ b/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.test.js
@@ -499,8 +499,8 @@ describe('Size', () => {
 
     const svg = container.querySelector('svg');
 
-    expect(svg).toHaveAttribute('height', '24');
-    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', magma.iconSizes.medium.toString());
+    expect(svg).toHaveAttribute('width', magma.iconSizes.medium.toString());
   });
 
   it('Medium', () => {
@@ -513,8 +513,8 @@ describe('Size', () => {
     );
 
     const svg = container.querySelector('svg');
-    expect(svg).toHaveAttribute('height', '20');
-    expect(svg).toHaveAttribute('width', '20');
+    expect(svg).toHaveAttribute('height', magma.iconSizes.small.toString());
+    expect(svg).toHaveAttribute('width', magma.iconSizes.small.toString());
   });
 
   it('Small', () => {
@@ -527,7 +527,7 @@ describe('Size', () => {
     );
 
     const svg = container.querySelector('svg');
-    expect(svg).toHaveAttribute('height', '16');
-    expect(svg).toHaveAttribute('width', '16');
+    expect(svg).toHaveAttribute('height', magma.iconSizes.xSmall.toString());
+    expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
   });
 });

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1383,9 +1383,9 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
               class="icon"
               data-testid="caretDown"
               fill="currentColor"
-              height="24"
+              height="20"
               viewBox="0 0 24 24"
-              width="24"
+              width="20"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -1447,9 +1447,9 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
               class="icon"
               data-testid="caretDown"
               fill="currentColor"
-              height="24"
+              height="20"
               viewBox="0 0 24 24"
-              width="24"
+              width="20"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -2138,9 +2138,9 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
               class="icon"
               data-testid="caretDown"
               fill="currentColor"
-              height="24"
+              height="20"
               viewBox="0 0 24 24"
-              width="24"
+              width="20"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -2202,9 +2202,9 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
               class="icon"
               data-testid="caretDown"
               fill="currentColor"
-              height="24"
+              height="20"
               viewBox="0 0 24 24"
-              width="24"
+              width="20"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -2971,9 +2971,9 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
               class="icon"
               data-testid="caretDown"
               fill="currentColor"
-              height="24"
+              height="20"
               viewBox="0 0 24 24"
-              width="24"
+              width="20"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
@@ -3035,9 +3035,9 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
               class="icon"
               data-testid="caretDown"
               fill="currentColor"
-              height="24"
+              height="20"
               viewBox="0 0 24 24"
-              width="24"
+              width="20"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path

--- a/packages/react-magma-dom/src/components/ButtonGroup/index.tsx
+++ b/packages/react-magma-dom/src/components/ButtonGroup/index.tsx
@@ -208,7 +208,7 @@ const StyledButtonGroup = styled.div<{
     ${props =>
       props.noSpace &&
       props.orientation === ButtonGroupOrientation.horizontal &&
-      props.variant == ButtonVariant.solid &&
+      props.variant === ButtonVariant.solid &&
       props.alignment !== ButtonGroupAlignment.apart &&
       css`
         &:first-child:not(:only-child) {
@@ -261,7 +261,7 @@ const StyledButtonGroup = styled.div<{
     ${props =>
       props.noSpace &&
       props.orientation === ButtonGroupOrientation.horizontal &&
-      props.variant == ButtonVariant.solid &&
+      props.variant === ButtonVariant.solid &&
       props.alignment !== ButtonGroupAlignment.apart &&
       css`
         &:first-child:not(:only-child) {

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -2,39 +2,41 @@ import React from 'react';
 
 import {
   act,
-  render,
   fireEvent,
-  getByTestId,
   getByLabelText,
+  getByTestId,
+  render,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
 import {
   AsteriskIcon,
+  CheckIcon,
   ReorderIcon,
   RestaurantMenuIcon,
   SettingsIcon,
 } from 'react-magma-icons';
 
 import { magma } from '../../theme/magma';
+import { ButtonSize } from '../Button';
 import { ButtonIconPosition } from '../IconButton';
 import { Modal } from '../Modal';
 
 import {
   Dropdown,
+  DropdownButton,
   DropdownContent,
   DropdownDivider,
-  DropdownHeader,
-  DropdownMenuItem,
-  DropdownMenuGroup,
-  DropdownSplitButton,
-  DropdownButton,
-  DropdownMenuNavItem,
+  DropdownExpandableMenuButton,
   DropdownExpandableMenuGroup,
   DropdownExpandableMenuItem,
   DropdownExpandableMenuListItem,
-  DropdownExpandableMenuButton,
   DropdownExpandableMenuPanel,
+  DropdownHeader,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuNavItem,
+  DropdownSplitButton,
 } from '.';
 
 describe('Dropdown', () => {
@@ -1509,6 +1511,56 @@ describe('Dropdown', () => {
       );
 
       expect(container.querySelectorAll('svg').length).toBe(1);
+    });
+  });
+
+  describe('Size', () => {
+    const icon = <CheckIcon />;
+
+    it('Large', () => {
+      const { container } = render(
+        <Dropdown>
+          <DropdownButton icon={icon} size={ButtonSize.large}>
+            Large
+          </DropdownButton>
+          <DropdownContent />
+        </Dropdown>
+      );
+
+      const svg = container.querySelector('svg');
+
+      expect(svg).toHaveAttribute('height', '24');
+      expect(svg).toHaveAttribute('width', '24');
+    });
+
+    it('Medium', () => {
+      const { container } = render(
+        <Dropdown>
+          <DropdownButton icon={icon} size={ButtonSize.medium}>
+            Medium
+          </DropdownButton>
+          <DropdownContent />
+        </Dropdown>
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', '20');
+      expect(svg).toHaveAttribute('width', '20');
+    });
+
+    it('Small', () => {
+      const { container } = render(
+        <Dropdown>
+          <DropdownButton icon={icon} size={ButtonSize.small}>
+            Small
+          </DropdownButton>
+          <DropdownContent />
+        </Dropdown>
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', '16');
+      expect(svg).toHaveAttribute('width', '16');
     });
   });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -1563,4 +1563,52 @@ describe('Dropdown', () => {
       expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
     });
   });
+
+  describe('Size for Dropdown split button', () => {
+    it('Large', () => {
+      const { container } = render(
+        <Dropdown>
+          <DropdownSplitButton size={ButtonSize.large} aria-label="Split Large">
+            Large
+          </DropdownSplitButton>
+          <DropdownContent />
+        </Dropdown>
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.medium.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.medium.toString());
+    });
+
+    it('Medium', () => {
+      const { container } = render(
+        <Dropdown>
+          <DropdownSplitButton
+            size={ButtonSize.medium}
+            aria-label="Split Medium"
+          >
+            Medium
+          </DropdownSplitButton>
+          <DropdownContent />
+        </Dropdown>
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.small.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.small.toString());
+    });
+
+    it('Small', () => {
+      const { container } = render(
+        <Dropdown>
+          <DropdownSplitButton size={ButtonSize.small} aria-label="Split Small">
+            Small
+          </DropdownSplitButton>
+          <DropdownContent />
+        </Dropdown>
+      );
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.xSmall.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -1529,8 +1529,8 @@ describe('Dropdown', () => {
 
       const svg = container.querySelector('svg');
 
-      expect(svg).toHaveAttribute('height', '24');
-      expect(svg).toHaveAttribute('width', '24');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.medium.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.medium.toString());
     });
 
     it('Medium', () => {
@@ -1544,8 +1544,8 @@ describe('Dropdown', () => {
       );
 
       const svg = container.querySelector('svg');
-      expect(svg).toHaveAttribute('height', '20');
-      expect(svg).toHaveAttribute('width', '20');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.small.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.small.toString());
     });
 
     it('Small', () => {
@@ -1559,8 +1559,8 @@ describe('Dropdown', () => {
       );
 
       const svg = container.querySelector('svg');
-      expect(svg).toHaveAttribute('height', '16');
-      expect(svg).toHaveAttribute('width', '16');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.xSmall.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
     });
   });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -9,7 +9,7 @@ import {
   ButtonStyles,
   ButtonVariant,
 } from '../Button';
-import { IconButton } from '../IconButton';
+import { getIconSize, IconButton } from '../IconButton';
 import { DropdownContext, DropdownDropDirection } from './Dropdown';
 import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
@@ -67,13 +67,13 @@ export const DropdownSplitButton = React.forwardRef<
   const buttonIcon =
     resolvedContext.dropDirection === DropdownDropDirection.up ? (
       <ArrowDropUpIcon
-        size={theme.iconSizes.medium}
+        size={getIconSize(other.size, theme)}
         testId="caretUp"
         aria-hidden="true"
       />
     ) : (
       <ArrowDropDownIcon
-        size={theme.iconSizes.medium}
+        size={getIconSize(other.size, theme)}
         testId="caretDown"
         aria-hidden="true"
       />

--- a/packages/react-magma-dom/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/react-magma-dom/src/components/IconButton/IconButton.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { Global, css } from '@emotion/react';
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { css, Global } from '@emotion/react';
+import { Meta, Story } from '@storybook/react/types-6-0';
 import {
-  SettingsIcon,
-  NotificationsIcon,
   ExpandMoreIcon,
+  NotificationsIcon,
+  SettingsIcon,
 } from 'react-magma-icons';
 
 import {
@@ -16,8 +16,7 @@ import {
   ButtonType,
   ButtonVariant,
 } from '../Button';
-import { Card } from '../Card';
-import { CardBody } from '../Card/CardBody';
+import { Card, CardBody } from '../Card';
 
 import { ButtonIconPosition, IconButton, IconButtonProps } from '.';
 

--- a/packages/react-magma-dom/src/components/IconButton/IconButton.test.js
+++ b/packages/react-magma-dom/src/components/IconButton/IconButton.test.js
@@ -322,8 +322,11 @@ describe('IconButton', () => {
 
         const svg = container.querySelector('svg');
 
-        expect(svg).toHaveAttribute('height', '24');
-        expect(svg).toHaveAttribute('width', '24');
+        expect(svg).toHaveAttribute(
+          'height',
+          magma.iconSizes.medium.toString()
+        );
+        expect(svg).toHaveAttribute('width', magma.iconSizes.medium.toString());
       });
 
       it('Medium', () => {
@@ -335,8 +338,8 @@ describe('IconButton', () => {
         );
 
         const svg = container.querySelector('svg');
-        expect(svg).toHaveAttribute('height', '20');
-        expect(svg).toHaveAttribute('width', '20');
+        expect(svg).toHaveAttribute('height', magma.iconSizes.small.toString());
+        expect(svg).toHaveAttribute('width', magma.iconSizes.small.toString());
       });
 
       it('Small', () => {
@@ -348,8 +351,11 @@ describe('IconButton', () => {
         );
 
         const svg = container.querySelector('svg');
-        expect(svg).toHaveAttribute('height', '16');
-        expect(svg).toHaveAttribute('width', '16');
+        expect(svg).toHaveAttribute(
+          'height',
+          magma.iconSizes.xSmall.toString()
+        );
+        expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
       });
     });
 

--- a/packages/react-magma-dom/src/components/IconButton/IconButton.test.js
+++ b/packages/react-magma-dom/src/components/IconButton/IconButton.test.js
@@ -113,11 +113,11 @@ describe('IconButton', () => {
         );
         expect(container.querySelector('svg')).toHaveAttribute(
           'height',
-          magma.iconSizes.large.toString()
+          magma.iconSizes.medium.toString()
         );
         expect(container.querySelector('svg')).toHaveAttribute(
           'width',
-          magma.iconSizes.large.toString()
+          magma.iconSizes.medium.toString()
         );
       });
 
@@ -134,11 +134,11 @@ describe('IconButton', () => {
         );
         expect(container.querySelector('svg')).toHaveAttribute(
           'height',
-          magma.iconSizes.medium.toString()
+          magma.iconSizes.small.toString()
         );
         expect(container.querySelector('svg')).toHaveAttribute(
           'width',
-          magma.iconSizes.medium.toString()
+          magma.iconSizes.small.toString()
         );
       });
 
@@ -155,11 +155,11 @@ describe('IconButton', () => {
         );
         expect(container.querySelector('svg')).toHaveAttribute(
           'height',
-          magma.iconSizes.small.toString()
+          magma.iconSizes.xSmall.toString()
         );
         expect(container.querySelector('svg')).toHaveAttribute(
           'width',
-          magma.iconSizes.small.toString()
+          magma.iconSizes.xSmall.toString()
         );
       });
     });
@@ -322,8 +322,8 @@ describe('IconButton', () => {
 
         const svg = container.querySelector('svg');
 
-        expect(svg).toHaveAttribute('height', '32');
-        expect(svg).toHaveAttribute('width', '32');
+        expect(svg).toHaveAttribute('height', '24');
+        expect(svg).toHaveAttribute('width', '24');
       });
 
       it('Medium', () => {
@@ -335,8 +335,8 @@ describe('IconButton', () => {
         );
 
         const svg = container.querySelector('svg');
-        expect(svg).toHaveAttribute('height', '24');
-        expect(svg).toHaveAttribute('width', '24');
+        expect(svg).toHaveAttribute('height', '20');
+        expect(svg).toHaveAttribute('width', '20');
       });
 
       it('Small', () => {
@@ -348,8 +348,8 @@ describe('IconButton', () => {
         );
 
         const svg = container.querySelector('svg');
-        expect(svg).toHaveAttribute('height', '20');
-        expect(svg).toHaveAttribute('width', '20');
+        expect(svg).toHaveAttribute('height', '16');
+        expect(svg).toHaveAttribute('width', '16');
       });
     });
 

--- a/packages/react-magma-dom/src/components/IconButton/__snapshots__/IconButton.test.js.snap
+++ b/packages/react-magma-dom/src/components/IconButton/__snapshots__/IconButton.test.js.snap
@@ -219,9 +219,9 @@ exports[`IconButton Icon Only Button Snapshot should render with large size 1`] 
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="32"
+        height="24"
         viewBox="0 0 24 24"
-        width="32"
+        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -453,9 +453,9 @@ exports[`IconButton Icon Only Button Snapshot should render with small size 1`] 
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="20"
+        height="16"
         viewBox="0 0 24 24"
-        width="20"
+        width="16"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -687,9 +687,9 @@ exports[`IconButton Icon Only Button Snapshot should render with updated color 1
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="24"
+        height="20"
         viewBox="0 0 24 24"
-        width="24"
+        width="20"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -921,9 +921,9 @@ exports[`IconButton Icon Only Button Snapshot should render with updated shape 1
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="24"
+        height="20"
         viewBox="0 0 24 24"
-        width="24"
+        width="20"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -1155,9 +1155,9 @@ exports[`IconButton Icon Only Button Snapshot should render with updated variant
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="24"
+        height="20"
         viewBox="0 0 24 24"
-        width="24"
+        width="20"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -1382,9 +1382,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with large size
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="32"
+        height="24"
         viewBox="0 0 24 24"
-        width="32"
+        width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -1609,9 +1609,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with medium siz
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="24"
+        height="20"
         viewBox="0 0 24 24"
-        width="24"
+        width="20"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -1836,9 +1836,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with small size
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="20"
+        height="16"
         viewBox="0 0 24 24"
-        width="20"
+        width="16"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2063,9 +2063,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated co
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="24"
+        height="20"
         viewBox="0 0 24 24"
-        width="24"
+        width="20"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2290,9 +2290,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated sh
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="24"
+        height="20"
         viewBox="0 0 24 24"
-        width="24"
+        width="20"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2517,9 +2517,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated te
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="24"
+        height="20"
         viewBox="0 0 24 24"
-        width="24"
+        width="20"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
@@ -2744,9 +2744,9 @@ exports[`IconButton Icon With Text Button Snapshot should render with updated va
         aria-hidden="true"
         class="icon"
         fill="currentColor"
-        height="24"
+        height="20"
         viewBox="0 0 24 24"
-        width="24"
+        width="20"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path

--- a/packages/react-magma-dom/src/components/IconButton/index.tsx
+++ b/packages/react-magma-dom/src/components/IconButton/index.tsx
@@ -88,11 +88,11 @@ function getIconPadding(props) {
 function getIconSize(size, theme) {
   switch (size) {
     case 'large':
-      return theme.iconSizes.large;
-    case 'small':
-      return theme.iconSizes.small;
-    default:
       return theme.iconSizes.medium;
+    case 'small':
+      return theme.iconSizes.xSmall;
+    default:
+      return theme.iconSizes.small;
   }
 }
 

--- a/packages/react-magma-dom/src/components/IconButton/index.tsx
+++ b/packages/react-magma-dom/src/components/IconButton/index.tsx
@@ -85,7 +85,7 @@ function getIconPadding(props) {
   }
 }
 
-function getIconSize(size, theme) {
+export function getIconSize(size, theme) {
   switch (size) {
     case 'large':
       return theme.iconSizes.medium;

--- a/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.test.js
+++ b/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.test.js
@@ -268,8 +268,8 @@ describe('ToggleButton', () => {
 
       const svg = container.querySelector('svg');
 
-      expect(svg).toHaveAttribute('height', '24');
-      expect(svg).toHaveAttribute('width', '24');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.medium.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.medium.toString());
     });
 
     it('Medium', () => {
@@ -283,8 +283,8 @@ describe('ToggleButton', () => {
       );
 
       const svg = container.querySelector('svg');
-      expect(svg).toHaveAttribute('height', '20');
-      expect(svg).toHaveAttribute('width', '20');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.small.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.small.toString());
     });
 
     it('Small', () => {
@@ -298,8 +298,8 @@ describe('ToggleButton', () => {
       );
 
       const svg = container.querySelector('svg');
-      expect(svg).toHaveAttribute('height', '16');
-      expect(svg).toHaveAttribute('width', '16');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.xSmall.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
     });
   });
 });

--- a/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.test.js
+++ b/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { act, fireEvent, render } from '@testing-library/react';
 import { transparentize } from 'polished';
-import { SettingsIcon } from 'react-magma-icons';
+import { CheckIcon, SettingsIcon } from 'react-magma-icons';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
@@ -250,6 +250,56 @@ describe('ToggleButton', () => {
       act(() => {
         expect(onClickMock).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('Size', () => {
+    const icon = <CheckIcon />;
+
+    it('Large', () => {
+      const { container } = render(
+        <ToggleButton
+          size={ButtonSize.large}
+          icon={icon}
+          value={value}
+          testId={testId}
+        />
+      );
+
+      const svg = container.querySelector('svg');
+
+      expect(svg).toHaveAttribute('height', '24');
+      expect(svg).toHaveAttribute('width', '24');
+    });
+
+    it('Medium', () => {
+      const { container } = render(
+        <ToggleButton
+          size={ButtonSize.medium}
+          icon={icon}
+          value={value}
+          testId={testId}
+        />
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', '20');
+      expect(svg).toHaveAttribute('width', '20');
+    });
+
+    it('Small', () => {
+      const { container } = render(
+        <ToggleButton
+          size={ButtonSize.small}
+          icon={icon}
+          value={value}
+          testId={testId}
+        />
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', '16');
+      expect(svg).toHaveAttribute('width', '16');
     });
   });
 });

--- a/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.tsx
@@ -8,9 +8,9 @@ import { IconProps } from 'react-magma-icons';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { XOR } from '../../utils';
-import { Button, ButtonProps, ButtonSize, ButtonColor } from '../Button';
+import { Button, ButtonColor, ButtonProps, ButtonSize } from '../Button';
 import { IconButton } from '../IconButton';
-import { ToggleButtonGroupContext } from '../ToggleButtonGroup/ToggleButtonGroup';
+import { ToggleButtonGroupContext } from '../ToggleButtonGroup';
 
 export interface ToggleButtonTextProps extends ButtonProps {
   /**

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -1832,9 +1832,9 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                 aria-hidden="true"
                 class="icon"
                 fill="currentColor"
-                height="20"
+                height="16"
                 viewBox="0 0 24 24"
-                width="20"
+                width="16"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -3959,9 +3959,9 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                 aria-hidden="true"
                 class="icon"
                 fill="currentColor"
-                height="20"
+                height="16"
                 viewBox="0 0 24 24"
-                width="20"
+                width="16"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -5955,9 +5955,9 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                 aria-hidden="true"
                 class="icon"
                 fill="currentColor"
-                height="20"
+                height="16"
                 viewBox="0 0 24 24"
-                width="20"
+                width="16"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -7951,9 +7951,9 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                 aria-hidden="true"
                 class="icon"
                 fill="currentColor"
-                height="20"
+                height="16"
                 viewBox="0 0 24 24"
-                width="20"
+                width="16"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -10078,9 +10078,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                 aria-hidden="true"
                 class="icon"
                 fill="currentColor"
-                height="20"
+                height="16"
                 viewBox="0 0 24 24"
-                width="20"
+                width="16"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -12205,9 +12205,9 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                 aria-hidden="true"
                 class="icon"
                 fill="currentColor"
-                height="20"
+                height="16"
                 viewBox="0 0 24 24"
-                width="20"
+                width="16"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -14201,9 +14201,9 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                 aria-hidden="true"
                 class="icon"
                 fill="currentColor"
-                height="20"
+                height="16"
                 viewBox="0 0 24 24"
-                width="20"
+                width="16"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path


### PR DESCRIPTION
Closes: #1738

## What I did
**Update icon size for buttons:**
- Icon button
- Dropdown button
- Button group
- Toggle button

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
For all icons should be:

Large = **24px**
Medium = **20px**
Small = **16px**
 
Go to `Storybook` -> `ToogleButton` -> Icon 
Go to `Storybook` -> `ToogleButtonGroup` -> Default
Go to `Storybook` -> `IconButton` -> Default
Go to `Storybook` -> `ButtonGroup` -> Default
Go to `Storybook` -> `Dropdown` -> Leading Icon


