### PR TITLE
fix(TreeView): Fix double event triggering.

### DIFF
--- a/.changeset/fix-TreeItem-calls-events-twice.md
+++ b/.changeset/fix-TreeItem-calls-events-twice.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(TreeItem): Fixed issue with twice calling event.

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
@@ -146,6 +146,9 @@ export const DropdownMenuItem = React.forwardRef<
   });
 
   function handleClick(event: React.SyntheticEvent | React.KeyboardEvent) {
+    //Prevent checkbox selection when using dropdown menu item
+    event.preventDefault();
+
     if (context.activeItemIndex >= 0) {
       context.setActiveItemIndex(index);
     }

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -354,9 +354,8 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
         'button, [role="button"], a[href], input, select, textarea, [role="menuitem"]'
       );
 
-      // Preventing selecting the item when clicking on interactive elements
+      // Preventing selecting the item when clicking on interactive elements when `selectable` is `single`
       if (interactiveElement) {
-        interactiveElement.click();
         event.stopPropagation();
         return;
       }
@@ -381,7 +380,6 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
         style={labelStyle}
         id={`${itemId}-label`}
         data-testid={`${testId || itemId}-label`}
-        onClick={handleOnClick}
       >
         {hasIcons && (
           <IconWrapper
@@ -402,7 +400,6 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
         theme={theme}
         id={`${itemId}-additionalcontentwrapper`}
         data-testid={`${testId ?? itemId}-additionalcontentwrapper`}
-        onClick={handleOnClick}
       >
         {additionalContent}
       </AdditionalContentWrapper>
@@ -530,6 +527,7 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
             style={style}
             theme={theme}
             ref={mergeRefs(ref, focusTrapElement)}
+            onClick={handleOnClick}
           >
             {hasOwnTreeItems && (
               <StyledExpandWrapper


### PR DESCRIPTION
Closes: #1845

## What I did
Fixed double event triggering in the TreeView component in the label and additionalContent.

## Screenshots

## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to `Storybook` -> `Treeview` -> `Complex with additional content` -> click on the `Rename` in the dropdown button -> check the console -> there should be only one message.
