### PR TITLE
fix(Alert): Add aria-label for icon.

### DIFF
--- a/.changeset/fix-Alert-add_aria-label-for-icon.md
+++ b/.changeset/fix-Alert-add_aria-label-for-icon.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Alert): Add aria-label and role="img" for icon.

--- a/packages/react-magma-dom/src/components/Alert/Alert.test.js
+++ b/packages/react-magma-dom/src/components/Alert/Alert.test.js
@@ -1,6 +1,12 @@
 import React from 'react';
 
-import { act, render, fireEvent } from '@testing-library/react';
+import {
+  act,
+  render,
+  fireEvent,
+  getAllByAltText,
+  getAllByLabelText,
+} from '@testing-library/react';
 import { v4 as uuid } from 'uuid';
 
 import { axe } from '../../../axe-helper';
@@ -208,5 +214,50 @@ describe('Alert', () => {
     );
 
     expect(getByText('Test Component')).toBeInTheDocument();
+  });
+
+  describe('Icon accessibility', () => {
+    it('should render icon with role="img" and default aria-label', () => {
+      const { getAllByLabelText } = render(<Alert>Default Info Alert</Alert>);
+      const icon = getAllByLabelText('info icon')[0];
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('role', 'img');
+    });
+
+    it('should render icon with role="img" and aria-label="info icon"', () => {
+      const { getAllByLabelText } = render(
+        <Alert variant={AlertVariant.info}>Info Alert</Alert>
+      );
+      const icon = getAllByLabelText('info icon')[0];
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('role', 'img');
+    });
+
+    it('should render icon with role="img" and aria-label="success icon"', () => {
+      const { getAllByLabelText } = render(
+        <Alert variant={AlertVariant.success}>Success Alert</Alert>
+      );
+      const icon = getAllByLabelText('success icon')[0];
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('role', 'img');
+    });
+
+    it('should render icon with role="img" and aria-label="warning icon"', () => {
+      const { getAllByLabelText } = render(
+        <Alert variant={AlertVariant.warning}>Warning Alert</Alert>
+      );
+      const icon = getAllByLabelText('warning icon')[0];
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('role', 'img');
+    });
+
+    it('should render icon with role="img" and aria-label="danger icon"', () => {
+      const { getAllByLabelText } = render(
+        <Alert variant={AlertVariant.danger}>Danger Alert</Alert>
+      );
+      const icon = getAllByLabelText('danger icon')[0];
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('role', 'img');
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -510,7 +510,9 @@ exports[`Alert Variants should render an alert with danger variant 1`] = `
       class="emotion-2 emotion-3"
     >
       <span
+        aria-label="danger icon"
         class="emotion-4 emotion-5"
+        role="img"
       >
         <svg
           class="icon"
@@ -765,7 +767,9 @@ exports[`Alert Variants should render an alert with info variant 1`] = `
       class="emotion-2 emotion-3"
     >
       <span
+        aria-label="info icon"
         class="emotion-4 emotion-5"
+        role="img"
       >
         <svg
           class="icon"
@@ -1020,7 +1024,9 @@ exports[`Alert Variants should render an alert with warning variant 1`] = `
       class="emotion-2 emotion-3"
     >
       <span
+        aria-label="warning icon"
         class="emotion-4 emotion-5"
+        role="img"
       >
         <svg
           class="icon"
@@ -1275,7 +1281,9 @@ exports[`Alert should render an alert with default variant 1`] = `
       class="emotion-2 emotion-3"
     >
       <span
+        aria-label="info icon"
         class="emotion-4 emotion-5"
+        role="img"
       >
         <svg
           class="icon"

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -386,6 +386,19 @@ const AlertSpan = styled.span`
   white-space: pre-line;
 `;
 
+function getAriaLabelIcon(variant: string): string {
+  switch (variant) {
+    case 'success':
+      return 'success icon';
+    case 'warning':
+      return 'warning icon';
+    case 'danger':
+      return 'danger icon';
+    default:
+      return 'info icon';
+  }
+}
+
 function renderIcon(
   variant = 'info',
   isToast?: boolean,
@@ -394,7 +407,12 @@ function renderIcon(
   const Icon = VARIANT_ICON[variant];
 
   return (
-    <IconWrapper isToast={isToast} theme={theme}>
+    <IconWrapper
+      aria-label={getAriaLabelIcon(variant)}
+      role="img"
+      isToast={isToast}
+      theme={theme}
+    >
       <Icon size={theme.iconSizes.medium} />
     </IconWrapper>
   );


### PR DESCRIPTION
Closes: #1766

## What I did
Added aria-labels for all `Alert` types and HTML attribute role="img"

## Screenshots

## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to `Storybook` -> `Alert` -> Default -> Turn on `Voice over` -> It should pronounce:
`image info icon` -> `default`
`success info icon` -> `success`
`warning info icon` -> `warning`
`danger info icon` -> `danger`
