### PR TITLE
feat(TreeView): Add styles customization support

### DIFF
--- a/.changeset/feat-Treeview-add-styles-customixation.support.md
+++ b/.changeset/feat-Treeview-add-styles-customixation.support.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): Add new expandIconSize and expandIconColor props for TreeView. Add styles customization support and hoverColor prop for TreeItem.

--- a/.changeset/feat-Treeview-add-styles-customixation.support.md
+++ b/.changeset/feat-Treeview-add-styles-customixation.support.md
@@ -2,4 +2,4 @@
 'react-magma-dom': minor
 ---
 
-feat(TreeView): Add new expandIconSize and expandIconColor props for TreeView. Add styles customization support and hoverColor prop for TreeItem.
+feat(TreeView): Add new expandIconStyles prop for TreeView. Add styles customization support and hoverColor prop for TreeItem.

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
@@ -211,6 +211,7 @@ describe('TreeItem', () => {
       expect(treeItem).toHaveFocus();
     });
   });
+
   describe('hover styles', () => {
     it('should have default hover color', () => {
       const { getByTestId } = render(
@@ -233,16 +234,18 @@ describe('TreeItem', () => {
           label={labelText}
           testId={testId}
           itemId={itemId}
-          hoverColor={magma.colors.blue500}
+          hoverColor={magma.colors.primary500}
         />
       );
 
       expect(getByTestId(testId)).toBeInTheDocument();
-      userEvent.hover(getByTestId(testId));
-
-      expect(getByTestId(testId)).toHaveStyle({
-        background: magma.colors.blue500,
-      });
+      expect(getByTestId(testId)).toHaveStyleRule(
+        'background',
+        magma.colors.primary500,
+        {
+          target: ':hover',
+        }
+      );
     });
   });
 });

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
@@ -211,4 +211,38 @@ describe('TreeItem', () => {
       expect(treeItem).toHaveFocus();
     });
   });
+  describe('hover styles', () => {
+    it('should have default hover color', () => {
+      const { getByTestId } = render(
+        <TreeItem label={labelText} testId={testId} itemId={itemId} />
+      );
+
+      expect(getByTestId(testId)).toBeInTheDocument();
+      expect(getByTestId(testId)).toHaveStyleRule(
+        'background',
+        transparentize(0.95, magma.colors.neutral900),
+        {
+          target: ':hover',
+        }
+      );
+    });
+
+    it('should have custom hover color', () => {
+      const { getByTestId } = render(
+        <TreeItem
+          label={labelText}
+          testId={testId}
+          itemId={itemId}
+          hoverColor={magma.colors.blue500}
+        />
+      );
+
+      expect(getByTestId(testId)).toBeInTheDocument();
+      userEvent.hover(getByTestId(testId));
+
+      expect(getByTestId(testId)).toHaveStyle({
+        background: magma.colors.blue500,
+      });
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -112,16 +112,23 @@ const StyledTreeItem = styled.li<{
       `}
     &:hover {
       background: ${props =>
-        !props.isDisabled
-          ? props.hoverColor
-            ? props.hoverColor
-            : props.isInverse
-              ? transparentize(0.8, props.theme.colors.neutral900)
-              : transparentize(0.95, props.theme.colors.neutral900)
-          : undefined};
+        getHoverBackground({
+          isDisabled: props.isDisabled,
+          hoverColor: props.hoverColor,
+          isInverse: props.isInverse,
+          theme: props.theme,
+        })};
     }
   }
 `;
+
+function getHoverBackground({ isDisabled, hoverColor, isInverse, theme }) {
+  if (isDisabled) return undefined;
+  if (hoverColor) return hoverColor;
+
+  const transparency = isInverse ? 0.8 : 0.95;
+  return transparentize(transparency, theme.colors.neutral900);
+}
 
 const IconWrapper = styled.span<{
   theme?: ThemeInterface;
@@ -228,8 +235,7 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
     const isInverse = useIsInverse();
 
     const {
-      expandIconColor,
-      expandIconSize,
+      expandIconStyles,
       handleExpandedChange,
       hasIcons,
       itemToFocus,
@@ -534,7 +540,7 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
               data-testid={`${testId ?? itemId}-itemwrapper`}
               depth={itemDepth}
               hasAdditionalContent={!!additionalContent}
-              hasCustomIconSize={!!expandIconSize}
+              hasCustomIconSize={!!expandIconStyles?.size}
               id={`${itemId}-itemwrapper`}
               isDisabled={isDisabled}
               isInverse={isInverse}
@@ -548,8 +554,8 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
               {hasOwnTreeItems && (
                 <StyledExpandWrapper
                   aria-hidden={Boolean(!expanded)}
-                  size={expandIconSize}
-                  color={expandIconColor}
+                  size={expandIconStyles?.size}
+                  color={expandIconStyles?.color}
                   data-testid={`${testId || itemId}-expand`}
                   isDisabled={isDisabled}
                   isInverse={isInverse}
@@ -561,9 +567,12 @@ export const TreeItem = React.forwardRef<HTMLLIElement, TreeItemProps>(
                   theme={theme}
                 >
                   {expanded ? (
-                    <ExpandMoreIcon aria-hidden size={expandIconSize} />
+                    <ExpandMoreIcon aria-hidden size={expandIconStyles?.size} />
                   ) : (
-                    <ChevronRightIcon aria-hidden size={expandIconSize} />
+                    <ChevronRightIcon
+                      aria-hidden
+                      size={expandIconStyles?.size}
+                    />
                   )}
                 </StyledExpandWrapper>
               )}

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -3234,8 +3234,7 @@ export function CustomExpandIconArrowAndTreeItemStyles() {
   return (
     <TreeView
       initialExpandedItems={['Dogs', 'Cats']}
-      expandIconSize={32}
-      expandIconColor="#3942B0"
+      expandIconStyles={{ size: 32, color: '#3942B0' }}
     >
       <TreeItem
         hoverColor="#ACF0C1"

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -3229,3 +3229,65 @@ export function TreeViewWithDifferentElements() {
     </TreeView>
   );
 }
+
+export function CustomExpandIconArrowAndTreeItemStyles() {
+  return (
+    <TreeView
+      initialExpandedItems={['Dogs', 'Cats']}
+      expandIconSize={32}
+      expandIconColor="#3942B0"
+    >
+      <TreeItem
+        hoverColor="#ACF0C1"
+        icon={<FolderIcon aria-hidden />}
+        label="Mammals"
+        itemId="Mammals"
+        treeItemStyles={{
+          backgroundColor: '#E8E9F8',
+        }}
+      >
+        <TreeItem label="Dogs" itemId="Dogs" hoverColor="#ACF0C1">
+          <TreeItem
+            label="German Shepherd"
+            itemId="German Shepherd"
+            hoverColor="#ACF0C1"
+          />
+          <TreeItem
+            label="Labrador Retriever"
+            itemId="Labrador Retriever"
+            hoverColor="#ACF0C1"
+          />
+          <TreeItem
+            label="American Bully"
+            itemId="American Bully"
+            hoverColor="#ACF0C1"
+          />
+        </TreeItem>
+        <TreeItem label="Cats" itemId="Cats" hoverColor="#ACF0C1">
+          <TreeItem label="Siamese" itemId="Siamese" hoverColor="#ACF0C1" />
+          <TreeItem label="Persian" itemId="Persian" hoverColor="#ACF0C1" />
+          <TreeItem label="Bengal" itemId="Bengal" hoverColor="#ACF0C1" />
+        </TreeItem>
+      </TreeItem>
+      <TreeItem label="Birds" itemId="Birds">
+        <TreeItem label="Parrots" itemId="Parrots">
+          <TreeItem label="African Grey" itemId="African Grey" />
+          <TreeItem label="Cockatiel" itemId="Cockatiel" />
+          <TreeItem label="Budgerigar" itemId="Budgerigar" />
+        </TreeItem>
+        <TreeItem label="Birds of Prey" itemId="Birds of Prey">
+          <TreeItem label="Eagles" itemId="Eagles" />
+          <TreeItem label="Hawks" itemId="Hawks" />
+          <TreeItem label="Falcons" itemId="Falcons" />
+        </TreeItem>
+      </TreeItem>
+      <TreeItem
+        label="Amphibians"
+        itemId="Amphibians"
+        treeItemStyles={{
+          backgroundColor: '#A6DEFF',
+        }}
+      />
+    </TreeView>
+  );
+}

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -19,6 +19,7 @@ import {
   DropdownContent,
   DropdownMenuItem,
 } from '../..';
+import { getTreeItemLabelColor } from './utils';
 
 import { TreeItem, TreeView, TreeViewSelectable } from '.';
 
@@ -5147,5 +5148,51 @@ describe('TreeView', () => {
 
     userEvent.click(getByTestId('click-button'));
     expect(handleClick).toHaveBeenCalledTimes(2);
+  });
+
+  describe('expand arrow size and color', () => {
+    it('should have default styles', () => {
+      const { getByTestId } = render(
+        <TreeView testId={testId}>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(getByTestId('item1')).toBeInTheDocument();
+      expect(getByTestId('item1-expand')).toBeInTheDocument();
+      expect(getByTestId('item1-expand')).toHaveStyle({
+        width: '24px',
+        height: '24px',
+        color: getTreeItemLabelColor(false, false, magma),
+      });
+    });
+
+    it('should have custom styles', () => {
+      const { getByTestId } = render(
+        <TreeView expandIconColor="red" expandIconSize={32} testId={testId}>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(getByTestId('item1')).toBeInTheDocument();
+      expect(getByTestId('item1-expand')).toBeInTheDocument();
+      expect(getByTestId('item1-expand')).toHaveStyle({
+        width: '32px',
+        height: '32px',
+        color: 'red',
+      });
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -5175,7 +5175,7 @@ describe('TreeView', () => {
 
     it('should have custom styles', () => {
       const { getByTestId } = render(
-        <TreeView expandIconColor="red" expandIconSize={32} testId={testId}>
+        <TreeView expandIconStyles={{ size: 32, color: 'red' }} testId={testId}>
           <TreeItem label="Node 1" itemId="item1" testId="item1">
             <TreeItem
               label="Child 1"

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { TreeViewSelectable } from './types';
+import { magma } from '../../theme/magma';
 import { IndeterminateCheckboxStatus } from '../IndeterminateCheckbox';
 
 export interface TreeItemSelectedInterface {
@@ -16,6 +17,11 @@ export interface TreeViewItemInterface {
   checkedStatus: IndeterminateCheckboxStatus;
   hasOwnTreeItems: boolean;
   isDisabled?: boolean;
+}
+
+export interface ExpandIconInterface {
+  size?: number;
+  color?: string;
 }
 
 export interface TreeViewContextInterface {
@@ -49,8 +55,7 @@ export interface TreeViewContextInterface {
   ) => void;
   expandedSet: Set<string>;
   isTopLevelSelectable?: boolean;
-  expandIconSize?: number;
-  expandIconColor?: string;
+  expandIconStyles?: ExpandIconInterface;
 }
 
 export const TreeViewContext = React.createContext<TreeViewContextInterface>({
@@ -66,6 +71,8 @@ export const TreeViewContext = React.createContext<TreeViewContextInterface>({
   handleExpandedChange: () => undefined,
   isTopLevelSelectable: true,
   expandedSet: new Set<string>(),
-  expandIconSize: 24,
-  expandIconColor: undefined,
+  expandIconStyles: {
+    size: magma.iconSizes.medium,
+    color: undefined,
+  },
 });

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewContext.ts
@@ -49,6 +49,8 @@ export interface TreeViewContextInterface {
   ) => void;
   expandedSet: Set<string>;
   isTopLevelSelectable?: boolean;
+  expandIconSize?: number;
+  expandIconColor?: string;
 }
 
 export const TreeViewContext = React.createContext<TreeViewContextInterface>({
@@ -64,4 +66,6 @@ export const TreeViewContext = React.createContext<TreeViewContextInterface>({
   handleExpandedChange: () => undefined,
   isTopLevelSelectable: true,
   expandedSet: new Set<string>(),
+  expandIconSize: 24,
+  expandIconColor: undefined,
 });

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -1451,368 +1451,378 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
             class="emotion-24 emotion-25"
             role="tree"
           >
-            <li
-              aria-checked="false"
-              class="emotion-26 emotion-27"
-              data-testid="item-id-1"
-              id="item-id-1"
-              role="treeitem"
-              title="item-title-1"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-1-itemwrapper"
-                id="item-id-1-itemwrapper"
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-26 emotion-27"
+                data-testid="item-id-1"
+                id="item-id-1"
+                role="treeitem"
+                title="item-title-1"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-1-itemwrapper"
+                  id="item-id-1-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-1"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-1-checkbox"
-                      disabled=""
-                      id="item-id-1-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-1-checkbox"
-                      style="padding: 0px; width: 100%;"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
-                        disabled=""
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-1-label"
-                        id="item-id-1-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-1
-                      </span>
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              class="emotion-42 emotion-27"
-              data-testid="item-id-2"
-              id="item-id-2"
-              role="treeitem"
-              tabindex="0"
-              title="item-title-2"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-2-itemwrapper"
-                id="item-id-2-itemwrapper"
-              >
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-label="item-title-2"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-2-checkbox"
-                      id="item-id-2-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-2-checkbox"
-                      style="padding: 0px; width: 100%;"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-2-label"
-                        id="item-id-2-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-2
-                      </span>
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              class="emotion-26 emotion-27"
-              data-testid="item-id-3"
-              id="item-id-3"
-              role="treeitem"
-              title="item-title-3"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-3-itemwrapper"
-                id="item-id-3-itemwrapper"
-              >
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-label="item-title-3"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-3-checkbox"
-                      disabled=""
-                      id="item-id-3-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-3-checkbox"
-                      style="padding: 0px; width: 100%;"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
-                        disabled=""
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-3-label"
-                        id="item-id-3-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-3
-                      </span>
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              class="emotion-42 emotion-27"
-              data-testid="item-id-4"
-              id="item-id-4"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-4"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-4-itemwrapper"
-                id="item-id-4-itemwrapper"
-              >
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-label="item-title-4"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-4-checkbox"
-                      id="item-id-4-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px; width: 100%;"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-90 emotion-27"
-              data-testid="item-id-5"
-              id="item-id-5"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-5"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-5-itemwrapper"
-                id="item-id-5-itemwrapper"
-              >
-                <div
-                  aria-hidden="true"
-                  class="emotion-94 emotion-95"
-                  data-testid="item-id-5-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-5-checkbox"
-                      id="item-id-5-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-5-checkbox"
-                      style="padding: 0px; width: 100%;"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-5-label"
-                        id="item-id-5-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-5
-                      </span>
-                    </label>
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-108 emotion-109"
+                      <input
+                        aria-label="item-title-1"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-1-checkbox"
+                        disabled=""
+                        id="item-id-1-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-1-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-5 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-1-label"
+                          id="item-id-1-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-1
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-42 emotion-27"
+                data-testid="item-id-2"
+                id="item-id-2"
+                role="treeitem"
+                tabindex="0"
+                title="item-title-2"
+              >
+                <div
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-2-itemwrapper"
+                  id="item-id-2-itemwrapper"
+                >
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-label="item-title-2"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-2-checkbox"
+                        id="item-id-2-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-2-checkbox"
+                        style="padding: 0px; width: 100%;"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-2-label"
+                          id="item-id-2-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-2
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-26 emotion-27"
+                data-testid="item-id-3"
+                id="item-id-3"
+                role="treeitem"
+                title="item-title-3"
+              >
+                <div
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-3-itemwrapper"
+                  id="item-id-3-itemwrapper"
+                >
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-label="item-title-3"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-3-checkbox"
+                        disabled=""
+                        id="item-id-3-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-3-checkbox"
+                        style="padding: 0px; width: 100%;"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-3-label"
+                          id="item-id-3-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-3
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-42 emotion-27"
+                data-testid="item-id-4"
+                id="item-id-4"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-4"
+              >
+                <div
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-4-itemwrapper"
+                  id="item-id-4-itemwrapper"
+                >
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-label="item-title-4"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-4-checkbox"
+                        id="item-id-4-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px; width: 100%;"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-90 emotion-27"
+                data-testid="item-id-5"
+                id="item-id-5"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-5"
+              >
+                <div
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-5-itemwrapper"
+                  id="item-id-5-itemwrapper"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="emotion-94 emotion-95"
+                    data-testid="item-id-5-expand"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-5-checkbox"
+                        id="item-id-5-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-5-checkbox"
+                        style="padding: 0px; width: 100%;"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-5-label"
+                          id="item-id-5-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-5
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-108 emotion-109"
+                        >
+                          No subitems are checked for item-title-5 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
+              </li>
+            </div>
           </ul>
           <span
             class="emotion-22 emotion-9"
@@ -3517,429 +3527,439 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
             class="emotion-24 emotion-25"
             role="tree"
           >
-            <li
-              aria-checked="false"
-              class="emotion-26 emotion-27"
-              data-testid="item-id-1"
-              id="item-id-1"
-              role="treeitem"
-              title="item-title-1"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-1-itemwrapper"
-                id="item-id-1-itemwrapper"
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-26 emotion-27"
+                data-testid="item-id-1"
+                id="item-id-1"
+                role="treeitem"
+                title="item-title-1"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-1-itemwrapper"
+                  id="item-id-1-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-1"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-1-checkbox"
-                      disabled=""
-                      id="item-id-1-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-1-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <input
+                        aria-label="item-title-1"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-1-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-1-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-1-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-1-label"
-                        id="item-id-1-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-1
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-1-label"
+                          id="item-id-1-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-1
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="true"
-              class="emotion-42 emotion-27"
-              data-testid="item-id-2"
-              id="item-id-2"
-              role="treeitem"
-              tabindex="0"
-              title="item-title-2"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-2-itemwrapper"
-                id="item-id-2-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="true"
+                class="emotion-42 emotion-27"
+                data-testid="item-id-2"
+                id="item-id-2"
+                role="treeitem"
+                tabindex="0"
+                title="item-title-2"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-2-itemwrapper"
+                  id="item-id-2-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-2"
-                      checked=""
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-2-checkbox"
-                      id="item-id-2-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-2-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <input
+                        aria-label="item-title-2"
+                        checked=""
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-2-checkbox"
+                        id="item-id-2-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-2-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8.29 13.29c-.39.39-1.02.39-1.41 0L5.71 12.7a.9959.9959 0 010-1.41c.39-.39 1.02-.39 1.41 0L10 14.17l6.88-6.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-7.58 7.59z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-2-label"
-                        id="item-id-2-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-2
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8.29 13.29c-.39.39-1.02.39-1.41 0L5.71 12.7a.9959.9959 0 010-1.41c.39-.39 1.02-.39 1.41 0L10 14.17l6.88-6.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-7.58 7.59z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-2-label"
+                          id="item-id-2-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-2
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-58 emotion-27"
-              data-testid="item-id-3"
-              id="item-id-3"
-              role="treeitem"
-              title="item-title-3"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-3-itemwrapper"
-                id="item-id-3-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-58 emotion-27"
+                data-testid="item-id-3"
+                id="item-id-3"
+                role="treeitem"
+                title="item-title-3"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-62 emotion-63"
-                  data-testid="item-id-3-expand"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-3-itemwrapper"
+                  id="item-id-3-itemwrapper"
                 >
-                  <svg
+                  <div
                     aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                    class="emotion-62 emotion-63"
+                    data-testid="item-id-3-expand"
                   >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-3-checkbox"
-                      disabled=""
-                      id="item-id-3-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-3-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-3-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-3-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-3-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-3-label"
-                        id="item-id-3-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-3
-                      </span>
-                    </label>
-                    <div
-                      aria-live="polite"
-                    >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-3-label"
+                          id="item-id-3-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-3
+                        </span>
+                      </label>
                       <div
-                        class="emotion-76 emotion-77"
+                        aria-live="polite"
                       >
-                        No subitems are checked for item-title-3 checkbox
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-3 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-4"
-              id="item-id-4"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-4"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-4-itemwrapper"
-                id="item-id-4-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-4"
+                id="item-id-4"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-4"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-4-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-4-itemwrapper"
+                  id="item-id-4-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-4-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-4-checkbox"
-                      id="item-id-4-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-92 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-4-checkbox"
+                        id="item-id-4-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-4 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-92 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-4 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-5"
-              id="item-id-5"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-5"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-5-itemwrapper"
-                id="item-id-5-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-5"
+                id="item-id-5"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-5"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-5-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-5-itemwrapper"
+                  id="item-id-5-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-5-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-5-checkbox"
-                      id="item-id-5-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-5-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-92 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-5-label"
-                        id="item-id-5-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-5
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-5-checkbox"
+                        id="item-id-5-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-5-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-5 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-92 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-5-label"
+                          id="item-id-5-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-5
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-5 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
+              </li>
+            </div>
           </ul>
           <span
             class="emotion-22 emotion-9"
@@ -5514,428 +5534,438 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
             class="emotion-24 emotion-25"
             role="tree"
           >
-            <li
-              aria-checked="false"
-              class="emotion-26 emotion-27"
-              data-testid="item-id-1"
-              id="item-id-1"
-              role="treeitem"
-              title="item-title-1"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-1-itemwrapper"
-                id="item-id-1-itemwrapper"
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-26 emotion-27"
+                data-testid="item-id-1"
+                id="item-id-1"
+                role="treeitem"
+                title="item-title-1"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-1-itemwrapper"
+                  id="item-id-1-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-1"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-1-checkbox"
-                      disabled=""
-                      id="item-id-1-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-1-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <input
+                        aria-label="item-title-1"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-1-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-1-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-1-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-1-label"
-                        id="item-id-1-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-1
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-1-label"
+                          id="item-id-1-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-1
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              class="emotion-42 emotion-27"
-              data-testid="item-id-2"
-              id="item-id-2"
-              role="treeitem"
-              tabindex="0"
-              title="item-title-2"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-2-itemwrapper"
-                id="item-id-2-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-42 emotion-27"
+                data-testid="item-id-2"
+                id="item-id-2"
+                role="treeitem"
+                tabindex="0"
+                title="item-title-2"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-2-itemwrapper"
+                  id="item-id-2-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-2"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-2-checkbox"
-                      id="item-id-2-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-2-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <input
+                        aria-label="item-title-2"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-2-checkbox"
+                        id="item-id-2-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-2-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-2-label"
-                        id="item-id-2-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-2
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-2-label"
+                          id="item-id-2-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-2
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-58 emotion-27"
-              data-testid="item-id-3"
-              id="item-id-3"
-              role="treeitem"
-              title="item-title-3"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-3-itemwrapper"
-                id="item-id-3-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-58 emotion-27"
+                data-testid="item-id-3"
+                id="item-id-3"
+                role="treeitem"
+                title="item-title-3"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-62 emotion-63"
-                  data-testid="item-id-3-expand"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-3-itemwrapper"
+                  id="item-id-3-itemwrapper"
                 >
-                  <svg
+                  <div
                     aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                    class="emotion-62 emotion-63"
+                    data-testid="item-id-3-expand"
                   >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-3-checkbox"
-                      disabled=""
-                      id="item-id-3-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-3-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-3-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-3-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-3-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-3-label"
-                        id="item-id-3-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-3
-                      </span>
-                    </label>
-                    <div
-                      aria-live="polite"
-                    >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-3-label"
+                          id="item-id-3-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-3
+                        </span>
+                      </label>
                       <div
-                        class="emotion-76 emotion-77"
+                        aria-live="polite"
                       >
-                        No subitems are checked for item-title-3 checkbox
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-3 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-4"
-              id="item-id-4"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-4"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-4-itemwrapper"
-                id="item-id-4-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-4"
+                id="item-id-4"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-4"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-4-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-4-itemwrapper"
+                  id="item-id-4-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-4-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-4-checkbox"
-                      id="item-id-4-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-4-checkbox"
+                        id="item-id-4-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-4 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-4 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-5"
-              id="item-id-5"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-5"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-5-itemwrapper"
-                id="item-id-5-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-5"
+                id="item-id-5"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-5"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-5-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-5-itemwrapper"
+                  id="item-id-5-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-5-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-5-checkbox"
-                      id="item-id-5-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-5-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-5-label"
-                        id="item-id-5-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-5
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-5-checkbox"
+                        id="item-id-5-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-5-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-5 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-5-label"
+                          id="item-id-5-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-5
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-5 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
+              </li>
+            </div>
           </ul>
           <span
             class="emotion-22 emotion-9"
@@ -7510,428 +7540,438 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
             class="emotion-24 emotion-25"
             role="tree"
           >
-            <li
-              aria-checked="false"
-              class="emotion-26 emotion-27"
-              data-testid="item-id-1"
-              id="item-id-1"
-              role="treeitem"
-              title="item-title-1"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-1-itemwrapper"
-                id="item-id-1-itemwrapper"
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-26 emotion-27"
+                data-testid="item-id-1"
+                id="item-id-1"
+                role="treeitem"
+                title="item-title-1"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-1-itemwrapper"
+                  id="item-id-1-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-1"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-1-checkbox"
-                      disabled=""
-                      id="item-id-1-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-1-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <input
+                        aria-label="item-title-1"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-1-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-1-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-1-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-1-label"
-                        id="item-id-1-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-1
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-1-label"
+                          id="item-id-1-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-1
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              class="emotion-42 emotion-27"
-              data-testid="item-id-2"
-              id="item-id-2"
-              role="treeitem"
-              tabindex="0"
-              title="item-title-2"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-2-itemwrapper"
-                id="item-id-2-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-42 emotion-27"
+                data-testid="item-id-2"
+                id="item-id-2"
+                role="treeitem"
+                tabindex="0"
+                title="item-title-2"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-2-itemwrapper"
+                  id="item-id-2-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-2"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-2-checkbox"
-                      id="item-id-2-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-2-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <input
+                        aria-label="item-title-2"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-2-checkbox"
+                        id="item-id-2-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-2-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-2-label"
-                        id="item-id-2-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-2
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-2-label"
+                          id="item-id-2-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-2
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-58 emotion-27"
-              data-testid="item-id-3"
-              id="item-id-3"
-              role="treeitem"
-              title="item-title-3"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-3-itemwrapper"
-                id="item-id-3-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-58 emotion-27"
+                data-testid="item-id-3"
+                id="item-id-3"
+                role="treeitem"
+                title="item-title-3"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-62 emotion-63"
-                  data-testid="item-id-3-expand"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-3-itemwrapper"
+                  id="item-id-3-itemwrapper"
                 >
-                  <svg
+                  <div
                     aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                    class="emotion-62 emotion-63"
+                    data-testid="item-id-3-expand"
                   >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-3-checkbox"
-                      disabled=""
-                      id="item-id-3-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-3-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-3-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-3-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-3-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-3-label"
-                        id="item-id-3-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-3
-                      </span>
-                    </label>
-                    <div
-                      aria-live="polite"
-                    >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-3-label"
+                          id="item-id-3-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-3
+                        </span>
+                      </label>
                       <div
-                        class="emotion-76 emotion-77"
+                        aria-live="polite"
                       >
-                        No subitems are checked for item-title-3 checkbox
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-3 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-4"
-              id="item-id-4"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-4"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-4-itemwrapper"
-                id="item-id-4-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-4"
+                id="item-id-4"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-4"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-4-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-4-itemwrapper"
+                  id="item-id-4-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-4-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-4-checkbox"
-                      id="item-id-4-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-4-checkbox"
+                        id="item-id-4-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-4 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-4 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-5"
-              id="item-id-5"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-5"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-5-itemwrapper"
-                id="item-id-5-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-5"
+                id="item-id-5"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-5"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-5-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-5-itemwrapper"
+                  id="item-id-5-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-5-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-5-checkbox"
-                      id="item-id-5-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-5-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-5-label"
-                        id="item-id-5-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-5
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-5-checkbox"
+                        id="item-id-5-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-5-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-5 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-5-label"
+                          id="item-id-5-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-5
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-5 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
+              </li>
+            </div>
           </ul>
           <span
             class="emotion-22 emotion-9"
@@ -9636,429 +9676,439 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
             class="emotion-24 emotion-25"
             role="tree"
           >
-            <li
-              aria-checked="false"
-              class="emotion-26 emotion-27"
-              data-testid="item-id-1"
-              id="item-id-1"
-              role="treeitem"
-              title="item-title-1"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-1-itemwrapper"
-                id="item-id-1-itemwrapper"
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-26 emotion-27"
+                data-testid="item-id-1"
+                id="item-id-1"
+                role="treeitem"
+                title="item-title-1"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-1-itemwrapper"
+                  id="item-id-1-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-1"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-1-checkbox"
-                      disabled=""
-                      id="item-id-1-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-1-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <input
+                        aria-label="item-title-1"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-1-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-1-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-1-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-1-label"
-                        id="item-id-1-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-1
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-1-label"
+                          id="item-id-1-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-1
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="true"
-              class="emotion-42 emotion-27"
-              data-testid="item-id-2"
-              id="item-id-2"
-              role="treeitem"
-              tabindex="0"
-              title="item-title-2"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-2-itemwrapper"
-                id="item-id-2-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="true"
+                class="emotion-42 emotion-27"
+                data-testid="item-id-2"
+                id="item-id-2"
+                role="treeitem"
+                tabindex="0"
+                title="item-title-2"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-2-itemwrapper"
+                  id="item-id-2-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-2"
-                      checked=""
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-2-checkbox"
-                      id="item-id-2-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-2-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <input
+                        aria-label="item-title-2"
+                        checked=""
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-2-checkbox"
+                        id="item-id-2-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-2-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8.29 13.29c-.39.39-1.02.39-1.41 0L5.71 12.7a.9959.9959 0 010-1.41c.39-.39 1.02-.39 1.41 0L10 14.17l6.88-6.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-7.58 7.59z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-2-label"
-                        id="item-id-2-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-2
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8.29 13.29c-.39.39-1.02.39-1.41 0L5.71 12.7a.9959.9959 0 010-1.41c.39-.39 1.02-.39 1.41 0L10 14.17l6.88-6.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-7.58 7.59z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-2-label"
+                          id="item-id-2-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-2
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-58 emotion-27"
-              data-testid="item-id-3"
-              id="item-id-3"
-              role="treeitem"
-              title="item-title-3"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-3-itemwrapper"
-                id="item-id-3-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-58 emotion-27"
+                data-testid="item-id-3"
+                id="item-id-3"
+                role="treeitem"
+                title="item-title-3"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-62 emotion-63"
-                  data-testid="item-id-3-expand"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-3-itemwrapper"
+                  id="item-id-3-itemwrapper"
                 >
-                  <svg
+                  <div
                     aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                    class="emotion-62 emotion-63"
+                    data-testid="item-id-3-expand"
                   >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-3-checkbox"
-                      disabled=""
-                      id="item-id-3-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-3-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-3-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-3-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-3-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-3-label"
-                        id="item-id-3-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-3
-                      </span>
-                    </label>
-                    <div
-                      aria-live="polite"
-                    >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-3-label"
+                          id="item-id-3-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-3
+                        </span>
+                      </label>
                       <div
-                        class="emotion-76 emotion-77"
+                        aria-live="polite"
                       >
-                        No subitems are checked for item-title-3 checkbox
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-3 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-4"
-              id="item-id-4"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-4"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-4-itemwrapper"
-                id="item-id-4-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-4"
+                id="item-id-4"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-4"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-4-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-4-itemwrapper"
+                  id="item-id-4-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-4-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-4-checkbox"
-                      id="item-id-4-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-92 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-4-checkbox"
+                        id="item-id-4-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-4 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-92 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-4 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-5"
-              id="item-id-5"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-5"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-5-itemwrapper"
-                id="item-id-5-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-5"
+                id="item-id-5"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-5"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-5-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-5-itemwrapper"
+                  id="item-id-5-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-5-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-5-checkbox"
-                      id="item-id-5-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-5-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-92 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-5-label"
-                        id="item-id-5-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-5
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-5-checkbox"
+                        id="item-id-5-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-5-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-5 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-92 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-5-label"
+                          id="item-id-5-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-5
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-5 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
+              </li>
+            </div>
           </ul>
           <span
             class="emotion-22 emotion-9"
@@ -11763,429 +11813,439 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
             class="emotion-24 emotion-25"
             role="tree"
           >
-            <li
-              aria-checked="false"
-              class="emotion-26 emotion-27"
-              data-testid="item-id-1"
-              id="item-id-1"
-              role="treeitem"
-              title="item-title-1"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-1-itemwrapper"
-                id="item-id-1-itemwrapper"
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-26 emotion-27"
+                data-testid="item-id-1"
+                id="item-id-1"
+                role="treeitem"
+                title="item-title-1"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-1-itemwrapper"
+                  id="item-id-1-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-1"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-1-checkbox"
-                      disabled=""
-                      id="item-id-1-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-1-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <input
+                        aria-label="item-title-1"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-1-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-1-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-1-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-1-label"
-                        id="item-id-1-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-1
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-1-label"
+                          id="item-id-1-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-1
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="true"
-              class="emotion-42 emotion-27"
-              data-testid="item-id-2"
-              id="item-id-2"
-              role="treeitem"
-              tabindex="0"
-              title="item-title-2"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-2-itemwrapper"
-                id="item-id-2-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="true"
+                class="emotion-42 emotion-27"
+                data-testid="item-id-2"
+                id="item-id-2"
+                role="treeitem"
+                tabindex="0"
+                title="item-title-2"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-2-itemwrapper"
+                  id="item-id-2-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-2"
-                      checked=""
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-2-checkbox"
-                      id="item-id-2-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-2-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <input
+                        aria-label="item-title-2"
+                        checked=""
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-2-checkbox"
+                        id="item-id-2-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-2-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8.29 13.29c-.39.39-1.02.39-1.41 0L5.71 12.7a.9959.9959 0 010-1.41c.39-.39 1.02-.39 1.41 0L10 14.17l6.88-6.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-7.58 7.59z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-2-label"
-                        id="item-id-2-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-2
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-8.29 13.29c-.39.39-1.02.39-1.41 0L5.71 12.7a.9959.9959 0 010-1.41c.39-.39 1.02-.39 1.41 0L10 14.17l6.88-6.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-7.58 7.59z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-2-label"
+                          id="item-id-2-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-2
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-58 emotion-27"
-              data-testid="item-id-3"
-              id="item-id-3"
-              role="treeitem"
-              title="item-title-3"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-3-itemwrapper"
-                id="item-id-3-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-58 emotion-27"
+                data-testid="item-id-3"
+                id="item-id-3"
+                role="treeitem"
+                title="item-title-3"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-62 emotion-63"
-                  data-testid="item-id-3-expand"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-3-itemwrapper"
+                  id="item-id-3-itemwrapper"
                 >
-                  <svg
+                  <div
                     aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                    class="emotion-62 emotion-63"
+                    data-testid="item-id-3-expand"
                   >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-3-checkbox"
-                      disabled=""
-                      id="item-id-3-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-3-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-3-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-3-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-3-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-3-label"
-                        id="item-id-3-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-3
-                      </span>
-                    </label>
-                    <div
-                      aria-live="polite"
-                    >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-3-label"
+                          id="item-id-3-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-3
+                        </span>
+                      </label>
                       <div
-                        class="emotion-76 emotion-77"
+                        aria-live="polite"
                       >
-                        No subitems are checked for item-title-3 checkbox
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-3 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-4"
-              id="item-id-4"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-4"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-4-itemwrapper"
-                id="item-id-4-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-4"
+                id="item-id-4"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-4"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-4-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-4-itemwrapper"
+                  id="item-id-4-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-4-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-4-checkbox"
-                      id="item-id-4-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-92 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-4-checkbox"
+                        id="item-id-4-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-4 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-92 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-4 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-5"
-              id="item-id-5"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-5"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-5-itemwrapper"
-                id="item-id-5-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-5"
+                id="item-id-5"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-5"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-5-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-5-itemwrapper"
+                  id="item-id-5-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-5-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-5-checkbox"
-                      id="item-id-5-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-5-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-92 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-5-label"
-                        id="item-id-5-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-5
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-5-checkbox"
+                        id="item-id-5-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-5-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-5 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-92 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-5-label"
+                          id="item-id-5-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-5
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-5 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
+              </li>
+            </div>
           </ul>
           <span
             class="emotion-22 emotion-9"
@@ -13760,428 +13820,438 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
             class="emotion-24 emotion-25"
             role="tree"
           >
-            <li
-              aria-checked="false"
-              class="emotion-26 emotion-27"
-              data-testid="item-id-1"
-              id="item-id-1"
-              role="treeitem"
-              title="item-title-1"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-1-itemwrapper"
-                id="item-id-1-itemwrapper"
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-26 emotion-27"
+                data-testid="item-id-1"
+                id="item-id-1"
+                role="treeitem"
+                title="item-title-1"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-1-itemwrapper"
+                  id="item-id-1-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-1"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-1-checkbox"
-                      disabled=""
-                      id="item-id-1-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-1-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <input
+                        aria-label="item-title-1"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-1-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-1-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-1-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-1-label"
-                        id="item-id-1-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-1
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-1-label"
+                          id="item-id-1-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-1
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              class="emotion-42 emotion-27"
-              data-testid="item-id-2"
-              id="item-id-2"
-              role="treeitem"
-              tabindex="0"
-              title="item-title-2"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-2-itemwrapper"
-                id="item-id-2-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                class="emotion-42 emotion-27"
+                data-testid="item-id-2"
+                id="item-id-2"
+                role="treeitem"
+                tabindex="0"
+                title="item-title-2"
               >
                 <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-2-itemwrapper"
+                  id="item-id-2-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    class="emotion-30 emotion-31"
                   >
-                    <input
-                      aria-label="item-title-2"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-2-checkbox"
-                      id="item-id-2-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-2-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <div
+                      class="emotion-32 emotion-33"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
+                      <input
+                        aria-label="item-title-2"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-2-checkbox"
+                        id="item-id-2-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-2-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-2-label"
-                        id="item-id-2-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-2
-                      </span>
-                    </label>
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-2-label"
+                          id="item-id-2-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-2
+                        </span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-58 emotion-27"
-              data-testid="item-id-3"
-              id="item-id-3"
-              role="treeitem"
-              title="item-title-3"
-            >
-              <div
-                class="emotion-28 emotion-29"
-                data-testid="item-id-3-itemwrapper"
-                id="item-id-3-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-58 emotion-27"
+                data-testid="item-id-3"
+                id="item-id-3"
+                role="treeitem"
+                title="item-title-3"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-62 emotion-63"
-                  data-testid="item-id-3-expand"
+                  class="emotion-28 emotion-29"
+                  data-testid="item-id-3-itemwrapper"
+                  id="item-id-3-itemwrapper"
                 >
-                  <svg
+                  <div
                     aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
+                    class="emotion-62 emotion-63"
+                    data-testid="item-id-3-expand"
                   >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
-                >
-                  <div
-                    class="emotion-32 emotion-33"
-                  >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-3-checkbox"
-                      disabled=""
-                      id="item-id-3-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-3-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-38 emotion-39"
-                        color="#3942B0"
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
+                    <div
+                      class="emotion-32 emotion-33"
+                    >
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-3-checkbox"
                         disabled=""
-                        style="margin-right: 8px;"
+                        id="item-id-3-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-3-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          aria-hidden="true"
+                          class="emotion-38 emotion-39"
+                          color="#3942B0"
+                          disabled=""
+                          style="margin-right: 8px;"
                         >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-40 emotion-41"
-                        data-testid="item-id-3-label"
-                        id="item-id-3-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-3
-                      </span>
-                    </label>
-                    <div
-                      aria-live="polite"
-                    >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-40 emotion-41"
+                          data-testid="item-id-3-label"
+                          id="item-id-3-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-3
+                        </span>
+                      </label>
                       <div
-                        class="emotion-76 emotion-77"
+                        aria-live="polite"
                       >
-                        No subitems are checked for item-title-3 checkbox
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-3 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-4"
-              id="item-id-4"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-4"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-4-itemwrapper"
-                id="item-id-4-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-4"
+                id="item-id-4"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-4"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-4-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-4-itemwrapper"
+                  id="item-id-4-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-4-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-4-checkbox"
-                      id="item-id-4-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-4-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-4-label"
-                        id="item-id-4-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-4
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-4-checkbox"
+                        id="item-id-4-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-4-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-4 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-4-label"
+                          id="item-id-4-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-4
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-4 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
-            <li
-              aria-checked="false"
-              aria-expanded="false"
-              class="emotion-78 emotion-27"
-              data-testid="item-id-5"
-              id="item-id-5"
-              role="treeitem"
-              tabindex="-1"
-              title="item-title-5"
-            >
-              <div
-                class="emotion-44 emotion-29"
-                data-testid="item-id-5-itemwrapper"
-                id="item-id-5-itemwrapper"
+              </li>
+            </div>
+            <div>
+              <li
+                aria-checked="false"
+                aria-expanded="false"
+                class="emotion-78 emotion-27"
+                data-testid="item-id-5"
+                id="item-id-5"
+                role="treeitem"
+                tabindex="-1"
+                title="item-title-5"
               >
                 <div
-                  aria-hidden="true"
-                  class="emotion-82 emotion-63"
-                  data-testid="item-id-5-expand"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="icon"
-                    fill="currentColor"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="emotion-30 emotion-31"
+                  class="emotion-44 emotion-29"
+                  data-testid="item-id-5-itemwrapper"
+                  id="item-id-5-itemwrapper"
                 >
                   <div
-                    class="emotion-32 emotion-33"
+                    aria-hidden="true"
+                    class="emotion-82 emotion-63"
+                    data-testid="item-id-5-expand"
                   >
-                    <input
-                      aria-checked="false"
-                      class="emotion-34 emotion-35"
-                      data-testid="item-id-5-checkbox"
-                      id="item-id-5-checkbox"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                    <label
-                      class="emotion-36 emotion-37"
-                      for="item-id-5-checkbox"
-                      style="padding: 0px; width: 100%;"
+                    <svg
+                      aria-hidden="true"
+                      class="icon"
+                      fill="currentColor"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <span
-                        aria-hidden="true"
-                        class="emotion-54 emotion-39"
-                        color="#3942B0"
-                        style="margin-right: 8px;"
-                      >
-                        <svg
-                          class="icon"
-                          fill="currentColor"
-                          height="24"
-                          viewBox="0 0 24 24"
-                          width="24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="emotion-56 emotion-41"
-                        data-testid="item-id-5-label"
-                        id="item-id-5-label"
-                        style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
-                      >
-                        item-title-5
-                      </span>
-                    </label>
+                      <path
+                        d="M9.29 6.71c-.39.39-.39 1.02 0 1.41L13.17 12l-3.88 3.88c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41L10.7 6.7c-.38-.38-1.02-.38-1.41.01z"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="emotion-30 emotion-31"
+                  >
                     <div
-                      aria-live="polite"
+                      class="emotion-32 emotion-33"
                     >
-                      <div
-                        class="emotion-76 emotion-77"
+                      <input
+                        aria-checked="false"
+                        class="emotion-34 emotion-35"
+                        data-testid="item-id-5-checkbox"
+                        id="item-id-5-checkbox"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <label
+                        class="emotion-36 emotion-37"
+                        for="item-id-5-checkbox"
+                        style="padding: 0px; width: 100%;"
                       >
-                        No subitems are checked for item-title-5 checkbox
+                        <span
+                          aria-hidden="true"
+                          class="emotion-54 emotion-39"
+                          color="#3942B0"
+                          style="margin-right: 8px;"
+                        >
+                          <svg
+                            class="icon"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h12c.55 0 1 .45 1 1v12c0 .55-.45 1-1 1zm1-16H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="emotion-56 emotion-41"
+                          data-testid="item-id-5-label"
+                          id="item-id-5-label"
+                          style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
+                        >
+                          item-title-5
+                        </span>
+                      </label>
+                      <div
+                        aria-live="polite"
+                      >
+                        <div
+                          class="emotion-76 emotion-77"
+                        >
+                          No subitems are checked for item-title-5 checkbox
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </li>
+              </li>
+            </div>
           </ul>
           <span
             class="emotion-22 emotion-9"

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -16,30 +16,44 @@ export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
    */
   additionalContent?: React.ReactNode;
   /**
+   * Tree item hover color
+   * @default transparent
+   */
+  hoverColor?: string;
+  /**
+   * Icon for the tree item
+   */
+  icon?: React.ReactElement<IconProps>;
+  /**
+   * If true, element is disabled
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
    * Index number
    * private
    */
   index?: number;
   /**
-   * Item name
+   * @internal
    */
-  label: React.ReactNode;
+  itemDepth?: number;
   /**
    * Item id
    */
   itemId: string;
   /**
-   * @internal
+   * Item name
    */
-  testId?: string;
+  label: React.ReactNode;
+  /**
+   * Style properties for the tree item label
+   */
+  labelStyle?: React.CSSProperties;
   /**
    * Action that fires when the item is clicked
    */
   onClick?: () => void;
-  /**
-   * Icon for the tree item
-   */
-  icon?: React.ReactElement<IconProps>;
   /**
    * @internal
    */
@@ -47,21 +61,16 @@ export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
   /**
    * @internal
    */
-  itemDepth?: number;
-  /**
-   * If true, element is disabled
-   * @default false
-   */
-  isDisabled?: boolean;
-  /**
-   * Style properties for the tree item label
-   */
-  labelStyle?: React.CSSProperties;
+  testId?: string;
   /**
    * @internal
    * Whether this item is a top-level item (no parent)
    */
   topLevel?: boolean;
+  /**
+   * Style properties for the tree item
+   */
+  treeItemStyles?: React.CSSProperties;
 }
 
 export const checkedStatusToBoolean = (

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -73,14 +73,9 @@ export interface UseTreeViewProps {
   checkChildren?: boolean;
   children?: React.ReactNode[] | React.ReactNode;
   /**
-   * Size for the expand/collapse icon.
-   * @default 24
+   * Expand icon styles.
    */
-  expandIconSize?: number;
-  /**
-   * Color for the expand/collapse icon.
-   */
-  expandIconColor?: string;
+  expandIconStyles?: ExpandIconStylesProps;
   /**
    * If true, every item is disabled
    * @default false
@@ -132,6 +127,18 @@ export interface UseTreeViewProps {
   testId?: string;
 }
 
+interface ExpandIconStylesProps {
+  /**
+   * Size for the expand/collapse icon.
+   * @default 24
+   */
+  size?: number;
+  /**
+   * Color for the expand/collapse icon.
+   */
+  color?: string;
+}
+
 export function useTreeView(props: UseTreeViewProps) {
   const {
     selectable = TreeViewSelectable.single,
@@ -145,8 +152,7 @@ export function useTreeView(props: UseTreeViewProps) {
     apiRef,
     isDisabled,
     isTopLevelSelectable = true,
-    expandIconSize,
-    expandIconColor,
+    expandIconStyles,
   } = props;
 
   const hasPreselectedItems = Boolean(preselectedItems);
@@ -650,8 +656,7 @@ export function useTreeView(props: UseTreeViewProps) {
     selectItem,
     handleExpandedChange,
     expandedSet,
-    expandIconSize,
-    expandIconColor,
+    expandIconStyles,
     isTopLevelSelectable,
   };
 

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -35,6 +35,18 @@ export interface TreeViewApi {
 
 export interface UseTreeViewProps {
   /**
+   * The ref object that allows TreeView manipulation.
+   * Actions available:
+   * selectItem({ itemId, checkedStatus }: Pick<TreeViewItemInterface, 'itemId' | 'checkedStatus'>): void - action that allows to change item selection,
+   * selectAll(): void - action that allows to select all items,
+   * clearAll(): void - action that allows to unselect all items.
+   * showMore(): void - action that gets called when a tree has hidden items and they get expanded.
+   * showLess(): void - action that gets called when a tree has hidden items and they get collapsed.
+   * expandAll(): void - action that allows to expand all items.
+   * collapseAll(): void - action that allows to collapse all items.
+   */
+  apiRef?: React.MutableRefObject<TreeViewApi | undefined>;
+  /**
    * Text for aria-label attribute for the tree.
    * If there is no visible name for the element you can reference, use aria-label to provide the user with a recognizable accessible name.
    * It's required to use either `ariaLabel` OR `ariaLabelledBy`.
@@ -47,6 +59,34 @@ export interface UseTreeViewProps {
    */
   ariaLabelledBy?: string;
   /**
+   * Only affects if selectable mode is TreeViewSelectable.multi.
+   * Determines if the parent checkbox will get selected when the user selects all its children checkboxes.
+   * When checkParents is enabled, the TreeView displays the indeterminate state of the parent checkboxes too.
+   * @default true
+   */
+  checkParents?: boolean;
+  /**
+   * Only affects if selectable mode is TreeViewSelectable.multi.
+   * Determines if the child checkboxes get selected when the user selects parent checkbox.
+   * @default true
+   */
+  checkChildren?: boolean;
+  children?: React.ReactNode[] | React.ReactNode;
+  /**
+   * Size for the expand/collapse icon.
+   * @default 24
+   */
+  expandIconSize?: number;
+  /**
+   * Color for the expand/collapse icon.
+   */
+  expandIconColor?: string;
+  /**
+   * If true, every item is disabled
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
    * Array list of itemIds of items that should be expanded by default.
    * For all items expanded, provide an array with all the indexes
    * @default [] (no items expanded)
@@ -54,19 +94,11 @@ export interface UseTreeViewProps {
   initialExpandedItems?: Array<string>;
   isInverse?: boolean;
   /**
-   * Array list of itemIds of items that should be selected when the component renders
-   * * @default [] (no items selected)
+   * If false, top-level items will not be selectable in multi-select mode.
+   * Their checkboxes will be hidden, and they will only function as expandable groups.
+   * @default true
    */
-  preselectedItems?: Array<TreeItemSelectedInterface>;
-  /**
-   * How many items can be selected in the tree view: single, multi, off
-   * @default TreeViewSelectable.single
-   */
-  selectable?: TreeViewSelectable;
-  /**
-   * @internal
-   */
-  testId?: string;
+  isTopLevelSelectable?: boolean;
   /**
    * Action that fires when an item is expanded or collapsed
    * Return an array of itemIds of items that are expanded
@@ -85,42 +117,19 @@ export interface UseTreeViewProps {
     selectedItems: Array<TreeItemSelectedInterface>
   ) => void;
   /**
-   * Only affects if selectable mode is TreeViewSelectable.multi.
-   * Determines if the parent checkbox will get selected when the user selects all its children checkboxes.
-   * When checkParents is enabled, the TreeView displays the indeterminate state of the parent checkboxes too.
-   * @default true
+   * Array list of itemIds of items that should be selected when the component renders
+   * * @default [] (no items selected)
    */
-  checkParents?: boolean;
+  preselectedItems?: Array<TreeItemSelectedInterface>;
   /**
-   * Only affects if selectable mode is TreeViewSelectable.multi.
-   * Determines if the child checkboxes get selected when the user selects parent checkbox.
-   * @default true
+   * How many items can be selected in the tree view: single, multi, off
+   * @default TreeViewSelectable.single
    */
-  checkChildren?: boolean;
-  children?: React.ReactNode[] | React.ReactNode;
+  selectable?: TreeViewSelectable;
   /**
-   * The ref object that allows TreeView manipulation.
-   * Actions available:
-   * selectItem({ itemId, checkedStatus }: Pick<TreeViewItemInterface, 'itemId' | 'checkedStatus'>): void - action that allows to change item selection,
-   * selectAll(): void - action that allows to select all items,
-   * clearAll(): void - action that allows to unselect all items.
-   * showMore(): void - action that gets called when a tree has hidden items and they get expanded.
-   * showLess(): void - action that gets called when a tree has hidden items and they get collapsed.
-   * expandAll(): void - action that allows to expand all items.
-   * collapseAll(): void - action that allows to collapse all items.
+   * @internal
    */
-  apiRef?: React.MutableRefObject<TreeViewApi | undefined>;
-  /**
-   * If true, every item is disabled
-   * @default false
-   */
-  isDisabled?: boolean;
-  /**
-   * If false, top-level items will not be selectable in multi-select mode.
-   * Their checkboxes will be hidden, and they will only function as expandable groups.
-   * @default true
-   */
-  isTopLevelSelectable?: boolean;
+  testId?: string;
 }
 
 export function useTreeView(props: UseTreeViewProps) {
@@ -136,6 +145,8 @@ export function useTreeView(props: UseTreeViewProps) {
     apiRef,
     isDisabled,
     isTopLevelSelectable = true,
+    expandIconSize,
+    expandIconColor,
   } = props;
 
   const hasPreselectedItems = Boolean(preselectedItems);
@@ -639,6 +650,8 @@ export function useTreeView(props: UseTreeViewProps) {
     selectItem,
     handleExpandedChange,
     expandedSet,
+    expandIconSize,
+    expandIconColor,
     isTopLevelSelectable,
   };
 


### PR DESCRIPTION
Closes: #1839 

## What I did
- Added new prop for `TreeView`: **expandIconStyles** 
- Added new props for `TreeItem`:  **hoverColor** and **treeItemStyles**

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open Storybook -> Treeview -> **Open Custom Expand Icon Arrow And TreeItem Styles:**
1. `Mammals` should have a custom background and hover color
2. `Amphibians`should have a custom background color
