### PR TITLE
feat(Popover):  Support programmatically opening

### DIFF
--- a/.changeset/feat-Popover-support-programmatically-opening.md
+++ b/.changeset/feat-Popover-support-programmatically-opening.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Popover): Add support programmatically opening.

--- a/packages/react-magma-dom/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-magma-dom/src/components/Popover/Popover.stories.tsx
@@ -15,7 +15,13 @@ import { Popover, PopoverApi, PopoverPosition } from './Popover';
 import { PopoverContent } from './PopoverContent';
 import { PopoverTrigger } from './PopoverTrigger';
 import { magma } from '../../theme/magma';
-import { Button, ButtonColor, ButtonSize, ButtonType } from '../Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonType,
+  ButtonVariant,
+} from '../Button';
 import { ButtonGroup, ButtonGroupAlignment } from '../ButtonGroup';
 import { Card } from '../Card';
 import { PopoverHeader, PopoverFooter } from './PopoverSection';
@@ -23,7 +29,9 @@ import { Checkbox, CheckboxTextPosition } from '../Checkbox';
 import { Form } from '../Form';
 import { FormGroup } from '../FormGroup';
 import { Hyperlink } from '../Hyperlink';
+import { IconButton } from '../IconButton';
 import { Input } from '../Input';
+import { Paragraph } from '../Paragraph';
 import { PasswordInput } from '../PasswordInput';
 import { Spacer } from '../Spacer';
 import { Toggle } from '../Toggle';
@@ -1056,3 +1064,71 @@ DontShowAgain.args = {
   openByDefault: true,
 };
 DontShowAgain.parameters = { controls: { exclude: ['hoverable'] } };
+
+export const ProgrammaticallyOpening = args => {
+  const popoverApiRef = React.useRef<PopoverApi>();
+
+  function handleClose(event: React.SyntheticEvent) {
+    popoverApiRef.current?.closePopoverManually(event);
+  }
+
+  function handleOpenPopover(event: React.KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      popoverApiRef.current?.openPopoverManually(event);
+    }
+  }
+
+  return (
+    <Card
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        height: '300px',
+        justifyContent: 'center',
+      }}
+      isInverse={args.isInverse}
+    >
+      <Popover {...args} isInverse apiRef={popoverApiRef}>
+        <PopoverTrigger>
+          <span
+            tabIndex={0}
+            role="button"
+            style={{
+              textDecoration: 'underline',
+              color: magma.colors.primary,
+              cursor: 'pointer',
+            }}
+            onKeyDown={handleOpenPopover}
+          >
+            Press Enter or Space to open popover
+          </span>
+        </PopoverTrigger>
+        <PopoverContent>
+          <PopoverHeader>
+            <div>Popover Header</div>
+          </PopoverHeader>
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <Paragraph noMargins isInverse>
+              Popover Content
+            </Paragraph>
+          </div>
+          <PopoverFooter style={{ justifyContent: 'end' }}>
+            <div>
+              <IconButton
+                icon={<CloseIcon />}
+                aria-label="Close"
+                size={ButtonSize.small}
+                isInverse
+                variant={ButtonVariant.link}
+                onClick={handleClose}
+              >
+                Close
+              </IconButton>
+            </div>
+          </PopoverFooter>
+        </PopoverContent>
+      </Popover>
+    </Card>
+  );
+};

--- a/packages/react-magma-dom/src/components/Popover/Popover.test.js
+++ b/packages/react-magma-dom/src/components/Popover/Popover.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FilterAltIcon } from 'react-magma-icons';
 
@@ -181,7 +181,7 @@ describe('Popover', () => {
     expect(popoverContent).not.toBeVisible();
   });
 
-  it('sholud close the popover on tab if there is no focusable items in the popover', async () => {
+  it('should close the popover on tab if there is no focusable items in the popover', async () => {
     const { container, getByTestId, getByText } = render(
       <Popover>
         <PopoverTrigger />
@@ -535,6 +535,56 @@ describe('Popover', () => {
 
     expect(popoverContent).not.toBeVisible();
     expect(closeButton).not.toBeVisible();
+  });
+
+  it('should open popover manually on span with api ref', async () => {
+    const triggerTestId = 'trigger-test-id';
+    const popoverContentTestId = 'popover-content-test-id';
+    const popoverApiRef = React.createRef();
+
+    function handleOpenPopover(event) {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        popoverApiRef.current?.openPopoverManually(event);
+      }
+    }
+
+    const { getByTestId, getByText } = render(
+      <Popover apiRef={popoverApiRef}>
+        <PopoverTrigger>
+          <span
+            tabIndex={0}
+            role="button"
+            onKeyDown={handleOpenPopover}
+            data-testid={triggerTestId}
+          >
+            Press Enter or Space to open popover
+          </span>
+        </PopoverTrigger>
+        <PopoverContent testId={popoverContentTestId}>
+          <PopoverHeader>
+            <div>Popover Header</div>
+          </PopoverHeader>
+          <div>Popover Content</div>
+        </PopoverContent>
+      </Popover>
+    );
+    const popoverContent = getByTestId(popoverContentTestId);
+    const triggerButton = getByTestId(triggerTestId);
+    const openButton = getByText('Press Enter or Space to open popover');
+
+    expect(triggerButton).toBeInTheDocument();
+    expect(openButton).toBeInTheDocument();
+    expect(popoverContent).not.toBeVisible();
+
+    await act(async () => {
+      triggerButton.focus();
+      userEvent.keyboard('{Enter}');
+    });
+
+    expect(popoverContent).toBeVisible();
+    expect(getByText('Popover Header')).toBeVisible();
+    expect(getByText('Popover Content')).toBeVisible();
   });
 
   it('should open popover by default if openByDefault property was passed', () => {

--- a/packages/react-magma-dom/src/components/Popover/Popover.tsx
+++ b/packages/react-magma-dom/src/components/Popover/Popover.tsx
@@ -23,6 +23,7 @@ export enum PopoverPosition {
 
 export interface PopoverApi {
   closePopoverManually(event): void;
+  openPopoverManually(event): void;
 }
 export interface PopoverProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -81,6 +82,7 @@ export interface PopoverProps extends React.HTMLAttributes<HTMLDivElement> {
    * The ref object that allows Popover manipulation.
    * Actions available:
    * closePopoverManually(event): void - Closes the popover manually.
+   * openPopoverManually(event): void - Opens the popover manually.
    */
   apiRef?: React.MutableRefObject<PopoverApi | undefined>;
   /**
@@ -184,6 +186,9 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
         apiRef.current = {
           closePopoverManually(event) {
             closePopover(event);
+          },
+          openPopoverManually(event) {
+            openPopover();
           },
         };
       }

--- a/website/react-magma-docs/src/pages/api/popover.mdx
+++ b/website/react-magma-docs/src/pages/api/popover.mdx
@@ -116,34 +116,20 @@ import {
 } from 'react-magma-dom';
 
 export function Example() {
-  const closePopoverApiRef = React.useRef<PopoverApi>();
-  const openPopoverApiRef = React.useRef<PopoverApi>();
+  const popoverApiRef = React.useRef<PopoverApi>();
 
   function handleClose(event: React.SyntheticEvent) {
-    if (closePopoverApiRef.current) {
-      closePopoverApiRef.current.closePopoverManually(event);
+    if (popoverApiRef.current) {
+      popoverApiRef.current.closePopoverManually(event);
     }
   }
 
   function handleOpen(event: React.KeyboardEvent) {
-    openPopoverApiRef.current.openPopoverManually(event);
+    popoverApiRef.current.openPopoverManually(event);
   }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-      <Popover apiRef={closePopoverApiRef}>
-        <PopoverTrigger aria-label="Toggle popover">
-          Toggle Popover
-        </PopoverTrigger>
-        <PopoverContent>
-          <div>
-            Popover Content
-            <Button onClick={handleClose}>Close Popover</Button>
-          </div>
-        </PopoverContent>
-      </Popover>
-      <Spacer axis={SpacerAxis.vertical} size={16} />
-
       <Button
         variant={ButtonVariant.link}
         size={ButtonSize.small}
@@ -152,7 +138,7 @@ export function Example() {
       >
         Open Popover
       </Button>
-      <Popover apiRef={openPopoverApiRef}>
+      <Popover apiRef={popoverApiRef}>
         <PopoverTrigger aria-label="Toggle popover">Popover</PopoverTrigger>
         <PopoverContent>
           <div>

--- a/website/react-magma-docs/src/pages/api/popover.mdx
+++ b/website/react-magma-docs/src/pages/api/popover.mdx
@@ -112,6 +112,7 @@ import {
   PopoverContent,
   PopoverApi,
   Button,
+  magma,
 } from 'react-magma-dom';
 
 export function Example() {
@@ -123,24 +124,50 @@ export function Example() {
     }
   }
 
-  function handleOpen(event: React.SyntheticEvent) {
-    if (popoverApiRef.current) {
+  function handleOpen(event: React.KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
       popoverApiRef.current.openPopoverManually(event);
     }
   }
 
   return (
-    <Popover apiRef={popoverApiRef}>
-      <PopoverTrigger aria-label="Toggle popover" onKeyDown={handleOpen}>
-        Toggle Popover
-      </PopoverTrigger>
-      <PopoverContent>
-        <div>
-          Popover Content
-          <Button onClick={handleClose}>Close Popover</Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <Popover apiRef={popoverApiRef}>
+        <PopoverTrigger aria-label="Toggle popover">
+          Toggle Popover
+        </PopoverTrigger>
+        <PopoverContent>
+          <div>
+            Popover Content
+            <Button onClick={handleClose}>Close Popover</Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <Popover apiRef={popoverApiRef}>
+        <PopoverTrigger>
+          <span
+            tabIndex={0}
+            role="button"
+            style={{
+              textDecoration: 'underline',
+              cursor: 'pointer',
+              color: magma.colors.primary,
+            }}
+            onKeyDown={handleOpen}
+          >
+            Press Enter or Space to open popover
+          </span>
+        </PopoverTrigger>
+        <PopoverContent>
+          <div>
+            Popover Content
+            <Button onClick={handleClose}>Close Popover</Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
   );
 }
 ```

--- a/website/react-magma-docs/src/pages/api/popover.mdx
+++ b/website/react-magma-docs/src/pages/api/popover.mdx
@@ -101,7 +101,7 @@ export function Example() {
 
 ## Controlled Popover with API Ref
 
-You can programmatically control the popover by providing an `apiRef`. The Popover API exposes methods such as `closePopoverManually` to close the popover when needed.
+You can programmatically control the popover by providing an `apiRef`. The Popover API exposes methods such as `openPopoverManually` and `closePopoverManually` to open and close the popover when needed.
 
 ```tsx
 import React from 'react';
@@ -123,9 +123,15 @@ export function Example() {
     }
   }
 
+  function handleOpen(event: React.SyntheticEvent) {
+    if (popoverApiRef.current) {
+      popoverApiRef.current.openPopoverManually(event);
+    }
+  }
+
   return (
     <Popover apiRef={popoverApiRef}>
-      <PopoverTrigger aria-label="Toggle popover">
+      <PopoverTrigger aria-label="Toggle popover" onKeyDown={handleOpen}>
         Toggle Popover
       </PopoverTrigger>
       <PopoverContent>

--- a/website/react-magma-docs/src/pages/api/popover.mdx
+++ b/website/react-magma-docs/src/pages/api/popover.mdx
@@ -112,28 +112,26 @@ import {
   PopoverContent,
   PopoverApi,
   Button,
-  magma,
+  Spacer,
 } from 'react-magma-dom';
 
 export function Example() {
-  const popoverApiRef = React.useRef<PopoverApi>();
+  const closePopoverApiRef = React.useRef<PopoverApi>();
+  const openPopoverApiRef = React.useRef<PopoverApi>();
 
   function handleClose(event: React.SyntheticEvent) {
-    if (popoverApiRef.current) {
-      popoverApiRef.current.closePopoverManually(event);
+    if (closePopoverApiRef.current) {
+      closePopoverApiRef.current.closePopoverManually(event);
     }
   }
 
   function handleOpen(event: React.KeyboardEvent) {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      popoverApiRef.current.openPopoverManually(event);
-    }
+    openPopoverApiRef.current.openPopoverManually(event);
   }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-      <Popover apiRef={popoverApiRef}>
+      <Popover apiRef={closePopoverApiRef}>
         <PopoverTrigger aria-label="Toggle popover">
           Toggle Popover
         </PopoverTrigger>
@@ -144,26 +142,29 @@ export function Example() {
           </div>
         </PopoverContent>
       </Popover>
+      <Spacer axis={SpacerAxis.vertical} size={16} />
 
-      <Popover apiRef={popoverApiRef}>
-        <PopoverTrigger>
-          <span
-            tabIndex={0}
-            role="button"
-            style={{
-              textDecoration: 'underline',
-              cursor: 'pointer',
-              color: magma.colors.primary,
-            }}
-            onKeyDown={handleOpen}
-          >
-            Press Enter or Space to open popover
-          </span>
-        </PopoverTrigger>
+      <Button
+        variant={ButtonVariant.link}
+        size={ButtonSize.small}
+        onClick={handleOpen}
+        style={{ width: '120px' }}
+      >
+        Open Popover
+      </Button>
+      <Popover apiRef={openPopoverApiRef}>
+        <PopoverTrigger aria-label="Toggle popover">Popover</PopoverTrigger>
         <PopoverContent>
           <div>
             Popover Content
-            <Button onClick={handleClose}>Close Popover</Button>
+            <Spacer axis={SpacerAxis.horizontal} size={8} />
+            <Button
+              variant={ButtonVariant.link}
+              size={ButtonSize.small}
+              onClick={handleClose}
+            >
+              Close Popover
+            </Button>
           </div>
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
Closes: #1853 

## What I did
Added supporting `Popover` programmatically opening.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> `Popover` -> `Programatically Opening` -> Focus on text -> Press `Enter` or `Space` -> Popover should be opened
Go to React Magma Docs -> `Components` -> `Popover` -> `Controlled Popover via with API ref` -> The  `openPopoverManually` API should be added to the example -> click on `Open Popover` button -> `Popover` should be opened