### PR TITLE
feat(Popover): Support alignment prop & width > 300px

### DIFF
--- a/.changeset/feat-Popover-alignment-prop-custom-width.md
+++ b/.changeset/feat-Popover-alignment-prop-custom-width.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Popover): Add the `alignment` prop and allow customization of the width.

--- a/packages/react-magma-dom/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-magma-dom/src/components/Popover/Popover.stories.tsx
@@ -11,7 +11,12 @@ import {
   SettingsIcon,
 } from 'react-magma-icons';
 
-import { Popover, PopoverApi, PopoverPosition } from './Popover';
+import {
+  Popover,
+  PopoverApi,
+  PopoverPosition,
+  PopoverAlignment,
+} from './Popover';
 import { PopoverContent } from './PopoverContent';
 import { PopoverTrigger } from './PopoverTrigger';
 import { magma } from '../../theme/magma';
@@ -51,6 +56,12 @@ export default {
       control: {
         type: 'select',
         options: PopoverPosition,
+      },
+    },
+    alignment: {
+      control: {
+        type: 'select',
+        options: PopoverAlignment,
       },
     },
     hoverable: {

--- a/packages/react-magma-dom/src/components/Popover/Popover.test.js
+++ b/packages/react-magma-dom/src/components/Popover/Popover.test.js
@@ -4,7 +4,7 @@ import { act, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FilterAltIcon } from 'react-magma-icons';
 
-import { PopoverPosition } from './Popover';
+import { PopoverAlignment, PopoverPosition } from './Popover';
 import { PopoverHeader, PopoverFooter } from './PopoverSection';
 import { Button } from '../Button';
 
@@ -615,5 +615,73 @@ describe('Popover', () => {
 
     expect(popoverContent).toBeInTheDocument();
     expect(popoverContent).toMatchSnapshot();
+  });
+
+  describe('PopoverAlignment', () => {
+    it('should render Popover with default alignment', () => {
+      const { getByTestId, container } = render(
+        <Popover>
+          <PopoverTrigger />
+          <PopoverContent>
+            <span>Content</span>
+          </PopoverContent>
+        </Popover>
+      );
+      const popoverTrigger = container.querySelector('button');
+      userEvent.click(popoverTrigger);
+
+      const popoverContent = getByTestId('popoverContent');
+      expect(popoverContent).toBeInTheDocument();
+
+      const popoverArrow = getByTestId('popoverArrow');
+      expect(popoverArrow).toHaveAttribute('data-popover-placement', 'bottom');
+    });
+
+    it('should render Popover with start alignment and bottom position', () => {
+      const { getByTestId, container } = render(
+        <Popover
+          alignment={PopoverAlignment.start}
+          position={PopoverPosition.bottom}
+        >
+          <PopoverTrigger />
+          <PopoverContent>
+            <span>Content</span>
+          </PopoverContent>
+        </Popover>
+      );
+      const popoverTrigger = container.querySelector('button');
+      userEvent.click(popoverTrigger);
+
+      const popoverContent = getByTestId('popoverContent');
+      expect(popoverContent).toBeInTheDocument();
+
+      const popoverArrow = getByTestId('popoverArrow');
+      expect(popoverArrow).toHaveAttribute(
+        'data-popover-placement',
+        'bottom-start'
+      );
+    });
+
+    it('should render Popover with end alignment and top position', () => {
+      const { getByTestId, container } = render(
+        <Popover
+          alignment={PopoverAlignment.end}
+          position={PopoverPosition.top}
+        >
+          <PopoverTrigger />
+          <PopoverContent>
+            <span>Content</span>
+          </PopoverContent>
+        </Popover>
+      );
+      const popoverTrigger = container.querySelector('button');
+      userEvent.click(popoverTrigger);
+
+      const popoverContent = getByTestId('popoverContent');
+      expect(popoverContent).toBeInTheDocument();
+
+      const popoverArrow = getByTestId('popoverArrow');
+      expect(popoverArrow).toHaveAttribute('data-popover-placement', 'top-end');
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/Popover/Popover.tsx
+++ b/packages/react-magma-dom/src/components/Popover/Popover.tsx
@@ -6,10 +6,10 @@ import {
   flip,
   autoUpdate,
   ReferenceType,
-  AlignedPlacement,
   arrow,
   shift,
   useFloating,
+  AlignedPlacement,
 } from '@floating-ui/react';
 
 import { useIsInverse } from '../../inverse';
@@ -20,6 +20,20 @@ export enum PopoverPosition {
   bottom = 'bottom', //default
   top = 'top',
 }
+
+export enum PopoverAlignment {
+  center = 'center', //default
+  start = 'start',
+  end = 'end',
+}
+
+export type PopoverPlacement =
+  | 'bottom'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'top'
+  | 'top-start'
+  | 'top-end';
 
 export interface PopoverApi {
   closePopoverManually(event): void;
@@ -91,11 +105,16 @@ export interface PopoverProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default false
    */
   focusTrap?: boolean;
+  /**
+   * Alignment of the popover content
+   * @default PopoverAlignment.center
+   */
+  alignment?: PopoverAlignment;
 }
 
 export interface PopoverContextInterface {
   floatingStyles?: React.CSSProperties;
-  position?: PopoverPosition;
+  position?: PopoverPlacement;
   closePopover?: (event: React.SyntheticEvent | React.KeyboardEvent) => void;
   popoverTriggerId?: React.MutableRefObject<string>;
   popoverContentId?: React.MutableRefObject<string>;
@@ -178,6 +197,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
       id: defaultId,
       apiRef,
       focusTrap,
+      alignment = PopoverAlignment.center,
       ...other
     } = props;
 
@@ -273,21 +293,38 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
       }
     }
 
-    const { refs, floatingStyles, placement, context, elements, update } =
-      useFloating({
-        //flip() - Changes the placement of the floating element to keep it in view.
-        //offset() - Translates the floating element along the specified axes. (Space between the Trigger and the Content).
-        //shift() - Shifts the floating element along the specified axes to keep it in view within the clipping context or viewport.
-        //arrow() - Positions an arrow element pointing at the reference element, ensuring proper alignment.
-        middleware: [
-          flip(),
-          shift({ padding: 12 }),
-          offset(hasPointer ? 12 : 4),
-          arrow({ element: arrowRef }),
-        ],
-        placement: position as AlignedPlacement,
-        whileElementsMounted: autoUpdate,
-      });
+    const [placement, setPlacement] = React.useState('bottom');
+
+    function changePlacement(
+      position: PopoverPosition,
+      alignment: PopoverAlignment
+    ) {
+      const placementMap = new Map([
+        ['bottom-start', 'bottom-start'],
+        ['bottom-end', 'bottom-end'],
+        ['bottom-center', 'bottom'],
+        ['top-start', 'top-start'],
+        ['top-end', 'top-end'],
+        ['top-center', 'top'],
+      ]);
+      const contentPosition = `${position}-${alignment}`;
+      setPlacement(placementMap.get(contentPosition) ?? 'bottom');
+    }
+
+    const { refs, floatingStyles, context, elements, update } = useFloating({
+      //flip() - Changes the placement of the floating element to keep it in view.
+      //offset() - Translates the floating element along the specified axes. (Space between the Trigger and the Content).
+      //shift() - Shifts the floating element along the specified axes to keep it in view within the clipping context or viewport.
+      //arrow() - Positions an arrow element pointing at the reference element, ensuring proper alignment.
+      middleware: [
+        flip(),
+        shift({ padding: 12 }),
+        offset(hasPointer ? 12 : 4),
+        arrow({ element: arrowRef }),
+      ],
+      placement: placement as AlignedPlacement,
+      whileElementsMounted: autoUpdate,
+    });
 
     React.useEffect(() => {
       const referenceElement = elements.reference;
@@ -297,6 +334,10 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
         return autoUpdate(referenceElement, floatingElement, update);
       }
     }, [isOpen, elements, update]);
+
+    React.useEffect(() => {
+      changePlacement(position, alignment);
+    }, [position, alignment]);
 
     const maxHeightString =
       typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight;
@@ -318,7 +359,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
       <PopoverContext.Provider
         value={{
           floatingStyles,
-          position: placement as AlignedPlacement,
+          position: placement as PopoverPlacement,
           closePopover,
           popoverTriggerId,
           popoverContentId,

--- a/packages/react-magma-dom/src/components/Popover/PopoverContent.tsx
+++ b/packages/react-magma-dom/src/components/Popover/PopoverContent.tsx
@@ -3,11 +3,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import { FloatingArrow } from '@floating-ui/react';
 
-import {
-  hasActiveElementsChecker,
-  PopoverContext,
-  PopoverPosition,
-} from './Popover';
+import { hasActiveElementsChecker, PopoverContext } from './Popover';
 import { PopoverHeader, PopoverFooter } from './PopoverSection';
 import { useFocusLock } from '../../hooks/useFocusLock';
 import { ThemeInterface } from '../../theme/magma';
@@ -29,7 +25,6 @@ export interface PopoverContentProps
 }
 
 const StyledCard = styled(Card)<{
-  position: PopoverPosition;
   isInverse?: boolean;
   isOpen?: boolean;
   maxHeight?: string;
@@ -54,7 +49,6 @@ const StyledCard = styled(Card)<{
         ? props.theme.colors.primary400
         : props.theme.colors.neutral300};
   width: ${props => (props.width ? props.width : '100%')};
-  max-width: 300px;
 `;
 
 const StyledAnnounce = styled(Announce)`
@@ -143,7 +137,6 @@ export const PopoverContent = React.forwardRef<
 
       <StyledCard
         {...other}
-        position={context.position}
         hasDropShadow
         isInverse={context.isInverse}
         isOpen={context.isOpen}

--- a/packages/react-magma-dom/src/components/Popover/PopoverContent.tsx
+++ b/packages/react-magma-dom/src/components/Popover/PopoverContent.tsx
@@ -49,6 +49,7 @@ const StyledCard = styled(Card)<{
         ? props.theme.colors.primary400
         : props.theme.colors.neutral300};
   width: ${props => (props.width ? props.width : '100%')};
+  max-width: ${props => (props.width ? props.width : '300px')};
 `;
 
 const StyledAnnounce = styled(Announce)`

--- a/packages/react-magma-dom/src/components/Popover/__snapshots__/Popover.test.js.snap
+++ b/packages/react-magma-dom/src/components/Popover/__snapshots__/Popover.test.js.snap
@@ -31,6 +31,7 @@ exports[`Popover should render the popover with isInverse prop 1`] = `
   white-space: nowrap;
   border: 1px solid #5D65CB;
   width: 100%;
+  max-width: 300px;
 }
 
 .emotion-3 {
@@ -88,6 +89,7 @@ exports[`Popover should render the popover with isInverse prop 1`] = `
   white-space: nowrap;
   border: 1px solid #5D65CB;
   width: 100%;
+  max-width: 300px;
 }
 
 .emotion-3 {
@@ -176,6 +178,7 @@ exports[`Popover should render the popover with pointer by default 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 100%;
+  max-width: 300px;
 }
 
 .emotion-3 {
@@ -233,6 +236,7 @@ exports[`Popover should render the popover with pointer by default 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 100%;
+  max-width: 300px;
 }
 
 .emotion-3 {
@@ -321,6 +325,7 @@ exports[`Popover should render the popover with target width 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 0px;
+  max-width: 0px;
 }
 
 .emotion-3 {
@@ -378,6 +383,7 @@ exports[`Popover should render the popover with target width 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 0px;
+  max-width: 0px;
 }
 
 .emotion-3 {
@@ -466,6 +472,7 @@ exports[`Popover should render the popover without pointer 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 100%;
+  max-width: 300px;
 }
 
 .emotion-3 {
@@ -523,6 +530,7 @@ exports[`Popover should render the popover without pointer 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 100%;
+  max-width: 300px;
 }
 
 .emotion-3 {

--- a/packages/react-magma-dom/src/components/Popover/__snapshots__/Popover.test.js.snap
+++ b/packages/react-magma-dom/src/components/Popover/__snapshots__/Popover.test.js.snap
@@ -31,7 +31,6 @@ exports[`Popover should render the popover with isInverse prop 1`] = `
   white-space: nowrap;
   border: 1px solid #5D65CB;
   width: 100%;
-  max-width: 300px;
 }
 
 .emotion-3 {
@@ -89,7 +88,6 @@ exports[`Popover should render the popover with isInverse prop 1`] = `
   white-space: nowrap;
   border: 1px solid #5D65CB;
   width: 100%;
-  max-width: 300px;
 }
 
 .emotion-3 {
@@ -178,7 +176,6 @@ exports[`Popover should render the popover with pointer by default 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 100%;
-  max-width: 300px;
 }
 
 .emotion-3 {
@@ -236,7 +233,6 @@ exports[`Popover should render the popover with pointer by default 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 100%;
-  max-width: 300px;
 }
 
 .emotion-3 {
@@ -325,7 +321,6 @@ exports[`Popover should render the popover with target width 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 0px;
-  max-width: 300px;
 }
 
 .emotion-3 {
@@ -383,7 +378,6 @@ exports[`Popover should render the popover with target width 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 0px;
-  max-width: 300px;
 }
 
 .emotion-3 {
@@ -472,7 +466,6 @@ exports[`Popover should render the popover without pointer 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 100%;
-  max-width: 300px;
 }
 
 .emotion-3 {
@@ -530,7 +523,6 @@ exports[`Popover should render the popover without pointer 1`] = `
   white-space: nowrap;
   border: 1px solid #D4D4D4;
   width: 100%;
-  max-width: 300px;
 }
 
 .emotion-3 {

--- a/packages/react-magma-dom/src/index.ts
+++ b/packages/react-magma-dom/src/index.ts
@@ -254,6 +254,7 @@ export {
   Popover,
   PopoverProps,
   PopoverPosition,
+  PopoverAlignment,
   PopoverApi,
 } from './components/Popover';
 export {

--- a/website/react-magma-docs/src/pages/api/popover.mdx
+++ b/website/react-magma-docs/src/pages/api/popover.mdx
@@ -5,6 +5,7 @@ props:
   - Popover
   - PopoverProps
   - PopoverPosition
+  - PopoverAlignment
   - PopoverApi
   - PopoverTrigger
   - PopoverTriggerProps
@@ -280,6 +281,53 @@ export function Example() {
         </PopoverTrigger>
         <PopoverContent>
           <div>This popover appears above the trigger</div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+```
+
+## Popover Alignment
+
+The `alignment` prop sets the default alignment of the `Popover` in relation to its trigger. It uses <Link to='https://floating-ui.com/docs/useFloating#placement'>floating-ui's/placement</Link> to align the `Popover` content to the `center`, `left` or `right` side of Popover trigger button.
+The available options are `PopoverAlignment.center` (default), `PopoverAlignment.start`, and `PopoverAlignment.end`.
+
+```tsx
+import React from 'react';
+
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAlignment,
+} from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <Popover alignment={PopoverAlignment.center}>
+        <PopoverTrigger aria-label="Open center popover alignment">
+          Center alignment Popover
+        </PopoverTrigger>
+        <PopoverContent>
+          <div>This popover is aligned in the center of the trigger</div>
+        </PopoverContent>
+      </Popover>
+      <Popover alignment={PopoverAlignment.start}>
+        <PopoverTrigger aria-label="Open start popover alignment">
+          Start alignment Popover
+        </PopoverTrigger>
+        <PopoverContent>
+          <div>This popover is aligned on the left side of the trigger</div>
+        </PopoverContent>
+      </Popover>
+      <Popover alignment={PopoverAlignment.end}>
+        <PopoverTrigger aria-label="Open end popover alignment">
+          End alignment Popover
+        </PopoverTrigger>
+        <PopoverContent>
+          <div>This popover is aligned on the right side of the trigger</div>
         </PopoverContent>
       </Popover>
     </div>


### PR DESCRIPTION
Closes: #1820 

## What I did
- Added the new `alignment` prop
- Deleted hardcoded `max-width` for customizing
- Updated docs with additional examples.

## Screenshots
<img width="1851" height="933" alt="Screenshot from 2025-08-05 19-22-08" src="https://github.com/user-attachments/assets/f955e21a-2c86-42e1-bbc8-d84e7d4f28ec" />
<img width="1846" height="920" alt="Screenshot from 2025-08-06 11-53-07" src="https://github.com/user-attachments/assets/230190ae-fe8e-4ca8-bf78-7a447b098cfe" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
`Storybook` -> `Popover` -> `Default` -> pass in the control panel different options of `alignment` -> should align `PopoverContent` according to the passed option.
`React Magma Docs` -> Components -> Popover -> `Popover Alignment` -> should be added new example with description of new prop
`React Magma Docs` -> Components -> Popover -> `Popover Props` -> should be added documentation about new prop.