### PR TITLE
fix(Date Picker): Update selecting focus behaviour

### DIFF
--- a/.changeset/fix-DatePicker-update-focus-behaviour.md
+++ b/.changeset/fix-DatePicker-update-focus-behaviour.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix (Date Picker): Update focus behaviour - shifting focus to selected date.

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarContext.ts
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarContext.ts
@@ -17,6 +17,7 @@ export interface CalendarContextInterface {
   onPrevMonthClick: () => void;
   onNextMonthClick: () => void;
   setDateFocused: (value: boolean) => void;
+  setFocusedDate: (day: Date) => void;
   setFocusedTodayDate: (event: React.SyntheticEvent) => void;
 }
 
@@ -34,5 +35,6 @@ export const CalendarContext = React.createContext<CalendarContextInterface>({
   onPrevMonthClick: () => {},
   onNextMonthClick: () => {},
   setDateFocused: (value: boolean) => {},
+  setFocusedDate: (day: Date) => {},
   setFocusedTodayDate: (event: React.SyntheticEvent) => {},
 });

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.test.js
@@ -249,4 +249,63 @@ describe('Calendar Day', () => {
 
     expect(onDateChange).not.toHaveBeenCalled();
   });
+
+  describe('focus date', () => {
+    it('should call setFocusedDate on mouseDown when the day is in current month', () => {
+      const defaultDate = new Date(2019, 0, 17);
+      const setFocusedDate = jest.fn();
+
+      const { getByText } = render(
+        <CalendarContext.Provider
+          value={{
+            setFocusedDate,
+            focusedDate: new Date(2019, 0, 17),
+          }}
+        >
+          <table>
+            <tbody>
+              <tr>
+                <CalendarDay day={defaultDate} />
+                <CalendarDay day={new Date(2019, 0, 18)} />
+                <CalendarDay day={new Date(2019, 0, 19)} />
+                <CalendarDay day={new Date(2019, 0, 20)} />
+              </tr>
+            </tbody>
+          </table>
+        </CalendarContext.Provider>
+      );
+
+      fireEvent.mouseDown(getByText('20'));
+
+      expect(setFocusedDate).toHaveBeenCalled();
+    });
+
+    it('should not call setFocusedDate on mouseDown when the day is not in current month or is disabled', () => {
+      const defaultDate = new Date(2019, 0, 17);
+      const nextMonthDay = new Date(2019, 1, 1);
+      const setFocusedDate = jest.fn();
+
+      const { getByText } = render(
+        <CalendarContext.Provider
+          value={{
+            setFocusedDate,
+            focusedDate: new Date(2019, 0, 17),
+          }}
+        >
+          <table>
+            <tbody>
+              <tr>
+                <CalendarDay day={defaultDate} />
+                <CalendarDay disabled day={nextMonthDay} />
+              </tr>
+            </tbody>
+          </table>
+        </CalendarContext.Provider>
+      );
+
+      fireEvent.mouseDown(getByText('1'));
+
+      expect(setFocusedDate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
@@ -214,8 +214,9 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
     chosenDate,
     maxDate,
     minDate,
-    setDateFocused,
     onDateChange,
+    setDateFocused,
+    setFocusedDate,
     isInverse,
   } = React.useContext(CalendarContext);
   const [focused, setFocused] = React.useState<boolean>(false);
@@ -243,6 +244,14 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
     }
 
     onDateChange(day, event);
+  }
+
+  function onFocusDay(event: React.SyntheticEvent) {
+    if (disabled || !isSameMonth(day, focusedDate)) {
+      event.preventDefault();
+      return;
+    }
+    setFocusedDate(day);
   }
 
   const disabled: boolean =
@@ -285,6 +294,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
           state={dayState}
           isInverse={isInverse}
           onClick={onDayClick}
+          onMouseDown={onFocusDay}
           ref={dayRef}
           tabIndex={sameDateAsFocusedDate ? 0 : -1}
           type="button"

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -217,7 +217,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       setCalendarOpened(false);
     }
 
-    const setFocusedCurrentDate = (event: React.SyntheticEvent) => {
+    const setFocusedTodayDate = (event: React.SyntheticEvent) => {
       const isKeyboardEvent = event.type === 'keydown';
 
       if (
@@ -484,7 +484,8 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
           onNextMonthClick,
           onDateChange: handleDaySelection,
           setDateFocused,
-          setFocusedTodayDate: setFocusedCurrentDate,
+          setFocusedTodayDate,
+          setFocusedDate,
           onClose: closeHelperInformation,
         }}
       >


### PR DESCRIPTION
Closes: #1879 

## What I did
- Updated focus behavior when the user selects a day in the calendar.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to `Storybook` -> `Date Picker` -> `Default` -> select day in current month -> while clicking on the day, the focus **SHOULD** go to this date
Go to `Storybook` -> `Date Picker` -> `Default` -> select day in next or previous current month -> while clicking on the day, the focus **SHOULD** **NOT** go to this date
