### PR TITLE
chore: add documentation for css prop and emotion v11 media query 

### DIFF
--- a/.changeset/chore-css-prop.md
+++ b/.changeset/chore-css-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+chore: add documentation for css prop and emotion v11 media query overrides

--- a/website/react-magma-docs/src/pages/api-intro/styles-and-themes.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/styles-and-themes.mdx
@@ -98,6 +98,34 @@ export function Example() {
 }
 ```
 
+## Emotion v11 Migration: Media Query Overrides
+
+**Important**: If you've upgraded from Emotion v10 to v11, you may notice that media query overrides no longer work as expected. This is due to changes in CSS specificity handling in Emotion v11.
+
+### ✅ Correct way to override media queries (Emotion v11+):
+
+Style the component directly and target the media queries within the styled component:
+
+```tsx
+import React from 'react';
+
+import styled from '@emotion/styled';
+import { CardBody } from 'react-magma-dom';
+
+const CustomCardBody = styled(CardBody)`
+  padding: '16px';
+  background: lightblue;
+
+  @media (min-width: 600px) {
+    padding: '48px';
+    background: lightgray;
+  }
+`;
+export function Example() {
+  return <CustomCardBody>Hello world</CustomCardBody>;
+}
+```
+
 ## Using Themes
 
 By default, all components in the React Magma library use the Magma theme. You can use the ThemeContext to pass in a custom theme.


### PR DESCRIPTION
Closes: #1826

## What I did
add documentation for css prop and emotion v11 media query 


## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
docs preview /api-intro/styles-and-themes/#emotion_v11_migration:_media_query_overrides