### PR TITLE
feat(drawer): add isanimated prop to control slide animation

### DIFF
--- a/.changeset/feat-drawer-isAnimated.md
+++ b/.changeset/feat-drawer-isAnimated.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+feat(Drawer): add isAnimated prop to control slide animation

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -83,8 +83,8 @@ describe('Date Picker', () => {
 
     fireEvent.click(getByLabelText('Toggle Calendar Widget'));
 
-    expect(getAllByText(day)[0]).toBeInTheDocument();
-    fireEvent.click(getAllByText(day)[0]);
+    expect(getAllByText(day)[1]).toBeInTheDocument();
+    fireEvent.click(getAllByText(day)[1]);
 
     expect(getByText('Chosen Date:').nextSibling.innerHTML).toEqual(chosenDate);
 
@@ -109,8 +109,8 @@ describe('Date Picker', () => {
 
     fireEvent.click(getByLabelText('Toggle Calendar Widget'));
 
-    expect(getAllByText(day)[0]).toBeInTheDocument();
-    fireEvent.click(getAllByText(day)[0]);
+    expect(getAllByText(day)[1]).toBeInTheDocument();
+    fireEvent.click(getAllByText(day)[1]);
 
     expect(getByText('Chosen Date:').nextSibling.innerHTML).toEqual(chosenDate);
 

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Button } from '../Button';
 import { VisuallyHidden } from '../VisuallyHidden';
-import { DrawerPosition } from './Drawer';
+import { DrawerPosition, DrawerProps } from './Drawer';
 import { NavTab, NavTabs } from '../NavTabs';
 import { TabsOrientation } from '../Tabs/shared';
 
@@ -28,12 +28,21 @@ const info = {
         type: 'boolean',
       },
     },
+    isAnimated: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 };
 
 export default info;
 
-export const Default = args => {
+export const Default = (
+  args: React.JSX.IntrinsicAttributes &
+    DrawerProps &
+    React.RefAttributes<HTMLDivElement>
+) => {
   const [showDrawer, setShowDrawer] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement | null>(null);
 
@@ -62,7 +71,11 @@ export const Default = args => {
   );
 };
 
-export const SiteNavigation = args => {
+export const SiteNavigation = (
+  args: React.JSX.IntrinsicAttributes &
+    DrawerProps &
+    React.RefAttributes<HTMLDivElement>
+) => {
   const [showDrawer, setShowDrawer] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement | null>(null);
 

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
@@ -144,4 +144,38 @@ describe('Drawer', () => {
       );
     });
   });
+
+  describe('isAnimated prop', () => {
+    const drawerContent = 'Animated drawer content';
+
+    it('should not have transform property when isAnimated is false (default)', () => {
+      const { getByTestId } = render(
+        <Drawer position="left" header="Hello" isOpen testId={TEST_ID}>
+          {drawerContent}
+        </Drawer>
+      );
+
+      const transition = getByTestId(TEST_ID);
+
+      expect(transition.style.transform).toBe('');
+    });
+
+    it('should have transform property when isAnimated is true', () => {
+      const { getByTestId } = render(
+        <Drawer
+          position="left"
+          header="Hello"
+          isAnimated
+          isOpen
+          testId={TEST_ID}
+        >
+          {drawerContent}
+        </Drawer>
+      );
+
+      const transition = getByTestId(TEST_ID);
+
+      expect(transition.style.transform).toContain('translate');
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
@@ -46,29 +46,45 @@ export interface DrawerProps extends Omit<ModalProps, 'size'> {
    * @default true
    */
   showBackgroundOverlay?: boolean;
+  /**
+   * If true, enables sliding animations for the drawer
+   * @default false
+   */
+  isAnimated?: boolean;
   isInverse?: boolean;
 }
 
 export const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
-  (props, ref) => {
-    const { style, containerStyle, position, ...rest } = props;
+  (props, _ref) => {
+    const {
+      style,
+      containerStyle,
+      position,
+      isAnimated = false,
+      ...rest
+    } = props;
     const theme = React.useContext(ThemeContext);
+    const drawerPosition: DrawerPosition = position ?? DrawerPosition.top;
     const drawerStyle = {
       ...theme.drawer.default,
-      ...theme.drawer[DrawerPosition[position]],
+      ...theme.drawer[drawerPosition],
     } as React.CSSProperties;
+
+    let containerTransition: Omit<TransitionProps, 'isOpen'> | undefined;
+    if (isAnimated) {
+      containerTransition = position
+        ? transitionPreset[DrawerPosition[position]]
+        : transitionPreset[DrawerPosition[DrawerPosition.top]];
+    }
+
     return (
       <Modal
         containerStyle={{
           padding: '0',
           ...containerStyle,
         }}
-        containerTransition={
-          position
-            ? transitionPreset[DrawerPosition[position]]
-            : transitionPreset[DrawerPosition[DrawerPosition.top]]
-        }
-        hasDrawerAnimation
+        containerTransition={containerTransition}
+        hasDrawerAnimation={isAnimated}
         style={{ ...drawerStyle, ...style }}
         {...rest}
       />

--- a/website/react-magma-docs/src/pages/api/drawer.mdx
+++ b/website/react-magma-docs/src/pages/api/drawer.mdx
@@ -197,6 +197,51 @@ export function Example() {
 }
 ```
 
+## Animations
+
+The `isAnimated` prop controls whether the drawer has sliding animations when opening and closing. By default, animations are disabled (`isAnimated={false}`).
+
+```tsx
+import React from 'react';
+
+import {
+  Button,
+  Drawer,
+  DrawerPosition,
+  VisuallyHidden,
+} from 'react-magma-dom';
+
+export function Example() {
+  const [showDrawer, setShowDrawer] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>();
+
+  return (
+    <>
+      <Drawer
+        closeAriaLabel="Close drawer"
+        header="Animated Drawer"
+        isAnimated
+        isOpen={showDrawer}
+        onClose={() => {
+          setShowDrawer(false);
+          buttonRef.current.focus();
+        }}
+        position={DrawerPosition.left}
+      >
+        <p>This drawer slides in from the left with animation.</p>
+        <p>
+          <Button>This is a button</Button>
+        </p>
+      </Drawer>
+      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
+        Show Animated Drawer
+        <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
+      </Button>
+    </>
+  );
+}
+```
+
 ## Internationalization
 
 If you're using strings in your component, they must be internationalized.


### PR DESCRIPTION
Closes: #1890

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Added isAnimated prop to control slide animation, the animation has been broken since v4.0.0 so making it disabled by default wont be a breaking change. fixing it is what caused the regression on dev

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->

https://storybook-preview-dev--upbeat-sinoussi-f675aa.netlify.app/?path=/story/drawer--default

test isAnimated prop behaviour 