### PR TITLE
fix(Drawer): Fix issue with forcing height to 300px

### DIFF
--- a/.changeset/fix-Drawer-height-forced-to-300px.md
+++ b/.changeset/fix-Drawer-height-forced-to-300px.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Drawer): Fix forced height to 300px.

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
@@ -64,10 +64,9 @@ export const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
       ...rest
     } = props;
     const theme = React.useContext(ThemeContext);
-    const drawerPosition: DrawerPosition = position ?? DrawerPosition.top;
     const drawerStyle = {
       ...theme.drawer.default,
-      ...theme.drawer[drawerPosition],
+      ...theme.drawer[DrawerPosition[position]],
     } as React.CSSProperties;
 
     let containerTransition: Omit<TransitionProps, 'isOpen'> | undefined;


### PR DESCRIPTION
Closes: #1906 

## What I did
- Fixed default styles for `Drawer`

## Screenshots
<img width="588" height="636" alt="Screenshot from 2025-09-02 12-24-06" src="https://github.com/user-attachments/assets/b97650c4-3feb-401f-b34a-bf8e1b9d6ebe" />

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Clone caldera
- Navigate to https://local-explore.cengage.com/CourseSelector and select any course
- Click view as student on sidebar
- Click on bottom right hand gear and toggle k-5 theme on
- Look at the page on a mobile screen size and notice the drawer -> should have `height: 100%`

Existing behavior and styles must not be changed.
