### PR TITLE
fix(tooltip): improve screen reader accessibility for non-interactive…

### DIFF
--- a/.changeset/fix-Tooltip-focus-v2.md
+++ b/.changeset/fix-Tooltip-focus-v2.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tooltip): Fix screen reader behaviour for tooltips with non-interactive elements

--- a/packages/react-magma-dom/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/Tooltip.stories.tsx
@@ -6,6 +6,7 @@ import {
   KeyboardArrowRightIcon,
   KeyboardArrowDownIcon,
   KeyboardArrowUpIcon,
+  HelpOutlineIcon,
 } from 'react-magma-icons';
 
 import { magma } from '../../theme/magma';
@@ -18,6 +19,7 @@ import {
   DropdownDropDirection,
   DropdownMenuItem,
 } from '../Dropdown';
+import { Flex, FlexBehavior, FlexAlignItems } from '../Flex';
 import { IconButton } from '../IconButton';
 import { Modal } from '../Modal';
 import { Tag } from '../Tag';
@@ -280,4 +282,46 @@ const CustomStylesTemplate: Story<TooltipProps> = args => {
 export const CustomStyles = CustomStylesTemplate.bind({});
 CustomStyles.args = {
   content: 'Lorem ipsum dolar sit amet. Vel molestie no, ut vim.',
+};
+
+export const OnNonInteractiveElements = () => {
+  const tooltipContentShort = (
+    <>
+      Tooltip wrapped in <b>div</b>
+    </>
+  );
+  const tooltipContentLong = (
+    <>
+      Tooltip wrapped in <b>span</b>
+    </>
+  );
+
+  return (
+    <div
+      style={{
+        padding: '80px',
+        display: 'flex',
+        justifyContent: 'center',
+        background: magma.colors.neutral100,
+      }}
+    >
+      <Flex
+        behavior={FlexBehavior.container}
+        alignItems={FlexAlignItems.center}
+        spacing={2}
+      >
+        <Tooltip content={tooltipContentShort}>
+          <div style={{ width: 'fit-content', height: 'fit-content' }}>
+            <HelpOutlineIcon size={40} />
+          </div>
+        </Tooltip>
+
+        <Tooltip content={tooltipContentLong}>
+          <span>
+            <HelpOutlineIcon />
+          </span>
+        </Tooltip>
+      </Flex>
+    </div>
+  );
 };

--- a/packages/react-magma-dom/src/components/Tooltip/Tooltip.test.js
+++ b/packages/react-magma-dom/src/components/Tooltip/Tooltip.test.js
@@ -282,6 +282,17 @@ describe('Tooltip', () => {
     console.error = originalError;
   });
 
+  it('should add tabIndex="0" to non-interactive elements without tabIndex', () => {
+    const { container } = render(
+      <Tooltip content={CONTENT_TEXT}>
+        <span>Non-interactive span</span>
+      </Tooltip>
+    );
+
+    const triggerElement = container.querySelector('span');
+    expect(triggerElement).toHaveAttribute('tabIndex', '0');
+  });
+
   it('Does not violate accessibility standards', () => {
     const { container } = render(
       <Tooltip content={CONTENT_TEXT}>{TRIGGER_ELEMENT}</Tooltip>

--- a/packages/react-magma-dom/src/components/Tooltip/index.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/index.tsx
@@ -14,7 +14,12 @@ import {
 
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { useForkedRef, useGenerateId, removePxStyleStrings } from '../../utils';
+import {
+  useForkedRef,
+  useGenerateId,
+  removePxStyleStrings,
+  isNonInteractive,
+} from '../../utils';
 
 export enum TooltipPosition {
   bottom = 'bottom',
@@ -215,8 +220,12 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
     throw new Error('Tooltip children can only be one element.');
   }
 
+  const nonInteractive = isNonInteractive(children);
+
   const tooltipTrigger = React.cloneElement(children, {
     'aria-describedby': isVisible ? id : null,
+    ...(nonInteractive &&
+      children.props.tabIndex === undefined && { tabIndex: 0 }),
     onBlur: hideTooltip,
     onFocus: showTooltip,
     ref: combinedRef,

--- a/packages/react-magma-dom/src/utils/index.ts
+++ b/packages/react-magma-dom/src/utils/index.ts
@@ -345,3 +345,94 @@ export const mergeRefs = <T>(...refs: Array<React.Ref<T> | undefined>) => {
     });
   };
 };
+
+export const isNonInteractive = (
+  children: React.ReactElement<any, string | React.JSXElementConstructor<any>> &
+    React.ReactNode
+) => {
+  const childType = children.type;
+
+  if (typeof childType === 'string') {
+    const nonInteractiveElements = [
+      'div',
+      'span',
+      'p',
+      'img',
+      'svg',
+      'i',
+      'b',
+      'strong',
+      'em',
+      'small',
+      'abbr',
+      'label',
+      'pre',
+      'code',
+      's',
+      'sub',
+      'sup',
+      'mark',
+      'q',
+      'dfn',
+      'var',
+      'samp',
+      'kbd',
+      'u',
+      'time',
+      'data',
+      'wbr',
+      'br',
+      'hr',
+      'caption',
+      'col',
+      'colgroup',
+      'thead',
+      'tbody',
+      'tfoot',
+      'tr',
+      'th',
+      'td',
+      'ol',
+      'ul',
+      'li',
+      'dl',
+      'dt',
+      'dd',
+      'article',
+      'section',
+      'nav',
+      'aside',
+      'header',
+      'footer',
+      'main',
+      'figure',
+      'figcaption',
+      'details',
+      'summary',
+      'dialog',
+      'menu',
+      'menuitem',
+      'fieldset',
+      'legend',
+      'output',
+      'progress',
+      'meter',
+      'template',
+      'slot',
+      'picture',
+      'source',
+      'track',
+      'map',
+      'area',
+      'bdi',
+      'bdo',
+      'ruby',
+      'rt',
+      'rp',
+      'wbr',
+    ];
+    return nonInteractiveElements.includes(childType.toLowerCase());
+  }
+
+  return false;
+};


### PR DESCRIPTION
Closes: #1922

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

**Bug fix** - Fixed screen reader accessibility issue for tooltips wrapped around non-interactive elements.

**Changes made:**
- Added automatic detection of non-interactive elements (div, span, p, img, svg, i) in Tooltip component
- Added `tabIndex="0"` to non-interactive elements that don't already have a tabIndex to ensure keyboard accessibility
- Preserved existing `role` and `tabIndex` attributes when present to avoid overriding user-defined values


## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->

**Manual Testing:**
1. Open Storybook and navigate to the Tooltip → "On Non Interactive Elements" story
2. Use a screen reader (NVDA, JAWS, VoiceOver) to test the tooltips
3. Tab to the elements and verify the tooltip content is announced
4. Test with keyboard navigation (Tab key) and mouse hover