### PR TITLE
fix(Tooltip): Fix issue with screenreaders on non interactive elements

### DIFF
--- a/.changeset/fix-Tooltip-non-interactive-focus.md
+++ b/.changeset/fix-Tooltip-non-interactive-focus.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tooltip): Fix issue with screenreaders on non interactive elements.

--- a/packages/react-magma-dom/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/Tooltip.stories.tsx
@@ -6,6 +6,7 @@ import {
   KeyboardArrowRightIcon,
   KeyboardArrowDownIcon,
   KeyboardArrowUpIcon,
+  HelpOutlineIcon,
 } from 'react-magma-icons';
 
 import { magma } from '../../theme/magma';
@@ -18,6 +19,7 @@ import {
   DropdownDropDirection,
   DropdownMenuItem,
 } from '../Dropdown';
+import { Flex, FlexAlignItems, FlexBehavior } from '../Flex';
 import { IconButton } from '../IconButton';
 import { Modal } from '../Modal';
 import { Tag } from '../Tag';
@@ -281,3 +283,43 @@ export const CustomStyles = CustomStylesTemplate.bind({});
 CustomStyles.args = {
   content: 'Lorem ipsum dolar sit amet. Vel molestie no, ut vim.',
 };
+
+export function Example() {
+  const tooltipContentShort = (
+    <>
+      Tooltip wrapped in <b>div</b>
+    </>
+  );
+  const tooltipContentLong = (
+    <>
+      Tooltip wrapped in <b>span</b>
+    </>
+  );
+
+  return (
+    <Flex
+      behavior={FlexBehavior.container}
+      alignItems={FlexAlignItems.center}
+      spacing={2}
+    >
+      <Tooltip content={tooltipContentShort}>
+        <div style={{ width: 'fit-content', height: 'fit-content' }}>
+          <HelpOutlineIcon
+            tabIndex="0"
+            size={40}
+            aria-label={'Tooltip wrapped in div'}
+          />
+        </div>
+      </Tooltip>
+
+      <Tooltip content={tooltipContentLong}>
+        <span>
+          <HelpOutlineIcon
+            tabIndex="0"
+            aria-label={'Tooltip wrapped in span'}
+          />
+        </span>
+      </Tooltip>
+    </Flex>
+  );
+}

--- a/website/react-magma-docs/src/pages/api/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/api/tooltip.mdx
@@ -124,6 +124,12 @@ child cannot accept a ref, the tooltip may not position correctly.
 
 <Alert variant="info">
   You can get around this by adding a wrapping element.
+  <br />
+  <br />
+  <b>For accessibility:</b> When using Tooltip on a non-interactive element, you
+  should add <inlineCode>aria-label</inlineCode> with the tooltip content to the
+  trigger element. This ensures screen readers will announce the tooltip
+  content.
 </Alert>
 
 ```tsx
@@ -152,13 +158,20 @@ export function Example() {
     >
       <Tooltip content={tooltipContentShort}>
         <div style={{ width: 'fit-content', height: 'fit-content' }}>
-          <HelpOutlineIcon tabIndex="0" size={40} />
+          <HelpOutlineIcon
+            tabIndex="0"
+            size={40}
+            aria-label={'Tooltip wrapped in div'}
+          />
         </div>
       </Tooltip>
 
       <Tooltip content={tooltipContentLong}>
         <span>
-          <HelpOutlineIcon tabIndex="0" />
+          <HelpOutlineIcon
+            tabIndex="0"
+            aria-label={'Tooltip wrapped in span'}
+          />
         </span>
       </Tooltip>
     </Flex>


### PR DESCRIPTION
Closes: #1922

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix issue with screenreaders on non interactive elements

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open docs -> Tooltip -> `On non-interactive element` section -> Turn on VoiceOver/NVDA -> Check behavior 

**Note**
On Windows 10/11 + Firefox, NVDA announces it twice because of content + aria-label