### PR TITLE
fix(DatePicker): Announcement during the change to the next or previous month.

### DIFF
--- a/.changeset/fix-DatePicker-add-announcement-next-previous-buttons.md
+++ b/.changeset/fix-DatePicker-add-announcement-next-previous-buttons.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix (Date Picker): Add an announcement during the change to the next or previous month.

--- a/.changeset/fix-DatePicker-add-announcement-next-previous-buttons.md
+++ b/.changeset/fix-DatePicker-add-announcement-next-previous-buttons.md
@@ -1,5 +1,0 @@
----
-'react-magma-dom': patch
----
-
-fix (Date Picker): Add an announcement during the change to the next or previous month.

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
@@ -16,6 +16,8 @@ import { ButtonColor, ButtonType, ButtonVariant } from '../Button';
 import { IconButton } from '../IconButton';
 import { MonthPicker } from './MonthPicker';
 import { YearPicker } from './YearPicker';
+import { Announce, AnnouncePoliteness } from '../Announce';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 interface CalendarHeaderProps {
   focusHeader?: boolean;
@@ -84,6 +86,11 @@ export const CalendarHeader: React.FunctionComponent<
             isInverse={props.isInverse}
           />
         </MonthYearWrapper>
+        <VisuallyHidden>
+          <Announce politeness={AnnouncePoliteness.polite} aria-atomic="true">
+            {monthAndYear.month} {monthAndYear.year}
+          </Announce>
+        </VisuallyHidden>
       </CalendarHeaderText>
       <NavigationWrapper>
         <IconButton

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
@@ -16,8 +16,6 @@ import { ButtonColor, ButtonType, ButtonVariant } from '../Button';
 import { IconButton } from '../IconButton';
 import { MonthPicker } from './MonthPicker';
 import { YearPicker } from './YearPicker';
-import { Announce, AnnouncePoliteness } from '../Announce';
-import { VisuallyHidden } from '../VisuallyHidden';
 
 interface CalendarHeaderProps {
   focusHeader?: boolean;
@@ -86,11 +84,6 @@ export const CalendarHeader: React.FunctionComponent<
             isInverse={props.isInverse}
           />
         </MonthYearWrapper>
-        <VisuallyHidden>
-          <Announce politeness={AnnouncePoliteness.polite} aria-atomic="true">
-            {monthAndYear.month} {monthAndYear.year}
-          </Announce>
-        </VisuallyHidden>
       </CalendarHeaderText>
       <NavigationWrapper>
         <IconButton

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -530,33 +530,33 @@ describe('Date Picker', () => {
   it('should go to the previous month when the previous month button is clicked', () => {
     const defaultDate = new Date(2019, 0, 17);
     const labelText = 'Date Picker Label';
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getAllByText } = render(
       <DatePicker defaultDate={defaultDate} labelText={labelText} />
     );
 
     fireEvent.click(getByLabelText('Toggle Calendar Widget'));
 
-    expect(getByText(/january/i)).toBeInTheDocument();
+    expect(getAllByText(/january/i)[0]).toBeInTheDocument();
 
     fireEvent.click(getByLabelText(/Navigate back/i));
 
-    expect(getByText(/december/i)).toBeInTheDocument();
+    expect(getAllByText(/december/i)[0]).toBeInTheDocument();
   });
 
   it('should go to the next month when the next month button is clicked', () => {
     const defaultDate = new Date(2019, 0, 17);
     const labelText = 'Date Picker Label';
-    const { getByLabelText, getByText } = render(
+    const { getByLabelText, getAllByText } = render(
       <DatePicker defaultDate={defaultDate} labelText={labelText} />
     );
 
     fireEvent.click(getByLabelText('Toggle Calendar Widget'));
 
-    expect(getByText(/january/i)).toBeInTheDocument();
+    expect(getAllByText(/january/i)[0]).toBeInTheDocument();
 
     fireEvent.click(getByLabelText(/Navigate forward/i));
 
-    expect(getByText(/february/i)).toBeInTheDocument();
+    expect(getAllByText(/february/i)[0]).toBeInTheDocument();
   });
 
   it('should close the calendar when the close button is clicked', () => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -530,33 +530,33 @@ describe('Date Picker', () => {
   it('should go to the previous month when the previous month button is clicked', () => {
     const defaultDate = new Date(2019, 0, 17);
     const labelText = 'Date Picker Label';
-    const { getByLabelText, getAllByText } = render(
+    const { getByLabelText, getByText } = render(
       <DatePicker defaultDate={defaultDate} labelText={labelText} />
     );
 
     fireEvent.click(getByLabelText('Toggle Calendar Widget'));
 
-    expect(getAllByText(/january/i)[0]).toBeInTheDocument();
+    expect(getByText(/january/i)).toBeInTheDocument();
 
     fireEvent.click(getByLabelText(/Navigate back/i));
 
-    expect(getAllByText(/december/i)[0]).toBeInTheDocument();
+    expect(getByText(/december/i)).toBeInTheDocument();
   });
 
   it('should go to the next month when the next month button is clicked', () => {
     const defaultDate = new Date(2019, 0, 17);
     const labelText = 'Date Picker Label';
-    const { getByLabelText, getAllByText } = render(
+    const { getByLabelText, getByText } = render(
       <DatePicker defaultDate={defaultDate} labelText={labelText} />
     );
 
     fireEvent.click(getByLabelText('Toggle Calendar Widget'));
 
-    expect(getAllByText(/january/i)[0]).toBeInTheDocument();
+    expect(getByText(/january/i)).toBeInTheDocument();
 
     fireEvent.click(getByLabelText(/Navigate forward/i));
 
-    expect(getAllByText(/february/i)[0]).toBeInTheDocument();
+    expect(getByText(/february/i)).toBeInTheDocument();
   });
 
   it('should close the calendar when the close button is clicked', () => {

--- a/packages/react-magma-dom/src/components/DatePicker/MonthPicker.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/MonthPicker.tsx
@@ -32,17 +32,19 @@ export const MonthPicker: React.FunctionComponent<MonthPickerProps> = props => {
   const getTextWidth = (text: string, font: string) => {
     const canvas = document.createElement('canvas');
     const context = canvas.getContext('2d');
+
     context.font = font;
+
     return context.measureText(text).width;
   };
 
-  const getMonthWidth = (month: string) => {
+  const width = React.useMemo(() => {
+    const currentLabel = currentMonth;
     const font = `${theme.typeScale.size03.fontSize} ${theme.bodyFont}`;
     const padding = parseInt(theme.spaceScale.spacing03, 10) * 2;
-    return Math.ceil(getTextWidth(month, font) + padding);
-  };
 
-  const width = getMonthWidth(currentMonth);
+    return Math.ceil(getTextWidth(currentLabel, font) + padding);
+  }, [currentMonth]);
 
   return (
     <StyledSelect isInverse={isInverse} theme={theme}>

--- a/packages/react-magma-dom/src/components/DatePicker/MonthPicker.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/MonthPicker.tsx
@@ -32,19 +32,17 @@ export const MonthPicker: React.FunctionComponent<MonthPickerProps> = props => {
   const getTextWidth = (text: string, font: string) => {
     const canvas = document.createElement('canvas');
     const context = canvas.getContext('2d');
-
     context.font = font;
-
     return context.measureText(text).width;
   };
 
-  const width = React.useMemo(() => {
-    const currentLabel = currentMonth;
+  const getMonthWidth = (month: string) => {
     const font = `${theme.typeScale.size03.fontSize} ${theme.bodyFont}`;
     const padding = parseInt(theme.spaceScale.spacing03, 10) * 2;
+    return Math.ceil(getTextWidth(month, font) + padding);
+  };
 
-    return Math.ceil(getTextWidth(currentLabel, font) + padding);
-  }, [currentMonth]);
+  const width = getMonthWidth(currentMonth);
 
   return (
     <StyledSelect isInverse={isInverse} theme={theme}>


### PR DESCRIPTION
Closes: #1917

## What I did
- Fixed announcement during the change to the next or previous month.
- Update logic of showing month in calendar header. 

## Screenshots

## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Storybook -> DatePicker -> Default -> Turn on Voice Over -> Click on `next` or `previous` month button -> After changing month, VO should announce updated month and year.
