### PR TITLE
Replace GATSBY_EMPTY_ALT with empty alt for images

### DIFF
--- a/.changeset/a11y-docs-img-empty-alts.md
+++ b/.changeset/a11y-docs-img-empty-alts.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Docs): replace "GATSBY_EMPTY_ALT" as alt text for empty alts.

--- a/website/react-magma-docs/src/pages/api-intro/page-templates.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/page-templates.mdx
@@ -14,10 +14,7 @@ order: 2
 This template is ideal for applications that need as much of the screen as possible.
 
 <figure>
-  <img
-    src="../../images/layout/template-full-width.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/layout/template-full-width.png" alt=" " />
 </figure>
 
 ```tsx
@@ -142,10 +139,7 @@ export function Example() {
 This template is great for pages that focus more on reading content like marketing materials, articles, etc.
 
 <figure>
-  <img
-    src="../../images/layout/template-restricted-width.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/layout/template-restricted-width.png" alt=" " />
 </figure>
 
 ```tsx
@@ -251,10 +245,7 @@ export function Example() {
 This template includes a screen region for a left sidebar and includes all of the necessary responsive behavior.
 
 <figure>
-  <img
-    src="../../images/layout/template-sidebar-app-header.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/layout/template-sidebar-app-header.png" alt=" " />
 </figure>
 
 ```tsx
@@ -351,10 +342,7 @@ export function Example() {
 This template also includes the sidebar screen region, but the header extends all the way across the top of the page.
 
 <figure>
-  <img
-    src="../../images/layout/template-sidebar-global-header.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/layout/template-sidebar-global-header.png" alt=" " />
 </figure>
 
 ```tsx

--- a/website/react-magma-docs/src/pages/data-visualization/chart-types.mdx
+++ b/website/react-magma-docs/src/pages/data-visualization/chart-types.mdx
@@ -21,10 +21,7 @@ Comparison charts compare data between multiple distinct categories.
 <div className="container">
   <div className="item">
     <figure>
-      <img
-        src="../../images/chart-types/simple-bar.jpg"
-        alt="GATSBY_EMPTY_ALT"
-      />
+      <img src="../../images/chart-types/simple-bar.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Simple Bar</h2>
@@ -37,10 +34,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img
-        src="../../images/chart-types/grouped-bar.jpg"
-        alt="GATSBY_EMPTY_ALT"
-      />
+      <img src="../../images/chart-types/grouped-bar.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Grouped Bar</h2>
@@ -54,10 +48,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img
-        src="../../images/chart-types/floating-bar.jpg"
-        alt="GATSBY_EMPTY_ALT"
-      />
+      <img src="../../images/chart-types/floating-bar.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Floating Bar</h2>
@@ -71,7 +62,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/bubble.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/bubble.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Bubble</h2>
@@ -84,7 +75,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/radar.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/radar.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Radar</h2>
@@ -98,7 +89,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/lollipop.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/lollipop.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Lollipop</h2>
@@ -112,7 +103,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/combo.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/combo.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Combo</h2>
@@ -132,7 +123,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
 <div className="container">
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/line.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/line.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Line</h2>
@@ -146,7 +137,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/area.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/area.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Area</h2>
@@ -159,7 +150,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/boxplot.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/boxplot.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Boxplot</h2>
@@ -172,10 +163,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
   </div>
   <div className="item">
     <figure>
-      <img
-        src="../../images/chart-types/histogram.jpg"
-        alt="GATSBY_EMPTY_ALT"
-      />
+      <img src="../../images/chart-types/histogram.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Histogram</h2>
@@ -189,10 +177,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
   </div>
   <div className="item">
     <figure>
-      <img
-        src="../../images/chart-types/sparkline.jpg"
-        alt="GATSBY_EMPTY_ALT"
-      />
+      <img src="../../images/chart-types/sparkline.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Sparkline</h2>
@@ -205,7 +190,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/step.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/step.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Step</h2>
@@ -225,7 +210,7 @@ Part-to-whole charts show how partial elements add up to a total.
 <div className="container">
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/pie.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/pie.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Pie</h2>
@@ -238,7 +223,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/donut.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/donut.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Donut</h2>
@@ -252,10 +237,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img
-        src="../../images/chart-types/stacked-bar.jpg"
-        alt="GATSBY_EMPTY_ALT"
-      />
+      <img src="../../images/chart-types/stacked-bar.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Stacked Bar</h2>
@@ -268,7 +250,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/bullet.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/bullet.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Bullet</h2>
@@ -281,10 +263,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img
-        src="../../images/chart-types/stacked-area.jpg"
-        alt="GATSBY_EMPTY_ALT"
-      />
+      <img src="../../images/chart-types/stacked-area.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Stacked area</h2>
@@ -297,7 +276,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/meter.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/meter.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Meter</h2>
@@ -310,7 +289,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/gauge.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/gauge.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Gauge</h2>
@@ -330,7 +309,7 @@ Correlation charts show the relationship between two or more variables.
 <div className="container">
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/scatter.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/scatter.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Scatter</h2>

--- a/website/react-magma-docs/src/pages/design-intro/layout.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/layout.mdx
@@ -27,10 +27,7 @@ import {
 Every layout is made up of columns, gutters, and margins that respond accordingly to the size of the viewport.
 
 <figure>
-  <img
-    src="../../images/layout/columns-gutters-margins.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/layout/columns-gutters-margins.png" alt=" " />
 </figure>
 
 1. Columns
@@ -42,7 +39,7 @@ Every layout is made up of columns, gutters, and margins that respond accordingl
 The columns indicate where the content of the page goes. The widths of the columns are fluid, allowing content to scale and resize depending on the width of the device. The number of columns is determined by pre-defined breakpoint ranges.
 
 <figure>
-  <img src="../../images/layout/columns-12.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/columns-12.png" alt=" " />
   <figcaption>
     When the viewport is greater than 768px wide, the layout has 12 columns.
   </figcaption>
@@ -51,7 +48,7 @@ The columns indicate where the content of the page goes. The widths of the colum
 <span className="horizontal-spacer" />
 
 <figure>
-  <img src="../../images/layout/columns-6.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/columns-6.png" alt=" " />
   <figcaption>
     When the viewport is 768px wide or smaller, the layout has 6 columns.
   </figcaption>
@@ -60,7 +57,7 @@ The columns indicate where the content of the page goes. The widths of the colum
 <span className="horizontal-spacer" />
 
 <figure>
-  <img src="../../images/layout/columns-4.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/columns-4.png" alt=" " />
   <figcaption>
     When the viewport is 375px wide and smaller, the layout changes to 4
     columns.
@@ -74,7 +71,7 @@ Gutters are the spaces in between columns. This space is used to separate conten
 The width of gutters on standard Cengage page layouts should be set to 24px. On smaller screens the gutters change to 16px.
 
 <figure>
-  <img src="../../images/layout/gutters-24.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/gutters-24.png" alt=" " />
   <figcaption>
     When the viewport is greater than 600px wide, gutters are 24px wide.
   </figcaption>
@@ -83,7 +80,7 @@ The width of gutters on standard Cengage page layouts should be set to 24px. On 
 <span className="horizontal-spacer" />
 
 <figure>
-  <img src="../../images/layout/gutters-16.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/gutters-16.png" alt=" " />
   <figcaption>
     When the viewport is 600px wide and smaller, gutters are 16px wide.
   </figcaption>
@@ -100,7 +97,7 @@ Margins are a fixed value, typically consistent with the gutter widths. The widt
 The width of margins on standard Cengage full-width page layouts should be set to 24px. On smaller screens the margins change to 16px.
 
 <figure>
-  <img src="../../images/layout/layout-full-width.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/layout-full-width.png" alt=" " />
 </figure>
 
 #### Restricted-width Layout
@@ -108,10 +105,7 @@ The width of margins on standard Cengage full-width page layouts should be set t
 Larger margins based on percentages can be used to restrict the maximum width of the content area. Commonly used for text-heavy pages displaying sales materials, articles, etc.
 
 <figure>
-  <img
-    src="../../images/layout/layout-restricted-width.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/layout/layout-restricted-width.png" alt=" " />
 </figure>
 
 ---
@@ -170,10 +164,7 @@ _\* Even for full-width layouts, we are only allowing the content area to size u
 Some Cengage web applications have a global sidebar on the left side of the page. This sidebar necessitates that the main content changes from 12 columns to 6 at 1024px wide and below. This is much earlier than the other layouts detailed above.
 
 <figure>
-  <img
-    src="../../images/layout/layout-with-sidebar.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/layout/layout-with-sidebar.png" alt=" " />
   <figcaption>
     When using the global sidebar, the main content area still has 12 columns
     when the viewport is wider than 1024px
@@ -183,10 +174,7 @@ Some Cengage web applications have a global sidebar on the left side of the page
 <span className="horizontal-spacer" />
 
 <figure>
-  <img
-    src="../../images/layout/layout-with-sidebar-1024.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/layout/layout-with-sidebar-1024.png" alt=" " />
   <figcaption>
     When using the global sidebar, the main content area changes to 6 columns
     when the viewport is 1024px wide and below.

--- a/website/react-magma-docs/src/pages/design-intro/spacing.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/spacing.mdx
@@ -154,10 +154,7 @@ The spacing scale helps us determine how much space to put between or inside of 
 <span className="horizontal-spacer" />
 
 <figure>
-  <img
-    src="../../images/spacing/icon-text-balance-correct.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/spacing/icon-text-balance-correct.png" alt=" " />
   <figcaption>
     Example of using spacing properties to add padding inside a card, as well as
     the margins between the content within the card.
@@ -167,7 +164,7 @@ The spacing scale helps us determine how much space to put between or inside of 
 <span className="horizontal-spacer" />
 
 <figure>
-  <img src="../../images/spacing/spacing-example.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/spacing/spacing-example.png" alt=" " />
   <figcaption>
     Example of using spacing properties to create the space between cards in a
     grid.

--- a/website/react-magma-docs/src/pages/design-intro/typography.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/typography.mdx
@@ -807,10 +807,7 @@ The headings presets above are assigned by default to H1 through H6 in the <Link
 One example of this is in the <Link to="/api/modal/">Modal component</Link>. For optimal accessibility the title of the modal needs to be an H1, but we definitely don't want it to be styled with text that large. So we use an H1, but apply the Productive Heading Small style to it. This flexibility allows consumers of Magma to design using the styles that work best for the UI, but still have a clear informational hierarchy for assistive technologies.
 
 <figure>
-  <img
-    src="../../images/typography/modal-title-style.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/typography/modal-title-style.png" alt=" " />
 </figure>
 
 #### Consistency is Key
@@ -822,10 +819,7 @@ Continuing from above, there isn't just one way an H1 or and H3 should be styled
 Another advantage to using the presets above is that Responsive behavior is already built into each style so you don't have to figure out and include it yourself. This means a number of the larger sizes will automatically reduce in size at 600px wide. This ensures we have appropriate text sizes on smaller devices. The breakpoint can be overridden if you want this change to happen earlier or later.
 
 <figure>
-  <img
-    src="../../images/typography/responsive-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/typography/responsive-example.png" alt=" " />
 </figure>
 
 ---
@@ -847,10 +841,7 @@ Our primary typface is Work Sans. It’s clear and approachable and is great for
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/typography/work-sans-characters.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/work-sans-characters.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
@@ -882,10 +873,7 @@ Noto Serif is a beautiful serif font. It's easy to read, provides a nice contras
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/typography/noto-serif-characters.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/noto-serif-characters.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
@@ -919,7 +907,7 @@ Line-heights are also defined at this level to adhere to an 8px spacing system, 
 If you have a need to use a font size outside of the pre-made sets above, you may only choose from this list.
 
 <figure>
-  <img src="../../images/typography/type-scale.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/typography/type-scale.png" alt=" " />
 </figure>
 
 ---
@@ -934,10 +922,7 @@ Font weight is an important typographic variable that can add emphasis and diffe
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/typography/font-weights.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/font-weights.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -952,10 +937,7 @@ Each weight has an italic style, which should only be used when you need to emph
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/typography/font-italic.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/font-italic.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -970,10 +952,7 @@ Type color should be carefully considered, with legibility and accessibility as 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/typography/text-color-neutral-1.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/text-color-neutral-1.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -985,10 +964,7 @@ Type color should be carefully considered, with legibility and accessibility as 
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/typography/text-color-neutral-2.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/text-color-neutral-2.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>On dark backgrounds, neutral text appears as white.</p>
@@ -999,10 +975,7 @@ Type color should be carefully considered, with legibility and accessibility as 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/typography/text-color-decoration.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/text-color-decoration.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Don't use color as decoration.</p>
@@ -1011,10 +984,7 @@ Type color should be carefully considered, with legibility and accessibility as 
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/typography/text-color-contrast.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/text-color-contrast.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -1028,10 +998,7 @@ Type color should be carefully considered, with legibility and accessibility as 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/typography/text-color-meaning.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/text-color-meaning.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -1044,10 +1011,7 @@ Type color should be carefully considered, with legibility and accessibility as 
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/typography/text-color-meaning-2.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/text-color-meaning-2.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -1068,18 +1032,12 @@ It is common to lighten certain pieces of text in order to create more contrast.
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/typography/subdued-example-1.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/subdued-example-1.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/typography/subdued-example-2.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/typography/subdued-example-2.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -1092,10 +1050,7 @@ It is common to lighten certain pieces of text in order to create more contrast.
 Headings and paragraphs have margins built into them by default. These margins provide the desired rhythm created by spacing when they are used together in a traditional narrative context. These margins can be easily modified using the spacing scale or completely removed when using headings or paragraphs in other contexts.
 
 <figure>
-  <img
-    src="../../images/typography/margins-illustration.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/typography/margins-illustration.png" alt=" " />
 </figure>
 
 </PageContent>

--- a/website/react-magma-docs/src/pages/design/accordion.mdx
+++ b/website/react-magma-docs/src/pages/design/accordion.mdx
@@ -43,10 +43,7 @@ In some scenarios, the accordion can be modified to place the chevron icon in fr
 
 <div className="image-grid">
   <figure>
-    <img
-      src="../../images/accordion/accordion-good-alignment.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/accordion/accordion-good-alignment.png" alt=" " />
     <figcaption>
       <p className="title title-correct">Correct</p>
       <p>
@@ -56,10 +53,7 @@ In some scenarios, the accordion can be modified to place the chevron icon in fr
     </figcaption>
   </figure>
   <figure>
-    <img
-      src="../../images/accordion/accordion-bad-alignment.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/accordion/accordion-bad-alignment.png" alt=" " />
     <figcaption>
       <p className="title title-caution">Caution</p>
       <p>
@@ -77,7 +71,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
   <figure>
     <img
       src="../../images/accordion/accordion-incorrect-icon-orientation.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
     <figcaption>
       <p className="title title-incorrect">Incorrect</p>
@@ -88,10 +82,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
     </figcaption>
   </figure>
   <figure>
-    <img
-      src="../../images/accordion/accordion-incorrect-icons.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/accordion/accordion-incorrect-icons.png" alt=" " />
     <figcaption>
       <p className="title title-incorrect">Incorrect</p>
       <p>
@@ -103,10 +94,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
 </div>
 
 <figure>
-  <img
-    src="../../images/accordion/accordion-crowded-icons.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/accordion/accordion-crowded-icons.png" alt=" " />
   <figcaption>
     <p className="title title-incorrect">Incorrect</p>
     <p>
@@ -122,22 +110,13 @@ Accordions can be placed within main page content or placed inside of a containe
 
 <div className="image-grid">
   <figure>
-    <img
-      src="../../images/accordion/accordion-in-page.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/accordion/accordion-in-page.png" alt=" " />
   </figure>
   <figure>
-    <img
-      src="../../images/accordion/accordion-sidebar.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/accordion/accordion-sidebar.png" alt=" " />
   </figure>
   <figure>
-    <img
-      src="../../images/accordion/accordion-drawer.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/accordion/accordion-drawer.png" alt=" " />
   </figure>
 </div>
 

--- a/website/react-magma-docs/src/pages/design/alert.mdx
+++ b/website/react-magma-docs/src/pages/design/alert.mdx
@@ -20,7 +20,7 @@ This page focuses primarily on the commonalities between the different alert typ
 Use alerts to inform users of updates, changes to system status, or as feedback to an action they have taken. Proactively communicating with users and providing immediate feedback is important for building trust and maintaining a constant awareness of the system status. While alerts are an effective method of communicating with users, they have the potential to be disruptive and should be used with care.
 
 <figure>
-  <img src="../../images/alerts/alert-intro-image.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/alerts/alert-intro-image.png" alt=" " />
 </figure>
 
 ---
@@ -46,7 +46,7 @@ Alerts are interruptive, but their level of interruption should match the inform
 The basic anatomy of the alert is the same across all three types (banner, inline, toast).
 
 <figure>
-  <img src="../../images/alerts/alert-anatomy.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/alerts/alert-anatomy.png" alt=" " />
 </figure>
 
 1. Container
@@ -102,19 +102,13 @@ Alerts have an inverse option where we have defined colors that are optimized fo
 Inline alerts are embedded within the content of a page. They can provide the user with helpful information regarding a specific process or part of the interface. They can also be triggered by an action the user took, like submitting a form before filling out all the required fields.
 
 <figure>
-  <img
-    src="../../images/alerts/inline-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/inline-alert-example.png" alt=" " />
 </figure>
 
 If an inline alert is being used to communicate some general information to the user, then you can choose to allow them to dismiss the alert to get it out of their way. However, error messages are typically not dismissible by the user and persist until the issue is fixed either by the user or the system.
 
 <figure>
-  <img
-    src="../../images/alerts/inline-alert-example-2.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/inline-alert-example-2.png" alt=" " />
 </figure>
 
 ---
@@ -124,10 +118,7 @@ If an inline alert is being used to communicate some general information to the 
 When the viewport is 600px wide and smaller, we automatically reduce the icon and font size to optimize the amount of space given to the message and optional links or buttons in the alert.
 
 <figure>
-  <img
-    src="../../images/alerts/mobile-inline-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/mobile-inline-alert-example.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 

--- a/website/react-magma-docs/src/pages/design/badge.mdx
+++ b/website/react-magma-docs/src/pages/design/badge.mdx
@@ -18,7 +18,7 @@ import './design-guidelines-styles.css';
 Badges are used as a form of inline feedback and labeling. They are typically used to provide additional context to components already on the page.
 
 <figure>
-  <img src="../../images/badges/Badges.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/badges/Badges.png" alt=" " />
 </figure>
 
 ---
@@ -26,7 +26,7 @@ Badges are used as a form of inline feedback and labeling. They are typically us
 ## Text Badges
 
 <figure>
-  <img src="../../images/badges/label-example.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/badges/label-example.png" alt=" " />
 </figure>
 
 Text badges provide a way to provide feedback or label pieces of data.
@@ -40,7 +40,7 @@ Unless the context is clear, consider including additional context with a visual
 ## Counters
 
 <figure>
-  <img src="../../images/badges/counter-example.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/badges/counter-example.png" alt=" " />
 </figure>
 
 Counters can be used as part of links or buttons, or simply in a context that conveys the count of something to the user. When space is limited, and if the exact count isn't important, you may consider limiting the count to "99+".
@@ -50,7 +50,7 @@ Counters can be used as part of links or buttons, or simply in a context that co
 ## Color
 
 <figure>
-  <img src="../../images/badges/label-colors.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/badges/label-colors.png" alt=" " />
 </figure>
 
 There are multiple colors available for badges, but they should be used with purpose. The colors that should be used most commonly are primary, secondary/high contrast, and light/low contrast. The best color to use will most likely be determined by which one gives the appropriate level of emphasis with the surrounding content.

--- a/website/react-magma-docs/src/pages/design/banner.mdx
+++ b/website/react-magma-docs/src/pages/design/banner.mdx
@@ -13,10 +13,7 @@ import './design-guidelines-styles.css';
 </LeadParagraph>
 
 <figure>
-  <img
-    src="../../images/alerts/banner-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/banner-alert-example.png" alt=" " />
 </figure>
 
 ## Usage
@@ -30,10 +27,7 @@ Banner alerts typically appear at the very top of the browser viewport and exten
 When the viewport is 600px wide and smaller, we automatically reduce the icon and font size to optimize the amount of space given to the message and optional links or buttons in the alert.
 
 <figure>
-  <img
-    src="../../images/alerts/mobile-banner-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/mobile-banner-alert-example.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 

--- a/website/react-magma-docs/src/pages/design/breadcrumb.mdx
+++ b/website/react-magma-docs/src/pages/design/breadcrumb.mdx
@@ -18,10 +18,7 @@ import './design-guidelines-styles.css';
 The default breadcrumb component is styled for use on backgrounds **neutral100** or **neutral200**. For dark backgrounds you can use the inverse version.
 
 <figure>
-  <img
-    src="../../images/breadcrumbs/example-breadcrumbs.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/breadcrumbs/example-breadcrumbs.png" alt=" " />
 </figure>
 
 ---
@@ -34,10 +31,7 @@ As the viewport gets smaller, the breadcrumb component will simply wrap to as ma
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/breadcrumbs/breadcrumbs-wrap.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/breadcrumbs/breadcrumbs-wrap.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />

--- a/website/react-magma-docs/src/pages/design/button.mdx
+++ b/website/react-magma-docs/src/pages/design/button.mdx
@@ -67,7 +67,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_1.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>Keep labels short</p>
@@ -76,7 +76,7 @@ Text labels should always be short and have clear purpose. If a button requires 
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_2.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_2.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -90,7 +90,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_3.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_3.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -106,7 +106,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_4.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_4.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -118,7 +118,7 @@ Text labels should always be short and have clear purpose. If a button requires 
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_5.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_5.png" alt=" " />
         <figcaption>
           <p className="title title-caution">Caution</p>
           <p>
@@ -140,7 +140,7 @@ You can place icons next to text labels to both clarify an action and call atten
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_6.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_6.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>Use icons that clearly communicate their meaning.</p>
@@ -149,7 +149,7 @@ You can place icons next to text labels to both clarify an action and call atten
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_7.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_7.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -163,7 +163,7 @@ You can place icons next to text labels to both clarify an action and call atten
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_8.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_8.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -175,7 +175,7 @@ You can place icons next to text labels to both clarify an action and call atten
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_9.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_9.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Don’t use two icons in the same button.</p>
@@ -215,7 +215,7 @@ When you are pairing together primary and secondary actions such as "Save" and "
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_6_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_6_1.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -232,18 +232,12 @@ An additional benefit of the subtle button's very neutral appearance is to help 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/buttons/subtle_button_example_1.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/buttons/subtle_button_example_1.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/buttons/subtle_button_example_2.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/buttons/subtle_button_example_2.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -257,7 +251,7 @@ For actions that delete things, you can emphasize this action with the **danger*
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_6_3.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_6_3.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -278,7 +272,7 @@ If your button is going on a dark background, all of the buttons have an inverse
   <div className="row">
     <div className="col">
       <figure>
-        <img src="../../images/buttons/ex_6_4.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_6_4.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -294,7 +288,7 @@ Buttons have clear states to provide feedback to the user.
   <div className="row">
     <div className="col">
       <figure>
-        <img src="../../images/buttons/ex_7_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_7_1.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -310,7 +304,7 @@ The solid outline is 2px thick with at least a 2px offset, and the color is info
   <div className="row">
     <div className="col">
       <figure>
-        <img src="../../images/buttons/ex_7_2.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_7_2.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -338,7 +332,7 @@ Multiple button types can be used to express different emphasis levels. When usi
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_8_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_8_1.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -350,7 +344,7 @@ Multiple button types can be used to express different emphasis levels. When usi
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_8_2.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_8_2.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -365,7 +359,7 @@ Multiple button types can be used to express different emphasis levels. When usi
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_8_3.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_8_3.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -389,7 +383,7 @@ Button sizes and placements will sometimes need to change because of the size of
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_9_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_9_1.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -402,7 +396,7 @@ Button sizes and placements will sometimes need to change because of the size of
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_9_2.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_9_2.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>

--- a/website/react-magma-docs/src/pages/design/buttongroup.mdx
+++ b/website/react-magma-docs/src/pages/design/buttongroup.mdx
@@ -26,10 +26,7 @@ ButtonGroup can be either horizontal or vertical in its orientation. By default,
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/button-group/orientation.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/orientation.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -44,7 +41,7 @@ ButtonGroup comes in three different sizes: small, medium, and large. The medium
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/button-group/size.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/button-group/size.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -59,10 +56,7 @@ You can easily remove the space between buttons to create a single unit. When yo
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/button-group/no-space.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/no-space.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -81,18 +75,12 @@ The most critical action within a ButtonGroup should be a primary, marketing, or
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/button-group/good-groupings.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/good-groupings.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/button-group/bad-groupings.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/bad-groupings.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -106,10 +94,7 @@ ButtonGroups are aligned contextually. In general, ButtonGroups are left-aligned
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/button-group/alignment.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/alignment.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -124,18 +109,12 @@ The order of button priority should match the alignment of surrounding text. Whe
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/button-group/button-order-good.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/button-order-good.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/button-group/button-order-bad.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/button-order-bad.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -149,18 +128,12 @@ Not all buttons in a group require an icon, but buttons with icons should always
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/button-group/icons-good.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/icons-good.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/button-group/icons-bad.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/icons-bad.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -174,10 +147,7 @@ Use ButtonGroup to show any additional actions related to the most critical acti
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/button-group/additional-actions.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/button-group/additional-actions.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />

--- a/website/react-magma-docs/src/pages/design/card.mdx
+++ b/website/react-magma-docs/src/pages/design/card.mdx
@@ -22,15 +22,12 @@ Cards are one of the core building blocks in React Magma. They can be used to cr
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/cards/cards-layout.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/cards/cards-layout.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/cards/cards-related-pieces.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/cards/cards-related-pieces.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -42,7 +39,7 @@ Cards are one of the core building blocks in React Magma. They can be used to cr
 The only part of a card that is required is the container itself. All other content is optional and completely depends on the purpose of the card.
 
 <figure>
-  <img src="../../images/cards/card-anatomy.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-anatomy.png" alt=" " />
 </figure>
 
 1. Container
@@ -60,7 +57,7 @@ Inset dividers do not extend to the edges of the card. Inset dividers are used t
 Use full-width dividers that extend to the edges of a card to separate more distinct pieces of content or isolate actions that have more to do with the card than any specific piece of content within it.
 
 <figure>
-  <img src="../../images/cards/card-dividers.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-dividers.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -79,7 +76,7 @@ The card component is by default displayed as flat. This implies the card itself
 If a card can move, such as in a carousel or a drag and drop scenario, you should use the property that adds a dropshadow to the container to help communicate the dynamic nature of that component.
 
 <figure>
-  <img src="../../images/cards/card-depth.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-depth.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -95,10 +92,7 @@ To avoid these issues, you should instead provide links within the card to view 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/cards/card-truncate-correct.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/cards/card-truncate-correct.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -111,10 +105,7 @@ To avoid these issues, you should instead provide links within the card to view 
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/cards/card-scrolling-incorrect.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/cards/card-scrolling-incorrect.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -136,7 +127,7 @@ To avoid these issues, you should instead provide links within the card to view 
 Depending how the card is being used, the card could contain any number of action buttons. Like with everything else, make sure the primary action is clear compared to any secondary actions. For small cards, avoid cluttering the card with too many actions by creating an overflow menu within a dropdown.
 
 <figure>
-  <img src="../../images/cards/card-overflow.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-overflow.png" alt=" " />
 </figure>
 
 ### UI Controls
@@ -144,7 +135,7 @@ Depending how the card is being used, the card could contain any number of actio
 Cards can contain many kinds of UI controls, including buttons, tabs, toggle switches, etc. These allow the user to interact with the content of the card.
 
 <figure>
-  <img src="../../images/cards/card-ui-controls.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-ui-controls.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -157,7 +148,7 @@ Various colors from the global color palette may be used as the background of a 
 **Important:** Conveying meaning with color does not translate to assistive technologies. If the communication of this meaning is important, make sure it is also obvious in the content that is visible, or is possibly delivered through alternative methods such as visibly hidden text that is read by screen readers.
 
 <figure>
-  <img src="../../images/cards/card-colors.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-colors.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -170,7 +161,7 @@ Callout cards add a band of color to the left edge of the container. This can be
 **Important:** Conveying meaning with color does not translate to assistive technologies. If the communication of this meaning is important, make sure it is also obvious in the content that is visible, or is possibly delivered through alternative methods such as visibly hidden text that is read by screen readers.
 
 <figure>
-  <img src="../../images/cards/card-callout.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-callout.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -185,10 +176,7 @@ When cards are grouped together, it's because they are working together for a co
 In general, cards change size depending on the amount of content within them. But you can emphasize certain cards creating a layout that implies a hierarchy on the page with different sized columns. Just be mindful the card is large enough to support the content of the card, and that the content responds appropriately on smaller screens.
 
 <figure>
-  <img
-    src="../../images/cards/card-general-layout.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/cards/card-general-layout.png" alt=" " />
 </figure>
 
 ### Scannable
@@ -196,7 +184,7 @@ In general, cards change size depending on the amount of content within them. Bu
 If you want a group of cards to be easy to scan, use a clean and consistent pattern for the layout.
 
 <figure>
-  <img src="../../images/cards/card-scannable.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-scannable.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 

--- a/website/react-magma-docs/src/pages/design/character-counter.mdx
+++ b/website/react-magma-docs/src/pages/design/character-counter.mdx
@@ -41,10 +41,7 @@ The character counter initially tells the user the maximum number of characters 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/character-counter/behavior-1.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/character-counter/behavior-1.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -57,10 +54,7 @@ As the user types, the character counter updates in real-time and informs the us
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/character-counter/behavior-2.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/character-counter/behavior-2.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -73,10 +67,7 @@ When the user exceeds the maximum number of characters allowed, the character co
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/character-counter/behavior-3.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/character-counter/behavior-3.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />

--- a/website/react-magma-docs/src/pages/design/checkboxes.mdx
+++ b/website/react-magma-docs/src/pages/design/checkboxes.mdx
@@ -23,10 +23,7 @@ Use checkboxes to:
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/selection-controls/Checkbox-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/selection-controls/Checkbox-example.png" alt=" " />
   </div>
   <figcaption>
     <p>Checkboxes</p>
@@ -45,7 +42,7 @@ Checkboxes can have a parent-child relationship with other checkboxes.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-parent-child-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -59,10 +56,7 @@ Checkboxes can be selected, unselected, or indeterminate. Checkboxes have enable
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/selection-controls/Checkbox-states.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/selection-controls/Checkbox-states.png" alt=" " />
   </div>
   <figcaption>
     <p>Checkbox states</p>
@@ -77,7 +71,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-alternate-colors.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -91,7 +85,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
       <figure>
         <img
           src="../../images/selection-controls/Checkbox-incorrect-multi-color.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -106,7 +100,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
       <figure>
         <img
           src="../../images/selection-controls/Checkbox-incorrect-neutral.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -126,10 +120,7 @@ Use the inverse version when using the checkboxes on a dark background.
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/selection-controls/Checkbox-inverse.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/selection-controls/Checkbox-inverse.png" alt=" " />
   </div>
   <figcaption>
     <p>Inverse colors</p>

--- a/website/react-magma-docs/src/pages/design/date-picker.mdx
+++ b/website/react-magma-docs/src/pages/design/date-picker.mdx
@@ -14,10 +14,7 @@ order: 1
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/date-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/date-input-example.png" alt=" " />
   </div>
 </figure>
 
@@ -51,10 +48,7 @@ The field label tells the user what information they need to input. Using placeh
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/wrong-truncate-label.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/wrong-truncate-label.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Do not truncate field labels.</p>
@@ -63,10 +57,7 @@ The field label tells the user what information they need to input. Using placeh
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/inputs/caution-wrap-label.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/caution-wrap-label.png" alt=" " />
         <figcaption>
           <p className="title title-caution">Caution</p>
           <p>
@@ -88,7 +79,7 @@ Placeholder text provides hints or examples of what to enter. Placeholder text d
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/inputs/input-text.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/inputs/input-text.png" alt=" " />
         <figcaption>
           <p>
             This example shows how the placeholder text provides a hint to the
@@ -109,10 +100,7 @@ Helper text is pertinent information that assists the user in completing a field
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-helper-text.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-helper-text.png" alt=" " />
         <figcaption>
           <p>Example of input helper text</p>
         </figcaption>
@@ -130,10 +118,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/single-required-field.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/single-required-field.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -146,10 +131,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/inputs/multiple-required-fields.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/multiple-required-fields.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -163,10 +145,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/wrong-optional-field.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/wrong-optional-field.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -196,10 +175,7 @@ Inputs have a 5px border radius to be consistent with buttons, which often accom
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-container.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-container.png" alt=" " />
         <figcaption>
           <p>Examples of text fields on light and dark backgrounds.</p>
         </figcaption>
@@ -219,10 +195,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-leading-icon.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-leading-icon.png" alt=" " />
         <figcaption>
           <p>
             Example of input with leading icon. The Visa icon helps identify the
@@ -233,10 +206,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/inputs/input-trailing-icon.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-trailing-icon.png" alt=" " />
         <figcaption>
           <p>
             Example of input with trailing icon. The calendar icon is a button
@@ -258,10 +228,7 @@ The icon can be configured to simply display a message within a tooltip or also 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-what-is-this.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-what-is-this.png" alt=" " />
         <figcaption>
           <p>Example of input with Help icon</p>
         </figcaption>
@@ -279,10 +246,7 @@ The icon can be configured to simply display a message within a tooltip or also 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-states.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-states.png" alt=" " />
         <figcaption>
           <p>
             Inputs can display the following states: active, disabled, focused,
@@ -310,10 +274,7 @@ When the input provided is invalid, an error message should be used to provide i
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-error-message.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-error-message.png" alt=" " />
         <figcaption>
           <p>Example of input with error message</p>
         </figcaption>

--- a/website/react-magma-docs/src/pages/design/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/design/dropdown.mdx
@@ -16,10 +16,7 @@ import './design-guidelines-styles.css';
 ## Usage
 
 <figure>
-  <img
-    src="../../images/dropdowns/dropdown-intro-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/dropdowns/dropdown-intro-example.png" alt=" " />
 </figure>
 
 ---
@@ -34,10 +31,7 @@ Dropdown menus typically contain a list of text-only menu items.
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/dropdowns/anatomy-text-list.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/anatomy-text-list.png" alt=" " />
         <figcaption>
           <p>
             There is 8px of space above the first item in the dropdown, and
@@ -65,10 +59,7 @@ Dropdown menu items may also use an icon on the left side to help clarify the me
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/dropdowns/anatomy-icon-and-text.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/anatomy-icon-and-text.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
@@ -92,7 +83,7 @@ Dropdown menus may use a selection state by placing a checkmark next to the curr
       <figure>
         <img
           src="../../images/dropdowns/anatomy-selection-state-list.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -114,10 +105,7 @@ Some dropdowns benefit from organizing the choices or options into groups, and t
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/dropdowns/dropdown-groups.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/dropdown-groups.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -134,10 +122,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/dropdowns/menu-too-wide.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/menu-too-wide.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -149,10 +134,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/dropdowns/menu-item-wrapped.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/menu-item-wrapped.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -166,10 +148,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/dropdowns/menu-adjust-placement.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/menu-adjust-placement.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -191,10 +170,7 @@ Dropdowns have a default max-height of 250px and will scroll if necessary. This 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/dropdowns/menu-max-height.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/menu-max-height.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -206,10 +182,7 @@ Dropdowns have a default max-height of 250px and will scroll if necessary. This 
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/dropdowns/menu-too-long.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/menu-too-long.png" alt=" " />
         <figcaption>
           <p className="title title-caution">Caution</p>
           <p>
@@ -234,10 +207,7 @@ The standard dropdown button is the most common element used to trigger a dropdo
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/dropdowns/simple-dropdown-button.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/simple-dropdown-button.png" alt=" " />
         <figcaption>
           <p>Example of single dropdown button.</p>
         </figcaption>
@@ -255,10 +225,7 @@ Split buttons combine a single action button with a menu of related choices into
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/dropdowns/split-dropdown-button.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/dropdowns/split-dropdown-button.png" alt=" " />
         <figcaption>
           <p>Example of split-dropdown button.</p>
         </figcaption>
@@ -278,7 +245,7 @@ Other button variants may be used as a trigger for a dropdown menu. Caution shou
       <figure>
         <img
           src="../../images/dropdowns/custom-dropdown-button-1.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -292,7 +259,7 @@ Other button variants may be used as a trigger for a dropdown menu. Caution shou
       <figure>
         <img
           src="../../images/dropdowns/custom-dropdown-button-2.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of a "more options" dropdown menu.</p>
@@ -311,20 +278,14 @@ Dropdowns are positioned relative to the trigger element that is clicked on to o
 A dropdown is typically displayed below the trigger element, and the left edge of the dropdown is aligned with the left edge of the trigger element. To make sure dropdowns don’t become obscured by running off the edge of the browser, you may position the dropdown to the left, right, or above the trigger element. You may also change the alignment to the right, top, or bottom edges.
 
 <figure>
-  <img
-    src="../../images/dropdowns/dropdown-alignment-1.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/dropdowns/dropdown-alignment-1.png" alt=" " />
   <figcaption>
     <p>Dropdowns can be left or right aligned.</p>
   </figcaption>
 </figure>
 
 <figure>
-  <img
-    src="../../images/dropdowns/dropdown-alignment-2.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/dropdowns/dropdown-alignment-2.png" alt=" " />
   <figcaption>
     <p>
       Dropdowns can be positioned above the trigger element. If using a button,
@@ -334,10 +295,7 @@ A dropdown is typically displayed below the trigger element, and the left edge o
 </figure>
 
 <figure>
-  <img
-    src="../../images/dropdowns/dropdown-alignment-3.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/dropdowns/dropdown-alignment-3.png" alt=" " />
   <figcaption>
     <p>
       Dropdowns can be positioned to the left or right of the trigger element.

--- a/website/react-magma-docs/src/pages/design/header.mdx
+++ b/website/react-magma-docs/src/pages/design/header.mdx
@@ -31,16 +31,13 @@ The header component is designed to be extremely flexible allowing designers to 
 
 <figure>
   <div className="background">
-    <img
-      src="../../images/header/anatomy-standard-responsive.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/header/anatomy-standard-responsive.png" alt=" " />
   </div>
   <figcaption>Header on small/mobile screen</figcaption>
 </figure>
 
 <figure className="with-background">
-  <img src="../../images/header/anatomy-standard.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/header/anatomy-standard.png" alt=" " />
   <figcaption>Header on large/desktop screen</figcaption>
 </figure>
 
@@ -49,23 +46,17 @@ The header component is designed to be extremely flexible allowing designers to 
 Horizontal specifications are consistent across all “flavors” of the header (standard, compact, and responsive.)
 
 <figure>
-  <img
-    src="../../images/header/h-specs-standard-responsive.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/header/h-specs-standard-responsive.png" alt=" " />
   <figcaption>Header on small/mobile screen</figcaption>
 </figure>
 
 <figure>
-  <img src="../../images/header/h-specs-standard.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/header/h-specs-standard.png" alt=" " />
   <figcaption>Header on large/desktop screen</figcaption>
 </figure>
 
 <figure>
-  <img
-    src="../../images/header/h-specs-standard-with-sidebar.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/header/h-specs-standard-with-sidebar.png" alt=" " />
   <figcaption>Header with sidebar menu icon</figcaption>
 </figure>
 
@@ -74,10 +65,7 @@ Horizontal specifications are consistent across all “flavors” of the header 
 In certain circumstances, designers may need to left-justify header features. The component allows for this and uses the same basic rules of horizontal and vertical spacing.
 
 <figure>
-  <img
-    src="../../images/header/left-justification.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/header/left-justification.png" alt=" " />
   <figcaption>Header with left justification</figcaption>
 </figure>
 
@@ -86,7 +74,7 @@ In certain circumstances, designers may need to left-justify header features. Th
 The header should span the full width of the screen. On extra wide displays, the content may include expanded margins on each side, but the header logo should remain left-justfied to the edge of the screen, and (in most cases) the icons, features and inputs should remain right-justfied to the edge of the screen.
 
 <figure>
-  <img src="../../images/header/span-width.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/header/span-width.png" alt=" " />
 </figure>
 
 ## Vertical Specifications
@@ -94,12 +82,12 @@ The header should span the full width of the screen. On extra wide displays, the
 Vertical specifications vary between the standard and compact views.
 
 <figure>
-  <img src="../../images/header/v-specs-compact.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/header/v-specs-compact.png" alt=" " />
   <figcaption>Compact header</figcaption>
 </figure>
 
 <figure>
-  <img src="../../images/header/v-specs-standard.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/header/v-specs-standard.png" alt=" " />
   <figcaption>Standard header</figcaption>
 </figure>
 
@@ -134,7 +122,7 @@ Here are several examples of strategies that designers should avoid:
 ### Don't use too many icons
 
 <figure>
-  <img src="../../images/header/too-many-icons.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/header/too-many-icons.png" alt=" " />
   <figcaption>
     <p className="title title-incorrect">Incorrect</p>
     <p>Incorrect: Too many icons create inbalance and clutter</p>
@@ -146,7 +134,7 @@ Here are several examples of strategies that designers should avoid:
 Don't duplicate items that already exist in the sidebar or elsewhere on the UI.
 
 <figure>
-  <img src="../../images/header/duplicate-sidebar.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/header/duplicate-sidebar.png" alt=" " />
   <figcaption>
     <p className="title title-incorrect">Incorrect</p>
     <p>These already exist in the sidebar or are better suited there</p>
@@ -156,10 +144,7 @@ Don't duplicate items that already exist in the sidebar or elsewhere on the UI.
 ### Don't use a collapsed sidebar and hamburger menu
 
 <figure>
-  <img
-    src="../../images/header/sidebar-and-hamburger.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/header/sidebar-and-hamburger.png" alt=" " />
   <figcaption>
     <p className="title title-incorrect">Incorrect</p>
     <p>Sidebar controls should never co-exist with the hamburger menu</p>

--- a/website/react-magma-docs/src/pages/design/icon.mdx
+++ b/website/react-magma-docs/src/pages/design/icon.mdx
@@ -36,10 +36,7 @@ This example illustrates how 12px, 14px, 16px, and 20px text strings are paired 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/icons/icon-text-balance-correct.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/icons/icon-text-balance-correct.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -51,10 +48,7 @@ This example illustrates how 12px, 14px, 16px, and 20px text strings are paired 
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/icons/icon-text-balance-incorrect.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/icons/icon-text-balance-incorrect.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -79,10 +73,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/icons/icon-color-correct.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/icons/icon-color-correct.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -95,10 +86,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/icons/icon-color-too-light.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/icons/icon-color-too-light.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -113,10 +101,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/icons/icon-mixed-colors.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/icons/icon-mixed-colors.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -141,10 +126,7 @@ When positioning an icon next to text you should always center-align them.
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/icons/icon-text-centered.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/icons/icon-text-centered.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -155,10 +137,7 @@ When positioning an icon next to text you should always center-align them.
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/icons/icon-text-wrong-alignment.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/icons/icon-text-wrong-alignment.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>

--- a/website/react-magma-docs/src/pages/design/indeterminate.mdx
+++ b/website/react-magma-docs/src/pages/design/indeterminate.mdx
@@ -24,7 +24,7 @@ View the <Link to="/design/checkboxes/">documentation for checkboxes</Link> for 
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-parent-child-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>

--- a/website/react-magma-docs/src/pages/design/input.mdx
+++ b/website/react-magma-docs/src/pages/design/input.mdx
@@ -16,10 +16,7 @@ Inputs can be used alone or they can be combined with other types of inputs to c
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/inputs-intro-image.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/inputs-intro-image.png" alt=" " />
   </div>
 </figure>
 
@@ -53,10 +50,7 @@ View <Link to="/api/input/">component API</Link> for text fields.
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/text-field-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/text-field-example.png" alt=" " />
   </div>
 </figure>
 
@@ -68,10 +62,7 @@ View <Link to="/api/textarea/">component API</Link> for text areas.
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/text-area-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/text-area-example.png" alt=" " />
   </div>
 </figure>
 
@@ -83,10 +74,7 @@ View the <Link to="/design/password-input/">password input documentation</Link> 
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/password-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/password-input-example.png" alt=" " />
   </div>
 </figure>
 
@@ -98,10 +86,7 @@ View <Link to="/api/input/">component API</Link> for number inputs.
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/number-field-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/number-field-example.png" alt=" " />
   </div>
 </figure>
 
@@ -113,10 +98,7 @@ View <Link to="/api/search/">component API</Link> or <Link to="/design/search/">
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/search-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/search-input-example.png" alt=" " />
   </div>
 </figure>
 
@@ -128,10 +110,7 @@ View <Link to="/api/date-pickers/">component API</Link> for date inputs.
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/date-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/date-input-example.png" alt=" " />
   </div>
 </figure>
 
@@ -165,10 +144,7 @@ The field label tells the user what information they need to input. Using placeh
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/wrong-truncate-label.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/wrong-truncate-label.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Do not truncate field labels.</p>
@@ -177,10 +153,7 @@ The field label tells the user what information they need to input. Using placeh
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/inputs/caution-wrap-label.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/caution-wrap-label.png" alt=" " />
         <figcaption>
           <p className="title title-caution">Caution</p>
           <p>
@@ -202,7 +175,7 @@ Placeholder text provides hints or examples of what to enter. Placeholder text d
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/inputs/input-text.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/inputs/input-text.png" alt=" " />
         <figcaption>
           <p>
             This example shows how the placeholder text provides a hint to the
@@ -223,10 +196,7 @@ Helper text is pertinent information that assists the user in completing a field
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-helper-text.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-helper-text.png" alt=" " />
         <figcaption>
           <p>Example of input helper text</p>
         </figcaption>
@@ -244,10 +214,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/single-required-field.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/single-required-field.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -260,10 +227,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/inputs/multiple-required-fields.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/multiple-required-fields.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -277,10 +241,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/wrong-optional-field.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/wrong-optional-field.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -310,10 +271,7 @@ Inputs have a 5px border radius to be consistent with buttons, which often accom
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-container.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-container.png" alt=" " />
         <figcaption>
           <p>Examples of text fields on light and dark backgrounds.</p>
         </figcaption>
@@ -333,10 +291,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-leading-icon.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-leading-icon.png" alt=" " />
         <figcaption>
           <p>
             Example of input with leading icon. The Visa icon helps identify the
@@ -347,10 +302,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/inputs/input-trailing-icon.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-trailing-icon.png" alt=" " />
         <figcaption>
           <p>
             Example of input with trailing icon. The calendar icon is a button
@@ -372,10 +324,7 @@ The icon can be configured to simply display a message within a tooltip or also 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-what-is-this.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-what-is-this.png" alt=" " />
         <figcaption>
           <p>Example of input with Help icon</p>
         </figcaption>
@@ -393,10 +342,7 @@ The icon can be configured to simply display a message within a tooltip or also 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-states.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-states.png" alt=" " />
         <figcaption>
           <p>
             Inputs can display the following states: active, disabled, focused,
@@ -424,10 +370,7 @@ When the input provided is invalid, an error message should be used to provide i
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/input-error-message.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/input-error-message.png" alt=" " />
         <figcaption>
           <p>Example of input with error message</p>
         </figcaption>

--- a/website/react-magma-docs/src/pages/design/list.mdx
+++ b/website/react-magma-docs/src/pages/design/list.mdx
@@ -27,10 +27,7 @@ Use ordered (numbered) lists when you need to convey a sequence or hierarchy bet
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/lists/unordered-list.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/lists/unordered-list.png" alt=" " />
         <figcaption>
           The list in this image shows a list of grocery items in no particular
           order.
@@ -39,7 +36,7 @@ Use ordered (numbered) lists when you need to convey a sequence or hierarchy bet
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/lists/ordered-list.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/lists/ordered-list.png" alt=" " />
         <figcaption>
           The list in this image shows a list of the top 7 best-selling car
           brands.
@@ -79,18 +76,12 @@ You can use the spacing tokens in React Magma to increase the vertical space bet
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/lists/small-spacing.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/lists/small-spacing.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/lists/larger-spacing.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/lists/larger-spacing.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -104,7 +95,7 @@ The icon list is really just a variant of the Unordered List, but instead of bul
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/lists/icon-list.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/lists/icon-list.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -119,7 +110,7 @@ There are three icon size choices, including small, medium, and large. These siz
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/lists/icon-sizes.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/lists/icon-sizes.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -134,10 +125,7 @@ You can align the icon with the center or top of the associated content. This la
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/lists/icon-alignment.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/lists/icon-alignment.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />

--- a/website/react-magma-docs/src/pages/design/loading-indicator.mdx
+++ b/website/react-magma-docs/src/pages/design/loading-indicator.mdx
@@ -31,7 +31,7 @@ Circular spinners are used when the amount of time needed to run a process or lo
       <figure>
         <img
           src="../../images/loading-indicators/circular-spinner.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -47,10 +47,7 @@ Progress bars should be used when real progress data can be fed to it, and you a
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/loading-indicators/progress-bar.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/loading-indicators/progress-bar.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -68,10 +65,7 @@ Many actions happen quickly, such as saving updates, submitting a form, or loadi
 If you know that it will take less than a second to complete an action, then no loading indicator is necessary. If you know the action is going to take 1 - 5 seconds to complete, you should use a circular spinner.
 
 <figure>
-  <img
-    src="../../images/loading-indicators/Button-loading.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/loading-indicators/Button-loading.png" alt=" " />
   <figcaption>
     <p>
       Replace the label in the button with the circular spinner after clicking
@@ -86,10 +80,7 @@ If you know that it will take less than a second to complete an action, then no 
 If you are loading large amounts of data like an entire page or large areas of data, the amount of time it takes to load can vary greatly. We need to effectively communicate with the user what is happening, but that takes some informed decisions on our part.
 
 <figure>
-  <img
-    src="../../images/loading-indicators/mindtap-loading.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/loading-indicators/mindtap-loading.png" alt=" " />
   <figcaption>
     <p>
       In this example, we are using a loading indicator while the Learning Path
@@ -106,7 +97,7 @@ If there is no way of measuring how long it will take in real-time, but you know
 <figure>
   <img
     src="../../images/loading-indicators/example-spinner-message.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>Messaging should tell the user what is happening and what to expect.</p>
@@ -123,10 +114,7 @@ If you know from testing that it typically takes more than 15 seconds to load, *
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/progress-bars/Progress-bar-dynamic.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/progress-bars/Progress-bar-dynamic.png" alt=" " />
   </div>
   <figcaption>
     <p>
@@ -143,7 +131,7 @@ This component also allows for three messages, although at different intervals t
 <figure>
   <img
     src="../../images/loading-indicators/example-progress-bar-message.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>Messaging should tell the user what is happening and what to expect.</p>

--- a/website/react-magma-docs/src/pages/design/modal.mdx
+++ b/website/react-magma-docs/src/pages/design/modal.mdx
@@ -26,13 +26,13 @@ A modal is intentionally interruptive and blocks the user from interacting with 
 
 Clearly describe the decision being made by the user, and explain any possible consequences it could cause. The primary button should also reinforce the action being taken. If the action being taken is irreversible, make that clear to the user as well. The user should also be able to cancel the action with a secondary button or closing the modal.
 
-<img src="../../images/modals/confirm-decision.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/confirm-decision.png" alt=" " />
 
 ### Edit or Manage Tasks
 
 It's very common to use a modal to quickly edit or manage one or more items on a page without going back and forth between multiple pages. The emphasis here is "quickly". If the settings or management of an item becomes relatively complex and requires many decisions or multiple steps, please consider using a separate page or something other than a modal. If a particular action is often done repeatedly, consider allowing the action to be done directly on the main page rather than in a modal.
 
-<img src="../../images/modals/edit-item-example.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/edit-item-example.png" alt=" " />
 
 ---
 
@@ -40,7 +40,7 @@ It's very common to use a modal to quickly edit or manage one or more items on a
 
 Modals come in three responsive sizes: small, medium, and large.
 
-<img src="../../images/modals/modal-sizes.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/modal-sizes.png" alt=" " />
 
 ### Small
 
@@ -84,12 +84,12 @@ Modals should always contain a way to close them, and there are typically multip
 
 When a modal is opened, the focus is automatically put on the title of the modal rather than the first actionable element. We intentionally do this to provide an optimal experience for both people using assistive technologies and those who don't.
 
-<img src="../../images/modals/modal-focus-example.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/modal-focus-example.png" alt=" " />
 
 ### Validation
 
 Always validate a user's input entries before a modal is closed. If there are any errors, an inline error alert should be displayed above the form, as well as error messages on any specific inputs that failed validation. The error messages should provide clear instructions on how to resolve the errors and complete the action.
 
-<img src="../../images/modals/modal-validation.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/modal-validation.png" alt=" " />
 
 </PageContent>

--- a/website/react-magma-docs/src/pages/design/password-input.mdx
+++ b/website/react-magma-docs/src/pages/design/password-input.mdx
@@ -13,10 +13,7 @@ order: 1
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/password-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/password-input-example.png" alt=" " />
   </div>
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/progress-bar.mdx
+++ b/website/react-magma-docs/src/pages/design/progress-bar.mdx
@@ -23,10 +23,7 @@ To see how progress bars are used as loading indicators, view the [loading indic
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/progress-bars/Progress-bar-intro.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/progress-bars/Progress-bar-intro.png" alt=" " />
   </div>
 </figure>
 
@@ -36,10 +33,7 @@ To see how progress bars are used as loading indicators, view the [loading indic
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/progress-bars/Progress-bar-anatomy.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/progress-bars/Progress-bar-anatomy.png" alt=" " />
   </div>
 </figure>
 
@@ -62,10 +56,7 @@ The width of the progress bar is controlled by the container it is within. For m
 When a static progress bar is used, it represents the progress of something at that point in time and does not change until an explicit action is performed that updates the progress bar.
 
 <figure>
-  <img
-    src="../../images/progress-bars/Progress-bar-static.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/progress-bars/Progress-bar-static.png" alt=" " />
   <figcaption>
     <p>
       Example of using progress bar to help communicate that the user is on step
@@ -74,10 +65,7 @@ When a static progress bar is used, it represents the progress of something at t
   </figcaption>
 </figure>
 <figure>
-  <img
-    src="../../images/progress-bars/Progress-bar-compare.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/progress-bars/Progress-bar-compare.png" alt=" " />
   <figcaption>
     <p>
       Progress bars can be used to visually display the same data point for
@@ -92,10 +80,7 @@ When a static progress bar is used, it represents the progress of something at t
 When a dynamic progress bar is used, it means it's updating in real-time while you wait for a series of processes outside of your control to complete.
 
 <figure>
-  <img
-    src="../../images/progress-bars/Progress-bar-dynamic.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/progress-bars/Progress-bar-dynamic.png" alt=" " />
   <figcaption>
     <p>
       Example of using progress bar to help communicate that the data is loading
@@ -120,10 +105,7 @@ The track on the dark/inverse progress bar has a black background at 25% opacity
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/progress-bars/Progress-bar-colors1.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/progress-bars/Progress-bar-colors1.png" alt=" " />
   </div>
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/radio.mdx
+++ b/website/react-magma-docs/src/pages/design/radio.mdx
@@ -22,7 +22,7 @@ Radio buttons should have the most commonly used option selected by default.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Radio-buttons-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -35,7 +35,7 @@ Radio buttons should have the most commonly used option selected by default.
       <figure>
         <img
           src="../../images/selection-controls/Radio-select-only-one.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -49,7 +49,7 @@ Radio buttons should have the most commonly used option selected by default.
       <figure>
         <img
           src="../../images/selection-controls/Radio-select-only-one-incorrect.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -64,10 +64,7 @@ Radio buttons should have the most commonly used option selected by default.
 </div>
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/selection-controls/Radio-example-2.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/selection-controls/Radio-example-2.png" alt=" " />
   </div>
   <figcaption>
     <p>Radio buttons - only one option can be selected at a time.</p>
@@ -80,10 +77,7 @@ Radio buttons can be off or on. Radio buttons have enabled, focused and pressed 
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/selection-controls/Radio-states.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/selection-controls/Radio-states.png" alt=" " />
   </div>
   <figcaption>
     <p>Radio states</p>
@@ -96,10 +90,7 @@ Use the inverse version when using the radio buttons on a dark background.
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/selection-controls/Radio-inverse.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/selection-controls/Radio-inverse.png" alt=" " />
   </div>
   <figcaption>
     <p>Inverse colors</p>

--- a/website/react-magma-docs/src/pages/design/search.mdx
+++ b/website/react-magma-docs/src/pages/design/search.mdx
@@ -26,18 +26,12 @@ Set the user’s context for the search with helpful placeholder text within the
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/inputs/header-search.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/header-search.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/inputs/inline-search.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/inputs/inline-search.png" alt=" " />
       </figure>
     </div>
   </div>

--- a/website/react-magma-docs/src/pages/design/stepper.mdx
+++ b/website/react-magma-docs/src/pages/design/stepper.mdx
@@ -17,7 +17,7 @@ import './design-guidelines-styles.css';
 Steppers aid in guiding a user's expectations while navigating through a multistep process. They indicate the current step, the total number of steps, and the overall progress towards task completion.
 
 <figure>
-  <img src="../../images/stepper/stepper-intro.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/stepper-intro.png" alt=" " />
 </figure>
 
 ### When to use
@@ -42,10 +42,7 @@ Steppers aid in guiding a user's expectations while navigating through a multist
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/stepper/step-anatomy.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/stepper/step-anatomy.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -65,7 +62,7 @@ Steppers aid in guiding a user's expectations while navigating through a multist
 The default placement of the labels is under each status indicator on the line. This layout benefits from short labels, especially as the number of steps increases.
 
 <figure>
-  <img src="../../images/stepper/standard-labels.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/standard-labels.png" alt=" " />
 </figure>
 
 #### No Labels
@@ -73,7 +70,7 @@ The default placement of the labels is under each status indicator on the line. 
 If the nature of the labels would simply be too much text to reasonably fit, then it is acceptable to hide the labels on the stepper component. However, this means having clear titles within the content of the step itself is extremely important. It can be helpful to change to this layout on small screens.
 
 <figure>
-  <img src="../../images/stepper/no-labels.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/no-labels.png" alt=" " />
 </figure>
 
 #### Summary View
@@ -81,7 +78,7 @@ If the nature of the labels would simply be too much text to reasonably fit, the
 The step summary layout shows the primary and secondary labels, but only for the step you are currently on. It also tells you what number step you are on, and how many steps there are in total. This layout can be a nice middle-point between showing all labels and not showing labels at all, and you can use it on large or small screens.
 
 <figure>
-  <img src="../../images/stepper/summary-view.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/summary-view.png" alt=" " />
 </figure>
 
 ### Placement
@@ -89,21 +86,15 @@ The step summary layout shows the primary and secondary labels, but only for the
 The stepper component can be placed on a full page, in a modal, or in a side panel.
 
 <figure>
-  <img
-    src="../../images/stepper/placement-full-page.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/stepper/placement-full-page.png" alt=" " />
 </figure>
 
 <figure>
-  <img
-    src="../../images/stepper/placement-side-panel.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/stepper/placement-side-panel.png" alt=" " />
 </figure>
 
 <figure>
-  <img src="../../images/stepper/placement-modal.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/placement-modal.png" alt=" " />
 </figure>
 
 ---
@@ -120,10 +111,7 @@ The label should succinctly convey the user's objectives for each step in one or
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/stepper/primary-label.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/stepper/primary-label.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -138,10 +126,7 @@ Secondary labels are optional and should be used if some additional description 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/stepper/secondary-label.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/stepper/secondary-label.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -158,7 +143,7 @@ When there isn’t enough space, the labels will wrap to as many lines as necess
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/stepper/text-wrap.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/stepper/text-wrap.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -181,10 +166,7 @@ A step is complete when a user has filled out the required information within a 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/stepper/step-complete.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/stepper/step-complete.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -199,10 +181,7 @@ A step is current when a user is interacting with the information within that st
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/stepper/step-active.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/stepper/step-active.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -217,10 +196,7 @@ A step is not started when a user has not yet interacted with that step. Steps t
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/stepper/step-incomplete.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/stepper/step-incomplete.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -235,7 +211,7 @@ A step may be in error when a user has entered invalid or incomplete information
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/stepper/step-error.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/stepper/step-error.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -249,7 +225,7 @@ Currently, the stepper is not interactive, providing only a visual update of the
 A common example includes buttons labeled as “Next” and “Back”, and often ending with a button labeled “Finish.” But the labels themselves need to make sense for the process being completed, so there isn’t any mandated language to use. You can also choose to not include a “Back” button if you don’t want the user to go back to previous steps. Whatever you do, we suggest conducting usability tests to ensure you have created the best experience possible.
 
 <figure>
-  <img src="../../images/stepper/step-navigation.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/step-navigation.png" alt=" " />
 </figure>
 
 ### Validation
@@ -259,7 +235,7 @@ When possible, use validation to confirm that a step has been completed before t
 If the user cannot proceed due to a server-side issue, then an inline alert should appear.
 
 <figure>
-  <img src="../../images/stepper/validation-error.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/validation-error.png" alt=" " />
 </figure>
 
 ### Responsive Behavior
@@ -272,10 +248,7 @@ If you don’t have very many steps and the labels are short, it is very possibl
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/stepper/mobile-standard-labels.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/stepper/mobile-standard-labels.png" alt=" " />
   </div>
 </figure>
 
@@ -285,10 +258,7 @@ Hiding the labels on small screens is acceptable, but only if you are using very
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/stepper/mobile-no-labels.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/stepper/mobile-no-labels.png" alt=" " />
   </div>
 </figure>
 
@@ -298,10 +268,7 @@ This may be the most common format for small screens or zooming in. You only dis
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/stepper/mobile-summary-view.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/stepper/mobile-summary-view.png" alt=" " />
   </div>
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/table.mdx
+++ b/website/react-magma-docs/src/pages/design/table.mdx
@@ -41,7 +41,7 @@ Tables display information in a grid-like format of rows and columns. They organ
 ## Anatomy
 
 <figure>
-  <img src="../../images/tables/table-anatomy.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/table-anatomy.png" alt=" " />
 </figure>
 
 1. Table title
@@ -55,7 +55,7 @@ Tables display information in a grid-like format of rows and columns. They organ
 Tables come in three different sizes or densities: compact, normal, and loose. This is applied to the entire table and not just a specific row or cell.
 
 <figure>
-  <img src="../../images/tables/table-densities.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/table-densities.png" alt=" " />
 </figure>
 
 ### Compact Density
@@ -63,7 +63,7 @@ Tables come in three different sizes or densities: compact, normal, and loose. T
 The compact density can be useful for tables with a relatively large number of columns and rows by allowing you to simply fit more on the screen at once.
 
 <figure>
-  <img src="../../images/tables/compact-density.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/compact-density.png" alt=" " />
 </figure>
 
 ### Normal Density
@@ -71,7 +71,7 @@ The compact density can be useful for tables with a relatively large number of c
 The default padding of tables is optimized for a nice balance between compact and loose densities.
 
 <figure>
-  <img src="../../images/tables/normal-density.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/normal-density.png" alt=" " />
 </figure>
 
 ### Loose Density
@@ -79,7 +79,7 @@ The default padding of tables is optimized for a nice balance between compact an
 The loose density can be useful if you have a relatively small amount of data and if the user would benefit from the table having more white-space within it.
 
 <figure>
-  <img src="../../images/tables/loose-density.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/loose-density.png" alt=" " />
 </figure>
 
 ---
@@ -95,15 +95,12 @@ The loose density can be useful if you have a relatively small amount of data an
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/tables/table-title.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/tables/table-title.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/tables/table-description.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tables/table-description.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -115,16 +112,13 @@ The loose density can be useful if you have a relatively small amount of data an
 - In cases where a column title is too long, the text will wrap to two lines.
 
 <figure>
-  <img src="../../images/tables/column-titles.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/column-titles.png" alt=" " />
 </figure>
 <div className="two-col">
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/tables/column-header-truncate.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tables/column-header-truncate.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Don't truncate column titles.</p>
@@ -133,10 +127,7 @@ The loose density can be useful if you have a relatively small amount of data an
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/tables/column-header-wrap.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tables/column-header-wrap.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>Let long column titles wrap naturally.</p>
@@ -161,7 +152,7 @@ The loose density can be useful if you have a relatively small amount of data an
 Striped rows (zebra striping) is an optional styling you may apply to your table. This can make data-heavy tables easier for your user to read, as the stripes help guide the eye across the table and then back to the next row.
 
 <figure>
-  <img src="../../images/tables/striped-rows.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/striped-rows.png" alt=" " />
 </figure>
 
 ### Hover
@@ -169,7 +160,7 @@ Striped rows (zebra striping) is an optional styling you may apply to your table
 The table’s row hover state can help your user visually scan the columns of data in a row even if the row is not interactive. This feature is optional and is easily enabled for any table, and may be used in combination with striped rows.
 
 <figure>
-  <img src="../../images/tables/row-hover.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/row-hover.png" alt=" " />
 </figure>
 
 ### Sorting
@@ -179,7 +170,7 @@ Columns can be sorted in ascending or descending order. Sorting controls are loc
 A sorted table has three states: unsorted (sort-double-arrow), sorted-up (arrow-upward) or sorted-down (arrow-downward). The icon indicates the current sorted state. All sortable columns display an arrow icon, but only one can be actively sorted at a time.
 
 <figure>
-  <img src="../../images/tables/table-sorting.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/table-sorting.png" alt=" " />
 </figure>
 
 ### Inline Actions
@@ -190,18 +181,12 @@ Inline actions are functions that may be performed on a specific table row. In o
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/tables/inline-actions.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tables/inline-actions.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/tables/inline-actions-overflow.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tables/inline-actions-overflow.png" alt=" " />
       </figure>
     </div>
   </div>

--- a/website/react-magma-docs/src/pages/design/tabs.mdx
+++ b/website/react-magma-docs/src/pages/design/tabs.mdx
@@ -20,11 +20,7 @@ import './design-guidelines-styles.css';
 ## Anatomy
 
 <figure>
-  <img
-    src="../../images/tabs/tabs-anatomy.png"
-    alt="GATSBY_EMPTY_ALT"
-    aria-hidden="true"
-  />
+  <img src="../../images/tabs/tabs-anatomy.png" alt=" " aria-hidden="true" />
 </figure>
 
 1. Tab
@@ -42,10 +38,7 @@ Text labels should clearly and succinctly describe the content they represent. T
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/tabs/tabs-line-wrap.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tabs/tabs-line-wrap.png" alt=" " />
         <figcaption>
           <p className="title title-caution">Caution</p>
           <p>
@@ -57,10 +50,7 @@ Text labels should clearly and succinctly describe the content they represent. T
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/tabs/tabs-resize-text.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tabs/tabs-resize-text.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -73,10 +63,7 @@ Text labels should clearly and succinctly describe the content they represent. T
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/tabs/tabs-truncate-text.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tabs/tabs-truncate-text.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -88,10 +75,7 @@ Text labels should clearly and succinctly describe the content they represent. T
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/tabs/tabs-icon-and-text-incorrect.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tabs/tabs-icon-and-text-incorrect.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -113,7 +97,7 @@ Icons can be very helpful in helping identify the type or context of the content
 Icons can be placed to the left of the label or on top of the label, depending on the desired outcome or constraints of the layout. The added space required by the icon requires even greater effort to make the text label as short as possible.
 
 <figure>
-  <img src="../../images/tabs/tabs-icon-and-text.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-icon-and-text.png" alt=" " />
   <figcaption>
     <p>
       Icons and text labels can be used together to help communicate what the
@@ -123,10 +107,7 @@ Icons can be placed to the left of the label or on top of the label, depending o
 </figure>
 <span className="horizontal-spacer" />
 <figure>
-  <img
-    src="../../images/tabs/tabs-icon-and-label-stacked.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/tabs/tabs-icon-and-label-stacked.png" alt=" " />
   <figcaption>
     <p>
       Icons can be stacked on top of the label which saves horizontal space, but
@@ -140,7 +121,7 @@ Icons can be placed to the left of the label or on top of the label, depending o
 Icon-only tabs can be very useful for communicating the content they represent, especially in small areas or on small devices.
 
 <figure>
-  <img src="../../images/tabs/tabs-icon-only.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-icon-only.png" alt=" " />
   <figcaption>
     <p className="title title-caution">Caution</p>
     <p>
@@ -159,10 +140,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/tabs/tabs-active-indicator-bottom.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tabs/tabs-active-indicator-bottom.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>The indicator appears on the bottom of the tab by default.</p>
@@ -171,10 +149,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/tabs/tabs-active-indicator-top.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tabs/tabs-active-indicator-top.png" alt=" " />
         <figcaption>
           <p className="title title-caution">Caution</p>
           <p>
@@ -195,7 +170,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
 ## States
 
 <figure>
-  <img src="../../images/tabs/tabs-states.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-states.png" alt=" " />
 </figure>
 
 1. Inactive
@@ -211,14 +186,14 @@ The active tab indicator helps make it very clear which tab is currently selecte
 Tabs are displayed in a single row or column, with each tab connected to the content they represent. Tabs can be attached to headers, main content areas, side panels, and nestled into cards.
 
 <figure>
-  <img src="../../images/tabs/tabs-header.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-header.png" alt=" " />
   <figcaption>
     <p>Example of tabs in the header of a panel.</p>
   </figcaption>
 </figure>
 <span className="horizontal-spacer" />
 <figure>
-  <img src="../../images/tabs/tabs-column.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-column.png" alt=" " />
   <figcaption>
     <p>Example of tabs in a column.</p>
   </figcaption>
@@ -228,10 +203,7 @@ Tabs are displayed in a single row or column, with each tab connected to the con
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/tabs/nesting-tabs-wrong.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tabs/nesting-tabs-wrong.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Don't nest tabs to create multiple levels.</p>
@@ -240,10 +212,7 @@ Tabs are displayed in a single row or column, with each tab connected to the con
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/tabs/stacking-tabs-wrong.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tabs/stacking-tabs-wrong.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Don't stack tabs meant to be horizontal on top of each other.</p>
@@ -266,21 +235,21 @@ The default width of a tab is undefined and is determined by the content within 
 Auto-width tabs can be left-aligned, right-aligned, or centered.
 
 <figure>
-  <img src="../../images/tabs/tabs-left-aligned.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-left-aligned.png" alt=" " />
   <figcaption>
     <p>By default, auto-width tabs are left aligned.</p>
   </figcaption>
 </figure>
 <span className="horizontal-spacer" />
 <figure>
-  <img src="../../images/tabs/tabs-right-aligned.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-right-aligned.png" alt=" " />
   <figcaption>
     <p>You may also right-align the tabs with the content below or above.</p>
   </figcaption>
 </figure>
 <span className="horizontal-spacer" />
 <figure>
-  <img src="../../images/tabs/tabs-centered.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-centered.png" alt=" " />
   <figcaption>
     <p>On wider layouts, centering the tabs may work well.</p>
   </figcaption>
@@ -291,10 +260,7 @@ Auto-width tabs can be left-aligned, right-aligned, or centered.
 The tab container for auto-width tabs will automatically scroll if the container becomes too small to show all the tabs. Buttons to scroll left and right will automatically be added, but users with touch-based devices will also be able to drag the tab container left and right.
 
 <figure>
-  <img
-    src="../../images/tabs/horizontal-scrolling-tabs.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/tabs/horizontal-scrolling-tabs.png" alt=" " />
   <figcaption>
     <p>
       If there are more tabs to see beyond the edge of the container, you will
@@ -308,17 +274,14 @@ The tab container for auto-width tabs will automatically scroll if the container
 Full-width tabs can be calculated by the width of the container divided by the number of tabs. Full-width tabs should only be used if you can guarantee that all tabs will be visible without truncation regardless of the size of the container.
 
 <figure>
-  <img src="../../images/tabs/tabs-full-width.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-full-width.png" alt=" " />
   <figcaption>
     <p>Simple example of full-width tabs, each tab being of equal width.</p>
   </figcaption>
 </figure>
 <span className="horizontal-spacer" />
 <figure>
-  <img
-    src="../../images/tabs/tabs-alignment-with-content.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/tabs/tabs-alignment-with-content.png" alt=" " />
   <figcaption>
     <p className="title title-caution">Caution</p>
     <p>
@@ -336,7 +299,7 @@ Tabs may also be placed to the left of their corresponding content in a vertical
 **NOTE:** There isn’t any default Responsive behavior for when the content area gets too narrow to display the tabs next to the content. You are encouraged to reuse solutions from other instances of vertical tabs. In the event no solution exists that will work in your scenario, a new solution will have to be designed.
 
 <figure>
-  <img src="../../images/tabs/tabs-vertical.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-vertical.png" alt=" " />
   <figcaption>
     <p>Simple example of vertical tabs on the left side of the content.</p>
   </figcaption>
@@ -347,10 +310,7 @@ Tabs may also be placed to the left of their corresponding content in a vertical
 Vertical tabs will also automatically scroll when the height of their container is too small to display all of the tabs.
 
 <figure>
-  <img
-    src="../../images/tabs/tabs-vertical-scrolling.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/tabs/tabs-vertical-scrolling.png" alt=" " />
   <figcaption>
     <p>
       If there are more tabs to see beyond the bottom of the container, you will
@@ -366,10 +326,7 @@ Vertical tabs will also automatically scroll when the height of their container 
 The tabs have inverse styling available for use on dark backgrounds. Take care with the color you choose for the background to make sure the necessary contrast ratios are upheld for accessibility compliance.
 
 <figure>
-  <img
-    src="../../images/tabs/tabs-inverse-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/tabs/tabs-inverse-example.png" alt=" " />
   <figcaption>
     <p>Example of tabs on a dark blue background.</p>
   </figcaption>

--- a/website/react-magma-docs/src/pages/design/time-picker.mdx
+++ b/website/react-magma-docs/src/pages/design/time-picker.mdx
@@ -14,10 +14,7 @@ The Time input gives the user the ability to input a time in a format the develo
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/time-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/time-input-example.png" alt=" " />
   </div>
 </figure>
 
@@ -27,10 +24,7 @@ You can tab into the Time input to individually manipulate the hours, minutes, a
 
 <figure>
   <div className="image-container">
-    <img
-      src="../../images/inputs/time-input-keyboard.png"
-      alt="GATSBY_EMPTY_ALT"
-    />
+    <img src="../../images/inputs/time-input-keyboard.png" alt=" " />
   </div>
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/toast.mdx
+++ b/website/react-magma-docs/src/pages/design/toast.mdx
@@ -18,10 +18,7 @@ import './design-guidelines-styles.css';
 Toasts are the least intrusive of the three types of alerts and are used primarily for communicating non-critical information to the user. Toasts appear in the lower-left corner of the viewport.
 
 <figure>
-  <img
-    src="../../images/alerts/toast-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/toast-alert-example.png" alt=" " />
 </figure>
 
 ---
@@ -31,7 +28,7 @@ Toasts are the least intrusive of the three types of alerts and are used primari
 The basic anatomy of the alert is the same across all three types (banner, inline, toast).
 
 <figure>
-  <img src="../../images/alerts/alert-anatomy.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/alerts/alert-anatomy.png" alt=" " />
 </figure>
 
 1. Container
@@ -47,10 +44,7 @@ The basic anatomy of the alert is the same across all three types (banner, inlin
 If multiple toasts are triggered, they will automatically stack vertically. When at all possible, try to group batch-like actions into a single toast instead of triggering multiple alerts.
 
 <figure>
-  <img
-    src="../../images/alerts/stack-toasts-incorrect.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/stack-toasts-incorrect.png" alt=" " />
   <figcaption>
     <p className="title title-incorrect">Incorrect</p>
     <p>
@@ -60,10 +54,7 @@ If multiple toasts are triggered, they will automatically stack vertically. When
   </figcaption>
 </figure>
 <figure>
-  <img
-    src="../../images/alerts/batch-actions-toast.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/batch-actions-toast.png" alt=" " />
   <figcaption>
     <p className="title title-correct">Correct</p>
     <p>Combine the results from a single action into a single toast alert.</p>
@@ -84,7 +75,7 @@ Avoid displaying errors or warnings with toasts, but if you have to, then these 
       <figure>
         <img
           src="../../images/alerts/toast-error-manually-dismiss.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -99,7 +90,7 @@ Avoid displaying errors or warnings with toasts, but if you have to, then these 
       <figure>
         <img
           src="../../images/alerts/toast-successful-auto-dismiss.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -132,10 +123,7 @@ Take the following guidelines into consideration when crafting your message:
 When the viewport is 600px wide and smaller, we automatically reduce the icon and font size to optimize the amount of space given to the message and optional links or buttons in the alert. The toast will also automatically stretch to 100% of the viewport width with spacing around it.
 
 <figure>
-  <img
-    src="../../images/alerts/mobile-toast-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
-  />
+  <img src="../../images/alerts/mobile-toast-alert-example.png" alt=" " />
 </figure>
 
 ---

--- a/website/react-magma-docs/src/pages/design/toggle.mdx
+++ b/website/react-magma-docs/src/pages/design/toggle.mdx
@@ -20,7 +20,7 @@ Toggle switches are a great way to adjust settings when you are simply turning s
   <div className="image-container">
     <img
       src="../../images/selection-controls/Toggle-switch-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -36,7 +36,7 @@ Toggles can be on, off, or disabled.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Toggle-switch-states.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>

--- a/website/react-magma-docs/src/pages/design/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/design/tooltip.mdx
@@ -21,10 +21,7 @@ Tooltips are necessary for interactive elements whose function may not be clearl
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/tooltips/Tooltip-imagery.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tooltips/Tooltip-imagery.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>Use tooltips for interactive imagery like icon buttons.</p>
@@ -33,10 +30,7 @@ Tooltips are necessary for interactive elements whose function may not be clearl
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/tooltips/Tooltip-repeat-word.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/tooltips/Tooltip-repeat-word.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Don’t use tooltips to restate visible UI text.</p>

--- a/website/react-magma-docs/src/pages/design/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/design/tree-view.mdx
@@ -19,7 +19,7 @@ A tree view comprises nested heading levels, establishing a content hierarchy fo
 
 <figure>
   <div className="image-container">
-    <img src="../../images/treeview/intro-image.png" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/treeview/intro-image.png" alt=" " />
   </div>
 </figure>
 
@@ -44,7 +44,7 @@ When dealing with a single level of nested information, consider utilizing an al
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/treeview/anatomy.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/treeview/anatomy.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -67,10 +67,7 @@ Nodes stack directly on top of each other with 0px space between them. Having no
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/treeview/stacking-nodes.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/stacking-nodes.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -85,18 +82,12 @@ Nested nodes in a tree view rely on organized and consistent alignment to group 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/treeview/nesting-alignment-1.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/nesting-alignment-1.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/treeview/nesting-alignment-1-1.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/nesting-alignment-1-1.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -122,10 +113,7 @@ Icons can be a helpful way of scanning a list for various item types. Icons shou
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/treeview/node-icons-correct.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/node-icons-correct.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>Do consistently use icons for each node in a tree view.</p>
@@ -134,10 +122,7 @@ Icons can be a helpful way of scanning a list for various item types. Icons shou
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/treeview/node-icons-wrong.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/node-icons-wrong.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Do not mix text-only and icon nodes in a tree view.</p>
@@ -159,18 +144,12 @@ Branch nodes and leaf nodes exhibit identical styles across various states. The 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/treeview/single-select-states.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/single-select-states.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
-        <img
-          src="../../images/treeview/multi-select-states.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/multi-select-states.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -190,10 +169,7 @@ To expand or collapse a branch node the user can click anywhere within the arrow
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/treeview/expanding-behavior.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/expanding-behavior.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -209,10 +185,7 @@ To expand or collapse a branch node the user can click anywhere within the arrow
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img
-          src="../../images/treeview/selecting-behavior.png"
-          alt="GATSBY_EMPTY_ALT"
-        />
+        <img src="../../images/treeview/selecting-behavior.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />


### PR DESCRIPTION
Closes: #1349

## What I did
- Replaced `GATSBY_EMPTY_ALT` with `empty` alt for images

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to React Magma Docs -> Design -> Button -> open dev tools -> for all images should be alt=` `

Need to repeat these steps for all updated pages.
