### PR TITLE
Replace GATSBY_EMPTY_ALT with empty alt for images (react-magma-5)

### DIFF
--- a/.changeset/a11y-docs-img-empty-alts.md
+++ b/.changeset/a11y-docs-img-empty-alts.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Docs): replace "GATSBY_EMPTY_ALT" as alt text for empty alts.

--- a/website/react-magma-docs/src/pages/api-intro/page-templates.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/page-templates.mdx
@@ -16,7 +16,7 @@ This template is ideal for applications that need as much of the screen as possi
 <figure>
   <img
     src="../../images/layout/template-full-width.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -144,7 +144,7 @@ This template is great for pages that focus more on reading content like marketi
 <figure>
   <img
     src="../../images/layout/template-restricted-width.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -253,7 +253,7 @@ This template includes a screen region for a left sidebar and includes all of th
 <figure>
   <img
     src="../../images/layout/template-sidebar-app-header.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -353,7 +353,7 @@ This template also includes the sidebar screen region, but the header extends al
 <figure>
   <img
     src="../../images/layout/template-sidebar-global-header.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 

--- a/website/react-magma-docs/src/pages/data-visualization/chart-types.future.txt
+++ b/website/react-magma-docs/src/pages/data-visualization/chart-types.future.txt
@@ -3,7 +3,7 @@
 Bubble:
 <div class="item">
   <figure>
-    <img src="../../images/chart-types/bubble.jpg" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/chart-types/bubble.jpg" alt=" " />
   </figure>
   <div class="description">
     <h2>Bubble</h2>
@@ -18,7 +18,7 @@ Bubble:
 Radar:
 <div class="item">
   <figure>
-    <img src="../../images/chart-types/radar.jpg" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/chart-types/radar.jpg" alt=" " />
   </figure>
   <div class="description">
     <h2>Radar</h2>
@@ -34,7 +34,7 @@ Radar:
 Histogram:
 <div class="item">
   <figure>
-    <img src="../../images/chart-types/histogram.jpg" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/chart-types/histogram.jpg" alt=" " />
   </figure>
   <div class="description">
     <h2>Histogram</h2>
@@ -50,7 +50,7 @@ Histogram:
 Boxplot:
 <div class="item">
   <figure>
-    <img src="../../images/chart-types/boxplot.jpg" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/chart-types/boxplot.jpg" alt=" " />
   </figure>
   <div class="description">
     <h2>Boxplot</h2>
@@ -65,7 +65,7 @@ Boxplot:
 Bullet:
 <div class="item">
   <figure>
-    <img src="../../images/chart-types/bullet.jpg" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/chart-types/bullet.jpg" alt=" " />
   </figure>
   <div class="description">
     <h2>Bullet</h2>
@@ -80,7 +80,7 @@ Bullet:
 Meter:
 <div class="item">
   <figure>
-    <img src="../../images/chart-types/meter.jpg" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/chart-types/meter.jpg" alt=" " />
   </figure>
   <div class="description">
     <h2>Meter</h2>
@@ -95,7 +95,7 @@ Meter:
 Gauge:
 <div class="item">
   <figure>
-    <img src="../../images/chart-types/gauge.jpg" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/chart-types/gauge.jpg" alt=" " />
   </figure>
   <div class="description">
     <h2>Gauge</h2>
@@ -110,7 +110,7 @@ Gauge:
 Combo:
 <div class="item">
   <figure>
-    <img src="../../images/chart-types/combo.jpg" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/chart-types/combo.jpg" alt=" " />
   </figure>
   <div class="description">
     <h2>Combo</h2>
@@ -128,7 +128,7 @@ Scatter:
 <div class="container">
   <div class="item">
     <figure>
-      <img src="../../images/chart-types/scatter.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/scatter.jpg" alt=" " />
     </figure>
     <div class="description">
       <h2>Scatter</h2>

--- a/website/react-magma-docs/src/pages/data-visualization/chart-types.mdx
+++ b/website/react-magma-docs/src/pages/data-visualization/chart-types.mdx
@@ -24,7 +24,7 @@ Comparison charts compare data between multiple distinct categories.
       <img
         className="chart-types-image"
         src="../../images/chart-types/simple-bar.jpg"
-        alt="GATSBY_EMPTY_ALT"
+        alt=" "
       />
     </figure>
     <div className="description">
@@ -41,7 +41,7 @@ Comparison charts compare data between multiple distinct categories.
       <img
         className="chart-types-image"
         src="../../images/chart-types/grouped-bar.jpg"
-        alt="GATSBY_EMPTY_ALT"
+        alt=" "
       />
     </figure>
     <div className="description">
@@ -59,7 +59,7 @@ Comparison charts compare data between multiple distinct categories.
       <img
         className="chart-types-image"
         src="../../images/chart-types/floating-bar.jpg"
-        alt="GATSBY_EMPTY_ALT"
+        alt=" "
       />
     </figure>
     <div className="description">
@@ -74,7 +74,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/bubble.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/bubble.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Bubble</h2>
@@ -87,7 +87,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/radar.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/radar.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Radar</h2>
@@ -101,7 +101,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/lollipop.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/lollipop.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Lollipop</h2>
@@ -115,7 +115,7 @@ Comparison charts compare data between multiple distinct categories.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/combo.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/combo.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Combo</h2>
@@ -138,7 +138,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
       <img
         className="chart-types-image"
         src="../../images/chart-types/line.jpg"
-        alt="GATSBY_EMPTY_ALT" />
+        alt=" " />
     </figure>
     <div className="description">
       <h2>Line</h2>
@@ -155,7 +155,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
       <img
         className="chart-types-image"
         src="../../images/chart-types/area.jpg"
-        alt="GATSBY_EMPTY_ALT" />
+        alt=" " />
     </figure>
     <div className="description">
       <h2>Area</h2>
@@ -168,7 +168,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/boxplot.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/boxplot.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Boxplot</h2>
@@ -183,7 +183,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
     <figure>
       <img
         src="../../images/chart-types/histogram.jpg"
-        alt="GATSBY_EMPTY_ALT"
+        alt=" "
       />
     </figure>
     <div className="description">
@@ -200,7 +200,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
     <figure>
       <img
         src="../../images/chart-types/sparkline.jpg"
-        alt="GATSBY_EMPTY_ALT"
+        alt=" "
       />
     </figure>
     <div className="description">
@@ -214,7 +214,7 @@ Trend charts show data over a period of time, to reveal trends or make compariso
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/step.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/step.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Step</h2>
@@ -237,7 +237,7 @@ Part-to-whole charts show how partial elements add up to a total.
       <img
         className="chart-types-image"
         src="../../images/chart-types/pie.jpg"
-        alt="GATSBY_EMPTY_ALT" />
+        alt=" " />
     </figure>
     <div className="description">
       <h2>Pie</h2>
@@ -253,7 +253,7 @@ Part-to-whole charts show how partial elements add up to a total.
       <img
         className="chart-types-image"
         src="../../images/chart-types/donut.jpg"
-        alt="GATSBY_EMPTY_ALT" />
+        alt=" " />
     </figure>
     <div className="description">
       <h2>Donut</h2>
@@ -270,7 +270,7 @@ Part-to-whole charts show how partial elements add up to a total.
       <img
         className="chart-types-image"
         src="../../images/chart-types/stacked-bar.jpg"
-        alt="GATSBY_EMPTY_ALT"
+        alt=" "
       />
     </figure>
     <div className="description">
@@ -284,7 +284,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/bullet.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/bullet.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Bullet</h2>
@@ -300,7 +300,7 @@ Part-to-whole charts show how partial elements add up to a total.
       <img
         className="chart-types-image"
         src="../../images/chart-types/stacked-area.jpg"
-        alt="GATSBY_EMPTY_ALT"
+        alt=" "
       />
     </figure>
     <div className="description">
@@ -314,7 +314,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/meter.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/meter.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Meter</h2>
@@ -327,7 +327,7 @@ Part-to-whole charts show how partial elements add up to a total.
   </div>
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/gauge.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/gauge.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Gauge</h2>
@@ -347,7 +347,7 @@ Correlation charts show the relationship between two or more variables.
 <div className="container">
   <div className="item">
     <figure>
-      <img src="../../images/chart-types/scatter.jpg" alt="GATSBY_EMPTY_ALT" />
+      <img src="../../images/chart-types/scatter.jpg" alt=" " />
     </figure>
     <div className="description">
       <h2>Scatter</h2>

--- a/website/react-magma-docs/src/pages/design-intro/layout.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/layout.mdx
@@ -29,7 +29,7 @@ Every layout is made up of columns, gutters, and margins that respond accordingl
 <figure>
   <img
     src="../../images/layout/columns-gutters-margins.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -42,7 +42,7 @@ Every layout is made up of columns, gutters, and margins that respond accordingl
 The columns indicate where the content of the page goes. The widths of the columns are fluid, allowing content to scale and resize depending on the width of the device. The number of columns is determined by pre-defined breakpoint ranges.
 
 <figure>
-  <img src="../../images/layout/columns-12.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/columns-12.png" alt=" " />
   <figcaption>
     When the viewport is greater than 768px wide, the layout has 12 columns.
   </figcaption>
@@ -51,7 +51,7 @@ The columns indicate where the content of the page goes. The widths of the colum
 <span className="horizontal-spacer" />
 
 <figure>
-  <img src="../../images/layout/columns-6.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/columns-6.png" alt=" " />
   <figcaption>
     When the viewport is 768px wide or smaller, the layout has 6 columns.
   </figcaption>
@@ -60,7 +60,7 @@ The columns indicate where the content of the page goes. The widths of the colum
 <span className="horizontal-spacer" />
 
 <figure>
-  <img src="../../images/layout/columns-4.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/columns-4.png" alt=" " />
   <figcaption>
     When the viewport is 375px wide and smaller, the layout changes to 4
     columns.
@@ -74,7 +74,7 @@ Gutters are the spaces in between columns. This space is used to separate conten
 The width of gutters on standard Cengage page layouts should be set to 24px. On smaller screens the gutters change to 16px.
 
 <figure>
-  <img src="../../images/layout/gutters-24.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/gutters-24.png" alt=" " />
   <figcaption>
     When the viewport is greater than 600px wide, gutters are 24px wide.
   </figcaption>
@@ -83,7 +83,7 @@ The width of gutters on standard Cengage page layouts should be set to 24px. On 
 <span className="horizontal-spacer" />
 
 <figure>
-  <img src="../../images/layout/gutters-16.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/gutters-16.png" alt=" " />
   <figcaption>
     When the viewport is 600px wide and smaller, gutters are 16px wide.
   </figcaption>
@@ -100,7 +100,7 @@ Margins are a fixed value, typically consistent with the gutter widths. The widt
 The width of margins on standard Cengage full-width page layouts should be set to 24px. On smaller screens the margins change to 16px.
 
 <figure>
-  <img src="../../images/layout/layout-full-width.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/layout/layout-full-width.png" alt=" " />
 </figure>
 
 #### Restricted-width Layout
@@ -110,7 +110,7 @@ Larger margins based on percentages can be used to restrict the maximum width of
 <figure>
   <img
     src="../../images/layout/layout-restricted-width.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -172,7 +172,7 @@ Some Cengage web applications have a global sidebar on the left side of the page
 <figure>
   <img
     src="../../images/layout/layout-with-sidebar.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     When using the global sidebar, the main content area still has 12 columns
@@ -185,7 +185,7 @@ Some Cengage web applications have a global sidebar on the left side of the page
 <figure>
   <img
     src="../../images/layout/layout-with-sidebar-1024.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     When using the global sidebar, the main content area changes to 6 columns

--- a/website/react-magma-docs/src/pages/design-intro/spacing.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/spacing.mdx
@@ -156,7 +156,7 @@ The spacing scale helps us determine how much space to put between or inside of 
 <figure>
   <img
     src="../../images/spacing/icon-text-balance-correct.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     Example of using spacing properties to add padding inside a card, as well as
@@ -167,7 +167,7 @@ The spacing scale helps us determine how much space to put between or inside of 
 <span className="horizontal-spacer" />
 
 <figure>
-  <img src="../../images/spacing/spacing-example.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/spacing/spacing-example.png" alt=" " />
   <figcaption>
     Example of using spacing properties to create the space between cards in a
     grid.

--- a/website/react-magma-docs/src/pages/design-intro/typography.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/typography.mdx
@@ -809,7 +809,7 @@ One example of this is in the <Link to="/api/modal/">Modal component</Link>. For
 <figure>
   <img
     src="../../images/typography/modal-title-style.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -824,7 +824,7 @@ Another advantage to using the presets above is that Responsive behavior is alre
 <figure>
   <img
     src="../../images/typography/responsive-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -849,7 +849,7 @@ Our primary typface is Work Sans. It’s clear and approachable and is great for
       <figure>
         <img
           src="../../images/typography/work-sans-characters.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -884,7 +884,7 @@ Noto Serif is a beautiful serif font. It's easy to read, provides a nice contras
       <figure>
         <img
           src="../../images/typography/noto-serif-characters.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -919,7 +919,7 @@ Line-heights are also defined at this level to adhere to an 8px spacing system, 
 If you have a need to use a font size outside of the pre-made sets above, you may only choose from this list.
 
 <figure>
-  <img src="../../images/typography/type-scale.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/typography/type-scale.png" alt=" " />
 </figure>
 
 ---
@@ -936,7 +936,7 @@ Font weight is an important typographic variable that can add emphasis and diffe
       <figure>
         <img
           src="../../images/typography/font-weights.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -954,7 +954,7 @@ Each weight has an italic style, which should only be used when you need to emph
       <figure>
         <img
           src="../../images/typography/font-italic.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -972,7 +972,7 @@ Type color should be carefully considered, with legibility and accessibility as 
       <figure>
         <img
           src="../../images/typography/text-color-neutral-1.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -987,7 +987,7 @@ Type color should be carefully considered, with legibility and accessibility as 
       <figure>
         <img
           src="../../images/typography/text-color-neutral-2.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -1001,7 +1001,7 @@ Type color should be carefully considered, with legibility and accessibility as 
       <figure>
         <img
           src="../../images/typography/text-color-decoration.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -1013,7 +1013,7 @@ Type color should be carefully considered, with legibility and accessibility as 
       <figure>
         <img
           src="../../images/typography/text-color-contrast.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -1030,7 +1030,7 @@ Type color should be carefully considered, with legibility and accessibility as 
       <figure>
         <img
           src="../../images/typography/text-color-meaning.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -1046,7 +1046,7 @@ Type color should be carefully considered, with legibility and accessibility as 
       <figure>
         <img
           src="../../images/typography/text-color-meaning-2.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -1070,7 +1070,7 @@ It is common to lighten certain pieces of text in order to create more contrast.
       <figure>
         <img
           src="../../images/typography/subdued-example-1.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -1078,7 +1078,7 @@ It is common to lighten certain pieces of text in order to create more contrast.
       <figure>
         <img
           src="../../images/typography/subdued-example-2.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -1094,7 +1094,7 @@ Headings and paragraphs have margins built into them by default. These margins p
 <figure>
   <img
     src="../../images/typography/margins-illustration.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/accordion.mdx
+++ b/website/react-magma-docs/src/pages/design/accordion.mdx
@@ -45,7 +45,7 @@ In some scenarios, the accordion can be modified to place the chevron icon in fr
   <figure>
     <img
       src="../../images/accordion/accordion-good-alignment.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
     <figcaption>
       <p className="title title-correct">Correct</p>
@@ -58,7 +58,7 @@ In some scenarios, the accordion can be modified to place the chevron icon in fr
   <figure>
     <img
       src="../../images/accordion/accordion-bad-alignment.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
     <figcaption>
       <p className="title title-caution">Caution</p>
@@ -77,7 +77,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
   <figure>
     <img
       src="../../images/accordion/accordion-incorrect-icon-orientation.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
     <figcaption>
       <p className="title title-incorrect">Incorrect</p>
@@ -90,7 +90,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
   <figure>
     <img
       src="../../images/accordion/accordion-incorrect-icons.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
     <figcaption>
       <p className="title title-incorrect">Incorrect</p>
@@ -105,7 +105,7 @@ If you place the chevron icon on the left side of the title, don’t be tempted 
 <figure>
   <img
     src="../../images/accordion/accordion-crowded-icons.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p className="title title-incorrect">Incorrect</p>
@@ -124,19 +124,19 @@ Accordions can be placed within main page content or placed inside of a containe
   <figure>
     <img
       src="../../images/accordion/accordion-in-page.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </figure>
   <figure>
     <img
       src="../../images/accordion/accordion-sidebar.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </figure>
   <figure>
     <img
       src="../../images/accordion/accordion-drawer.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </figure>
 </div>

--- a/website/react-magma-docs/src/pages/design/alert.mdx
+++ b/website/react-magma-docs/src/pages/design/alert.mdx
@@ -20,7 +20,7 @@ This page focuses primarily on the commonalities between the different alert typ
 Use alerts to inform users of updates, changes to system status, or as feedback to an action they have taken. Proactively communicating with users and providing immediate feedback is important for building trust and maintaining a constant awareness of the system status. While alerts are an effective method of communicating with users, they have the potential to be disruptive and should be used with care.
 
 <figure>
-  <img src="../../images/alerts/alert-intro-image.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/alerts/alert-intro-image.png" alt=" " />
 </figure>
 
 ---
@@ -46,7 +46,7 @@ Alerts are interruptive, but their level of interruption should match the inform
 The basic anatomy of the alert is the same across all three types (banner, inline, toast).
 
 <figure>
-  <img src="../../images/alerts/alert-anatomy.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/alerts/alert-anatomy.png" alt=" " />
 </figure>
 
 1. Container
@@ -102,7 +102,7 @@ Inline alerts are embedded within the content of a page. They can provide the us
 <figure>
   <img
     src="../../images/alerts/inline-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -111,7 +111,7 @@ If an inline alert is being used to communicate some general information to the 
 <figure>
   <img
     src="../../images/alerts/inline-alert-example-2.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -124,7 +124,7 @@ When the viewport is 600px wide and smaller, we automatically reduce the icon an
 <figure>
   <img
     src="../../images/alerts/mobile-inline-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 <span className="horizontal-spacer" />

--- a/website/react-magma-docs/src/pages/design/badge.mdx
+++ b/website/react-magma-docs/src/pages/design/badge.mdx
@@ -18,7 +18,7 @@ import './design-guidelines-styles.css';
 Badges are used as a form of inline feedback and labeling. They are typically used to provide additional context to components already on the page.
 
 <figure>
-  <img src="../../images/badges/Badges.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/badges/Badges.png" alt=" " />
 </figure>
 
 ---
@@ -26,7 +26,7 @@ Badges are used as a form of inline feedback and labeling. They are typically us
 ## Text Badges
 
 <figure>
-  <img src="../../images/badges/label-example.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/badges/label-example.png" alt=" " />
 </figure>
 
 Text badges provide a way to provide feedback or label pieces of data.
@@ -40,7 +40,7 @@ Unless the context is clear, consider including additional context with a visual
 ## Counters
 
 <figure>
-  <img src="../../images/badges/counter-example.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/badges/counter-example.png" alt=" " />
 </figure>
 
 Counters can be used as part of links or buttons, or simply in a context that conveys the count of something to the user. When space is limited, and if the exact count isn't important, you may consider limiting the count to "99+".
@@ -50,7 +50,7 @@ Counters can be used as part of links or buttons, or simply in a context that co
 ## Color
 
 <figure>
-  <img src="../../images/badges/label-colors.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/badges/label-colors.png" alt=" " />
 </figure>
 
 There are multiple colors available for badges, but they should be used with purpose. The colors that should be used most commonly are primary, secondary/high contrast, and light/low contrast. The best color to use will most likely be determined by which one gives the appropriate level of emphasis with the surrounding content.

--- a/website/react-magma-docs/src/pages/design/banner.mdx
+++ b/website/react-magma-docs/src/pages/design/banner.mdx
@@ -15,7 +15,7 @@ import './design-guidelines-styles.css';
 <figure>
   <img
     src="../../images/alerts/banner-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -32,7 +32,7 @@ When the viewport is 600px wide and smaller, we automatically reduce the icon an
 <figure>
   <img
     src="../../images/alerts/mobile-banner-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 <span className="horizontal-spacer" />

--- a/website/react-magma-docs/src/pages/design/breadcrumb.mdx
+++ b/website/react-magma-docs/src/pages/design/breadcrumb.mdx
@@ -20,7 +20,7 @@ The default breadcrumb component is styled for use on backgrounds **neutral100**
 <figure>
   <img
     src="../../images/breadcrumbs/example-breadcrumbs.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -36,7 +36,7 @@ As the viewport gets smaller, the breadcrumb component will simply wrap to as ma
       <figure>
         <img
           src="../../images/breadcrumbs/breadcrumbs-wrap.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>

--- a/website/react-magma-docs/src/pages/design/button.mdx
+++ b/website/react-magma-docs/src/pages/design/button.mdx
@@ -65,7 +65,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_1.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>Keep labels short</p>
@@ -74,7 +74,7 @@ Text labels should always be short and have clear purpose. If a button requires 
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_2.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_2.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -88,7 +88,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_3.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_3.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -104,7 +104,7 @@ Text labels should always be short and have clear purpose. If a button requires 
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_4.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_4.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -116,7 +116,7 @@ Text labels should always be short and have clear purpose. If a button requires 
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_5.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_5.png" alt=" " />
         <figcaption>
           <p className="title title-caution">Caution</p>
           <p>
@@ -138,7 +138,7 @@ You can place icons next to text labels to both clarify an action and call atten
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_6.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_6.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>Use icons that clearly communicate their meaning.</p>
@@ -147,7 +147,7 @@ You can place icons next to text labels to both clarify an action and call atten
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_7.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_7.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -161,7 +161,7 @@ You can place icons next to text labels to both clarify an action and call atten
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_4_8.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_8.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>
@@ -173,7 +173,7 @@ You can place icons next to text labels to both clarify an action and call atten
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_4_9.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_4_9.png" alt=" " />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
           <p>Don’t use two icons in the same button.</p>
@@ -213,7 +213,7 @@ When you are pairing together primary and secondary actions such as "Save" and "
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_6_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_6_1.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -232,7 +232,7 @@ An additional benefit of the subtle button's very neutral appearance is to help 
       <figure>
         <img
           src="../../images/buttons/subtle_button_example_1.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -240,7 +240,7 @@ An additional benefit of the subtle button's very neutral appearance is to help 
       <figure>
         <img
           src="../../images/buttons/subtle_button_example_2.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -255,7 +255,7 @@ For actions that delete things, you can emphasize this action with the **danger*
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_6_3.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_6_3.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -276,7 +276,7 @@ If your button is going on a dark background, all of the buttons have an inverse
   <div className="row">
     <div className="col">
       <figure>
-        <img src="../../images/buttons/ex_6_4.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_6_4.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -292,7 +292,7 @@ Buttons have clear states to provide feedback to the user.
   <div className="row">
     <div className="col">
       <figure>
-        <img src="../../images/buttons/ex_7_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_7_1.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -308,7 +308,7 @@ The solid outline is 2px thick with at least a 2px offset, and the color is info
   <div className="row">
     <div className="col">
       <figure>
-        <img src="../../images/buttons/ex_7_2.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_7_2.png" alt=" " />
       </figure>
     </div>
   </div>
@@ -336,7 +336,7 @@ Multiple button types can be used to express different emphasis levels. When usi
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_8_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_8_1.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -348,7 +348,7 @@ Multiple button types can be used to express different emphasis levels. When usi
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_8_2.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_8_2.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -363,7 +363,7 @@ Multiple button types can be used to express different emphasis levels. When usi
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_8_3.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_8_3.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -387,7 +387,7 @@ Button sizes and placements will sometimes need to change because of the size of
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/buttons/ex_9_1.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_9_1.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>
@@ -400,7 +400,7 @@ Button sizes and placements will sometimes need to change because of the size of
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/buttons/ex_9_2.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/buttons/ex_9_2.png" alt=" " />
         <figcaption>
           <p className="title title-correct">Correct</p>
           <p>

--- a/website/react-magma-docs/src/pages/design/buttongroup.mdx
+++ b/website/react-magma-docs/src/pages/design/buttongroup.mdx
@@ -28,7 +28,7 @@ ButtonGroup can be either horizontal or vertical in its orientation. By default,
       <figure>
         <img
           src="../../images/button-group/orientation.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -44,7 +44,7 @@ ButtonGroup comes in three different sizes: small, medium, and large. The medium
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/button-group/size.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/button-group/size.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -61,7 +61,7 @@ You can easily remove the space between buttons to create a single unit. When yo
       <figure>
         <img
           src="../../images/button-group/no-space.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -83,7 +83,7 @@ The most critical action within a ButtonGroup should be a primary, marketing, or
       <figure>
         <img
           src="../../images/button-group/good-groupings.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -91,7 +91,7 @@ The most critical action within a ButtonGroup should be a primary, marketing, or
       <figure>
         <img
           src="../../images/button-group/bad-groupings.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -108,7 +108,7 @@ ButtonGroups are aligned contextually. In general, ButtonGroups are left-aligned
       <figure>
         <img
           src="../../images/button-group/alignment.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -126,7 +126,7 @@ The order of button priority should match the alignment of surrounding text. Whe
       <figure>
         <img
           src="../../images/button-group/button-order-good.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -134,7 +134,7 @@ The order of button priority should match the alignment of surrounding text. Whe
       <figure>
         <img
           src="../../images/button-group/button-order-bad.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -151,7 +151,7 @@ Not all buttons in a group require an icon, but buttons with icons should always
       <figure>
         <img
           src="../../images/button-group/icons-good.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -159,7 +159,7 @@ Not all buttons in a group require an icon, but buttons with icons should always
       <figure>
         <img
           src="../../images/button-group/icons-bad.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -176,7 +176,7 @@ Use ButtonGroup to show any additional actions related to the most critical acti
       <figure>
         <img
           src="../../images/button-group/additional-actions.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>

--- a/website/react-magma-docs/src/pages/design/card.mdx
+++ b/website/react-magma-docs/src/pages/design/card.mdx
@@ -22,14 +22,14 @@ Cards are one of the core building blocks in React Magma. They can be used to cr
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/cards/cards-layout.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/cards/cards-layout.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
         <img
           src="../../images/cards/cards-related-pieces.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -42,7 +42,7 @@ Cards are one of the core building blocks in React Magma. They can be used to cr
 The only part of a card that is required is the container itself. All other content is optional and completely depends on the purpose of the card.
 
 <figure>
-  <img src="../../images/cards/card-anatomy.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-anatomy.png" alt=" " />
 </figure>
 
 1. Container
@@ -60,7 +60,7 @@ Inset dividers do not extend to the edges of the card. Inset dividers are used t
 Use full-width dividers that extend to the edges of a card to separate more distinct pieces of content or isolate actions that have more to do with the card than any specific piece of content within it.
 
 <figure>
-  <img src="../../images/cards/card-dividers.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-dividers.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -79,7 +79,7 @@ The card component is by default displayed as flat. This implies the card itself
 If a card can move, such as in a carousel or a drag and drop scenario, you should use the property that adds a dropshadow to the container to help communicate the dynamic nature of that component.
 
 <figure>
-  <img src="../../images/cards/card-depth.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-depth.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -97,7 +97,7 @@ To avoid these issues, you should instead provide links within the card to view 
       <figure>
         <img
           src="../../images/cards/card-truncate-correct.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -113,7 +113,7 @@ To avoid these issues, you should instead provide links within the card to view 
       <figure>
         <img
           src="../../images/cards/card-scrolling-incorrect.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -136,7 +136,7 @@ To avoid these issues, you should instead provide links within the card to view 
 Depending how the card is being used, the card could contain any number of action buttons. Like with everything else, make sure the primary action is clear compared to any secondary actions. For small cards, avoid cluttering the card with too many actions by creating an overflow menu within a dropdown.
 
 <figure>
-  <img src="../../images/cards/card-overflow.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-overflow.png" alt=" " />
 </figure>
 
 ### UI Controls
@@ -144,7 +144,7 @@ Depending how the card is being used, the card could contain any number of actio
 Cards can contain many kinds of UI controls, including buttons, tabs, toggle switches, etc. These allow the user to interact with the content of the card.
 
 <figure>
-  <img src="../../images/cards/card-ui-controls.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-ui-controls.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -157,7 +157,7 @@ Various colors from the global color palette may be used as the background of a 
 **Important:** Conveying meaning with color does not translate to assistive technologies. If the communication of this meaning is important, make sure it is also obvious in the content that is visible, or is possibly delivered through alternative methods such as visibly hidden text that is read by screen readers.
 
 <figure>
-  <img src="../../images/cards/card-colors.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-colors.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -170,7 +170,7 @@ Callout cards add a band of color to the left edge of the container. This can be
 **Important:** Conveying meaning with color does not translate to assistive technologies. If the communication of this meaning is important, make sure it is also obvious in the content that is visible, or is possibly delivered through alternative methods such as visibly hidden text that is read by screen readers.
 
 <figure>
-  <img src="../../images/cards/card-callout.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-callout.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 
@@ -187,7 +187,7 @@ In general, cards change size depending on the amount of content within them. Bu
 <figure>
   <img
     src="../../images/cards/card-general-layout.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -196,7 +196,7 @@ In general, cards change size depending on the amount of content within them. Bu
 If you want a group of cards to be easy to scan, use a clean and consistent pattern for the layout.
 
 <figure>
-  <img src="../../images/cards/card-scannable.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/cards/card-scannable.png" alt=" " />
 </figure>
 <span className="horizontal-spacer" />
 

--- a/website/react-magma-docs/src/pages/design/character-counter.mdx
+++ b/website/react-magma-docs/src/pages/design/character-counter.mdx
@@ -43,7 +43,7 @@ The character counter initially tells the user the maximum number of characters 
       <figure>
         <img
           src="../../images/character-counter/behavior-1.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -59,7 +59,7 @@ As the user types, the character counter updates in real-time and informs the us
       <figure>
         <img
           src="../../images/character-counter/behavior-2.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -75,7 +75,7 @@ When the user exceeds the maximum number of characters allowed, the character co
       <figure>
         <img
           src="../../images/character-counter/behavior-3.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>

--- a/website/react-magma-docs/src/pages/design/checkboxes.mdx
+++ b/website/react-magma-docs/src/pages/design/checkboxes.mdx
@@ -25,7 +25,7 @@ Use checkboxes to:
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -45,7 +45,7 @@ Checkboxes can have a parent-child relationship with other checkboxes.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-parent-child-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -61,7 +61,7 @@ Checkboxes can be selected, unselected, or indeterminate. Checkboxes have enable
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-states.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -77,7 +77,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-alternate-colors.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -91,7 +91,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
       <figure>
         <img
           src="../../images/selection-controls/Checkbox-incorrect-multi-color.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -106,7 +106,7 @@ The default color used for checked checkboxes is primary-500 from the Magma pale
       <figure>
         <img
           src="../../images/selection-controls/Checkbox-incorrect-neutral.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -128,7 +128,7 @@ Use the inverse version when using the checkboxes on a dark background.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-inverse.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>

--- a/website/react-magma-docs/src/pages/design/date-picker.mdx
+++ b/website/react-magma-docs/src/pages/design/date-picker.mdx
@@ -16,7 +16,7 @@ order: 1
   <div className="image-container">
     <img
       src="../../images/inputs/date-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -53,7 +53,7 @@ The field label tells the user what information they need to input. Using placeh
       <figure>
         <img
           src="../../images/inputs/wrong-truncate-label.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -65,7 +65,7 @@ The field label tells the user what information they need to input. Using placeh
       <figure>
         <img
           src="../../images/inputs/caution-wrap-label.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-caution">Caution</p>
@@ -88,7 +88,7 @@ Placeholder text provides hints or examples of what to enter. Placeholder text d
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/inputs/input-text.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/inputs/input-text.png" alt=" " />
         <figcaption>
           <p>
             This example shows how the placeholder text provides a hint to the
@@ -111,7 +111,7 @@ Helper text is pertinent information that assists the user in completing a field
       <figure>
         <img
           src="../../images/inputs/input-helper-text.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of input helper text</p>
@@ -132,7 +132,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
       <figure>
         <img
           src="../../images/inputs/single-required-field.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -148,7 +148,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
       <figure>
         <img
           src="../../images/inputs/multiple-required-fields.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -165,7 +165,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
       <figure>
         <img
           src="../../images/inputs/wrong-optional-field.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -198,7 +198,7 @@ Inputs have a 5px border radius to be consistent with buttons, which often accom
       <figure>
         <img
           src="../../images/inputs/input-container.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Examples of text fields on light and dark backgrounds.</p>
@@ -221,7 +221,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
       <figure>
         <img
           src="../../images/inputs/input-leading-icon.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -235,7 +235,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
       <figure>
         <img
           src="../../images/inputs/input-trailing-icon.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -260,7 +260,7 @@ The icon can be configured to simply display a message within a tooltip or also 
       <figure>
         <img
           src="../../images/inputs/input-what-is-this.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of input with Help icon</p>
@@ -281,7 +281,7 @@ The icon can be configured to simply display a message within a tooltip or also 
       <figure>
         <img
           src="../../images/inputs/input-states.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -312,7 +312,7 @@ When the input provided is invalid, an error message should be used to provide i
       <figure>
         <img
           src="../../images/inputs/input-error-message.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of input with error message</p>

--- a/website/react-magma-docs/src/pages/design/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/design/dropdown.mdx
@@ -18,7 +18,7 @@ import './design-guidelines-styles.css';
 <figure>
   <img
     src="../../images/dropdowns/dropdown-intro-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -36,7 +36,7 @@ Dropdown menus typically contain a list of text-only menu items.
       <figure>
         <img
           src="../../images/dropdowns/anatomy-text-list.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -67,7 +67,7 @@ Dropdown menu items may also use an icon on the left side to help clarify the me
       <figure>
         <img
           src="../../images/dropdowns/anatomy-icon-and-text.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -92,7 +92,7 @@ Dropdown menus may use a selection state by placing a checkmark next to the curr
       <figure>
         <img
           src="../../images/dropdowns/anatomy-selection-state-list.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -116,7 +116,7 @@ Some dropdowns benefit from organizing the choices or options into groups, and t
       <figure>
         <img
           src="../../images/dropdowns/dropdown-groups.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -136,7 +136,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
       <figure>
         <img
           src="../../images/dropdowns/menu-too-wide.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -151,7 +151,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
       <figure>
         <img
           src="../../images/dropdowns/menu-item-wrapped.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -168,7 +168,7 @@ A dropdown will stretch horizontally by default to fit the longest item in the l
       <figure>
         <img
           src="../../images/dropdowns/menu-adjust-placement.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -193,7 +193,7 @@ Dropdowns have a default max-height of 250px and will scroll if necessary. This 
       <figure>
         <img
           src="../../images/dropdowns/menu-max-height.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -208,7 +208,7 @@ Dropdowns have a default max-height of 250px and will scroll if necessary. This 
       <figure>
         <img
           src="../../images/dropdowns/menu-too-long.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-caution">Caution</p>
@@ -236,7 +236,7 @@ The standard dropdown button is the most common element used to trigger a dropdo
       <figure>
         <img
           src="../../images/dropdowns/simple-dropdown-button.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of single dropdown button.</p>
@@ -257,7 +257,7 @@ Split buttons combine a single action button with a menu of related choices into
       <figure>
         <img
           src="../../images/dropdowns/split-dropdown-button.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of split-dropdown button.</p>
@@ -278,7 +278,7 @@ Other button variants may be used as a trigger for a dropdown menu. Caution shou
       <figure>
         <img
           src="../../images/dropdowns/custom-dropdown-button-1.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -292,7 +292,7 @@ Other button variants may be used as a trigger for a dropdown menu. Caution shou
       <figure>
         <img
           src="../../images/dropdowns/custom-dropdown-button-2.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of a "more options" dropdown menu.</p>
@@ -313,7 +313,7 @@ A dropdown is typically displayed below the trigger element, and the left edge o
 <figure>
   <img
     src="../../images/dropdowns/dropdown-alignment-1.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>Dropdowns can be left or right aligned.</p>
@@ -323,7 +323,7 @@ A dropdown is typically displayed below the trigger element, and the left edge o
 <figure>
   <img
     src="../../images/dropdowns/dropdown-alignment-2.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -336,7 +336,7 @@ A dropdown is typically displayed below the trigger element, and the left edge o
 <figure>
   <img
     src="../../images/dropdowns/dropdown-alignment-3.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>

--- a/website/react-magma-docs/src/pages/design/icon.mdx
+++ b/website/react-magma-docs/src/pages/design/icon.mdx
@@ -38,7 +38,7 @@ This example illustrates how 12px, 14px, 16px, and 20px text strings are paired 
       <figure>
         <img
           src="../../images/icons/icon-text-balance-correct.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -53,7 +53,7 @@ This example illustrates how 12px, 14px, 16px, and 20px text strings are paired 
       <figure>
         <img
           src="../../images/icons/icon-text-balance-incorrect.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -81,7 +81,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
       <figure>
         <img
           src="../../images/icons/icon-color-correct.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -97,7 +97,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
       <figure>
         <img
           src="../../images/icons/icon-color-too-light.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -115,7 +115,7 @@ The color of an icon needs to hit a minimum color contrast ratio of 3:1 with the
       <figure>
         <img
           src="../../images/icons/icon-mixed-colors.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -143,7 +143,7 @@ When positioning an icon next to text you should always center-align them.
       <figure>
         <img
           src="../../images/icons/icon-text-centered.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -157,7 +157,7 @@ When positioning an icon next to text you should always center-align them.
       <figure>
         <img
           src="../../images/icons/icon-text-wrong-alignment.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>

--- a/website/react-magma-docs/src/pages/design/indeterminate.mdx
+++ b/website/react-magma-docs/src/pages/design/indeterminate.mdx
@@ -24,7 +24,7 @@ View the <Link to="/design/checkboxes/">documentation for checkboxes</Link> for 
   <div className="image-container">
     <img
       src="../../images/selection-controls/Checkbox-parent-child-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>

--- a/website/react-magma-docs/src/pages/design/input.mdx
+++ b/website/react-magma-docs/src/pages/design/input.mdx
@@ -18,7 +18,7 @@ Inputs can be used alone or they can be combined with other types of inputs to c
   <div className="image-container">
     <img
       src="../../images/inputs/inputs-intro-image.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -55,7 +55,7 @@ View <Link to="/api/input/">component API</Link> for text fields.
   <div className="image-container">
     <img
       src="../../images/inputs/text-field-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -70,7 +70,7 @@ View <Link to="/api/textarea/">component API</Link> for text areas.
   <div className="image-container">
     <img
       src="../../images/inputs/text-area-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -85,7 +85,7 @@ View the <Link to="/design/password-input/">password input documentation</Link> 
   <div className="image-container">
     <img
       src="../../images/inputs/password-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -100,7 +100,7 @@ View <Link to="/api/input/">component API</Link> for number inputs.
   <div className="image-container">
     <img
       src="../../images/inputs/number-field-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -115,7 +115,7 @@ View <Link to="/api/search/">component API</Link> or <Link to="/design/search/">
   <div className="image-container">
     <img
       src="../../images/inputs/search-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -130,7 +130,7 @@ View <Link to="/api/date-pickers/">component API</Link> for date inputs.
   <div className="image-container">
     <img
       src="../../images/inputs/date-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -167,7 +167,7 @@ The field label tells the user what information they need to input. Using placeh
       <figure>
         <img
           src="../../images/inputs/wrong-truncate-label.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -179,7 +179,7 @@ The field label tells the user what information they need to input. Using placeh
       <figure>
         <img
           src="../../images/inputs/caution-wrap-label.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-caution">Caution</p>
@@ -202,7 +202,7 @@ Placeholder text provides hints or examples of what to enter. Placeholder text d
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/inputs/input-text.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/inputs/input-text.png" alt=" " />
         <figcaption>
           <p>
             This example shows how the placeholder text provides a hint to the
@@ -225,7 +225,7 @@ Helper text is pertinent information that assists the user in completing a field
       <figure>
         <img
           src="../../images/inputs/input-helper-text.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of input helper text</p>
@@ -246,7 +246,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
       <figure>
         <img
           src="../../images/inputs/single-required-field.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -262,7 +262,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
       <figure>
         <img
           src="../../images/inputs/multiple-required-fields.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -279,7 +279,7 @@ Required fields should be indicated by putting an asterisk (\*) at the end of th
       <figure>
         <img
           src="../../images/inputs/wrong-optional-field.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -312,7 +312,7 @@ Inputs have a 5px border radius to be consistent with buttons, which often accom
       <figure>
         <img
           src="../../images/inputs/input-container.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Examples of text fields on light and dark backgrounds.</p>
@@ -335,7 +335,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
       <figure>
         <img
           src="../../images/inputs/input-leading-icon.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -349,7 +349,7 @@ Icons can be used to help provide clarity or functionality. Leading icons are ty
       <figure>
         <img
           src="../../images/inputs/input-trailing-icon.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -374,7 +374,7 @@ The icon can be configured to simply display a message within a tooltip or also 
       <figure>
         <img
           src="../../images/inputs/input-what-is-this.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of input with Help icon</p>
@@ -395,7 +395,7 @@ The icon can be configured to simply display a message within a tooltip or also 
       <figure>
         <img
           src="../../images/inputs/input-states.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>
@@ -426,7 +426,7 @@ When the input provided is invalid, an error message should be used to provide i
       <figure>
         <img
           src="../../images/inputs/input-error-message.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p>Example of input with error message</p>

--- a/website/react-magma-docs/src/pages/design/list.mdx
+++ b/website/react-magma-docs/src/pages/design/list.mdx
@@ -29,7 +29,7 @@ Use ordered (numbered) lists when you need to convey a sequence or hierarchy bet
       <figure>
         <img
           src="../../images/lists/unordered-list.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           The list in this image shows a list of grocery items in no particular
@@ -39,7 +39,7 @@ Use ordered (numbered) lists when you need to convey a sequence or hierarchy bet
     </div>
     <div className="col col-2">
       <figure>
-        <img src="../../images/lists/ordered-list.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/lists/ordered-list.png" alt=" " />
         <figcaption>
           The list in this image shows a list of the top 7 best-selling car
           brands.
@@ -81,7 +81,7 @@ You can use the spacing tokens in React Magma to increase the vertical space bet
       <figure>
         <img
           src="../../images/lists/small-spacing.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -89,7 +89,7 @@ You can use the spacing tokens in React Magma to increase the vertical space bet
       <figure>
         <img
           src="../../images/lists/larger-spacing.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -104,7 +104,7 @@ The icon list is really just a variant of the Unordered List, but instead of bul
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/lists/icon-list.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/lists/icon-list.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -119,7 +119,7 @@ There are three icon size choices, including small, medium, and large. These siz
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/lists/icon-sizes.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/lists/icon-sizes.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -136,7 +136,7 @@ You can align the icon with the center or top of the associated content. This la
       <figure>
         <img
           src="../../images/lists/icon-alignment.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>

--- a/website/react-magma-docs/src/pages/design/loading-indicator.mdx
+++ b/website/react-magma-docs/src/pages/design/loading-indicator.mdx
@@ -31,7 +31,7 @@ Circular spinners are used when the amount of time needed to run a process or lo
       <figure>
         <img
           src="../../images/loading-indicators/circular-spinner.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -49,7 +49,7 @@ Progress bars should be used when real progress data can be fed to it, and you a
       <figure>
         <img
           src="../../images/loading-indicators/progress-bar.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -70,7 +70,7 @@ If you know that it will take less than a second to complete an action, then no 
 <figure>
   <img
     src="../../images/loading-indicators/Button-loading.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -88,7 +88,7 @@ If you are loading large amounts of data like an entire page or large areas of d
 <figure>
   <img
     src="../../images/loading-indicators/mindtap-loading.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -106,7 +106,7 @@ If there is no way of measuring how long it will take in real-time, but you know
 <figure>
   <img
     src="../../images/loading-indicators/example-spinner-message.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>Messaging should tell the user what is happening and what to expect.</p>
@@ -125,7 +125,7 @@ If you know from testing that it typically takes more than 15 seconds to load, *
   <div className="image-container">
     <img
       src="../../images/progress-bars/Progress-bar-dynamic.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -143,7 +143,7 @@ This component also allows for three messages, although at different intervals t
 <figure>
   <img
     src="../../images/loading-indicators/example-progress-bar-message.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>Messaging should tell the user what is happening and what to expect.</p>

--- a/website/react-magma-docs/src/pages/design/modal.mdx
+++ b/website/react-magma-docs/src/pages/design/modal.mdx
@@ -26,13 +26,13 @@ A modal is intentionally interruptive and blocks the user from interacting with 
 
 Clearly describe the decision being made by the user, and explain any possible consequences it could cause. The primary button should also reinforce the action being taken. If the action being taken is irreversible, make that clear to the user as well. The user should also be able to cancel the action with a secondary button or closing the modal.
 
-<img src="../../images/modals/confirm-decision.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/confirm-decision.png" alt=" " />
 
 ### Edit or Manage Tasks
 
 It's very common to use a modal to quickly edit or manage one or more items on a page without going back and forth between multiple pages. The emphasis here is "quickly". If the settings or management of an item becomes relatively complex and requires many decisions or multiple steps, please consider using a separate page or something other than a modal. If a particular action is often done repeatedly, consider allowing the action to be done directly on the main page rather than in a modal.
 
-<img src="../../images/modals/edit-item-example.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/edit-item-example.png" alt=" " />
 
 ---
 
@@ -40,7 +40,7 @@ It's very common to use a modal to quickly edit or manage one or more items on a
 
 Modals come in three responsive sizes: small, medium, and large.
 
-<img src="../../images/modals/modal-sizes.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/modal-sizes.png" alt=" " />
 
 ### Small
 
@@ -84,12 +84,12 @@ Modals should always contain a way to close them, and there are typically multip
 
 When a modal is opened, the focus is automatically put on the title of the modal rather than the first actionable element. We intentionally do this to provide an optimal experience for both people using assistive technologies and those who don't.
 
-<img src="../../images/modals/modal-focus-example.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/modal-focus-example.png" alt=" " />
 
 ### Validation
 
 Always validate a user's input entries before a modal is closed. If there are any errors, an inline error alert should be displayed above the form, as well as error messages on any specific inputs that failed validation. The error messages should provide clear instructions on how to resolve the errors and complete the action.
 
-<img src="../../images/modals/modal-validation.png" alt="GATSBY_EMPTY_ALT" />
+<img src="../../images/modals/modal-validation.png" alt=" " />
 
 </PageContent>

--- a/website/react-magma-docs/src/pages/design/password-input.mdx
+++ b/website/react-magma-docs/src/pages/design/password-input.mdx
@@ -15,7 +15,7 @@ order: 1
   <div className="image-container">
     <img
       src="../../images/inputs/password-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>

--- a/website/react-magma-docs/src/pages/design/progress-bar.mdx
+++ b/website/react-magma-docs/src/pages/design/progress-bar.mdx
@@ -25,7 +25,7 @@ To see how progress bars are used as loading indicators, view the [loading indic
   <div className="image-container">
     <img
       src="../../images/progress-bars/Progress-bar-intro.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -38,7 +38,7 @@ To see how progress bars are used as loading indicators, view the [loading indic
   <div className="image-container">
     <img
       src="../../images/progress-bars/Progress-bar-anatomy.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -64,7 +64,7 @@ When a static progress bar is used, it represents the progress of something at t
 <figure>
   <img
     src="../../images/progress-bars/Progress-bar-static.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -76,7 +76,7 @@ When a static progress bar is used, it represents the progress of something at t
 <figure>
   <img
     src="../../images/progress-bars/Progress-bar-compare.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -94,7 +94,7 @@ When a dynamic progress bar is used, it means it's updating in real-time while y
 <figure>
   <img
     src="../../images/progress-bars/Progress-bar-dynamic.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -122,7 +122,7 @@ The track on the dark/inverse progress bar has a black background at 25% opacity
   <div className="image-container">
     <img
       src="../../images/progress-bars/Progress-bar-colors1.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>

--- a/website/react-magma-docs/src/pages/design/radio.mdx
+++ b/website/react-magma-docs/src/pages/design/radio.mdx
@@ -22,7 +22,7 @@ Radio buttons should have the most commonly used option selected by default.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Radio-buttons-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -35,7 +35,7 @@ Radio buttons should have the most commonly used option selected by default.
       <figure>
         <img
           src="../../images/selection-controls/Radio-select-only-one.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -49,7 +49,7 @@ Radio buttons should have the most commonly used option selected by default.
       <figure>
         <img
           src="../../images/selection-controls/Radio-select-only-one-incorrect.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -66,7 +66,7 @@ Radio buttons should have the most commonly used option selected by default.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Radio-example-2.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -82,7 +82,7 @@ Radio buttons can be off or on. Radio buttons have enabled, focused and pressed 
   <div className="image-container">
     <img
       src="../../images/selection-controls/Radio-states.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -98,7 +98,7 @@ Use the inverse version when using the radio buttons on a dark background.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Radio-inverse.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>

--- a/website/react-magma-docs/src/pages/design/search.mdx
+++ b/website/react-magma-docs/src/pages/design/search.mdx
@@ -28,7 +28,7 @@ Set the user’s context for the search with helpful placeholder text within the
       <figure>
         <img
           src="../../images/inputs/header-search.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -36,7 +36,7 @@ Set the user’s context for the search with helpful placeholder text within the
       <figure>
         <img
           src="../../images/inputs/inline-search.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>

--- a/website/react-magma-docs/src/pages/design/stepper.mdx
+++ b/website/react-magma-docs/src/pages/design/stepper.mdx
@@ -17,7 +17,7 @@ import './design-guidelines-styles.css';
 Steppers aid in guiding a user's expectations while navigating through a multistep process. They indicate the current step, the total number of steps, and the overall progress towards task completion.
 
 <figure>
-  <img src="../../images/stepper/stepper-intro.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/stepper-intro.png" alt=" " />
 </figure>
 
 ### When to use
@@ -44,7 +44,7 @@ Steppers aid in guiding a user's expectations while navigating through a multist
       <figure>
         <img
           src="../../images/stepper/step-anatomy.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -65,7 +65,7 @@ Steppers aid in guiding a user's expectations while navigating through a multist
 The default placement of the labels is under each status indicator on the line. This layout benefits from short labels, especially as the number of steps increases.
 
 <figure>
-  <img src="../../images/stepper/standard-labels.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/standard-labels.png" alt=" " />
 </figure>
 
 #### No Labels
@@ -73,7 +73,7 @@ The default placement of the labels is under each status indicator on the line. 
 If the nature of the labels would simply be too much text to reasonably fit, then it is acceptable to hide the labels on the stepper component. However, this means having clear titles within the content of the step itself is extremely important. It can be helpful to change to this layout on small screens.
 
 <figure>
-  <img src="../../images/stepper/no-labels.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/no-labels.png" alt=" " />
 </figure>
 
 #### Summary View
@@ -81,7 +81,7 @@ If the nature of the labels would simply be too much text to reasonably fit, the
 The step summary layout shows the primary and secondary labels, but only for the step you are currently on. It also tells you what number step you are on, and how many steps there are in total. This layout can be a nice middle-point between showing all labels and not showing labels at all, and you can use it on large or small screens.
 
 <figure>
-  <img src="../../images/stepper/summary-view.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/summary-view.png" alt=" " />
 </figure>
 
 ### Placement
@@ -91,19 +91,19 @@ The stepper component can be placed on a full page, in a modal, or in a side pan
 <figure>
   <img
     src="../../images/stepper/placement-full-page.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
 <figure>
   <img
     src="../../images/stepper/placement-side-panel.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
 <figure>
-  <img src="../../images/stepper/placement-modal.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/placement-modal.png" alt=" " />
 </figure>
 
 ---
@@ -122,7 +122,7 @@ The label should succinctly convey the user's objectives for each step in one or
       <figure>
         <img
           src="../../images/stepper/primary-label.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -140,7 +140,7 @@ Secondary labels are optional and should be used if some additional description 
       <figure>
         <img
           src="../../images/stepper/secondary-label.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -158,7 +158,7 @@ When there isn’t enough space, the labels will wrap to as many lines as necess
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/stepper/text-wrap.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/stepper/text-wrap.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -183,7 +183,7 @@ A step is complete when a user has filled out the required information within a 
       <figure>
         <img
           src="../../images/stepper/step-complete.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -201,7 +201,7 @@ A step is current when a user is interacting with the information within that st
       <figure>
         <img
           src="../../images/stepper/step-active.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -219,7 +219,7 @@ A step is not started when a user has not yet interacted with that step. Steps t
       <figure>
         <img
           src="../../images/stepper/step-incomplete.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -235,7 +235,7 @@ A step may be in error when a user has entered invalid or incomplete information
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/stepper/step-error.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/stepper/step-error.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -249,7 +249,7 @@ Currently, the stepper is not interactive, providing only a visual update of the
 A common example includes buttons labeled as “Next” and “Back”, and often ending with a button labeled “Finish.” But the labels themselves need to make sense for the process being completed, so there isn’t any mandated language to use. You can also choose to not include a “Back” button if you don’t want the user to go back to previous steps. Whatever you do, we suggest conducting usability tests to ensure you have created the best experience possible.
 
 <figure>
-  <img src="../../images/stepper/step-navigation.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/step-navigation.png" alt=" " />
 </figure>
 
 ### Validation
@@ -259,7 +259,7 @@ When possible, use validation to confirm that a step has been completed before t
 If the user cannot proceed due to a server-side issue, then an inline alert should appear.
 
 <figure>
-  <img src="../../images/stepper/validation-error.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/stepper/validation-error.png" alt=" " />
 </figure>
 
 ### Responsive Behavior
@@ -274,7 +274,7 @@ If you don’t have very many steps and the labels are short, it is very possibl
   <div className="image-container">
     <img
       src="../../images/stepper/mobile-standard-labels.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -287,7 +287,7 @@ Hiding the labels on small screens is acceptable, but only if you are using very
   <div className="image-container">
     <img
       src="../../images/stepper/mobile-no-labels.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -300,7 +300,7 @@ This may be the most common format for small screens or zooming in. You only dis
   <div className="image-container">
     <img
       src="../../images/stepper/mobile-summary-view.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>

--- a/website/react-magma-docs/src/pages/design/table.mdx
+++ b/website/react-magma-docs/src/pages/design/table.mdx
@@ -41,7 +41,7 @@ Tables display information in a grid-like format of rows and columns. They organ
 ## Anatomy
 
 <figure>
-  <img src="../../images/tables/table-anatomy.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/table-anatomy.png" alt=" " />
 </figure>
 
 1. Table title
@@ -55,7 +55,7 @@ Tables display information in a grid-like format of rows and columns. They organ
 Tables come in three different sizes or densities: compact, normal, and loose. This is applied to the entire table and not just a specific row or cell.
 
 <figure>
-  <img src="../../images/tables/table-densities.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/table-densities.png" alt=" " />
 </figure>
 
 ### Compact Density
@@ -63,7 +63,7 @@ Tables come in three different sizes or densities: compact, normal, and loose. T
 The compact density can be useful for tables with a relatively large number of columns and rows by allowing you to simply fit more on the screen at once.
 
 <figure>
-  <img src="../../images/tables/compact-density.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/compact-density.png" alt=" " />
 </figure>
 
 ### Normal Density
@@ -71,7 +71,7 @@ The compact density can be useful for tables with a relatively large number of c
 The default padding of tables is optimized for a nice balance between compact and loose densities.
 
 <figure>
-  <img src="../../images/tables/normal-density.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/normal-density.png" alt=" " />
 </figure>
 
 ### Loose Density
@@ -79,7 +79,7 @@ The default padding of tables is optimized for a nice balance between compact an
 The loose density can be useful if you have a relatively small amount of data and if the user would benefit from the table having more white-space within it.
 
 <figure>
-  <img src="../../images/tables/loose-density.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/loose-density.png" alt=" " />
 </figure>
 
 ---
@@ -95,14 +95,14 @@ The loose density can be useful if you have a relatively small amount of data an
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/tables/table-title.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/tables/table-title.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2">
       <figure>
         <img
           src="../../images/tables/table-description.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -115,7 +115,7 @@ The loose density can be useful if you have a relatively small amount of data an
 - In cases where a column title is too long, the text will wrap to two lines.
 
 <figure>
-  <img src="../../images/tables/column-titles.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/column-titles.png" alt=" " />
 </figure>
 <div className="two-col">
   <div className="row">
@@ -123,7 +123,7 @@ The loose density can be useful if you have a relatively small amount of data an
       <figure>
         <img
           src="../../images/tables/column-header-truncate.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -135,7 +135,7 @@ The loose density can be useful if you have a relatively small amount of data an
       <figure>
         <img
           src="../../images/tables/column-header-wrap.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -161,7 +161,7 @@ The loose density can be useful if you have a relatively small amount of data an
 Striped rows (zebra striping) is an optional styling you may apply to your table. This can make data-heavy tables easier for your user to read, as the stripes help guide the eye across the table and then back to the next row.
 
 <figure>
-  <img src="../../images/tables/striped-rows.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/striped-rows.png" alt=" " />
 </figure>
 
 ### Hover
@@ -169,7 +169,7 @@ Striped rows (zebra striping) is an optional styling you may apply to your table
 The table’s row hover state can help your user visually scan the columns of data in a row even if the row is not interactive. This feature is optional and is easily enabled for any table, and may be used in combination with striped rows.
 
 <figure>
-  <img src="../../images/tables/row-hover.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/row-hover.png" alt=" " />
 </figure>
 
 ### Sorting
@@ -179,7 +179,7 @@ Columns can be sorted in ascending or descending order. Sorting controls are loc
 A sorted table has three states: unsorted (sort-double-arrow), sorted-up (arrow-upward) or sorted-down (arrow-downward). The icon indicates the current sorted state. All sortable columns display an arrow icon, but only one can be actively sorted at a time.
 
 <figure>
-  <img src="../../images/tables/table-sorting.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tables/table-sorting.png" alt=" " />
 </figure>
 
 ### Inline Actions
@@ -192,7 +192,7 @@ Inline actions are functions that may be performed on a specific table row. In o
       <figure>
         <img
           src="../../images/tables/inline-actions.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -200,7 +200,7 @@ Inline actions are functions that may be performed on a specific table row. In o
       <figure>
         <img
           src="../../images/tables/inline-actions-overflow.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>

--- a/website/react-magma-docs/src/pages/design/tabs.mdx
+++ b/website/react-magma-docs/src/pages/design/tabs.mdx
@@ -22,7 +22,7 @@ import './design-guidelines-styles.css';
 <figure>
   <img
     src="../../images/tabs/tabs-anatomy.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
     aria-hidden="true"
   />
 </figure>
@@ -44,7 +44,7 @@ Text labels should clearly and succinctly describe the content they represent. T
       <figure>
         <img
           src="../../images/tabs/tabs-line-wrap.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-caution">Caution</p>
@@ -59,7 +59,7 @@ Text labels should clearly and succinctly describe the content they represent. T
       <figure>
         <img
           src="../../images/tabs/tabs-resize-text.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -75,7 +75,7 @@ Text labels should clearly and succinctly describe the content they represent. T
       <figure>
         <img
           src="../../images/tabs/tabs-truncate-text.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -90,7 +90,7 @@ Text labels should clearly and succinctly describe the content they represent. T
       <figure>
         <img
           src="../../images/tabs/tabs-icon-and-text-incorrect.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -113,7 +113,7 @@ Icons can be very helpful in helping identify the type or context of the content
 Icons can be placed to the left of the label or on top of the label, depending on the desired outcome or constraints of the layout. The added space required by the icon requires even greater effort to make the text label as short as possible.
 
 <figure>
-  <img src="../../images/tabs/tabs-icon-and-text.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-icon-and-text.png" alt=" " />
   <figcaption>
     <p>
       Icons and text labels can be used together to help communicate what the
@@ -125,7 +125,7 @@ Icons can be placed to the left of the label or on top of the label, depending o
 <figure>
   <img
     src="../../images/tabs/tabs-icon-and-label-stacked.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -140,7 +140,7 @@ Icons can be placed to the left of the label or on top of the label, depending o
 Icon-only tabs can be very useful for communicating the content they represent, especially in small areas or on small devices.
 
 <figure>
-  <img src="../../images/tabs/tabs-icon-only.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-icon-only.png" alt=" " />
   <figcaption>
     <p className="title title-caution">Caution</p>
     <p>
@@ -161,7 +161,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
       <figure>
         <img
           src="../../images/tabs/tabs-active-indicator-bottom.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -173,7 +173,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
       <figure>
         <img
           src="../../images/tabs/tabs-active-indicator-top.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-caution">Caution</p>
@@ -195,7 +195,7 @@ The active tab indicator helps make it very clear which tab is currently selecte
 ## States
 
 <figure>
-  <img src="../../images/tabs/tabs-states.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-states.png" alt=" " />
 </figure>
 
 1. Inactive
@@ -211,14 +211,14 @@ The active tab indicator helps make it very clear which tab is currently selecte
 Tabs are displayed in a single row or column, with each tab connected to the content they represent. Tabs can be attached to headers, main content areas, side panels, and nestled into cards.
 
 <figure>
-  <img src="../../images/tabs/tabs-header.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-header.png" alt=" " />
   <figcaption>
     <p>Example of tabs in the header of a panel.</p>
   </figcaption>
 </figure>
 <span className="horizontal-spacer" />
 <figure>
-  <img src="../../images/tabs/tabs-column.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-column.png" alt=" " />
   <figcaption>
     <p>Example of tabs in a column.</p>
   </figcaption>
@@ -230,7 +230,7 @@ Tabs are displayed in a single row or column, with each tab connected to the con
       <figure>
         <img
           src="../../images/tabs/nesting-tabs-wrong.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -242,7 +242,7 @@ Tabs are displayed in a single row or column, with each tab connected to the con
       <figure>
         <img
           src="../../images/tabs/stacking-tabs-wrong.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -266,21 +266,21 @@ The default width of a tab is undefined and is determined by the content within 
 Auto-width tabs can be left-aligned, right-aligned, or centered.
 
 <figure>
-  <img src="../../images/tabs/tabs-left-aligned.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-left-aligned.png" alt=" " />
   <figcaption>
     <p>By default, auto-width tabs are left aligned.</p>
   </figcaption>
 </figure>
 <span className="horizontal-spacer" />
 <figure>
-  <img src="../../images/tabs/tabs-right-aligned.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-right-aligned.png" alt=" " />
   <figcaption>
     <p>You may also right-align the tabs with the content below or above.</p>
   </figcaption>
 </figure>
 <span className="horizontal-spacer" />
 <figure>
-  <img src="../../images/tabs/tabs-centered.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-centered.png" alt=" " />
   <figcaption>
     <p>On wider layouts, centering the tabs may work well.</p>
   </figcaption>
@@ -293,7 +293,7 @@ The tab container for auto-width tabs will automatically scroll if the container
 <figure>
   <img
     src="../../images/tabs/horizontal-scrolling-tabs.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -308,7 +308,7 @@ The tab container for auto-width tabs will automatically scroll if the container
 Full-width tabs can be calculated by the width of the container divided by the number of tabs. Full-width tabs should only be used if you can guarantee that all tabs will be visible without truncation regardless of the size of the container.
 
 <figure>
-  <img src="../../images/tabs/tabs-full-width.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-full-width.png" alt=" " />
   <figcaption>
     <p>Simple example of full-width tabs, each tab being of equal width.</p>
   </figcaption>
@@ -317,7 +317,7 @@ Full-width tabs can be calculated by the width of the container divided by the n
 <figure>
   <img
     src="../../images/tabs/tabs-alignment-with-content.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p className="title title-caution">Caution</p>
@@ -336,7 +336,7 @@ Tabs may also be placed to the left of their corresponding content in a vertical
 **NOTE:** There isn’t any default Responsive behavior for when the content area gets too narrow to display the tabs next to the content. You are encouraged to reuse solutions from other instances of vertical tabs. In the event no solution exists that will work in your scenario, a new solution will have to be designed.
 
 <figure>
-  <img src="../../images/tabs/tabs-vertical.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/tabs/tabs-vertical.png" alt=" " />
   <figcaption>
     <p>Simple example of vertical tabs on the left side of the content.</p>
   </figcaption>
@@ -349,7 +349,7 @@ Vertical tabs will also automatically scroll when the height of their container 
 <figure>
   <img
     src="../../images/tabs/tabs-vertical-scrolling.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>
@@ -368,7 +368,7 @@ The tabs have inverse styling available for use on dark backgrounds. Take care w
 <figure>
   <img
     src="../../images/tabs/tabs-inverse-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p>Example of tabs on a dark blue background.</p>

--- a/website/react-magma-docs/src/pages/design/time-picker.mdx
+++ b/website/react-magma-docs/src/pages/design/time-picker.mdx
@@ -16,7 +16,7 @@ The Time input gives the user the ability to input a time in a format the develo
   <div className="image-container">
     <img
       src="../../images/inputs/time-input-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>
@@ -29,7 +29,7 @@ You can tab into the Time input to individually manipulate the hours, minutes, a
   <div className="image-container">
     <img
       src="../../images/inputs/time-input-keyboard.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
 </figure>

--- a/website/react-magma-docs/src/pages/design/toast.mdx
+++ b/website/react-magma-docs/src/pages/design/toast.mdx
@@ -20,7 +20,7 @@ Toasts are the least intrusive of the three types of alerts and are used primari
 <figure>
   <img
     src="../../images/alerts/toast-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 
@@ -31,7 +31,7 @@ Toasts are the least intrusive of the three types of alerts and are used primari
 The basic anatomy of the alert is the same across all three types (banner, inline, toast).
 
 <figure>
-  <img src="../../images/alerts/alert-anatomy.png" alt="GATSBY_EMPTY_ALT" />
+  <img src="../../images/alerts/alert-anatomy.png" alt=" " />
 </figure>
 
 1. Container
@@ -49,7 +49,7 @@ If multiple toasts are triggered, they will automatically stack vertically. When
 <figure>
   <img
     src="../../images/alerts/stack-toasts-incorrect.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p className="title title-incorrect">Incorrect</p>
@@ -62,7 +62,7 @@ If multiple toasts are triggered, they will automatically stack vertically. When
 <figure>
   <img
     src="../../images/alerts/batch-actions-toast.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
   <figcaption>
     <p className="title title-correct">Correct</p>
@@ -84,7 +84,7 @@ Avoid displaying errors or warnings with toasts, but if you have to, then these 
       <figure>
         <img
           src="../../images/alerts/toast-error-manually-dismiss.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -99,7 +99,7 @@ Avoid displaying errors or warnings with toasts, but if you have to, then these 
       <figure>
         <img
           src="../../images/alerts/toast-successful-auto-dismiss.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -134,7 +134,7 @@ When the viewport is 600px wide and smaller, we automatically reduce the icon an
 <figure>
   <img
     src="../../images/alerts/mobile-toast-alert-example.png"
-    alt="GATSBY_EMPTY_ALT"
+    alt=" "
   />
 </figure>
 

--- a/website/react-magma-docs/src/pages/design/toggle.mdx
+++ b/website/react-magma-docs/src/pages/design/toggle.mdx
@@ -20,7 +20,7 @@ Toggle switches are a great way to adjust settings when you are simply turning s
   <div className="image-container">
     <img
       src="../../images/selection-controls/Toggle-switch-example.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>
@@ -36,7 +36,7 @@ Toggles can be on, off, or disabled.
   <div className="image-container">
     <img
       src="../../images/selection-controls/Toggle-switch-states.png"
-      alt="GATSBY_EMPTY_ALT"
+      alt=" "
     />
   </div>
   <figcaption>

--- a/website/react-magma-docs/src/pages/design/tooltip.mdx
+++ b/website/react-magma-docs/src/pages/design/tooltip.mdx
@@ -23,7 +23,7 @@ Tooltips are necessary for interactive elements whose function may not be clearl
       <figure>
         <img
           src="../../images/tooltips/Tooltip-imagery.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -35,7 +35,7 @@ Tooltips are necessary for interactive elements whose function may not be clearl
       <figure>
         <img
           src="../../images/tooltips/Tooltip-repeat-word.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>

--- a/website/react-magma-docs/src/pages/design/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/design/tree-view.mdx
@@ -19,7 +19,7 @@ A tree view comprises nested heading levels, establishing a content hierarchy fo
 
 <figure>
   <div className="image-container">
-    <img src="../../images/treeview/intro-image.png" alt="GATSBY_EMPTY_ALT" />
+    <img src="../../images/treeview/intro-image.png" alt=" " />
   </div>
 </figure>
 
@@ -44,7 +44,7 @@ When dealing with a single level of nested information, consider utilizing an al
   <div className="row">
     <div className="col col-1">
       <figure>
-        <img src="../../images/treeview/anatomy.png" alt="GATSBY_EMPTY_ALT" />
+        <img src="../../images/treeview/anatomy.png" alt=" " />
       </figure>
     </div>
     <div className="col col-2" />
@@ -69,7 +69,7 @@ Nodes stack directly on top of each other with 0px space between them. Having no
       <figure>
         <img
           src="../../images/treeview/stacking-nodes.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -87,7 +87,7 @@ Nested nodes in a tree view rely on organized and consistent alignment to group 
       <figure>
         <img
           src="../../images/treeview/nesting-alignment-1.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -95,7 +95,7 @@ Nested nodes in a tree view rely on organized and consistent alignment to group 
       <figure>
         <img
           src="../../images/treeview/nesting-alignment-1-1.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -124,7 +124,7 @@ Icons can be a helpful way of scanning a list for various item types. Icons shou
       <figure>
         <img
           src="../../images/treeview/node-icons-correct.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-correct">Correct</p>
@@ -136,7 +136,7 @@ Icons can be a helpful way of scanning a list for various item types. Icons shou
       <figure>
         <img
           src="../../images/treeview/node-icons-wrong.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
         <figcaption>
           <p className="title title-incorrect">Incorrect</p>
@@ -161,7 +161,7 @@ Branch nodes and leaf nodes exhibit identical styles across various states. The 
       <figure>
         <img
           src="../../images/treeview/single-select-states.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -169,7 +169,7 @@ Branch nodes and leaf nodes exhibit identical styles across various states. The 
       <figure>
         <img
           src="../../images/treeview/multi-select-states.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -192,7 +192,7 @@ To expand or collapse a branch node the user can click anywhere within the arrow
       <figure>
         <img
           src="../../images/treeview/expanding-behavior.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>
@@ -211,7 +211,7 @@ To expand or collapse a branch node the user can click anywhere within the arrow
       <figure>
         <img
           src="../../images/treeview/selecting-behavior.png"
-          alt="GATSBY_EMPTY_ALT"
+          alt=" "
         />
       </figure>
     </div>


### PR DESCRIPTION
Closes: #1349

## What I did
- Replaced `GATSBY_EMPTY_ALT` with `empty` alt for images

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to React Magma Docs -> Design -> Button -> open dev tools -> for all images should be alt=` `

Need to repeat these steps for all updated pages.
