### PR TITLE
fix(timepicker): add functionality for up/down arrow keys and tests

### DIFF
--- a/.changeset/fix-timepicker-functionality-for-arrow-keys.md
+++ b/.changeset/fix-timepicker-functionality-for-arrow-keys.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(TimePicker): add functionality for up/down arrow keys and tests

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.stories.tsx
@@ -88,7 +88,11 @@ export const Events = () => {
       </Paragraph>
       <Paragraph>onChange called {onChangeCalledTimes} times</Paragraph>
 
-      <TimePicker labelText="Time Due" onChange={handleOnChange} />
+      <TimePicker
+        labelText="Time Due"
+        onChange={handleOnChange}
+        value={timeValue}
+      />
       <br />
       <Button onClick={() => setTimeValue(undefined)}>Clear Time</Button>
     </>

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
@@ -108,6 +108,52 @@ describe('TimePicker', () => {
       expect(getByTestId('minutesTimeInput')).toHaveFocus();
     });
 
+    it('should change the hour input if the up arrow key is clicked', () => {
+      const { getByTestId } = render(<TimePicker label="label" />);
+
+      const hoursInput = getByTestId('hoursTimeInput');
+      hoursInput.focus();
+
+      fireEvent.keyDown(hoursInput, { key: 'ArrowUp' });
+
+      expect(hoursInput.value).toEqual('01');
+
+      fireEvent.keyDown(hoursInput, { key: 'ArrowUp' });
+
+      expect(hoursInput.value).toEqual('02');
+
+      fireEvent.change(hoursInput, { target: { value: '12' } });
+
+      expect(hoursInput.value).toEqual('12');
+
+      fireEvent.keyDown(hoursInput, { key: 'ArrowUp' });
+
+      expect(hoursInput.value).toEqual('12');
+    });
+
+    it('should change the hour input if the down arrow key is clicked', () => {
+      const { getByTestId } = render(<TimePicker label="label" />);
+
+      const hoursInput = getByTestId('hoursTimeInput');
+      hoursInput.focus();
+
+      fireEvent.keyDown(hoursInput, { key: 'ArrowDown' });
+
+      expect(hoursInput.value).toEqual('01');
+
+      fireEvent.keyDown(hoursInput, { key: 'ArrowDown' });
+
+      expect(hoursInput.value).toEqual('01');
+
+      fireEvent.change(hoursInput, { target: { value: '12' } });
+
+      expect(hoursInput.value).toEqual('12');
+
+      fireEvent.keyDown(hoursInput, { key: 'ArrowDown' });
+
+      expect(hoursInput.value).toEqual('11');
+    });
+
     it('should call the onChange for a valid hour entered', () => {
       const onChange = jest.fn();
       const { getByTestId } = render(
@@ -232,6 +278,48 @@ describe('TimePicker', () => {
       fireEvent.keyDown(minsInput, { key: 'Backspace' });
 
       expect(onChange).toHaveBeenCalledWith('');
+    });
+
+    it('should change the minute input if the up arrow key is clicked', () => {
+      const { getByTestId } = render(<TimePicker label="label" />);
+
+      const minutesInput = getByTestId('minutesTimeInput');
+      minutesInput.focus();
+
+      fireEvent.keyDown(minutesInput, { key: 'ArrowUp' });
+
+      expect(minutesInput.value).toEqual('01');
+
+      fireEvent.keyDown(minutesInput, { key: 'ArrowUp' });
+
+      expect(minutesInput.value).toEqual('02');
+
+      fireEvent.change(minutesInput, { target: { value: '59' } });
+
+      expect(minutesInput.value).toEqual('59');
+
+      fireEvent.keyDown(minutesInput, { key: 'ArrowUp' });
+
+      expect(minutesInput.value).toEqual('59');
+    });
+
+    it('should change the minute input if the down arrow key is clicked', () => {
+      const { getByTestId } = render(<TimePicker label="label" />);
+
+      const minutesInput = getByTestId('minutesTimeInput');
+      minutesInput.focus();
+
+      fireEvent.keyDown(minutesInput, { key: 'ArrowDown' });
+
+      expect(minutesInput.value).toEqual('00');
+
+      fireEvent.change(minutesInput, { target: { value: '59' } });
+
+      expect(minutesInput.value).toEqual('59');
+
+      fireEvent.keyDown(minutesInput, { key: 'ArrowDown' });
+
+      expect(minutesInput.value).toEqual('58');
     });
 
     it('should call the onChange for a valid minute entered', () => {

--- a/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
+++ b/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
@@ -187,6 +187,34 @@ export function useTimePicker(props: UseTimePickerProps) {
     if (event.key === 'ArrowRight') {
       minuteRef.current.focus();
     }
+
+    if (event.key === 'ArrowUp') {
+      const next = Number(hour || '0') + 1;
+
+      if (next > 12) return;
+
+      const newHour = calculateHour(next);
+
+      setHour(newHour);
+      setMinute(minute || '00');
+      updateTime(`${newHour}:${minute || '00'} ${amPm}`);
+
+      event.preventDefault();
+    }
+
+    if (event.key === 'ArrowDown') {
+      const prev = hour ? Number(hour) - 1 : 1;
+
+      if (prev < 1) return;
+
+      const newHour = calculateHour(prev);
+
+      setHour(newHour);
+      setMinute(minute || '00');
+      updateTime(`${newHour}:${minute || '00'} ${amPm}`);
+
+      event.preventDefault();
+    }
   }
 
   function handleMinuteKeyDown(event: React.KeyboardEvent, minChangeFunc) {
@@ -202,6 +230,32 @@ export function useTimePicker(props: UseTimePickerProps) {
 
     if (event.key === 'ArrowRight') {
       amPmRef.current.focus();
+    }
+
+    if (event.key === 'ArrowUp') {
+      const next = Number(minute || '0') + 1;
+
+      if (next > 59) return;
+
+      const newMinute = calculateMinute(next);
+
+      setMinute(newMinute);
+      setHour(hour || '12');
+      updateTime(`${hour || '12'}:${newMinute} ${amPm}`);
+      event.preventDefault();
+    }
+
+    if (event.key === 'ArrowDown') {
+      const prev = minute ? Number(minute) - 1 : 0;
+
+      if (prev < 0) return;
+
+      const newMinute = calculateMinute(prev);
+
+      setMinute(newMinute);
+      setHour(hour || '12');
+      updateTime(`${hour || '12'}:${newMinute} ${amPm}`);
+      event.preventDefault();
     }
   }
 


### PR DESCRIPTION
Same PR as #1961 for react-17

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add functionality for up/down arrow keys and tests

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook -> TimePicker -> Check that arrows up/down work correctly and new tests pass

## Note
Now, when changing the time in Storybook -> TimePicker -> Events, the onChange call is executed twice. This happens because we pass the time as a prop value to TimePicker.