### PR TITLE
fix(datepicker): fix issue with canvas (jsdom error) for react-18

### DIFF
--- a/.changeset/fix-datepicker-canvas-issue-react-18.md
+++ b/.changeset/fix-datepicker-canvas-issue-react-18.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(DatePicker): fix issue with canvas (jsdom error) for react-18

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.test.js
@@ -6,11 +6,6 @@ import { CalendarContext } from './CalendarContext';
 import { CalendarHeader } from './CalendarHeader';
 import userEvent from '@testing-library/user-event';
 
-HTMLCanvasElement.prototype.getContext = () => ({
-  font: '',
-  measureText: text => ({ width: text.length * 8 }),
-});
-
 describe('Calendar Header', () => {
   describe('next month button', () => {
     it('should call to move forward a month when clicking the next month button', async () => {

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
@@ -7,11 +7,6 @@ import { CalendarContext } from './CalendarContext';
 import { CalendarMonth } from './CalendarMonth';
 import { getCalendarMonthWeeks } from './utils';
 
-HTMLCanvasElement.prototype.getContext = () => ({
-  font: '',
-  measureText: text => ({ width: text.length * 8 }),
-});
-
 describe('Calendar Month', () => {
   describe('focus trap', () => {
     it('should handle tab and loop it through the calendar month', async () => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -25,11 +25,6 @@ import { Modal } from '../Modal';
 
 import { DatePicker } from '.';
 
-HTMLCanvasElement.prototype.getContext = () => ({
-  font: '',
-  measureText: text => ({ width: text.length * 8 }),
-});
-
 const ClearingTheDate = args => {
   const [chosenDate, setChosenDate] = React.useState(undefined);
 

--- a/packages/react-magma-dom/src/components/DatePicker/MonthPicker.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/MonthPicker.tsx
@@ -55,12 +55,21 @@ export const MonthPicker: React.FunctionComponent<MonthPickerProps> = props => {
   }
 
   const getTextWidth = (text: string, font: string) => {
-    const canvas = document.createElement('canvas');
-    const context = canvas.getContext('2d');
+    try {
+      const canvas = document.createElement('canvas');
+      // Note: jsdom logs a console error here since Canvas 2D API is not implemented.
+      // Safe to ignore in test environment.
+      const context = canvas?.getContext?.('2d');
 
-    context.font = font;
+      if (!context) return 0;
 
-    return context.measureText(text).width;
+      context.font = font;
+
+      return context.measureText(text).width;
+    } catch {
+      // jsdom throws "Not implemented: HTMLCanvasElement.prototype.getContext"
+      return 0;
+    }
   };
 
   const getMonthWidth = (month: string) => {

--- a/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
+++ b/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
@@ -9,11 +9,6 @@ import { magma } from '../../theme/magma';
 
 import { DateTimePicker } from '.';
 
-HTMLCanvasElement.prototype.getContext = () => ({
-  font: '',
-  measureText: text => ({ width: text.length * 8 }),
-});
-
 describe('DateTimePicker', () => {
   it('should find element by testId', () => {
     const testId = 'test-id';


### PR DESCRIPTION
Same PR as #1967 for react-17

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix issue with canvas (jsdom error) for react-18

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
All tests pass, but a console error appears:
HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)
This happens because jsdom doesn’t implement the Canvas 2D API. The error doesn’t affect test results.