### PR TITLE
feat(SplitDropdown): Add new `leadingIcon` prop

### DIFF
--- a/.changeset/feat-SplitDropdown-add-leading-icon.md
+++ b/.changeset/feat-SplitDropdown-add-leading-icon.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(SplitDropdown): Add new `leadingIcon` prop.

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -9,6 +9,7 @@ import {
   RestaurantMenuIcon,
   SettingsIcon,
   GooglePlusIcon,
+  LibraryAddIcon,
 } from 'react-magma-icons';
 
 import { DropdownButton } from './DropdownButton';
@@ -235,79 +236,170 @@ export const SmallButton = {
 };
 
 const SplitTemplate: StoryFn<DropdownProps> = args => (
-  <div style={{ margin: '150px auto', textAlign: 'center' }}>
-    <Dropdown {...args}>
-      <DropdownSplitButton aria-label="Split" size={ButtonSize.medium}>
-        Split Dropdown
-      </DropdownSplitButton>
-      <DropdownContent>
-        <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-        <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-      </DropdownContent>
-    </Dropdown>
-    <br />
-    <br />
-    <Dropdown {...args}>
-      <DropdownSplitButton
-        aria-label="Split"
-        size={ButtonSize.medium}
-        variant={ButtonVariant.solid}
-        color={ButtonColor.secondary}
-      >
-        Split Dropdown
-      </DropdownSplitButton>
-      <DropdownContent>
-        <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-        <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-      </DropdownContent>
-    </Dropdown>
-    <br />
-    <br />
-    <Dropdown {...args}>
-      <DropdownSplitButton
-        aria-label="Split"
-        size={ButtonSize.medium}
-        variant={ButtonVariant.solid}
-        color={ButtonColor.danger}
-      >
-        Split Dropdown
-      </DropdownSplitButton>
-      <DropdownContent>
-        <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-        <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-      </DropdownContent>
-    </Dropdown>
-    <br />
-    <br />
-    <Dropdown {...args}>
-      <DropdownSplitButton
-        aria-label="Split"
-        size={ButtonSize.medium}
-        variant={ButtonVariant.solid}
-        color={ButtonColor.subtle}
-      >
-        Split Dropdown
-      </DropdownSplitButton>
-      <DropdownContent>
-        <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-        <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-      </DropdownContent>
-    </Dropdown>
-    <br />
-    <br />
-    <Dropdown isInverse>
-      <DropdownSplitButton
-        aria-label="Split"
-        size={ButtonSize.medium}
-        variant={ButtonVariant.solid}
-      >
-        Split Dropdown Inverse
-      </DropdownSplitButton>
-      <DropdownContent>
-        <DropdownMenuItem>Menu item 1</DropdownMenuItem>
-        <DropdownMenuItem>Menu item number two</DropdownMenuItem>
-      </DropdownContent>
-    </Dropdown>
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '150px',
+    }}
+  >
+    <div style={{ margin: '150px 0', textAlign: 'center' }}>
+      <Dropdown {...args}>
+        <DropdownSplitButton aria-label="Split" size={ButtonSize.medium}>
+          Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <br />
+      <br />
+      <Dropdown {...args}>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          variant={ButtonVariant.solid}
+          color={ButtonColor.secondary}
+        >
+          Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <br />
+      <br />
+      <Dropdown {...args}>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          variant={ButtonVariant.solid}
+          color={ButtonColor.danger}
+        >
+          Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <br />
+      <br />
+      <Dropdown {...args}>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          variant={ButtonVariant.solid}
+          color={ButtonColor.subtle}
+        >
+          Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <br />
+      <br />
+      <Dropdown isInverse>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          variant={ButtonVariant.solid}
+        >
+          Split Dropdown Inverse
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    </div>
+    <div style={{ margin: '150px 0', textAlign: 'center' }}>
+      <Dropdown {...args}>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          leadingIcon={<LibraryAddIcon />}
+        >
+          Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <br />
+      <br />
+      <Dropdown {...args}>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          variant={ButtonVariant.solid}
+          color={ButtonColor.secondary}
+          leadingIcon={<LibraryAddIcon />}
+        >
+          Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <br />
+      <br />
+      <Dropdown {...args}>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          variant={ButtonVariant.solid}
+          color={ButtonColor.danger}
+          leadingIcon={<LibraryAddIcon />}
+        >
+          Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <br />
+      <br />
+      <Dropdown {...args}>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          variant={ButtonVariant.solid}
+          color={ButtonColor.subtle}
+          leadingIcon={<LibraryAddIcon />}
+        >
+          Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <br />
+      <br />
+      <Dropdown isInverse>
+        <DropdownSplitButton
+          aria-label="Split"
+          size={ButtonSize.medium}
+          variant={ButtonVariant.solid}
+          leadingIcon={<LibraryAddIcon />}
+        >
+          Split Dropdown Inverse
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    </div>
   </div>
 );
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -6,6 +6,7 @@ import { transparentize } from 'polished';
 import {
   AsteriskIcon,
   CheckIcon,
+  LibraryAddIcon,
   ReorderIcon,
   RestaurantMenuIcon,
   SettingsIcon,
@@ -231,6 +232,35 @@ describe('Dropdown', () => {
     await waitFor(() => {
       expect(getByLabelText('Custom label')).toBeInTheDocument();
     });
+  });
+
+  it('should render a split dropdown with leading icon', async () => {
+    const { getByTestId, container } = render(
+      <Dropdown>
+        <DropdownSplitButton leadingIcon={<LibraryAddIcon />}>
+          Toggle me
+        </DropdownSplitButton>
+        <DropdownContent />
+      </Dropdown>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('caretDown')).toBeInTheDocument();
+      expect(container.querySelectorAll('button').length).toBe(2);
+      expect(container.querySelectorAll('svg').length).toBe(2);
+    });
+
+    const svgs = container.querySelectorAll('svg');
+
+    svgs.forEach(svg => {
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    const leadingIconSvg = svgs[0];
+    expect(leadingIconSvg).toBeInTheDocument();
+
+    const caretSvg = svgs[1];
+    expect(caretSvg).toBeInTheDocument();
   });
 
   it('should render a split dropdown with margin left on solid variants', async () => {

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 
-import {
-  ArrowDropDownIcon,
-  ArrowDropUpIcon,
-  HdIcon,
-  WcIcon,
-} from 'react-magma-icons';
+import { ArrowDropDownIcon, ArrowDropUpIcon } from 'react-magma-icons';
 
 import {
   Button,
@@ -14,7 +9,7 @@ import {
   ButtonStyles,
   ButtonVariant,
 } from '../Button';
-import { ButtonIconPosition, getIconSize, IconButton } from '../IconButton';
+import { getIconSize, IconButton } from '../IconButton';
 import { DropdownContext, DropdownDropDirection } from './Dropdown';
 import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 
-import { ArrowDropDownIcon, ArrowDropUpIcon } from 'react-magma-icons';
+import {
+  ArrowDropDownIcon,
+  ArrowDropUpIcon,
+  HdIcon,
+  WcIcon,
+} from 'react-magma-icons';
 
 import {
   Button,
@@ -9,7 +14,7 @@ import {
   ButtonStyles,
   ButtonVariant,
 } from '../Button';
-import { getIconSize, IconButton } from '../IconButton';
+import { ButtonIconPosition, getIconSize, IconButton } from '../IconButton';
 import { DropdownContext, DropdownDropDirection } from './Dropdown';
 import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
@@ -34,6 +39,10 @@ export interface DropdownSplitButtonProps extends ButtonStyles {
    */
   disabled?: boolean;
   /**
+   * Leading icon to display on the left side within the component
+   */
+  leadingIcon?: React.ReactElement;
+  /**
    * Function that fires when the button is clicked
    */
   onClick?: () => void;
@@ -56,6 +65,7 @@ export const DropdownSplitButton = React.forwardRef<
     id,
     variant = ButtonVariant.solid,
     onClick,
+    leadingIcon,
     ...other
   } = resolvedProps;
 
@@ -111,19 +121,36 @@ export const DropdownSplitButton = React.forwardRef<
 
   return (
     <div ref={context.setReference}>
-      <Button
-        {...other}
-        id={resolvedContext.dropdownButtonId.current}
-        isInverse={resolvedContext.isInverse}
-        onClick={handleButtonClick}
-        shape={ButtonShape.leftCap}
-        style={{ borderRight: 0, marginRight: 0 }}
-        variant={variant}
-        tabIndex={0}
-        ref={splitButtonRef}
-      >
-        {children}
-      </Button>
+      {leadingIcon ? (
+        <IconButton
+          {...other}
+          id={resolvedContext.dropdownButtonId.current}
+          isInverse={resolvedContext.isInverse}
+          onClick={handleButtonClick}
+          shape={ButtonShape.leftCap}
+          style={{ borderRight: 0, marginRight: 0 }}
+          variant={variant}
+          tabIndex={0}
+          ref={splitButtonRef}
+          icon={leadingIcon}
+        >
+          {children}
+        </IconButton>
+      ) : (
+        <Button
+          {...other}
+          id={resolvedContext.dropdownButtonId.current}
+          isInverse={resolvedContext.isInverse}
+          onClick={handleButtonClick}
+          shape={ButtonShape.leftCap}
+          style={{ borderRight: 0, marginRight: 0 }}
+          variant={variant}
+          tabIndex={0}
+          ref={splitButtonRef}
+        >
+          {children}
+        </Button>
+      )}
       <IconButton
         {...other}
         aria-expanded={resolvedContext.isOpen}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 
-import { ArrowDropDownIcon, ArrowDropUpIcon } from 'react-magma-icons';
+import {
+  ArrowDropDownIcon,
+  ArrowDropUpIcon,
+  IconProps,
+} from 'react-magma-icons';
 
 import {
   Button,
@@ -36,7 +40,7 @@ export interface DropdownSplitButtonProps extends ButtonStyles {
   /**
    * Leading icon to display on the left side within the component
    */
-  leadingIcon?: React.ReactElement;
+  leadingIcon?: React.ReactElement<IconProps>;
   /**
    * Function that fires when the button is clicked
    */

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -118,37 +118,29 @@ export const DropdownSplitButton = React.forwardRef<
     return theme.spaceScale.spacing01;
   }
 
+  const sharedButtonProps = React.useMemo(
+    () => ({
+      ...other,
+      id: resolvedContext.dropdownButtonId.current,
+      isInverse: resolvedContext.isInverse,
+      onClick: handleButtonClick,
+      shape: ButtonShape.leftCap,
+      style: { borderRight: 0, marginRight: 0 },
+      variant,
+      tabIndex: 0,
+      ref: splitButtonRef,
+    }),
+    [props]
+  );
+
   return (
     <div ref={context.setReference}>
       {leadingIcon ? (
-        <IconButton
-          {...other}
-          id={resolvedContext.dropdownButtonId.current}
-          isInverse={resolvedContext.isInverse}
-          onClick={handleButtonClick}
-          shape={ButtonShape.leftCap}
-          style={{ borderRight: 0, marginRight: 0 }}
-          variant={variant}
-          tabIndex={0}
-          ref={splitButtonRef}
-          icon={leadingIcon}
-        >
+        <IconButton {...sharedButtonProps} icon={leadingIcon}>
           {children}
         </IconButton>
       ) : (
-        <Button
-          {...other}
-          id={resolvedContext.dropdownButtonId.current}
-          isInverse={resolvedContext.isInverse}
-          onClick={handleButtonClick}
-          shape={ButtonShape.leftCap}
-          style={{ borderRight: 0, marginRight: 0 }}
-          variant={variant}
-          tabIndex={0}
-          ref={splitButtonRef}
-        >
-          {children}
-        </Button>
+        <Button {...sharedButtonProps}>{children}</Button>
       )}
       <IconButton
         {...other}

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -94,7 +94,7 @@ export function Example() {
 
 ### Leading Icon
 
-The `DropdownSplitButton` supports a `leadingIcon` prop that allows you to display an icon before the button text. This icon appears on the main action button (left side of the split), while the dropdown caret remains on the toggle button (right side).
+The `DropdownSplitButton` supports a `leadingIcon` prop that allows you to display an icon to the left of the button text. This icon appears on the main action button (left side of the split), while the dropdown caret remains on the toggle button (right side).
 
 ```tsx
 import React from 'react';

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -92,6 +92,44 @@ export function Example() {
 }
 ```
 
+### Leading Icon
+
+The `DropdownSplitButton` supports a `leadingIcon` prop that allows you to display an icon before the button text. This icon appears on the main action button (left side of the split), while the dropdown caret remains on the toggle button (right side).
+
+```tsx
+import React from 'react';
+
+import {
+  Dropdown,
+  DropdownContent,
+  DropdownMenuItem,
+  DropdownSplitButton,
+} from 'react-magma-dom';
+import { LibraryAddIcon } from 'react-magma-icons';
+
+export function Example() {
+  function handleSplitButtonClick() {
+    alert('Button Clicked!');
+  }
+
+  return (
+    <Dropdown>
+      <DropdownSplitButton
+        aria-label="Split Button"
+        onClick={handleSplitButtonClick}
+        leadingIcon={<LibraryAddIcon />}
+      >
+        Split Button
+      </DropdownSplitButton>
+      <DropdownContent>
+        <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+        <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+      </DropdownContent>
+    </Dropdown>
+  );
+}
+```
+
 ## Drop Direction (deprecated)
 
 Using the `dropDirection` prop will change where the menu appears and the arrow direction. Options are `down`, `up`, `left` and `right` with `down` being default.


### PR DESCRIPTION
Closes: #1842

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add new `leadingIcon` prop

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x]  Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
1. Open Storybook -> Dropdown -> Split Button
2. Open Docs -> Dropdown -> Split Button -> Leading Icon