### PR TITLE
fix(Modal & Drawer): The content behind the Drawer is scrollable.

### DIFF
--- a/.changeset/fix-drawer-scrollable-content.md
+++ b/.changeset/fix-drawer-scrollable-content.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Drawer & Modal): Fix content scrolling underneath the Drawer and Modal when it’s open

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
@@ -15,7 +15,13 @@ const info = {
     position: {
       control: {
         type: 'select',
-        options: DrawerPosition,
+      },
+      options: ['top', 'left', 'right', 'bottom'],
+      mapping: {
+        top: DrawerPosition.top,
+        left: DrawerPosition.left,
+        right: DrawerPosition.right,
+        bottom: DrawerPosition.bottom,
       },
     },
     isInverse: {

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -293,7 +293,7 @@ describe('Modal', () => {
       );
 
       expect(onCloseSpy).not.toHaveBeenCalled();
-      await waitForElementToBeRemoved(() => queryByText('Modal Content'));
+      expect(queryByText('Modal Content')).not.toBeInTheDocument();
     });
 
     it('should not force close when clicking the close button if isModalClosingControlledManually is true', async () => {
@@ -800,13 +800,13 @@ describe('Modal', () => {
       await userEvent.keyboard('{Escape}');
 
       expect(onEscKeyDown).toHaveBeenCalled();
-      await waitForElementToBeRemoved(() => queryByText('Modal Two Content'));
+      expect(queryByText('Modal Two Content')).not.toBeInTheDocument();
       expect(getByText('Modal Content')).toBeInTheDocument();
 
       await userEvent.keyboard('{Escape}');
 
       expect(onEscKeyDown).toHaveBeenCalled();
-      await waitForElementToBeRemoved(() => queryByText('Modal Content'));
+      expect(queryByText('Modal Content')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -384,97 +384,98 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       />
     );
 
-    // Fix for server-side rendering
-    if (typeof document === 'undefined') {
-      return null;
-    }
-
-    return ReactDOM.createPortal(
-      <div ref={focusTrapElement}>
-        <Global
-          styles={css`
-            html {
-              overflow: ${isOpen ? 'hidden' : 'auto'};
-            }
-          `}
-        />
-        <ModalContainer
-          aria-labelledby={header ? headingId : null}
-          aria-label={!header ? ariaLabel : null}
-          aria-modal
-          data-testid={testId}
-          id={id}
-          modalCount={modalCount}
-          onClick={isBackgroundClickDisabled ? null : handleModalClick}
-          onMouseDown={
-            isBackgroundClickDisabled ? null : handleModalOnMouseDown
-          }
-          role="dialog"
-          style={containerStyle}
-          theme={theme}
-          isOpen={isModalOpen}
-          {...containerTransition}
-          unmountOnExit={unmountOnExit}
-          hasDrawerAnimation={hasDrawerAnimation}
-        >
-          <ModalContent
-            {...other}
-            data-testid="modal-content"
-            id={contentId}
-            ref={ref}
-            showBackgroundOverlay={showBackgroundOverlay}
-            theme={theme}
-          >
-            {header && (
-              <ModalHeader theme={theme}>
+    return isModalOpen
+      ? ReactDOM.createPortal(
+          <div ref={focusTrapElement}>
+            <Global
+              styles={css`
+                html {
+                  overflow: ${isOpen ? 'hidden' : 'auto'};
+                }
+              `}
+            />
+            <ModalContainer
+              aria-labelledby={header ? headingId : null}
+              aria-label={!header ? ariaLabel : null}
+              aria-modal
+              data-testid={testId}
+              id={id}
+              modalCount={modalCount}
+              onClick={isBackgroundClickDisabled ? null : handleModalClick}
+              onMouseDown={
+                isBackgroundClickDisabled ? null : handleModalOnMouseDown
+              }
+              role="dialog"
+              style={containerStyle}
+              theme={theme}
+              isOpen={isModalOpen}
+              {...containerTransition}
+              unmountOnExit={unmountOnExit}
+              hasDrawerAnimation={hasDrawerAnimation}
+            >
+              <ModalContent
+                {...other}
+                data-testid="modal-content"
+                id={contentId}
+                ref={ref}
+                showBackgroundOverlay={showBackgroundOverlay}
+                theme={theme}
+              >
                 {header && (
-                  <H2
-                    id={headingId}
-                    isInverse={isInverse}
-                    level={headerLevel}
-                    ref={headingRef}
-                    visualStyle={TypographyVisualStyle.headingSmall}
-                    tabIndex={-1}
-                    theme={theme}
-                  >
-                    {header}
-                  </H2>
+                  <ModalHeader theme={theme}>
+                    {header && (
+                      <H2
+                        id={headingId}
+                        isInverse={isInverse}
+                        level={headerLevel}
+                        ref={headingRef}
+                        visualStyle={TypographyVisualStyle.headingSmall}
+                        tabIndex={-1}
+                        theme={theme}
+                      >
+                        {header}
+                      </H2>
+                    )}
+                  </ModalHeader>
                 )}
-              </ModalHeader>
+                <ModalWrapper ref={bodyRef} theme={theme}>
+                  {children}
+                </ModalWrapper>
+                {!isCloseButtonHidden && (
+                  <CloseBtn theme={theme}>
+                    <IconButton
+                      aria-label={
+                        closeAriaLabel
+                          ? closeAriaLabel
+                          : i18n.modal.closeAriaLabel
+                      }
+                      color={ButtonColor.primary}
+                      icon={CloseIconButton}
+                      isInverse={isInverse}
+                      onClick={handleClose}
+                      testId="modal-closebtn"
+                      variant={ButtonVariant.link}
+                    />
+                  </CloseBtn>
+                )}
+              </ModalContent>
+            </ModalContainer>
+            {showBackgroundOverlay && (
+              <ModalBackdrop
+                data-testid="modal-backdrop"
+                onMouseDown={
+                  isBackgroundClickDisabled ? undefined : handleClose
+                }
+                fade={hasDrawerAnimation}
+                isOpen={isModalOpen}
+                style={modalCount >= 2 && { zIndex: '998' }}
+                unmountOnExit
+                theme={theme}
+              />
             )}
-            <ModalWrapper ref={bodyRef} theme={theme}>
-              {children}
-            </ModalWrapper>
-            {!isCloseButtonHidden && (
-              <CloseBtn theme={theme}>
-                <IconButton
-                  aria-label={
-                    closeAriaLabel ? closeAriaLabel : i18n.modal.closeAriaLabel
-                  }
-                  color={ButtonColor.primary}
-                  icon={CloseIconButton}
-                  isInverse={isInverse}
-                  onClick={handleClose}
-                  testId="modal-closebtn"
-                  variant={ButtonVariant.link}
-                />
-              </CloseBtn>
-            )}
-          </ModalContent>
-        </ModalContainer>
-        {showBackgroundOverlay && (
-          <ModalBackdrop
-            data-testid="modal-backdrop"
-            onMouseDown={isBackgroundClickDisabled ? undefined : handleClose}
-            fade={hasDrawerAnimation}
-            isOpen={isModalOpen}
-            style={modalCount >= 2 && { zIndex: '998' }}
-            unmountOnExit
-            theme={theme}
-          />
-        )}
-      </div>,
-      document.getElementsByTagName('body')[0]
-    );
+          </div>,
+          document.getElementsByTagName('body')[0]
+        )
+      : null;
   }
 );


### PR DESCRIPTION
Closes: #1997

## What I did
- Fixed scrolling content under the Modal and Drawer components.
- Fixed DrawerPosition controls for the Drawer example in storybook.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
1. Go to React Magma Docs -> Drawer -> Basic Usage -> Click on `Show Drawer` -> the main content should not be scrollable under the Drawer content.
2. Go to React Magma Docs -> Modal -> Basic Usage -> Click on `Show Modal` -> the main content should not be  under the Modal content.
