### PR TITLE
fix(Modal&Drawer): Add aria-haspopup="dialog" for trigger buttons.

### DIFF
--- a/.changeset/fix-modal-trigger-button.md
+++ b/.changeset/fix-modal-trigger-button.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Modal & Drawer): Added aria-haspopup="dialog" for trigger buttons and updated documentation.

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
@@ -64,7 +64,11 @@ export const Default = {
             <Button>This is a button</Button>
           </p>
         </Drawer>
-        <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
+        <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowDrawer(true)}
+          ref={buttonRef}
+        >
           Show Drawer
           <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
         </Button>
@@ -105,7 +109,11 @@ export const SiteNavigation = {
             <NavTab to="#">Four</NavTab>
           </NavTabs>
         </Drawer>
-        <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
+        <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowDrawer(true)}
+          ref={buttonRef}
+        >
           Show Drawer
           <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
         </Button>

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -45,7 +45,11 @@ export const Default = () => {
           <Button>Save</Button>
         </ButtonGroup>
       </Modal>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
         Show Modal
         <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
       </Button>
@@ -74,7 +78,11 @@ export const BackgroundCickDisabled = () => {
           <Button>Save</Button>
         </ButtonGroup>
       </Modal>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
         Show Modal
         <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
       </Button>
@@ -138,7 +146,7 @@ export const LongContentWithScrolling = () => {
           culpa qui officia deserunt mollit anim id est laborum.
         </Paragraph>
       </Modal>
-      <Button onClick={onModalShow} ref={buttonRef}>
+      <Button aria-haspopup="dialog" onClick={onModalShow} ref={buttonRef}>
         Show Modal
       </Button>
     </>
@@ -167,7 +175,7 @@ export const RadioInModal = () => {
           <Radio labelText="Option two label" value="2" />
         </RadioGroup>
       </Modal>
-      <Button onClick={onModalShow} ref={buttonRef}>
+      <Button aria-haspopup="dialog" onClick={onModalShow} ref={buttonRef}>
         Show Modal
       </Button>
     </>
@@ -261,7 +269,7 @@ export const ModalContentUpdate = () => {
           )}
         </div>
       </Modal>
-      <Button onClick={onModalShow} ref={buttonRef}>
+      <Button aria-haspopup="dialog" onClick={onModalShow} ref={buttonRef}>
         Show Modal
       </Button>
     </>
@@ -299,7 +307,11 @@ export const NoHeaderOrFocusableContent = () => {
         </Paragraph>
       </Modal>
 
-      <Button onClick={onModalNoFocusShow} ref={buttonRef}>
+      <Button
+        aria-haspopup="dialog"
+        onClick={onModalNoFocusShow}
+        ref={buttonRef}
+      >
         Show Modal with nothing focusable
       </Button>
     </>
@@ -369,10 +381,16 @@ export const ModalInAModal = () => {
           isClearable
         />
         <Paragraph>
-          <Button onClick={() => setShowModal2(true)}>Show Modal 2</Button>
+          <Button aria-haspopup="dialog" onClick={() => setShowModal2(true)}>
+            Show Modal 2
+          </Button>
         </Paragraph>
       </Modal>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
         Show Modal
       </Button>
       <Modal
@@ -491,7 +509,11 @@ export const CloseModalWithConfirmation = () => {
 
   return (
     <>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
         Show Modal
       </Button>
       <Modal
@@ -625,10 +647,18 @@ export const HeaderReference = () => {
       </Modal>
 
       <ButtonGroup>
-        <Button onClick={onModalShow} ref={customButtonRef}>
+        <Button
+          aria-haspopup="dialog"
+          onClick={onModalShow}
+          ref={customButtonRef}
+        >
           Show Custom Heading Modal
         </Button>
-        <Button onClick={onModalShowDefault} ref={defaultButtonRef}>
+        <Button
+          aria-haspopup="dialog"
+          onClick={onModalShowDefault}
+          ref={defaultButtonRef}
+        >
           Show Modal with Default Heading
         </Button>
       </ButtonGroup>
@@ -659,7 +689,12 @@ export const Inverse = () => {
         </Paragraph>
       </Modal>
       <Container isInverse style={{ padding: '12px' }}>
-        <Button onClick={() => setShowModal(true)} ref={buttonRef} isInverse>
+        <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowModal(true)}
+          ref={buttonRef}
+          isInverse
+        >
           Show Modal
           <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>

--- a/website/react-magma-docs/src/pages/api/drawer.mdx
+++ b/website/react-magma-docs/src/pages/api/drawer.mdx
@@ -9,7 +9,7 @@ props:
 
 <LeadParagraph>A container with a transition</LeadParagraph>
 
-<Alert variant="warning">The modal trigger button must have the <code>aria-haspopup="dialog"</code> attribute for accessibility purposes.</Alert>
+<Alert variant="warning">The drawer trigger button must have the <code>aria-haspopup="dialog"</code> attribute for accessibility purposes.</Alert>
 
 ## Basic Usage
 

--- a/website/react-magma-docs/src/pages/api/drawer.mdx
+++ b/website/react-magma-docs/src/pages/api/drawer.mdx
@@ -9,6 +9,8 @@ props:
 
 <LeadParagraph>A container with a transition</LeadParagraph>
 
+<Alert variant="warning">The modal trigger button must have the <code>aria-haspopup="dialog"</code> attribute for accessibility purposes.</Alert>
+
 ## Basic Usage
 
 Drawer accepts a position (top, right, bottom, or left)
@@ -44,8 +46,12 @@ export function Example() {
           <Button>This is a button</Button>
         </p>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
-        Show Drawer
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowDrawer(true)}
+        ref={buttonRef}
+      >
+        Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
     </>
@@ -91,8 +97,12 @@ export function Example() {
           <NavTab to="#">Four</NavTab>
         </NavTabs>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
-        Show Drawer
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowDrawer(true)}
+        ref={buttonRef}
+      >
+        Navigation Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
     </>
@@ -141,8 +151,12 @@ export function Example() {
           <NavTab to="#">Four</NavTab>
         </NavTabs>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
-        Show Drawer
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowDrawer(true)}
+        ref={buttonRef}
+      >
+        Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
     </>
@@ -187,8 +201,13 @@ export function Example() {
             <Button isInverse>This is a button</Button>
           </p>
         </Drawer>
-        <Button onClick={() => setShowDrawer(true)} ref={buttonRef} isInverse>
-          Show Drawer
+        <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowDrawer(true)}
+          ref={buttonRef}
+          isInverse
+        >
+          Inverse Drawer
           <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
         </Button>
       </CardBody>
@@ -233,8 +252,12 @@ export function Example() {
           <Button>This is a button</Button>
         </p>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
-        Show Animated Drawer
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowDrawer(true)}
+        ref={buttonRef}
+      >
+        Animated Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
     </>
@@ -284,8 +307,12 @@ export function Example() {
       >
         <p>override default i18n value:</p>
       </Drawer>
-      <Button onClick={() => setShowDrawer(true)} ref={buttonRef}>
-        Show Drawer
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowDrawer(true)}
+        ref={buttonRef}
+      >
+        Drawer
         <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
       </Button>
     </I18nContext.Provider>

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -23,6 +23,8 @@ simply use `<Modal isOpen={flag} />`
 Although not required, it is helpful to inform users (especially screen reader users) when a button or link will trigger a modal dialog.
 This can be done by supplementing the button label or link text with "(opens modal dialog)" using the <Link to="/api/visually-hidden/">VisuallyHidden</Link> component.
 
+<Alert variant="warning">The modal trigger button must have the <code>aria-haspopup="dialog"</code> attribute for accessibility purposes.</Alert>
+
 ```tsx
 import React from 'react';
 
@@ -58,8 +60,12 @@ export function Example() {
           modal
         </Paragraph>
       </Modal>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
-        Show Modal
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
+        Modal
         <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
       </Button>
     </>
@@ -122,19 +128,21 @@ export function Example() {
 
       <ButtonGroup>
         <Button
+          aria-haspopup="dialog"
           size={ButtonSize.small}
           onClick={() => setShowSmallModal(true)}
           ref={smallButtonRef}
         >
-          Show Small Modal
+          Small Modal
           <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>
         <Button
+          aria-haspopup="dialog"
           size={ButtonSize.large}
           onClick={() => setShowLargeModal(true)}
           ref={largeButtonRef}
         >
-          Show Large Modal
+          Large Modal
           <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>
       </ButtonGroup>
@@ -206,7 +214,9 @@ export function Example() {
       >
         <Paragraph noTopMargin>This modal has no header.</Paragraph>
         <ButtonGroup alignment={ButtonGroupAlignment.center}>
-          <Button onClick={() => setShowModal(false)}>OK</Button>
+          <Button aria-haspopup="dialog" onClick={() => setShowModal(false)}>
+            OK
+          </Button>
         </ButtonGroup>
       </Modal>
       <Modal
@@ -221,7 +231,12 @@ export function Example() {
       >
         <Paragraph noTopMargin>This modal has a header.</Paragraph>
         <ButtonGroup alignment={ButtonGroupAlignment.center}>
-          <Button onClick={() => setShowModalHeader(false)}>OK</Button>
+          <Button
+            aria-haspopup="dialog"
+            onClick={() => setShowModalHeader(false)}
+          >
+            OK
+          </Button>
         </ButtonGroup>
       </Modal>
 
@@ -278,20 +293,29 @@ export function Example() {
       </Modal>
 
       <ButtonGroup>
-        <Button onClick={() => setShowModal(true)} ref={buttonRef}>
-          Show Modal with no header
-          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
-        </Button>
-        <Button onClick={() => setShowModalHeader(true)} ref={headerButtonRef}>
-          Show Modal with header
+        <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowModal(true)}
+          ref={buttonRef}
+        >
+          Modal with no header
           <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>
         <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowModalHeader(true)}
+          ref={headerButtonRef}
+        >
+          Modal with header
+          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+        </Button>
+        <Button
+          aria-haspopup="dialog"
           style={{ marginLeft: '0' }}
           onClick={() => setShowModalHeaderRef(true)}
           ref={headerRefButtonRef}
         >
-          Show Modal with headerRef
+          Modal with headerRef
         </Button>
       </ButtonGroup>
     </>
@@ -328,8 +352,12 @@ export function Example() {
         </Paragraph>
         <Button onClick={() => setShowModal(false)}>Close this Dialog</Button>
       </Modal>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
-        Show Modal
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
+        Modal
       </Button>
     </>
   );
@@ -376,8 +404,12 @@ export function Example() {
       <Paragraph>
         <strong>Internal Close Called Times:</strong> {internalCloseCalledTimes}
       </Paragraph>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
-        Show Modal <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
+        Modal <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
       </Button>
     </>
   );
@@ -424,21 +456,29 @@ export function Example() {
       >
         <Paragraph noTopMargin>This is a modal, doing modal things.</Paragraph>
 
-        <Button onClick={() => setShowModal2(true)} ref={nestedButtonRef}>
-          Show Modal 2
+        <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowModal2(true)}
+          ref={nestedButtonRef}
+        >
+          Nested Modal
         </Button>
       </Modal>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
-        Show Modal
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
+        Modal
         <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
       </Button>
       <Modal
         size={ModalSize.small}
-        header="Modal 2 Title"
+        header="Nested Modal Title"
         onClose={() => closeModal2()}
         isOpen={showModal2}
       >
-        <Paragraph noMargins>This is modal 2</Paragraph>
+        <Paragraph noMargins>This is nested modal</Paragraph>
       </Modal>
     </>
   );
@@ -492,8 +532,12 @@ export function Example() {
 
   return (
     <>
-      <Button onClick={() => setShowModal(true)} ref={buttonRef}>
-        Show Modal
+      <Button
+        aria-haspopup="dialog"
+        onClick={() => setShowModal(true)}
+        ref={buttonRef}
+      >
+        Confirmation Modal
       </Button>
       <Modal
         header="Modal Title"
@@ -591,8 +635,13 @@ export function Example() {
       </Modal>
       <Card isInverse>
         <CardBody>
-          <Button onClick={() => setShowModal(true)} ref={buttonRef} isInverse>
-            Show Modal
+          <Button
+            aria-haspopup="dialog"
+            onClick={() => setShowModal(true)}
+            ref={buttonRef}
+            isInverse
+          >
+            Inverse Modal
             <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
           </Button>
         </CardBody>


### PR DESCRIPTION
Closes: #2001 

## What I did
- Added aria-haspopup="dialog" for all trigger buttons for the Drawer and Modal components.
- Updated examples in docs and storybook.
-  Added an alert about using aria-haspopup="dialog" for Modal and Drawer trigger buttons.

## Screenshots
**Drawer**
<img width="930" height="831" alt="Screenshot from 2025-11-12 15-38-08" src="https://github.com/user-attachments/assets/d13048fd-848e-4ca3-8608-3f379850d74c" />

**Modal**
<img width="930" height="831" alt="Screenshot from 2025-11-12 15-38-51" src="https://github.com/user-attachments/assets/2f463d5d-4dc5-4974-b7f3-72b511c243c3" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to React Magma Docs -> Drawer -> check all trigger buttons
Go to React Magma Docs -> Modal -> check all trigger buttons
