### PR TITLE
chore: Update react magma icons to 3.2.2

### DIFF
--- a/.changeset/chore-update-react-magma-icons.version.md
+++ b/.changeset/chore-update-react-magma-icons.version.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+chore: Update React-magma-icons version to 3.2.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -39558,17 +39558,18 @@
       "license": "MIT"
     },
     "node_modules/node-notifier": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
-      "integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
-      "license": "MIT",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "growly": "^1.3.0",
-        "is-wsl": "^2.1.1",
-        "semver": "^6.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
         "shellwords": "^0.1.1",
-        "which": "^1.3.1"
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
       }
     },
     "node_modules/node-notifier/node_modules/is-docker": {
@@ -39577,6 +39578,7 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -39593,6 +39595,7 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -39600,27 +39603,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/node-notifier/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
+    "node_modules/node-notifier/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "optional": true,
+      "peer": true,
       "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/node-notifier/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-object-hash": {
@@ -43922,42 +43912,6 @@
     "node_modules/react-magma-dom": {
       "resolved": "packages/react-magma-dom",
       "link": true
-    },
-    "node_modules/react-magma-icons": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.1.tgz",
-      "integrity": "sha512-BadNRoXIVMczWOHut1B68Wa+l0WzF5kUXZakVGBcwhi1p2qRqQp2Nj/eoHJlfgzuV2XDaeFdq781Q9BGDUWX4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^17.0.39",
-        "@types/react": ">=17.0.5",
-        "@types/uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.2",
-        "react-dom": ">=17.0.2",
-        "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/uuid": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-magma-icons/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "license": "MIT"
-    },
-    "node_modules/react-magma-icons/node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
     },
     "node_modules/react-magma-landing": {
       "resolved": "website/react-magma-landing",
@@ -51641,6 +51595,21 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/tsdx/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "optional": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tsdx/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -51648,6 +51617,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tsdx/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "optional": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tsdx/node_modules/istanbul-lib-instrument": {
@@ -52523,6 +52504,40 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/tsdx/node_modules/node-notifier": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+      "integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+      "optional": true,
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.1.1",
+        "semver": "^6.3.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.1"
+      }
+    },
+    "node_modules/tsdx/node_modules/node-notifier/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/tsdx/node_modules/node-notifier/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/tsdx/node_modules/normalize-package-data": {
@@ -56725,7 +56740,7 @@
     },
     "packages/charts": {
       "name": "@react-magma/charts",
-      "version": "13.0.0",
+      "version": "14.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@carbon/charts-react": "1.23.7",
@@ -56741,8 +56756,8 @@
         "identity-obj-proxy": "3.0.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-magma-dom": "^5.0.1-rc.0",
-        "react-magma-icons": "^3.1.2"
+        "react-magma-dom": "^5.1.0-rc.3",
+        "react-magma-icons": "^3.2.2"
       },
       "engines": {
         "node": ">=14.15.0",
@@ -56753,9 +56768,21 @@
         "@emotion/styled": "^11.14.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-magma-dom": "^5.0.1-rc.0",
-        "react-magma-icons": "^3.2.1"
+        "react-magma-dom": "^5.1.0-rc.3",
+        "react-magma-icons": "^3.2.2"
       }
+    },
+    "packages/charts/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "packages/charts/node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "packages/charts/node_modules/framer-motion": {
       "version": "12.23.24",
@@ -56785,9 +56812,33 @@
         }
       }
     },
+    "packages/charts/node_modules/react-magma-icons": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.2.tgz",
+      "integrity": "sha512-hZWlCNXZ7hc2ZsbGN6E7gazH1okyLbcG0dM76cukKz6qeYcLXK5QVlyqkvAU9zVwaLsv24TzqXva5nH4rNjUxA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^17.0.39",
+        "@types/react": ">=17.0.5",
+        "@types/uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2",
+        "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/uuid": {
+          "optional": true
+        }
+      }
+    },
     "packages/dropzone": {
       "name": "@react-magma/dropzone",
-      "version": "13.0.0",
+      "version": "14.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "polished": "3.7.2",
@@ -56798,8 +56849,8 @@
         "@emotion/styled": "11.14.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-magma-dom": "^5.0.1-rc.0",
-        "react-magma-icons": "^3.1.2"
+        "react-magma-dom": "^5.1.0-rc.3",
+        "react-magma-icons": "^3.2.2"
       },
       "engines": {
         "node": ">=14.15.0",
@@ -56810,12 +56861,48 @@
         "@emotion/styled": "11.14.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-magma-dom": "^5.0.1-rc.0",
-        "react-magma-icons": "^3.2.1"
+        "react-magma-dom": "^5.1.0-rc.3",
+        "react-magma-icons": "^3.2.2"
+      }
+    },
+    "packages/dropzone/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "packages/dropzone/node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
+    },
+    "packages/dropzone/node_modules/react-magma-icons": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.2.tgz",
+      "integrity": "sha512-hZWlCNXZ7hc2ZsbGN6E7gazH1okyLbcG0dM76cukKz6qeYcLXK5QVlyqkvAU9zVwaLsv24TzqXva5nH4rNjUxA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^17.0.39",
+        "@types/react": ">=17.0.5",
+        "@types/uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2",
+        "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/uuid": {
+          "optional": true
+        }
       }
     },
     "packages/react-magma-dom": {
-      "version": "5.0.1-rc.0",
+      "version": "5.1.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.14.0",
@@ -56832,7 +56919,7 @@
         "mkdirp": "3.0.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-magma-icons": "^3.2.1",
+        "react-magma-icons": "^3.2.2",
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
@@ -56843,9 +56930,21 @@
         "framer-motion": "11.18.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-magma-icons": "^3.2.1",
+        "react-magma-icons": "^3.2.2",
         "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
+    },
+    "packages/react-magma-dom/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "packages/react-magma-dom/node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "packages/react-magma-dom/node_modules/framer-motion": {
       "version": "11.18.2",
@@ -56892,8 +56991,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "packages/react-magma-dom/node_modules/react-magma-icons": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.2.tgz",
+      "integrity": "sha512-hZWlCNXZ7hc2ZsbGN6E7gazH1okyLbcG0dM76cukKz6qeYcLXK5QVlyqkvAU9zVwaLsv24TzqXva5nH4rNjUxA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^17.0.39",
+        "@types/react": ">=17.0.5",
+        "@types/uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2",
+        "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/uuid": {
+          "optional": true
+        }
+      }
+    },
     "website/react-magma-docs": {
-      "version": "7.0.0-rc.1",
+      "version": "7.0.0-rc.4",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "7.27.1",
@@ -56902,8 +57025,8 @@
         "@emotion/styled": "11.14.0",
         "@mdx-js/mdx": "^2.3.0",
         "@mdx-js/react": "^2.3.0",
-        "@react-magma/charts": "^13.0.0",
-        "@react-magma/dropzone": "^13.0.0",
+        "@react-magma/charts": "^14.0.0-rc.1",
+        "@react-magma/dropzone": "^14.0.0-rc.1",
         "buble": "0.19.4",
         "buffer": "6.0.3",
         "core-js": "3.42.0",
@@ -56932,8 +57055,8 @@
         "react-focus-lock": "2.13.6",
         "react-helmet": "5.2.1",
         "react-live": "4.1.8",
-        "react-magma-dom": "^5.0.1-rc.0",
-        "react-magma-icons": "^3.1.2",
+        "react-magma-dom": "^5.1.0-rc.3",
+        "react-magma-icons": "^3.2.2",
         "react-spring": "6.1.10",
         "remark-mdx": "^3.1.0",
         "remark-parse": "^11.0.0",
@@ -56946,6 +57069,16 @@
       "devDependencies": {
         "ajv": "8.17.1"
       }
+    },
+    "website/react-magma-docs/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+    },
+    "website/react-magma-docs/node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
     "website/react-magma-docs/node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -57528,6 +57661,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "website/react-magma-docs/node_modules/react-magma-icons": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.2.tgz",
+      "integrity": "sha512-hZWlCNXZ7hc2ZsbGN6E7gazH1okyLbcG0dM76cukKz6qeYcLXK5QVlyqkvAU9zVwaLsv24TzqXva5nH4rNjUxA==",
+      "dependencies": {
+        "@types/node": "^17.0.39",
+        "@types/react": ">=17.0.5",
+        "@types/uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2",
+        "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/uuid": {
+          "optional": true
+        }
       }
     },
     "website/react-magma-docs/node_modules/readable-stream": {

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -43,7 +43,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-magma-dom": "^5.1.0-rc.3",
-    "react-magma-icons": "^3.1.2"
+    "react-magma-icons": "^3.2.2"
   },
   "peerDependencies": {
     "@emotion/react": "^11.14.0",
@@ -51,7 +51,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-magma-dom": "^5.1.0-rc.3",
-    "react-magma-icons": "^3.2.1"
+    "react-magma-icons": "^3.2.2"
   },
   "engines": {
     "node": ">=14.15.0",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -31,7 +31,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-magma-dom": "^5.1.0-rc.3",
-    "react-magma-icons": "^3.1.2"
+    "react-magma-icons": "^3.2.2"
   },
   "peerDependencies": {
     "@emotion/react": "11.14.0",
@@ -39,7 +39,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-magma-dom": "^5.1.0-rc.3",
-    "react-magma-icons": "^3.2.1"
+    "react-magma-icons": "^3.2.2"
   },
   "engines": {
     "node": ">=14.15.0",

--- a/packages/react-magma-dom/package.json
+++ b/packages/react-magma-dom/package.json
@@ -49,7 +49,7 @@
     "mkdirp": "3.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-magma-icons": "^3.2.1",
+    "react-magma-icons": "^3.2.2",
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
@@ -60,7 +60,7 @@
     "framer-motion": "11.18.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-magma-icons": "^3.2.1",
+    "react-magma-icons": "^3.2.2",
     "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   }
 }

--- a/website/react-magma-docs/package.json
+++ b/website/react-magma-docs/package.json
@@ -62,7 +62,7 @@
     "react-helmet": "5.2.1",
     "react-live": "4.1.8",
     "react-magma-dom": "^5.1.0-rc.3",
-    "react-magma-icons": "^3.1.2",
+    "react-magma-icons": "^3.2.2",
     "react-spring": "6.1.10",
     "remark-mdx": "^3.1.0",
     "remark-parse": "^11.0.0",


### PR DESCRIPTION
Closes: #1945 

## What I did
- Updated react-magma-icons to 3.2.2


## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Icon -> all icon examples should have `aria-hidden=false` and `role="img"` attributes 
All icons, which are used for our components, should have `aria-hidden=true` and `role="none"` attributes 
