### PR TITLE
fix(Combobox): NVDA does not identify the combo-boxes in browse mode

### DIFF
--- a/.changeset/fix-Combobox-accessibility.md
+++ b/.changeset/fix-Combobox-accessibility.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Combobox, MultiCombobox): Improve NVDA Browse Mode navigation across the page.

--- a/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
@@ -161,17 +161,16 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
 
   function handleBlur(e: React.FocusEvent) {
     setIsFocused(false);
-
-    onInputBlur && typeof onInputBlur === 'function' && onInputBlur(e);
+    onInputBlur?.(e);
   }
 
   function handleFocus(e: React.FocusEvent) {
     setIsFocused(true);
-
-    onInputFocus && typeof onInputFocus === 'function' && onInputFocus(e);
+    onInputFocus?.(e);
   }
 
   const inputProps = getInputProps({
+    ...getComboboxProps(),
     disabled: disabled,
     onBlur: handleBlur,
     onFocus: handleFocus,
@@ -197,9 +196,10 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
   return (
     <div ref={setReference}>
       <ComboBoxContainer
-        {...getComboboxProps()}
+        {...(getComboboxProps && getComboboxProps().ref
+          ? { ref: getComboboxProps().ref }
+          : {})}
         hasError={hasError}
-        disabled={disabled}
         isInverse={isInverse}
         theme={theme}
       >


### PR DESCRIPTION
Closes: #1950

Copy [this](https://github.com/cengage/react-magma/pull/2003) PR into `v4/dev` branch

## What I did
- Improved NVDA Browse Mode navigation across the page for Combobox and MultiCombobox.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to **Storybook** -> Combobox -> Full Page example -> Turn on NVDA -> navigate across comboboxes via pressing `C` in browse mode.

Go to **Docs** -> Components ->  Combobox ->Navigate across all examples via pressing `C` in browse mode.