### PR TITLE
fix(TablePagination): Remove aria label for row page selection.

### DIFF
--- a/.changeset/fix-table-rows-per-page-reads-twice.md
+++ b/.changeset/fix-table-rows-per-page-reads-twice.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Table): Fix reading twice rows per page in case selecting option.

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -185,7 +185,6 @@ const RowsPerPageController = (props: RowsPerPageControllerProps) => {
       </RowsPerPageLabel>
       <NativeSelect
         onChange={event => handleRowsPerPageChange(+event.target.value)}
-        aria-label={i18n.table.pagination.rowsPerPageLabel}
         style={{ minWidth: 80 }}
         testId="rowPerPageSelect"
         fieldId={''}


### PR DESCRIPTION

## What I did
- Cleared up the `aria-label` for TablePagination to avoid repeating the `rows per page` phrase announced by VoiceOver/NVDA

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Table -> Controlled with Pagination -> Turn on `VO/NVDA` -> update the `rows per page` selection -> the phase `rows per page` should not be announced twice.
