### PR TITLE
chore: Update react magma icons to 3.2.2

### DIFF
--- a/.changeset/chore-update-react-magma-icons-version.md
+++ b/.changeset/chore-update-react-magma-icons-version.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+chore: Update React-magma-icons version to 3.2.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -6876,6 +6876,20 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/@lerna/create/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@lerna/create/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -46130,20 +46144,20 @@
       "link": true
     },
     "node_modules/react-magma-icons": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.0.tgz",
-      "integrity": "sha512-CZnCIOHWlJbk/0VhH7P4Azah5lAcfWIbx73G0sQxPFxGhNxZ2xsodvsDyCHFy4jZrGtKhKssKjMSIPGv2vHCkA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.2.tgz",
+      "integrity": "sha512-hZWlCNXZ7hc2ZsbGN6E7gazH1okyLbcG0dM76cukKz6qeYcLXK5QVlyqkvAU9zVwaLsv24TzqXva5nH4rNjUxA==",
       "dependencies": {
         "@types/node": "^17.0.39",
-        "@types/react": "^17.0.5",
+        "@types/react": ">=17.0.5",
         "@types/uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2",
         "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       },
       "peerDependenciesMeta": {
@@ -60821,7 +60835,7 @@
     },
     "packages/charts": {
       "name": "@react-magma/charts",
-      "version": "12.0.1-next.0",
+      "version": "13.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "@carbon/charts-react": "^1.14.8",
@@ -60840,8 +60854,8 @@
         "identity-obj-proxy": "^3.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0",
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2",
         "rollup": "^4.52.4",
         "rollup-plugin-postcss": "^4.0.2"
       },
@@ -60854,8 +60868,8 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0"
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2"
       }
     },
     "packages/charts/node_modules/@rollup/plugin-commonjs": {
@@ -61014,7 +61028,7 @@
     },
     "packages/dropzone": {
       "name": "@react-magma/dropzone",
-      "version": "12.0.1-next.0",
+      "version": "13.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "polished": "^3.2.0",
@@ -61025,8 +61039,8 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0"
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2"
       },
       "engines": {
         "node": ">=14.15.0",
@@ -61037,8 +61051,8 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0"
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2"
       }
     },
     "packages/dropzone/node_modules/polished": {
@@ -61054,7 +61068,7 @@
       }
     },
     "packages/react-magma-dom": {
-      "version": "4.10.1-next.0",
+      "version": "4.11.0-next.8",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.13.0",
@@ -61071,7 +61085,7 @@
         "mkdirp": "^1.0.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-icons": "^3.2.0",
+        "react-magma-icons": "^3.2.2",
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
@@ -61082,7 +61096,7 @@
         "framer-motion": "^4.1.11",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-icons": "^3.2.0",
+        "react-magma-icons": "^3.2.2",
         "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
@@ -61100,7 +61114,7 @@
     },
     "packages/schema-renderer": {
       "name": "@react-magma/schema-renderer",
-      "version": "12.0.1-next.0",
+      "version": "13.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
         "@data-driven-forms/react-form-renderer": "^3.6.0",
@@ -61111,8 +61125,8 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-dropzone": "11.3.2",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0",
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2",
         "tsdx": "^0.14.1",
         "uuid": "^11.1.0"
       },
@@ -61127,14 +61141,14 @@
         "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0",
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2",
         "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
     "patterns/header": {
       "name": "@cengage-patterns/header",
-      "version": "13.0.1-next.0",
+      "version": "14.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
         "@emotion/react": "^11.13.0",
@@ -61143,8 +61157,8 @@
         "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0",
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2",
         "uuid": "^11.1.0"
       },
       "engines": {
@@ -61158,8 +61172,8 @@
         "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0",
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2",
         "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       },
       "peerDependenciesMeta": {
@@ -61176,19 +61190,19 @@
       }
     },
     "website/react-magma-docs": {
-      "version": "5.2.1-next.4",
+      "version": "5.3.0-next.5",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "7.10.4",
-        "@cengage-patterns/header": "13.0.1-next.0",
+        "@cengage-patterns/header": "14.0.0-next.1",
         "@data-driven-forms/react-form-renderer": "^3.6.0",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/mdx": "^1.5.5",
         "@mdx-js/react": "^1.5.5",
-        "@react-magma/charts": "^12.0.1-next.0",
-        "@react-magma/dropzone": "12.0.1-next.0",
-        "@react-magma/schema-renderer": "^12.0.1-next.0",
+        "@react-magma/charts": "^13.0.0-next.1",
+        "@react-magma/dropzone": "13.0.0-next.1",
+        "@react-magma/schema-renderer": "^13.0.0-next.1",
         "buble": "0.19.4",
         "buffer": "^6.0.3",
         "core-js": "^3.1.4",
@@ -61218,8 +61232,8 @@
         "react-focus-lock": "^2.9.2",
         "react-helmet": "5.2.0",
         "react-live": "^2.2.1",
-        "react-magma-dom": "^4.10.1-next.0",
-        "react-magma-icons": "^3.2.0",
+        "react-magma-dom": "^4.11.0-next.3",
+        "react-magma-icons": "^3.2.2",
         "react-spring": "6.1.9",
         "semver": "^7.3.4",
         "url-loader": "^1.1.2",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -43,7 +43,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0",
+    "react-magma-icons": "^3.2.2",
     "rollup": "^4.52.4",
     "rollup-plugin-postcss": "^4.0.2"
   },
@@ -53,7 +53,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0"
+    "react-magma-icons": "^3.2.2"
   },
   "engines": {
     "node": ">=14.15.0",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -28,7 +28,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0"
+    "react-magma-icons": "^3.2.2"
   },
   "peerDependencies": {
     "@emotion/react": "^11.13.0",
@@ -36,7 +36,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0"
+    "react-magma-icons": "^3.2.2"
   },
   "engines": {
     "node": ">=14.15.0",

--- a/packages/react-magma-dom/package.json
+++ b/packages/react-magma-dom/package.json
@@ -46,7 +46,7 @@
     "mkdirp": "^1.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-magma-icons": "^3.2.0",
+    "react-magma-icons": "^3.2.2",
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
@@ -57,7 +57,7 @@
     "framer-motion": "^4.1.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-magma-icons": "^3.2.0",
+    "react-magma-icons": "^3.2.2",
     "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   }
 }

--- a/packages/schema-renderer/package.json
+++ b/packages/schema-renderer/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^17.0.2",
     "react-dropzone": "11.3.2",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0",
+    "react-magma-icons": "^3.2.2",
     "tsdx": "^0.14.1",
     "uuid": "^11.1.0"
   },
@@ -38,7 +38,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0",
+    "react-magma-icons": "^3.2.2",
     "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "engines": {

--- a/patterns/header/package.json
+++ b/patterns/header/package.json
@@ -28,7 +28,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0",
+    "react-magma-icons": "^3.2.2",
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
@@ -40,7 +40,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0",
+    "react-magma-icons": "^3.2.2",
     "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "peerDependenciesMeta": {

--- a/website/react-magma-docs/package.json
+++ b/website/react-magma-docs/package.json
@@ -65,7 +65,7 @@
     "react-helmet": "5.2.0",
     "react-live": "^2.2.1",
     "react-magma-dom": "^4.11.0-next.3",
-    "react-magma-icons": "^3.2.0",
+    "react-magma-icons": "^3.2.2",
     "react-spring": "6.1.9",
     "semver": "^7.3.4",
     "url-loader": "^1.1.2",


### PR DESCRIPTION
Closes: #1945 

## What I did
- Updated react-magma-icons to 3.2.2
- Copy of [chore: Update react magma icons to 3.2.2](https://github.com/cengage/react-magma/pull/2012) for `v4/dev`

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Icon -> all icon examples should have `aria-hidden=false` and `role="img"` attributes 
All icons, which are used for our components, should have `aria-hidden=true` and `role="none"` attributes 
