### PR TITLE
fix(select): add cyclical navigation across options

### DIFF
--- a/.changeset/fix-select-focus-behaviour.md
+++ b/.changeset/fix-select-focus-behaviour.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(Select, NativeSelect, Combobox): Add cyclical navigation across options.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { render, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { magma } from '../../theme/magma';
 import { Modal } from '../Modal';
@@ -801,6 +802,34 @@ describe('Combobox', () => {
     );
 
     expect(getByTestId('customClearIndicator')).toBeInTheDocument();
+  });
+
+  it('should loop to the first item and last item when down arrow and up arrow is pressed', async () => {
+    const { getByLabelText, getByText } = render(
+      <Combobox labelText={labelText} items={items} />
+    );
+
+    const renderedCombobox = getByLabelText(labelText, {
+      selector: 'input',
+    });
+
+    await userEvent.click(renderedCombobox);
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
+
+    // Looping back to the first item
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    // Looping back to the last item
+    await userEvent.keyboard('{ArrowUp}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
   describe('events', () => {

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { act, fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { magma } from '../../theme/magma';
 import { Modal } from '../Modal';
@@ -996,6 +997,34 @@ describe('MultiCombobox', () => {
         queryByText(items[0], { selector: 'button' })
       ).not.toBeInTheDocument();
     });
+  });
+
+  it('should loop to the first item and last item when down arrow and up arrow is pressed', async () => {
+    const { getByLabelText, getByText } = render(
+      <MultiCombobox isMulti labelText={labelText} items={items} />
+    );
+
+    const renderedCombobox = getByLabelText(labelText, {
+      selector: 'input',
+    });
+
+    await userEvent.click(renderedCombobox);
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
+
+    // Looping back to the first item
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    // Looping back to the last item
+    await userEvent.keyboard('{ArrowUp}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
   describe('events', () => {

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
 import { HelpIcon } from 'react-magma-icons';
 
@@ -112,6 +113,36 @@ describe('NativeSelect', () => {
     );
 
     expect(getByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it('should have cycling navigation through options with arrow keys', async () => {
+    const testId = 'select';
+    const { getByTestId } = render(
+      <NativeSelect testId={testId} defaultValue="1">
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+      </NativeSelect>
+    );
+
+    const selectElement = getByTestId(testId);
+    selectElement.focus();
+
+    expect(selectElement).toHaveDisplayValue('1');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(selectElement).toHaveDisplayValue('2');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(selectElement).toHaveDisplayValue('3');
+
+    // Cycle back to first option
+    await userEvent.keyboard('{ArrowDown}');
+    expect(selectElement).toHaveDisplayValue('1');
+
+    // Cycle to last option
+    await userEvent.keyboard('{ArrowUp}');
+    expect(selectElement).toHaveDisplayValue('3');
   });
 
   describe('additional content', () => {

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -151,6 +151,32 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
 
     const hasLabel = !!labelText;
 
+    const selectRef = React.useRef<HTMLSelectElement>(null);
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLSelectElement>) => {
+      const select = selectRef.current;
+
+      if (!select) return;
+
+      const total = select.options.length;
+      let index = select.selectedIndex;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          index = (index + 1) % total;
+          break;
+        case 'ArrowUp':
+          index = (index - 1 + total) % total;
+          break;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      select.selectedIndex = index;
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+
     const nativeSelect = (
       <StyledFormFieldContainer
         additionalContent={additionalContent}
@@ -190,6 +216,8 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
             disabled={disabled}
             id={id}
             isInverse={isInverse}
+            ref={selectRef}
+            onKeyDown={handleKeyDown}
             theme={theme}
             {...other}
           >

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -97,9 +97,23 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
     );
   };
 
-  function handleEscape(event: React.KeyboardEvent) {
-    if (event.key === 'Escape') {
-      event.nativeEvent.stopImmediatePropagation();
+  function handleKeyDown(event: React.KeyboardEvent) {
+    switch (event.key) {
+      case 'Escape':
+        event.nativeEvent.stopImmediatePropagation();
+        break;
+      case 'ArrowDown':
+        if (highlightedIndex === items.length - 1) {
+          setHighlightedIndex?.(0);
+        }
+        break;
+      case 'ArrowUp':
+        if (highlightedIndex === 0) {
+          setHighlightedIndex?.(items.length - 1);
+        }
+        break;
+      default:
+        break;
     }
   }
 
@@ -112,7 +126,7 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
         hasDropShadow
         isInverse={isInverse}
         isOpen={isOpen}
-        onKeyDown={handleEscape}
+        onKeyDown={handleKeyDown}
         style={menuStyle}
         theme={theme}
       >
@@ -150,7 +164,7 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
 
               if (isDisabled) {
                 itemProps.onMouseEnter = () => {
-                  setHighlightedIndex && setHighlightedIndex(-1);
+                  setHighlightedIndex?.(-1);
                 };
               }
 

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { act, fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
@@ -611,6 +612,32 @@ describe('Select', () => {
     expect(getByText('Red')).toHaveAttribute('aria-disabled', 'true');
     expect(getByText('Blue')).toHaveAttribute('aria-disabled', 'false');
     expect(getByText('Green')).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  it('should loop to the first item and last item when down arrow and up arrow is pressed', async () => {
+    const { getByLabelText, getByText } = render(
+      <MultiSelect isMulti labelText={labelText} items={items} />
+    );
+
+    const renderedSelect = getByLabelText(labelText, { selector: 'div' });
+
+    await userEvent.click(renderedSelect);
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
+
+    // Looping back to the first item
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    // Looping back to the last item
+    await userEvent.keyboard('{ArrowUp}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
   describe('events', () => {

--- a/packages/react-magma-dom/src/components/Select/Select.test.js
+++ b/packages/react-magma-dom/src/components/Select/Select.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { act, fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { HelpIcon } from 'react-magma-icons';
 
 import { defaultI18n } from '../../i18n/default';
@@ -510,6 +511,32 @@ describe('Select', () => {
     );
 
     expect(getByTestId('customClearIndicator')).toBeInTheDocument();
+  });
+
+  it('should loop to the first item and last item when down arrow and up arrow is pressed', async () => {
+    const { getByLabelText, getByText } = render(
+      <Select labelText={labelText} items={items} />
+    );
+
+    const renderedSelect = getByLabelText(labelText, { selector: 'div' });
+
+    await userEvent.click(renderedSelect);
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
+
+    // Looping back to the first item
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    // Looping back to the last item
+    await userEvent.keyboard('{ArrowUp}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
   describe('additional content', () => {


### PR DESCRIPTION
Closes: #1944
- Copy of [fix(Select, NativeSelect, Combobox): Add cyclical navigation across options](https://github.com/cengage/react-magma/pull/1996) for `v4/dev`

## What I did
- Added cyclical navigation for such components:
- Select, Multi Select
- Native Select
- Combobox, Multi Combobox

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Select -> Default, Multi -> Open list of options -> navigate via arrows -> navigation should be from the last option to first by pressing `ArrowDown` and vice versa.

Go to Storybook -> Combobox -> Default, Multi  -> Open list of options -> navigate via arrows -> navigation should be from the last option to first by pressing `ArrowDown` and vice versa.

Go to Storybook -> NativeSelect -> Default -> navigate via arrows without opening options list -> navigation should be from the last option to first by pressing `ArrowDown` and vice versa.
