### PR TITLE
fix(Select & Multiselect): Add ariaLabel prop

### DIFF
--- a/.changeset/fix-select-aria-label.md
+++ b/.changeset/fix-select-aria-label.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Select & Multiselect): Add `ariaLabel` prop to provide alternative text for screen readers.

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -22,6 +22,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
   const {
     additionalContent,
     ariaDescribedBy,
+    ariaLabel,
     components: customComponents,
     errorMessage,
     hasError,
@@ -287,6 +288,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
   return (
     <SelectContainer
       additionalContent={additionalContent}
+      ariaLabel={ariaLabel}
       descriptionId={ariaDescribedBy}
       errorMessage={errorMessage}
       getLabelProps={getLabelProps}

--- a/packages/react-magma-dom/src/components/Select/Select.stories.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.stories.tsx
@@ -80,6 +80,7 @@ export const Default = {
     isLabelVisuallyHidden: false,
     isMulti: false,
     labelPosition: LabelPosition.top,
+    ariaLabel: 'Another select text',
   },
 };
 
@@ -107,6 +108,7 @@ export const Multi = {
   args: {
     ...Default.args,
     disabled: false,
+    ariaLabel: 'Multi select example',
   },
 };
 

--- a/packages/react-magma-dom/src/components/Select/Select.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.tsx
@@ -22,6 +22,7 @@ export function Select<T>(props: SelectProps<T>) {
   const {
     additionalContent,
     ariaDescribedBy,
+    ariaLabel,
     components: customComponents,
     defaultSelectedItem,
     errorMessage,
@@ -215,6 +216,7 @@ export function Select<T>(props: SelectProps<T>) {
   return (
     <SelectContainer
       additionalContent={additionalContent}
+      ariaLabel={ariaLabel}
       descriptionId={ariaDescribedBy}
       errorMessage={errorMessage}
       getLabelProps={getLabelProps}

--- a/packages/react-magma-dom/src/components/Select/SelectContainer.tsx
+++ b/packages/react-magma-dom/src/components/Select/SelectContainer.tsx
@@ -39,6 +39,7 @@ const InputMessageContainer = styled.div`
 
 interface SelectContainerInterface<T> {
   additionalContent?: React.ReactNode;
+  ariaLabel?: string;
   children: React.ReactNode[];
   containerStyle?: React.CSSProperties;
   descriptionId?: string;
@@ -97,6 +98,7 @@ const FieldContainer = styled.div`
 export function SelectContainer<T>(props: SelectContainerInterface<T>) {
   const {
     additionalContent,
+    ariaLabel,
     children,
     descriptionId,
     errorMessage,
@@ -159,12 +161,13 @@ export function SelectContainer<T>(props: SelectContainerInterface<T>) {
       <AdditionalContentWrapper labelPosition={labelPosition}>
         <Label
           {...getLabelProps()}
+          aria-label={ariaLabel}
           isInverse={isInverse}
           labelPosition={labelPosition}
           style={labelStyle}
         >
           {isLabelVisuallyHidden ? (
-            <VisuallyHidden>{labelText}</VisuallyHidden>
+            <VisuallyHidden>{ariaLabel || labelText}</VisuallyHidden>
           ) : (
             labelText
           )}

--- a/packages/react-magma-dom/src/components/Select/index.tsx
+++ b/packages/react-magma-dom/src/components/Select/index.tsx
@@ -122,6 +122,10 @@ export interface SelectProps<T extends SelectOptions>
    */
   ariaDescribedBy?: string;
   /**
+   * Aria label for the select trigger button
+   */
+  ariaLabel?: string;
+  /**
    * @internal
    */
   hasError?: boolean;


### PR DESCRIPTION
Closes: #2004 

Copy of [fix(Select & Multiselect): Add ariaLabel prop](https://github.com/cengage/react-magma/pull/2035) in `v4/dev`.

## What I did
- Added new `ariaLabel` prop to provide the ability to update text for screen readers.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Select -> Default -> Turn on VO or NVDA -> should announce  `Another select text` for the label.
Go to Storybook -> Select -> Multi -> Turn on VO or NVDA -> should announce  `Multi select example` for the label.
