### PR TITLE
V4/fix(docs): miscellaneous fixes (navtabs, tabs, toast) (#2036)

### DIFF
--- a/.changeset/fix-Docs-Miscellaneous-issues.md
+++ b/.changeset/fix-Docs-Miscellaneous-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(NavTabs, Tabs, Toast): Fix different issues.

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.stories.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.stories.tsx
@@ -61,7 +61,7 @@ export default {
 const Template: StoryFn<NavTabsProps> = args => {
   return (
     <Card isInverse={args.isInverse}>
-      <NavTabs aria-label="Nav Tabs" {...args}>
+      <NavTabs {...args} aria-label="Nav Tabs">
         <NavTab isActive to="#">
           Current Page
         </NavTab>
@@ -80,7 +80,7 @@ export const IconOnly: StoryObj<NavTabsProps> = {
   render: args => {
     return (
       <Card isInverse={args.isInverse}>
-        <NavTabs aria-label="Icon Only Nav Tabs" {...args}>
+        <NavTabs {...args} aria-label="Icon Only Nav Tabs">
           <NavTab aria-label="Email" icon={<EmailIcon />} to="#" isActive />
           <NavTab aria-label="Android" icon={<AndroidIcon />} to="#" />
           <NavTab
@@ -99,9 +99,9 @@ export const BackgroundColor: StoryObj<NavTabsProps> = {
     return (
       <Card isInverse={args.isInverse}>
         <NavTabs
+          {...args}
           aria-label="Nav Tabs"
           backgroundColor={args.isInverse ? '' : magma.colors.neutral200}
-          {...args}
         >
           <NavTab isActive to="#">
             Current Page
@@ -116,7 +116,7 @@ export const BackgroundColor: StoryObj<NavTabsProps> = {
 const InverseTemplate: StoryFn<NavTabsProps> = args => {
   return (
     <Card isInverse={args.isInverse}>
-      <NavTabs aria-label="Nav Tabs" {...args}>
+      <NavTabs {...args} aria-label="Nav Tabs">
         <NavTab isActive to="#">
           Current Page
         </NavTab>
@@ -140,7 +140,7 @@ export const CustomTab: StoryObj<NavTabsProps> = {
     );
     return (
       <Card isInverse={args.isInverse}>
-        <NavTabs aria-label="Sample Custom Component Navigation Tabs" {...args}>
+        <NavTabs {...args} aria-label="Sample Custom Component Navigation Tabs">
           <NavTab component={<Link to="./">Main page</Link>} />
           <NavTab isActive component={<Link to="./">FAQ</Link>} />
           <NavTab component={<Link to="./">About us</Link>} />
@@ -165,7 +165,7 @@ const ScrollingTemplate: StoryFn<
         }}
         activeIndex={args.activeIndex}
       >
-        <NavTabs aria-label="Sample Tabs" {...args}>
+        <NavTabs {...args} aria-label="Sample Tabs">
           {arr.map((item, index) => (
             <NavTab
               to={`#${item}`}

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
@@ -19,7 +19,9 @@ import { TabsOrientation, TabsTextTransform } from '../Tabs/shared';
 import { ButtonNext, ButtonPrev } from '../Tabs/TabsScrollButtons';
 import { useTabsMeta } from '../Tabs/utils';
 
-export type NavTabsProps = Omit<TabsProps, 'onChange'>;
+export interface NavTabsProps extends Omit<TabsProps, 'onChange'> {
+  'aria-label': string;
+}
 
 interface NavTabsContextInterface {
   borderPosition?: TabsBorderPosition;

--- a/website/react-magma-docs/src/components/layout.js
+++ b/website/react-magma-docs/src/components/layout.js
@@ -59,7 +59,7 @@ const SmartDocsHeading = props => {
   );
 };
 
-export const Layout = ({ children, pageContext }) => {
+export const Layout = ({ children, pageContext, location }) => {
   const title =
     pageContext && pageContext.frontmatter
       ? pageContext.frontmatter.pageTitle || pageContext.frontmatter.title || ''
@@ -67,6 +67,21 @@ export const Layout = ({ children, pageContext }) => {
   const heading =
     pageContext && pageContext.frontmatter ? pageContext.frontmatter.title : '';
   const properties = (pageContext && pageContext.properties) || [];
+
+  // Needed because of auto-scrolling to focused item issue #https://github.com/cengage/react-magma/issues/1925
+  React.useEffect(() => {
+    let timer;
+
+    if (location && location.pathname.includes('nav-tabs')) {
+      setTimeout(() => {
+        window.scrollTo(0, 0);
+      }, 1);
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [location]);
 
   return (
     <LayoutComponent title={title} heading={heading}>

--- a/website/react-magma-docs/src/pages/api/nav-tabs.mdx
+++ b/website/react-magma-docs/src/pages/api/nav-tabs.mdx
@@ -263,67 +263,6 @@ export function Example() {
 }
 ```
 
-## Text Transform
-
-#### For all NavTabs
-
-Options for the `textTransform` prop for navtabs include `uppercase` and `none`, with `uppercase` (all caps) being the default value.
-This sets the CSS `text-transform` property.
-
-```tsx
-import React from 'react';
-
-import { NavTabs, NavTab, TabsTextTransform } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <>
-      <NavTabs textTransform={TabsTextTransform.uppercase}>
-        <NavTab isActive to="#">
-          First uppercase
-        </NavTab>
-        <NavTab to="#">Second uppercase</NavTab>
-      </NavTabs>
-      <br />
-      <br />
-      <br />
-      <NavTabs textTransform={TabsTextTransform.none}>
-        <NavTab isActive to="#">
-          First lowercase
-        </NavTab>
-        <NavTab to="#">Second lowercase</NavTab>
-      </NavTabs>
-    </>
-  );
-}
-```
-
-#### For a certain Tab
-
-`textTransform` prop can also be used for `NavTab` component.
-
-```tsx
-import React from 'react';
-
-import { NavTabs, NavTab, TabsTextTransform } from 'react-magma-dom';
-
-export function Example() {
-  return (
-    <NavTabs>
-      <NavTab isActive to="#">
-        All caps (default)
-      </NavTab>
-      <NavTab to="#" textTransform={TabsTextTransform.none}>
-        No Text Transform
-      </NavTab>
-      <NavTab to="#" textTransform={TabsTextTransform.uppercase}>
-        Uppercase transform
-      </NavTab>
-    </NavTabs>
-  );
-}
-```
-
 ## Full-Width
 
 The `isFullWidth` prop is an optional boolean that will cause the tabs to take up the full width of their container. The `isFullWidth` prop is specified on the `NavTabs` component.

--- a/website/react-magma-docs/src/pages/api/toast.mdx
+++ b/website/react-magma-docs/src/pages/api/toast.mdx
@@ -490,7 +490,7 @@ export function Example() {
 }
 ```
 
-## isInverse
+## Inverse
 
 ```tsx
 import React from 'react';

--- a/website/react-magma-docs/src/pages/design-intro/get-started.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/get-started.mdx
@@ -133,6 +133,7 @@ React Magma helps us build tools that are relevant and easy to use, and create e
     <footer>&ndash; CNOW Student</footer>
   </blockquote>
 </div>
+
 <span className="horizontal-spacer" />
 
 </PageContent>

--- a/website/react-magma-docs/src/pages/design-intro/typography.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/typography.mdx
@@ -121,6 +121,7 @@ Productive type is reserved for use in web-based product design, where the user 
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 #### Productive Heading Text Styles
@@ -269,6 +270,7 @@ Productive type is reserved for use in web-based product design, where the user 
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 ### Expressive Type Set
@@ -309,6 +311,7 @@ Expressive type is reserved for use in editorial and digital marketing experienc
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 #### Expressive Heading Text Styles
@@ -532,6 +535,7 @@ Expressive type is reserved for use in editorial and digital marketing experienc
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 ### Narrative Type Set
@@ -626,6 +630,7 @@ Narrative type uses Noto Serif but is otherwise styled the same as the default P
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 #### Narrative Heading Text Styles
@@ -798,6 +803,7 @@ Narrative type uses Noto Serif but is otherwise styled the same as the default P
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 ### Changing Headings Styles

--- a/website/react-magma-docs/src/pages/design/alert.mdx
+++ b/website/react-magma-docs/src/pages/design/alert.mdx
@@ -129,6 +129,7 @@ When the viewport is 600px wide and smaller, we automatically reduce the icon an
     alt="GATSBY_EMPTY_ALT"
   />
 </figure>
+
 <span className="horizontal-spacer" />
 
 ---

--- a/website/react-magma-docs/src/pages/design/banner.mdx
+++ b/website/react-magma-docs/src/pages/design/banner.mdx
@@ -35,6 +35,7 @@ When the viewport is 600px wide and smaller, we automatically reduce the icon an
     alt="GATSBY_EMPTY_ALT"
   />
 </figure>
+
 <span className="horizontal-spacer" />
 
 ---

--- a/website/react-magma-docs/src/pages/design/card.mdx
+++ b/website/react-magma-docs/src/pages/design/card.mdx
@@ -35,6 +35,7 @@ Cards are one of the core building blocks in React Magma. They can be used to cr
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 ## Anatomy
@@ -62,6 +63,7 @@ Use full-width dividers that extend to the edges of a card to separate more dist
 <figure>
   <img src="../../images/cards/card-dividers.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
+
 <span className="horizontal-spacer" />
 
 ---
@@ -81,6 +83,7 @@ If a card can move, such as in a carousel or a drag and drop scenario, you shoul
 <figure>
   <img src="../../images/cards/card-depth.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
+
 <span className="horizontal-spacer" />
 
 ---
@@ -127,6 +130,7 @@ To avoid these issues, you should instead provide links within the card to view 
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 ---
@@ -146,6 +150,7 @@ Cards can contain many kinds of UI controls, including buttons, tabs, toggle swi
 <figure>
   <img src="../../images/cards/card-ui-controls.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
+
 <span className="horizontal-spacer" />
 
 ---
@@ -159,6 +164,7 @@ Various colors from the global color palette may be used as the background of a 
 <figure>
   <img src="../../images/cards/card-colors.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
+
 <span className="horizontal-spacer" />
 
 ---
@@ -172,6 +178,7 @@ Callout cards add a band of color to the left edge of the container. This can be
 <figure>
   <img src="../../images/cards/card-callout.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
+
 <span className="horizontal-spacer" />
 
 ---
@@ -198,6 +205,7 @@ If you want a group of cards to be easy to scan, use a clean and consistent patt
 <figure>
   <img src="../../images/cards/card-scannable.png" alt="GATSBY_EMPTY_ALT" />
 </figure>
+
 <span className="horizontal-spacer" />
 
 </PageContent>

--- a/website/react-magma-docs/src/pages/design/icon.mdx
+++ b/website/react-magma-docs/src/pages/design/icon.mdx
@@ -170,6 +170,7 @@ When positioning an icon next to text you should always center-align them.
     </div>
   </div>
 </div>
+
 <span className="horizontal-spacer" />
 
 </PageContent>

--- a/website/react-magma-docs/src/pages/design/indeterminate.mdx
+++ b/website/react-magma-docs/src/pages/design/indeterminate.mdx
@@ -20,6 +20,7 @@ Use the indeterminate state when the checkbox contains a sub list of selections,
 View the <Link to="/design/checkboxes/">documentation for checkboxes</Link> for more details.
 
 <span className="horizontal-spacer" />
+
 <figure>
   <div className="image-container">
     <img

--- a/website/react-magma-docs/src/pages/design/loading-indicator.mdx
+++ b/website/react-magma-docs/src/pages/design/loading-indicator.mdx
@@ -79,6 +79,7 @@ If you know that it will take less than a second to complete an action, then no 
     </p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
 
 ### Large Amounts of Data
@@ -136,6 +137,7 @@ If you know from testing that it typically takes more than 15 seconds to load, *
     </p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
 
 This component also allows for three messages, although at different intervals than the variant with the spinner above.

--- a/website/react-magma-docs/src/pages/design/tabs.mdx
+++ b/website/react-magma-docs/src/pages/design/tabs.mdx
@@ -121,7 +121,9 @@ Icons can be placed to the left of the label or on top of the label, depending o
     </p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
+
 <figure>
   <img
     src="../../images/tabs/tabs-icon-and-label-stacked.png"
@@ -149,6 +151,7 @@ Icon-only tabs can be very useful for communicating the content they represent, 
     </p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
 
 ### Active Tab Indicator
@@ -216,14 +219,18 @@ Tabs are displayed in a single row or column, with each tab connected to the con
     <p>Example of tabs in the header of a panel.</p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
+
 <figure>
   <img src="../../images/tabs/tabs-column.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>Example of tabs in a column.</p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
+
 <div className="two-col">
   <div className="row">
     <div className="col col-1">
@@ -271,14 +278,18 @@ Auto-width tabs can be left-aligned, right-aligned, or centered.
     <p>By default, auto-width tabs are left aligned.</p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
+
 <figure>
   <img src="../../images/tabs/tabs-right-aligned.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
     <p>You may also right-align the tabs with the content below or above.</p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
+
 <figure>
   <img src="../../images/tabs/tabs-centered.png" alt="GATSBY_EMPTY_ALT" />
   <figcaption>
@@ -313,7 +324,9 @@ Full-width tabs can be calculated by the width of the container divided by the n
     <p>Simple example of full-width tabs, each tab being of equal width.</p>
   </figcaption>
 </figure>
+
 <span className="horizontal-spacer" />
+
 <figure>
   <img
     src="../../images/tabs/tabs-alignment-with-content.png"


### PR DESCRIPTION
Closes: #1925

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix small issues in docs pages
Cherry-pick #2036 

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
1. Open docs -> NavTabs -> Focus doesn't go to `With Dark Grey Background` example
2. Open docs -> Tabs -> Design -> Check the `Placement` section  
3. Open docs -> Toast -> Check the `Inverse` section name
4. Open docs -> NavTabs -> Check all codesandbox examples (can't be tested before merge)

## Differences with V5:
- For `NavTabs`, setTimeout with `window.scroll(0, 0)` was added because react-17 automatically scrolls the page to the focused element, and this can't be handled in the mdx file; 
- For `Tabs` -> Design page (and for all other pages that use `<span className="horizontal-spacer" />`), space was added before and after the line because HTML places content after the span inside it, and this causes overlap problems.