### PR TITLE
fix(Dropdown): Add aria controls for dropdown trigger button.

### DIFF
--- a/.changeset/fix-Dropdown-add-aria-contols.md
+++ b/.changeset/fix-Dropdown-add-aria-contols.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Add aria-controls attribute for Dropdown trigger button.

--- a/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.test.js
+++ b/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.test.js
@@ -11,6 +11,7 @@ import {
   DropdownButton,
   DropdownContent,
   DropdownMenuItem,
+  DropdownSplitButton,
 } from '../Dropdown';
 import { IconButton } from '../IconButton';
 
@@ -429,13 +430,13 @@ describe('ButtonGroup', () => {
           <Button>1</Button>
           <Dropdown>
             <DropdownButton id="2">Dropdown 2</DropdownButton>
-            <DropdownContent>
+            <DropdownContent id="2">
               <DropdownMenuItem>Menu item 2.1</DropdownMenuItem>
             </DropdownContent>
           </Dropdown>
           <Dropdown>
             <DropdownButton id="3">Dropdown 3</DropdownButton>
-            <DropdownContent>
+            <DropdownContent id="3">
               <DropdownMenuItem>Menu item 3.1</DropdownMenuItem>
             </DropdownContent>
           </Dropdown>
@@ -457,13 +458,13 @@ describe('ButtonGroup', () => {
           <Button>1</Button>
           <Dropdown>
             <DropdownButton id="2">Dropdown 2</DropdownButton>
-            <DropdownContent>
+            <DropdownContent id="2">
               <DropdownMenuItem>Menu item 2.1</DropdownMenuItem>
             </DropdownContent>
           </Dropdown>
           <Dropdown>
             <DropdownButton id="3">Dropdown 3</DropdownButton>
-            <DropdownContent>
+            <DropdownContent id="3">
               <DropdownMenuItem>Menu item 3.1</DropdownMenuItem>
             </DropdownContent>
           </Dropdown>
@@ -484,13 +485,13 @@ describe('ButtonGroup', () => {
           <Button>1</Button>
           <Dropdown>
             <DropdownButton id="2">Dropdown 2</DropdownButton>
-            <DropdownContent>
+            <DropdownContent id="2">
               <DropdownMenuItem>Menu item 2.1</DropdownMenuItem>
             </DropdownContent>
           </Dropdown>
           <Dropdown>
             <DropdownButton id="3">Dropdown 3</DropdownButton>
-            <DropdownContent>
+            <DropdownContent id="3">
               <DropdownMenuItem>Menu item 3.1</DropdownMenuItem>
             </DropdownContent>
           </Dropdown>
@@ -501,52 +502,82 @@ describe('ButtonGroup', () => {
         expect(container).toMatchSnapshot();
       });
     });
-  });
-});
 
-describe('Size', () => {
-  const icon = <CheckIcon />;
+    it('Snapshot: SplitButton', async () => {
+      const { container } = render(
+        <ButtonGroup
+          orientation={ButtonGroupOrientation.vertical}
+          alignment={ButtonGroupAlignment.fill}
+        >
+          <Dropdown>
+            <DropdownSplitButton id="1">
+              Dropdown SplitButton 1
+            </DropdownSplitButton>
+            <DropdownContent id="1">
+              <DropdownMenuItem>Menu item 2.1</DropdownMenuItem>
+            </DropdownContent>
+          </Dropdown>
+          <Dropdown>
+            <DropdownSplitButton id="2">
+              Dropdown SplitButton 2
+            </DropdownSplitButton>
+            <DropdownContent id="2">
+              <DropdownMenuItem>Menu item 2.1</DropdownMenuItem>
+            </DropdownContent>
+          </Dropdown>
+        </ButtonGroup>
+      );
 
-  it('Large', () => {
-    const { container } = render(
-      <ButtonGroup>
-        <IconButton icon={icon} size={ButtonSize.large}>
-          Large
-        </IconButton>
-      </ButtonGroup>
-    );
-
-    const svg = container.querySelector('svg');
-
-    expect(svg).toHaveAttribute('height', magma.iconSizes.medium.toString());
-    expect(svg).toHaveAttribute('width', magma.iconSizes.medium.toString());
-  });
-
-  it('Medium', () => {
-    const { container } = render(
-      <ButtonGroup>
-        <IconButton icon={icon} size={ButtonSize.medium}>
-          Medium
-        </IconButton>
-      </ButtonGroup>
-    );
-
-    const svg = container.querySelector('svg');
-    expect(svg).toHaveAttribute('height', magma.iconSizes.small.toString());
-    expect(svg).toHaveAttribute('width', magma.iconSizes.small.toString());
+      await waitFor(() => {
+        expect(container).toMatchSnapshot();
+      });
+    });
   });
 
-  it('Small', () => {
-    const { container } = render(
-      <ButtonGroup>
-        <IconButton icon={icon} size={ButtonSize.small}>
-          Small
-        </IconButton>
-      </ButtonGroup>
-    );
+  describe('Size', () => {
+    const icon = <CheckIcon />;
 
-    const svg = container.querySelector('svg');
-    expect(svg).toHaveAttribute('height', magma.iconSizes.xSmall.toString());
-    expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
+    it('Large', () => {
+      const { container } = render(
+        <ButtonGroup>
+          <IconButton icon={icon} size={ButtonSize.large}>
+            Large
+          </IconButton>
+        </ButtonGroup>
+      );
+
+      const svg = container.querySelector('svg');
+
+      expect(svg).toHaveAttribute('height', magma.iconSizes.medium.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.medium.toString());
+    });
+
+    it('Medium', () => {
+      const { container } = render(
+        <ButtonGroup>
+          <IconButton icon={icon} size={ButtonSize.medium}>
+            Medium
+          </IconButton>
+        </ButtonGroup>
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.small.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.small.toString());
+    });
+
+    it('Small', () => {
+      const { container } = render(
+        <ButtonGroup>
+          <IconButton icon={icon} size={ButtonSize.small}>
+            Small
+          </IconButton>
+        </ButtonGroup>
+      );
+
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('height', magma.iconSizes.xSmall.toString());
+      expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1362,7 +1362,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
     >
       <div>
         <button
-          aria-controls="dropdownMenuId"
+          aria-controls="2_dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -1399,7 +1399,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
       </div>
       <div
         data-testid="dropdownContentWrapper"
-        id="dropdownMenuId"
+        id="2_dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -1428,7 +1428,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
     >
       <div>
         <button
-          aria-controls="dropdownMenuId"
+          aria-controls="3_dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -1465,7 +1465,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
       </div>
       <div
         data-testid="dropdownContentWrapper"
-        id="dropdownMenuId"
+        id="3_dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -1484,6 +1484,785 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
               tabindex="-1"
             >
               Menu item 3.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ButtonGroup With dropdowns Snapshot: SplitButton 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: stretch;
+  -ms-flex-pack: stretch;
+  -webkit-justify-content: stretch;
+  justify-content: stretch;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.emotion-0>button:first-child,
+.emotion-0>div:first-child {
+  margin-top: 0;
+}
+
+.emotion-0>button:last-child,
+.emotion-0>div:last-child {
+  margin-bottom: 0;
+}
+
+.emotion-0>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button {
+  width: 100%;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-2 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px 0 0 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-4:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-4:not(:disabled):hover,
+.emotion-4:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-4:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-4:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-4 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-6 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 0 8px 8px 0;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 40px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  line-height: 1;
+  min-width: 0;
+  padding: 0;
+}
+
+.emotion-8:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-8:not(:disabled):hover,
+.emotion-8:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-8:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-8:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-8 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-13:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-15 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-15:hover,
+.emotion-15:focus {
+  background: #F5F5F5;
+}
+
+.emotion-15:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-15:active {
+  outline-color: #0074B7;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: stretch;
+  -ms-flex-pack: stretch;
+  -webkit-justify-content: stretch;
+  justify-content: stretch;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.emotion-0>button:first-child,
+.emotion-0>div:first-child {
+  margin-top: 0;
+}
+
+.emotion-0>button:last-child,
+.emotion-0>div:last-child {
+  margin-bottom: 0;
+}
+
+.emotion-0>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button {
+  width: 100%;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-2 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px 0 0 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-4:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-4:not(:disabled):hover,
+.emotion-4:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-4:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-4:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-4 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-6 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 0 8px 8px 0;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 40px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  line-height: 1;
+  min-width: 0;
+  padding: 0;
+}
+
+.emotion-8:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-8:not(:disabled):hover,
+.emotion-8:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-8:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-8:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-8 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-13:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-15 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-15:hover,
+.emotion-15:focus {
+  background: #F5F5F5;
+}
+
+.emotion-15:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-15:active {
+  outline-color: #0074B7;
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+    color="primary"
+    orientation="vertical"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    >
+      <div>
+        <button
+          class="emotion-4 emotion-5"
+          color="primary"
+          id="1"
+          shape="leftCap"
+          style="border-right: 0; margin-right: 0px;"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="emotion-6 emotion-7"
+          >
+            Dropdown SplitButton 1
+          </span>
+        </button>
+        <button
+          aria-controls="1_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Toggle menu"
+          class="emotion-8 emotion-5"
+          color="primary"
+          shape="rightCap"
+          style="margin-left: 2px;"
+          type="button"
+        >
+          <span
+            class="emotion-6 emotion-7"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="1_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-12 emotion-13 emotion-14"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="1"
+            role="menu"
+          >
+            <div
+              class="emotion-15 emotion-16"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 2.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-2 emotion-3"
+    >
+      <div>
+        <button
+          class="emotion-4 emotion-5"
+          color="primary"
+          id="2"
+          shape="leftCap"
+          style="border-right: 0; margin-right: 0px;"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="emotion-6 emotion-7"
+          >
+            Dropdown SplitButton 2
+          </span>
+        </button>
+        <button
+          aria-controls="2_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Toggle menu"
+          class="emotion-8 emotion-5"
+          color="primary"
+          shape="rightCap"
+          style="margin-left: 2px;"
+          type="button"
+        >
+          <span
+            class="emotion-6 emotion-7"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="2_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-12 emotion-13 emotion-14"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="2"
+            role="menu"
+          >
+            <div
+              class="emotion-15 emotion-16"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 2.1
             </div>
           </div>
         </div>
@@ -2121,7 +2900,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
     >
       <div>
         <button
-          aria-controls="dropdownMenuId"
+          aria-controls="2_dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -2158,7 +2937,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
       </div>
       <div
         data-testid="dropdownContentWrapper"
-        id="dropdownMenuId"
+        id="2_dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -2187,7 +2966,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
     >
       <div>
         <button
-          aria-controls="dropdownMenuId"
+          aria-controls="3_dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -2224,7 +3003,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
       </div>
       <div
         data-testid="dropdownContentWrapper"
-        id="dropdownMenuId"
+        id="3_dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -2958,7 +3737,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
     >
       <div>
         <button
-          aria-controls="dropdownMenuId"
+          aria-controls="2_dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -2995,7 +3774,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
       </div>
       <div
         data-testid="dropdownContentWrapper"
-        id="dropdownMenuId"
+        id="2_dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -3024,7 +3803,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
     >
       <div>
         <button
-          aria-controls="dropdownMenuId"
+          aria-controls="3_dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -3061,7 +3840,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
       </div>
       <div
         data-testid="dropdownContentWrapper"
-        id="dropdownMenuId"
+        id="3_dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1362,6 +1362,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
     >
       <div>
         <button
+          aria-controls="dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -1398,6 +1399,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
       </div>
       <div
         data-testid="dropdownContentWrapper"
+        id="dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -1426,6 +1428,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
     >
       <div>
         <button
+          aria-controls="dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -1462,6 +1465,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] 
       </div>
       <div
         data-testid="dropdownContentWrapper"
+        id="dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -2117,6 +2121,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
     >
       <div>
         <button
+          aria-controls="dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -2153,6 +2158,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
       </div>
       <div
         data-testid="dropdownContentWrapper"
+        id="dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -2181,6 +2187,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
     >
       <div>
         <button
+          aria-controls="dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -2217,6 +2224,7 @@ exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
       </div>
       <div
         data-testid="dropdownContentWrapper"
+        id="dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -2950,6 +2958,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
     >
       <div>
         <button
+          aria-controls="dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -2986,6 +2995,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
       </div>
       <div
         data-testid="dropdownContentWrapper"
+        id="dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div
@@ -3014,6 +3024,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
     >
       <div>
         <button
+          aria-controls="dropdownMenuId"
           aria-expanded="false"
           aria-haspopup="true"
           class="emotion-8 emotion-9 emotion-3"
@@ -3050,6 +3061,7 @@ exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
       </div>
       <div
         data-testid="dropdownContentWrapper"
+        id="dropdownMenuId"
         style="position: absolute; left: 0px; top: 0px; z-index: 996;"
       >
         <div

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -126,30 +126,38 @@ const AlignmentTemplate: StoryFn<DropdownProps> = args => (
       dropDirection={DropdownDropDirection.right}
       activeIndex={1}
     >
-      <DropdownButton>Right Aligned Dropdown</DropdownButton>
-      <DropdownContent>
+      <DropdownButton id="rightAlignedDropdown">
+        Right Aligned Dropdown
+      </DropdownButton>
+      <DropdownContent id="rightAlignedDropdown">
         <DropdownMenuItem>Menu item 1</DropdownMenuItem>
         <DropdownMenuItem>Menu item number two</DropdownMenuItem>
       </DropdownContent>
     </Dropdown>
     <Dropdown {...args} dropDirection={DropdownDropDirection.left}>
-      <DropdownButton>Left Aligned Dropdown</DropdownButton>
-      <DropdownContent>
+      <DropdownButton id="leftAlignedDropdown">
+        Left Aligned Dropdown
+      </DropdownButton>
+      <DropdownContent id="leftAlignedDropdown">
         <DropdownMenuItem>Menu item 1</DropdownMenuItem>
         <DropdownMenuItem>Menu item number two</DropdownMenuItem>
       </DropdownContent>
     </Dropdown>
     <br />
     <Dropdown {...args} dropDirection={DropdownDropDirection.up}>
-      <DropdownButton>Top Aligned Dropdown</DropdownButton>
-      <DropdownContent>
+      <DropdownButton id="topAlignedDropdown">
+        Top Aligned Dropdown
+      </DropdownButton>
+      <DropdownContent id="topAlignedDropdown">
         <DropdownMenuItem>Menu item 1</DropdownMenuItem>
         <DropdownMenuItem>Menu item number two</DropdownMenuItem>
       </DropdownContent>
     </Dropdown>
     <Dropdown {...args} dropDirection={DropdownDropDirection.down}>
-      <DropdownButton>Bottom Aligned Dropdown</DropdownButton>
-      <DropdownContent>
+      <DropdownButton id="bottomAlignedDropdown">
+        Bottom Aligned Dropdown
+      </DropdownButton>
+      <DropdownContent id="bottomAlignedDropdown">
         <DropdownMenuItem>Menu item 1</DropdownMenuItem>
         <DropdownMenuItem>Menu item number two</DropdownMenuItem>
       </DropdownContent>
@@ -242,10 +250,14 @@ const SplitTemplate: StoryFn<DropdownProps> = args => (
   >
     <div style={{ margin: '150px 0', textAlign: 'center' }}>
       <Dropdown {...args}>
-        <DropdownSplitButton aria-label="Split" size={ButtonSize.medium}>
+        <DropdownSplitButton
+          aria-label="Split"
+          id="splitDropdown1"
+          size={ButtonSize.medium}
+        >
           Split Dropdown
         </DropdownSplitButton>
-        <DropdownContent>
+        <DropdownContent id="splitDropdown1">
           <DropdownMenuItem>Menu item 1</DropdownMenuItem>
           <DropdownMenuItem>Menu item number two</DropdownMenuItem>
         </DropdownContent>

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -13,7 +13,7 @@ import { ReferenceType } from '@floating-ui/react-dom/dist/floating-ui.react-dom
 
 import { useDescendants } from '../../hooks/useDescendants';
 import { useIsInverse } from '../../inverse';
-import { resolveProps, useForkedRef } from '../../utils';
+import { resolveProps, useForkedRef, useGenerateId } from '../../utils';
 import { ButtonGroupContext } from '../ButtonGroup';
 
 export enum DropdownDropDirection {
@@ -252,6 +252,8 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
     const isInverse = useIsInverse(resolvedProps.isInverse);
 
     const [placement, setPlacement] = useState('bottom-start');
+
+    dropdownButtonId.current = useGenerateId();
 
     const changePlacement = (
       dropDirection: string = DropdownDropDirection.down,

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
@@ -143,6 +143,7 @@ export const DropdownButton = React.forwardRef<
     <div ref={context.setReference}>
       <StyledIconButton
         {...other}
+        aria-controls={'dropdownMenuId'}
         aria-expanded={context.isOpen}
         aria-haspopup="true"
         icon={icon}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownButton.tsx
@@ -14,7 +14,7 @@ import { ButtonIconPosition, IconButton } from '../IconButton';
 import { DropdownContext, DropdownDropDirection } from './Dropdown';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { Omit, useForkedRef, useGenerateId, XOR } from '../../utils';
+import { Omit, useForkedRef, XOR } from '../../utils';
 import { ButtonProps, ButtonSize } from '../Button';
 
 export interface IconOnlyDropdownButtonProps
@@ -93,8 +93,6 @@ export const DropdownButton = React.forwardRef<
   const context = React.useContext(DropdownContext);
   const theme = React.useContext(ThemeContext);
 
-  context.dropdownButtonId.current = useGenerateId(props.id);
-
   const ref = useForkedRef(context.toggleRef, forwardedRef);
 
   function getButtonIcon(dropDirection: DropdownDropDirection) {
@@ -114,7 +112,7 @@ export const DropdownButton = React.forwardRef<
   const buttonIcon = getButtonIcon(context.dropDirection);
 
   let children;
-  const { icon = buttonIcon, iconPosition, leadingIcon, ...other } = props;
+  const { icon = buttonIcon, iconPosition, leadingIcon, id, ...other } = props;
 
   if (!instanceOfIconOnlyDropdownButton(props)) {
     children = props.children;
@@ -143,12 +141,14 @@ export const DropdownButton = React.forwardRef<
     <div ref={context.setReference}>
       <StyledIconButton
         {...other}
-        aria-controls={'dropdownMenuId'}
+        aria-controls={
+          (id ?? context.dropdownButtonId.current) + '_dropdownMenuId'
+        }
         aria-expanded={context.isOpen}
         aria-haspopup="true"
         icon={icon}
         iconPosition={iconPositionToUse}
-        id={context.dropdownButtonId.current}
+        id={id ?? context.dropdownButtonId.current}
         isInverse={context.isInverse}
         leadingIcon={leadingIcon}
         onClick={handleClick}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -67,7 +67,7 @@ export const DropdownContent = React.forwardRef<
   HTMLDivElement,
   DropdownContentProps
 >((props, forwardedRef) => {
-  const { children, testId, ...other } = props;
+  const { children, testId, id, ...other } = props;
   const context = React.useContext(DropdownContext);
   const theme = React.useContext(ThemeContext);
   const ref = useForkedRef(forwardedRef, context.menuRef);
@@ -94,7 +94,7 @@ export const DropdownContent = React.forwardRef<
   return (
     <div
       data-testid={'dropdownContentWrapper'}
-      id={'dropdownMenuId'}
+      id={(id ?? context.dropdownButtonId.current) + '_dropdownMenuId'}
       ref={el => {
         context.isOpen && context.setFloating(el);
       }}
@@ -122,7 +122,7 @@ export const DropdownContent = React.forwardRef<
         width={context.width}
       >
         <div
-          aria-labelledby={context.dropdownButtonId.current}
+          aria-labelledby={id ?? context.dropdownButtonId.current}
           role={hasItemChildren ? 'menu' : null}
         >
           {children}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -94,6 +94,7 @@ export const DropdownContent = React.forwardRef<
   return (
     <div
       data-testid={'dropdownContentWrapper'}
+      id={'dropdownMenuId'}
       ref={el => {
         context.isOpen && context.setFloating(el);
       }}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -144,6 +144,9 @@ export const DropdownSplitButton = React.forwardRef<
       )}
       <IconButton
         {...other}
+        aria-controls={
+          (id ?? context.dropdownButtonId.current) + '_dropdownMenuId'
+        }
         aria-expanded={resolvedContext.isOpen}
         aria-label={ariaLabel || i18n.dropdown.toggleMenuAriaLabel}
         aria-haspopup="true"


### PR DESCRIPTION
Closes: #2024

## What I did
- Added `aria-controls` attribute for DropdownButton.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Dropdown -> Default -> `aria-controls` for the trigger button, and the `id` for the dropdown content must be the same.
Go to Storybook -> Dropdown -> Split Button -> `aria-controls` for the trigger button, and the `id` for the dropdown content must be the same.
Go to Storybook -> Dropdown -> Alignment Button -> `aria-controls` for the trigger button, and the `id` for the dropdown content must be the same.
