### PR TITLE
fix(Alert): add the `dismissibleButtonRef` prop to the `Alert` and fix docs page

### DIFF
--- a/.changeset/fix-Alert-docs-acessibility-issues.md
+++ b/.changeset/fix-Alert-docs-acessibility-issues.md
@@ -1,5 +1,5 @@
 ---
-'react-magma-docs': patch
+'react-magma-dom': patch
 ---
 
 fix(Alert): add the `dismissibleButtonRef` prop to the `Alert` and fix docs page

--- a/.changeset/fix-Alert-docs-acessibility-issues.md
+++ b/.changeset/fix-Alert-docs-acessibility-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Alert): add the `dismissibleButtonRef` prop to the `Alert` and fix docs page

--- a/packages/react-magma-dom/src/components/Alert/index.tsx
+++ b/packages/react-magma-dom/src/components/Alert/index.tsx
@@ -21,6 +21,10 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default false
    */
   isDismissible?: boolean;
+  /**
+   * Reference to the dismiss button element
+   */
+  dismissibleButtonRef?: React.Ref<HTMLButtonElement>;
   isInverse?: boolean;
   /**
    * Action that fires when the close button is clicked (required when isDismissible is true)

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -47,6 +47,7 @@ export interface AlertBaseProps extends React.HTMLAttributes<HTMLDivElement> {
   isExiting?: boolean;
   isDismissed?: boolean;
   isDismissible?: boolean;
+  dismissibleButtonRef?: React.Ref<HTMLButtonElement>;
   isInverse?: boolean;
   isPaused?: boolean;
   isToast?: boolean;
@@ -430,6 +431,7 @@ export const AlertBase = React.forwardRef<HTMLDivElement, AlertBaseProps>(
       id: defaultId,
       isDismissed,
       isDismissible,
+      dismissibleButtonRef,
       isExiting: externalIsExiting,
       isPaused,
       isToast,
@@ -533,6 +535,7 @@ export const AlertBase = React.forwardRef<HTMLDivElement, AlertBaseProps>(
                 )}
                 {/* @ts-ignore */}
                 <DismissButton
+                  ref={dismissibleButtonRef}
                   alertVariant={variant}
                   {...(isToast
                     ? { title: closeAriaLabel || i18n.alert.dismissAriaLabel }

--- a/website/react-magma-docs/src/pages/api/alert.mdx
+++ b/website/react-magma-docs/src/pages/api/alert.mdx
@@ -77,24 +77,48 @@ The aria-label, by default is `Close this message` but can be overridden using t
 ```tsx
 import React from 'react';
 
-import { Alert, Button } from 'react-magma-dom';
+import { Alert, Button, Announce } from 'react-magma-dom';
 
 export function Example() {
   const [showAlert, updateShowAlert] = React.useState<boolean>(false);
+  const dismissAlertRef = React.useRef<HTMLButtonElement>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  const onDismiss = () => {
+    updateShowAlert(false);
+
+    buttonRef.current?.focus();
+  };
+
+  const onShowAlert = () => {
+    updateShowAlert(true);
+
+    setTimeout(() => {
+      dismissAlertRef.current?.focus();
+    }, 0);
+  };
 
   return (
     <>
-      {showAlert && (
-        <Alert isDismissible onDismiss={() => updateShowAlert(false)}>
-          Dismiss Me
-          <br />
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat.
-        </Alert>
-      )}
-      <Button onClick={() => updateShowAlert(true)}>Show Alert</Button>
+      <Announce>
+        {showAlert && (
+          <Alert
+            isDismissible
+            onDismiss={onDismiss}
+            dismissibleButtonRef={dismissAlertRef}
+          >
+            Dismiss Me
+            <br />
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat.
+          </Alert>
+        )}
+      </Announce>
+      <Button onClick={onShowAlert} ref={buttonRef}>
+        Show Alert
+      </Button>
     </>
   );
 }


### PR DESCRIPTION
Closes: #2039

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add the `dismissibleButtonRef` prop to the `Alert` and fix docs page.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
1. Open Docs -> Alert -> Dismissible section -> Turn on screenreader -> Click on the `Show Alert` button -> Observe if the alert content is announced 
2. Open Docs -> Alert -> Dismissible section -> Turn on screenreader -> Click on the `Show Alert` button -> Check that the focus now is on the `Close` button -> Click on the `Close` button -> Check that the focus now is on the `Show Alert` button