### PR TITLE
fix(Navtabs): Fix obscured content when element is focused.

### DIFF
--- a/.changeset/fix-NavTabs-fix-obscured-focus.md
+++ b/.changeset/fix-NavTabs-fix-obscured-focus.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Nav Tabs): Fix obscured content when the elements is focused.

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.test.js
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.test.js
@@ -10,6 +10,13 @@ import { magma } from '../../theme/magma';
 import { NavTabs } from '.';
 
 describe('NavTabs', () => {
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: jest.fn(),
+    });
+  });
+
   it('should find element by testId', () => {
     const testId = 'test-id';
     const { getByTestId } = render(<NavTabs testId={testId} />);

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
@@ -89,16 +89,28 @@ export const NavTabs = React.forwardRef<
     }
   });
 
+  const handleNavTabFocus = (event: React.FocusEvent<HTMLElement>) => {
+    const navTabElement = event.currentTarget;
+
+    navTabElement.scrollIntoView({
+      block: 'center',
+      inline: 'center',
+      behavior: 'smooth',
+    });
+  };
+
   const navTabsChildren = React.Children.map(children, (child, i) => {
     const item = child as React.ReactElement<
       React.PropsWithChildren<NavTabProps>
     >;
 
     if (item.type === NavTab) {
-      if (!hasChildFocus && i === 0) {
-        return React.cloneElement(item, { isFocused: true });
-      }
+      return React.cloneElement(item, {
+        onFocus: handleNavTabFocus,
+        isFocused: item.props.isFocused || (!hasChildFocus && i === 0),
+      });
     }
+
     return child;
   });
 


### PR DESCRIPTION
Closes: #2022

Copy [this](https://github.com/cengage/react-magma/pull/2049) PR in `v4/dev` branch

## What I did
- Fixed visibility when the user navigates across `NavTab` by tabbing.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> NavTabs -> Scrolling -> NavTab should be completely visible 
Go to React Magma Docs -> Components ->  NavTabs -> Scrollable & Scrollable Vertical Tabs -> NavTab should be completely visible 
