### PR TITLE
fix(Dropdown): Add aria attributes to improve accessibility

### DIFF
--- a/.changeset/fix-Dropdown-add-aria-attributes.md
+++ b/.changeset/fix-Dropdown-add-aria-attributes.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown & Accordion): Add aria attributes for Dropdown menu and nested items to improve accessibility.

--- a/packages/react-magma-dom/src/components/Accordion/AccordionPanel.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/AccordionPanel.tsx
@@ -41,13 +41,15 @@ export const AccordionPanel = React.forwardRef<
   const theme = React.useContext(ThemeContext);
   const isInverse = useIsInverse(isInverseProp);
 
-  const { isExpanded, panelId } = React.useContext(AccordionItemContext);
+  const { buttonId, isExpanded, panelId } =
+    React.useContext(AccordionItemContext);
 
   return (
     <Transition isOpen={isExpanded} collapse unmountOnExit>
       <StyledPanel
         {...rest}
         aria-hidden={!isExpanded}
+        aria-labelledby={buttonId}
         data-testid={testId}
         id={panelId}
         isInverse={isInverse}

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -567,6 +567,8 @@ export const ExpandableItems = {
               </DropdownExpandableMenuPanel>
             </DropdownExpandableMenuItem>
           </DropdownExpandableMenuGroup>
+          <DropdownDivider />
+          <DropdownExpandableMenuListItem>Pizza</DropdownExpandableMenuListItem>
         </DropdownContent>
       </Dropdown>
     );

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -123,7 +123,7 @@ export const DropdownContent = React.forwardRef<
       >
         <div
           aria-labelledby={id ?? context.dropdownButtonId.current}
-          role={hasItemChildren ? 'menu' : null}
+          role={hasItemChildren || hasExpandableItems ? 'menu' : null}
         >
           {children}
         </div>

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
@@ -3,7 +3,11 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import { IconProps } from 'react-magma-icons';
 
-import { AccordionButton, AccordionButtonProps } from '../Accordion';
+import {
+  AccordionButton,
+  AccordionButtonProps,
+  AccordionItemContext,
+} from '../Accordion';
 import { DropdownContext } from './Dropdown';
 import { DropdownExpandableMenuGroupContext } from './DropdownExpandableMenuGroup';
 import { DropdownExpandableMenuItemContext } from './DropdownExpandableMenuItem';
@@ -63,6 +67,8 @@ export const DropdownExpandableMenuButton = React.forwardRef<
     DropdownExpandableMenuItemContext
   );
 
+  const { isExpanded } = React.useContext(AccordionItemContext);
+
   const ownRef = React.useRef<HTMLDivElement>();
   const ref = useForkedRef(forwardedRef, ownRef);
 
@@ -82,7 +88,10 @@ export const DropdownExpandableMenuButton = React.forwardRef<
   return (
     <StyledAccordionButton
       {...other}
+      aria-expanded={isExpanded}
+      aria-haspopup="true"
       ref={ref}
+      role="menuitem"
       customOnKeyDown={handleCustomOnKeyDown}
       icon={icon}
       theme={theme}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuGroup.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuGroup.tsx
@@ -55,7 +55,6 @@ export const DropdownExpandableMenuGroup = React.forwardRef<
         iconPosition={AccordionIconPosition.right}
         isInverse={context.isInverse}
         ref={ref}
-        role="group"
         testId={testId}
       >
         {children}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuPanel.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuPanel.tsx
@@ -31,7 +31,7 @@ export const DropdownExpandableMenuPanel = React.forwardRef<
   });
 
   return (
-    <StyledAccordionPanel {...other} ref={ref} testId={testId}>
+    <StyledAccordionPanel {...other} ref={ref} role="menu" testId={testId}>
       {children}
     </StyledAccordionPanel>
   );

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -1430,6 +1430,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -3528,6 +3529,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -5557,6 +5559,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -7585,6 +7588,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -9743,6 +9747,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -11902,6 +11907,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -13931,6 +13937,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >


### PR DESCRIPTION
Closes: #2023 

## What I did
- Added `role="menu"` for the parent of the Dropdown list.
- Added `role="menuitem"`, `aria-haspopup="true"` and `aria-expanded` for expand buttons.
- Added `role="menu"` and `aria-labelledby` for the parent of the nested items. 
- Deleted `role="group"` for the `DropdownExpandableMenuGroup`

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Dropdown -> Expandable Items -> check all aria attributes.
