### PR TITLE
fix(Nav Tabs): Add aria-labelledby attribute for multi-instance docs examples.

### DIFF
--- a/.changeset/fix-NavsTab-add-region.md
+++ b/.changeset/fix-NavsTab-add-region.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Nav Tabs): Update documentation to include `aria-labelledby` attribute for multi-instance examples.

--- a/website/react-magma-docs/src/pages/api/nav-tabs.mdx
+++ b/website/react-magma-docs/src/pages/api/nav-tabs.mdx
@@ -207,6 +207,8 @@ export function Example() {
 Options for the `textTransform` prop for navtabs include `uppercase` and `none`, with `uppercase` (all caps) being the default value.
 This sets the CSS `text-transform` property.
 
+<Alert variant="warning" style={{padding: '4px'}}>When multiple `NavTabs` components are used on the same page, each one should have its own accessible name. You can provide this by using `aria-labelledby`, ensuring that every `NavTabs` instance has a unique label.</Alert>
+
 ```tsx
 import React from 'react';
 
@@ -215,7 +217,10 @@ import { NavTabs, NavTab, TabsTextTransform } from 'react-magma-dom';
 export function Example() {
   return (
     <>
-      <NavTabs textTransform={TabsTextTransform.uppercase}>
+      <NavTabs
+        textTransform={TabsTextTransform.uppercase}
+        aria-labelledby="Uppercase Nav Tabs region"
+      >
         <NavTab isActive to="javascript:void(0)">
           First uppercase
         </NavTab>
@@ -224,7 +229,10 @@ export function Example() {
       <br />
       <br />
       <br />
-      <NavTabs textTransform={TabsTextTransform.none}>
+      <NavTabs
+        textTransform={TabsTextTransform.none}
+        aria-labelledby="Lowercase Nav Tabs region"
+      >
         <NavTab isActive to="javascript:void(0)">
           First lowercase
         </NavTab>
@@ -453,6 +461,7 @@ export function Example() {
     <>
       <NavTabs
         aria-label="Icon Position Left Nav Tabs"
+        aria-labelledby="Icon Position Left Nav Tabs"
         iconPosition={TabsIconPosition.left}
       >
         <NavTab icon={<EmailIcon />} isActive to="javascript:void(0)">
@@ -472,6 +481,7 @@ export function Example() {
 
       <NavTabs
         aria-label="Icon Position Right Nav Tabs"
+        aria-labelledby="Icon Position Right Nav Tabs"
         iconPosition={TabsIconPosition.right}
       >
         <NavTab icon={<EmailIcon />} isActive to="javascript:void(0)">


### PR DESCRIPTION
Closes: #2021 

## What I did
- Added `aria-labelledby ` attribute for multi-instance docs examples.
- Added an alert about adding the `aria-labelledby ` attribute in case of using multiple Nav Tabs instances.

## Screenshots
<img width="784" height="531" alt="Screenshot from 2025-12-03 18-17-08" src="https://github.com/user-attachments/assets/ec66c14f-5a74-4636-9bb7-2e369d62ab79" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to `Docs` -> `Components` -> `Nav Tabs` -> `Text Transfrom` & `Icon Position`.
