### PR TITLE
fix(Accordion): Fix bug with not-announced `Expand All/Collapse All` button

### DIFF
--- a/.changeset/fix-Accordion-docs-accessibility-issue.md
+++ b/.changeset/fix-Accordion-docs-accessibility-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Accordion): Fix bug with not-announced `Expand All/Collapse All` button

--- a/website/react-magma-docs/src/pages/api/accordion.mdx
+++ b/website/react-magma-docs/src/pages/api/accordion.mdx
@@ -122,6 +122,7 @@ import {
   ButtonVariant,
   ButtonGroup,
   Spacer,
+  useDeviceDetect,
 } from 'react-magma-dom';
 
 export function Example() {
@@ -145,6 +146,8 @@ export function Example() {
     }
   };
 
+  const { isWindows, isSafari } = useDeviceDetect();
+
   return (
     <>
       <ButtonGroup>
@@ -152,7 +155,7 @@ export function Example() {
           onClick={handleToggleAll}
           size={ButtonSize.small}
           variant={ButtonVariant.solid}
-          role="status"
+          role={(isWindows || isSafari) && 'status'}
         >
           {isAllExpanded ? 'Collapse All' : 'Expand All'}
         </Button>

--- a/website/react-magma-docs/src/pages/api/accordion.mdx
+++ b/website/react-magma-docs/src/pages/api/accordion.mdx
@@ -126,6 +126,7 @@ import {
 
 export function Example() {
   const [expandedIndex, setExpandedIndex] = React.useState([]);
+  const [ariaLive, setAriaLive] = React.useState('polite');
 
   const isAllExpanded = expandedIndex.length > 0;
 
@@ -152,6 +153,7 @@ export function Example() {
           onClick={handleToggleAll}
           size={ButtonSize.small}
           variant={ButtonVariant.solid}
+          role="status"
         >
           {isAllExpanded ? 'Collapse All' : 'Expand All'}
         </Button>

--- a/website/react-magma-docs/src/pages/api/accordion.mdx
+++ b/website/react-magma-docs/src/pages/api/accordion.mdx
@@ -126,7 +126,6 @@ import {
 
 export function Example() {
   const [expandedIndex, setExpandedIndex] = React.useState([]);
-  const [ariaLive, setAriaLive] = React.useState('polite');
 
   const isAllExpanded = expandedIndex.length > 0;
 


### PR DESCRIPTION
Closes: #2038

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open docs -> Accordion -> Controlled Accordion -> Turn on Screen reader -> Press on Expand All/Collapse All button -> Check that it announces after changing text

## Note
The problem exists: in MacOS, when opening/closing any Accordion element, the text on the button changes and is announced after the Accordion element text is announced.
- `aria-live=“polite”`: announced twice in MacOS, 3-4 times in Windows + Firefox;
- `aria-label`: does not work in MacOS;
- `role=“status”` on the `<ButtonGroup>` component: does not work in Windows.