### PR TITLE
fix(Dropdown): Add aria attributes to improve accessibility.

### DIFF
--- a/.changeset/fix-Dropdown-add-aria-attributes.md
+++ b/.changeset/fix-Dropdown-add-aria-attributes.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown & Accordion): Add aria attributes for Dropdown menu and nested items to improve accessibility.

--- a/packages/react-magma-dom/src/components/Accordion/AccordionPanel.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/AccordionPanel.tsx
@@ -40,13 +40,15 @@ export const AccordionPanel = React.forwardRef<
   const theme = React.useContext(ThemeContext);
   const isInverse = useIsInverse(isInverseProp);
 
-  const { isExpanded, panelId } = React.useContext(AccordionItemContext);
+  const { buttonId, isExpanded, panelId } =
+    React.useContext(AccordionItemContext);
 
   return (
     <Transition isOpen={isExpanded} collapse unmountOnExit>
       <StyledPanel
         {...rest}
         aria-hidden={!isExpanded}
+        aria-labelledby={buttonId}
         data-testid={testId}
         id={panelId}
         isInverse={isInverse}

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -571,6 +571,8 @@ export const ExpandableItems = {
               </DropdownExpandableMenuPanel>
             </DropdownExpandableMenuItem>
           </DropdownExpandableMenuGroup>
+          <DropdownDivider />
+          <DropdownExpandableMenuListItem>Pizza</DropdownExpandableMenuListItem>
         </DropdownContent>
       </Dropdown>
     );

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -121,7 +121,7 @@ export const DropdownContent = React.forwardRef<
       >
         <div
           aria-labelledby={id ?? context.dropdownButtonId.current}
-          role={hasItemChildren ? 'menu' : null}
+          role={hasItemChildren || hasExpandableItems ? 'menu' : null}
         >
           {children}
         </div>

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuButton.tsx
@@ -3,7 +3,11 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import { IconProps } from 'react-magma-icons';
 
-import { AccordionButton, AccordionButtonProps } from '../Accordion';
+import {
+  AccordionButton,
+  AccordionButtonProps,
+  AccordionItemContext,
+} from '../Accordion';
 import { DropdownContext } from './Dropdown';
 import { DropdownExpandableMenuGroupContext } from './DropdownExpandableMenuGroup';
 import { DropdownExpandableMenuItemContext } from './DropdownExpandableMenuItem';
@@ -63,6 +67,8 @@ export const DropdownExpandableMenuButton = React.forwardRef<
     DropdownExpandableMenuItemContext
   );
 
+  const { isExpanded } = React.useContext(AccordionItemContext);
+
   const ownRef = React.useRef<HTMLDivElement>();
   const ref = useForkedRef(forwardedRef, ownRef);
 
@@ -82,7 +88,10 @@ export const DropdownExpandableMenuButton = React.forwardRef<
   return (
     <StyledAccordionButton
       {...other}
+      aria-expanded={isExpanded}
+      aria-haspopup="true"
       ref={ref}
+      role="menuitem"
       customOnKeyDown={handleCustomOnKeyDown}
       icon={icon}
       theme={theme}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuGroup.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuGroup.tsx
@@ -54,7 +54,6 @@ export const DropdownExpandableMenuGroup = React.forwardRef<
         iconPosition={AccordionIconPosition.right}
         isInverse={context.isInverse}
         ref={ref}
-        role="group"
         testId={testId}
       >
         {children}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuPanel.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuPanel.tsx
@@ -30,7 +30,7 @@ export const DropdownExpandableMenuPanel = React.forwardRef<
   });
 
   return (
-    <StyledAccordionPanel {...other} ref={ref} testId={testId}>
+    <StyledAccordionPanel {...other} ref={ref} role="menu" testId={testId}>
       {children}
     </StyledAccordionPanel>
   );

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -1456,6 +1456,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -3589,6 +3590,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -5653,6 +5655,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -7716,6 +7719,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -9909,6 +9913,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -12103,6 +12108,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >
@@ -14167,6 +14173,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
         >
           <div
             aria-hidden="false"
+            aria-labelledby="0_btn"
             class="emotion-12 emotion-13"
             id="0_panel"
           >


### PR DESCRIPTION
Closes: #2023 
Copy of [this](https://github.com/cengage/react-magma/pull/2062) PR into `v4/dev` branch.

## What I did
- Added `role="menu"` for the parent of the Dropdown list.
- Added `role="menuitem"`, `aria-haspopup="true"` and `aria-expanded` for expand buttons.
- Added `role="menu"` and `aria-labelledby` for the parent of the nested items. 
- Deleted `role="group"` for the `DropdownExpandableMenuGroup`

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Dropdown -> Expandable Items -> check all aria attributes.
