### PR TITLE
fix(Drawer): Fix scrolling with overflowing content.

### DIFF
--- a/.changeset/fix-Drawer-content-not-scrollable.md
+++ b/.changeset/fix-Drawer-content-not-scrollable.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Drawer): Fix content scrolling inside the Drawer when overflowing.

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
 import { Button } from '../Button';
+import { Container } from '../Container/Container';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { DrawerPosition, DrawerProps } from './Drawer';
 import { NavTab, NavTabs } from '../NavTabs';
+import { Paragraph } from '../Paragraph/index';
 import { TabsOrientation } from '../Tabs/shared';
 
 import { Drawer } from '.';
@@ -50,6 +52,7 @@ export const Default = {
     return (
       <>
         <Drawer
+          {...args}
           header="Drawer Title"
           onClose={() => {
             setShowDrawer(false);
@@ -57,7 +60,6 @@ export const Default = {
           }}
           isOpen={showDrawer}
           closeAriaLabel="Close drawer"
-          {...args}
         >
           <p>This is a Drawer, doing Drawer things.</p>
           <p>
@@ -89,6 +91,7 @@ export const SiteNavigation = {
     return (
       <>
         <Drawer
+          {...args}
           onClose={() => {
             setShowDrawer(false);
             buttonRef.current?.focus();
@@ -97,7 +100,6 @@ export const SiteNavigation = {
           position={DrawerPosition.right}
           ariaLabel="Site Navigation Drawer"
           closeAriaLabel="Close Navigation Drawer"
-          {...args}
         >
           <NavTabs
             orientation={TabsOrientation.vertical}
@@ -117,6 +119,111 @@ export const SiteNavigation = {
           Show Drawer
           <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
         </Button>
+      </>
+    );
+  },
+};
+
+export const WithLongContent = {
+  render: (
+    args: React.JSX.IntrinsicAttributes &
+      DrawerProps &
+      React.RefAttributes<HTMLDivElement>
+  ) => {
+    const [showDrawer, setShowDrawer] = React.useState(false);
+    const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+
+    return (
+      <>
+        <Drawer
+          {...args}
+          onClose={() => {
+            setShowDrawer(false);
+            buttonRef.current?.focus();
+          }}
+          isOpen={showDrawer}
+          position={DrawerPosition.right}
+          ariaLabel="Site Navigation Drawer"
+          closeAriaLabel="Close Navigation Drawer"
+          showBackgroundOverlay={false}
+        >
+          <Container isInverse={args.isInverse}>
+            <Paragraph>ONE</Paragraph>
+            <Paragraph>TWO</Paragraph>
+            <Paragraph>THREE</Paragraph>
+            <Paragraph>FOUR</Paragraph>
+            <Paragraph>FIVE</Paragraph>
+            <Paragraph>SIX</Paragraph>
+            <Paragraph>SEVEN</Paragraph>
+            <Paragraph>EIGHT</Paragraph>
+            <Paragraph>NINE</Paragraph>
+            <Paragraph>TEN</Paragraph>
+            <Paragraph>ELEVEN</Paragraph>
+            <Paragraph>TWELVE</Paragraph>
+            <Paragraph>THIRTEEN</Paragraph>
+            <Paragraph>FOURTEEN</Paragraph>
+            <Paragraph>FIFTEEN</Paragraph>
+            <Paragraph>SIXTEEN</Paragraph>
+            <Paragraph>SEVENTEEN</Paragraph>
+            <Paragraph>EIGHTEEN</Paragraph>
+            <Paragraph>NINETEEN</Paragraph>
+            <Paragraph>TWENTY</Paragraph>
+            <Paragraph>TWENTY-ONE</Paragraph>
+            <Paragraph>TWENTY-TWO</Paragraph>
+            <Paragraph>TWENTY-THREE</Paragraph>
+            <Paragraph>TWENTY-FOUR</Paragraph>
+            <Paragraph>TWENTY-FIVE</Paragraph>
+            <Paragraph>TWENTY-SIX</Paragraph>
+            <Paragraph>TWENTY-SEVEN</Paragraph>
+            <Paragraph>TWENTY-EIGHT</Paragraph>
+            <Paragraph>TWENTY-NINE</Paragraph>
+            <Paragraph>THIRTY</Paragraph>
+            <Paragraph>THIRTY-ONE</Paragraph>
+            <Paragraph>THIRTY-TWO</Paragraph>
+          </Container>
+        </Drawer>
+        <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowDrawer(true)}
+          ref={buttonRef}
+        >
+          Drawer
+          <VisuallyHidden>(opens drawer dialog)</VisuallyHidden>
+        </Button>
+        <Paragraph>LOTS OF TEXT ONE</Paragraph>
+        <Paragraph>LOTS OF TEXT TWO</Paragraph>
+        <Paragraph>LOTS OF TEXT THREE</Paragraph>
+        <Paragraph>LOTS OF TEXT FOUR</Paragraph>
+        <Paragraph>LOTS OF TEXT FIVE</Paragraph>
+        <Paragraph>LOTS OF TEXT SIX</Paragraph>
+        <Paragraph>LOTS OF TEXT SEVEN</Paragraph>
+        <Paragraph>LOTS OF TEXT EIGHT</Paragraph>
+        <Paragraph>LOTS OF TEXT NINE</Paragraph>
+        <Paragraph>LOTS OF TEXT TEN</Paragraph>
+        <Paragraph>LOTS OF TEXT ELEVEN</Paragraph>
+        <Paragraph>LOTS OF TEXT TWELVE</Paragraph>
+        <Paragraph>LOTS OF TEXT THIRTEEN</Paragraph>
+        <Paragraph>LOTS OF TEXT FOURTEEN</Paragraph>
+        <Paragraph>LOTS OF TEXT FIFTEEN</Paragraph>
+        <Paragraph>LOTS OF TEXT SIXTEEN</Paragraph>
+        <Paragraph>LOTS OF TEXT SEVENTEEN</Paragraph>
+        <Paragraph>LOTS OF TEXT EIGHTEEN</Paragraph>
+        <Paragraph>LOTS OF TEXT NINETEEN</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-ONE</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-TWO</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-THREE</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-FOUR</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-FIVE</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-SIX</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-SEVEN</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-EIGHT</Paragraph>
+        <Paragraph>LOTS OF TEXT TWENTY-NINE</Paragraph>
+        <Paragraph>LOTS OF TEXT THIRTY</Paragraph>
+        <Paragraph>LOTS OF TEXT THIRTY-ONE</Paragraph>
+        <Paragraph>LOTS OF TEXT THIRTY-TWO</Paragraph>
+        <Paragraph>LOTS OF TEXT THIRTY-THREE</Paragraph>
+        <Paragraph>LOTS OF TEXT THIRTY-FOUR</Paragraph>
       </>
     );
   },

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
@@ -67,6 +67,7 @@ export const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
     const drawerStyle = {
       ...theme.drawer.default,
       ...theme.drawer[DrawerPosition[position]],
+      overflowY: 'auto',
     } as React.CSSProperties;
 
     let containerTransition: Omit<TransitionProps, 'isOpen'> | undefined;


### PR DESCRIPTION
Closes: #2061


## What I did
- Added scrolling for the `Drawer` with overflowing content.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Drawer -> `With Long Content` -> Open Drawer -> content inside the component should be scrollable
