### PR TITLE
fix(Treeview): Fix virtualization styles.

### DIFF
--- a/.changeset/fix-Treeview-fix-virtulization-styling.md
+++ b/.changeset/fix-Treeview-fix-virtulization-styling.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Treeview): Fix virtualization styling when enableVirtualization is true.

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { fireEvent, getByTestId, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
 
@@ -12,6 +12,11 @@ import { TreeItem, TreeView } from '.';
 const labelText = 'Tree Item Node 0';
 const itemId = 'node0';
 const testId = `${itemId}-tree-item`;
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+}));
 
 describe('TreeItem', () => {
   it('should render the component', () => {

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -51,6 +51,7 @@ const StyledTreeItem = styled.li<{
   selectableType?: TreeViewSelectable;
   isDisabled?: boolean;
   hoverColor?: string;
+  isVirtualized?: boolean;
 }>`
   color: ${props =>
     props.isInverse
@@ -67,7 +68,13 @@ const StyledTreeItem = styled.li<{
   margin-bottom: 0;
 
   padding-inline-start: ${props =>
-    calculateOffset(props.nodeType, props.depth)};
+    calculateOffset(
+      props.nodeType,
+      props.depth,
+      false,
+      false,
+      props.isVirtualized
+    )};
 
   &:focus {
     outline: none;
@@ -91,9 +98,21 @@ const StyledTreeItem = styled.li<{
     position: relative;
 
     padding-inline-start: ${props =>
-      calculateOffset(props.nodeType, props.depth, true)};
+      calculateOffset(
+        props.nodeType,
+        props.depth,
+        true,
+        false,
+        props.isVirtualized
+      )};
     margin-inline-start: ${props =>
-      calculateOffset(props.nodeType, props.depth, true, true)};
+      calculateOffset(
+        props.nodeType,
+        props.depth,
+        true,
+        true,
+        props.isVirtualized
+      )};
     padding-block-end: ${props => props.theme.spaceScale.spacing02};
     padding-block-start: ${props => props.theme.spaceScale.spacing02};
     padding-right: ${props => props.theme.spaceScale.spacing02};
@@ -590,6 +609,7 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
             id={itemId}
             isDisabled={isDisabled}
             isInverse={isInverse}
+            isVirtualized={hierarchyContext.isVirtualized}
             nodeType={nodeType}
             role="treeitem"
             selectableType={selectable}

--- a/packages/react-magma-dom/src/components/TreeView/TreeItemHierarchyContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItemHierarchyContext.ts
@@ -10,6 +10,7 @@ interface TreeItemHierarchyContextInterface {
   parentDepth: number;
   isTopLevel: boolean;
   index: number;
+  isVirtualized?: boolean;
 }
 
 export const TreeItemHierarchyContext =
@@ -18,4 +19,5 @@ export const TreeItemHierarchyContext =
     parentDepth: 0,
     isTopLevel: true,
     index: 0,
+    isVirtualized: false,
   });

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -3049,6 +3049,16 @@ export const ComplexWithAdditionalContent = {
                 <DropdownMenuItem>Menu item number two</DropdownMenuItem>
               </DropdownContent>
             </Dropdown>
+            <Popover hasPointer={false} focusTrap={false}>
+              <PopoverTrigger aria-label="Open popover">
+                <Button size={ButtonSize.small} color={ButtonColor.subtle}>
+                  This opens a popover
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent>
+                <div>Im a popover.</div>
+              </PopoverContent>
+            </Popover>
           </ButtonGroup>
         </>
       );
@@ -3270,7 +3280,9 @@ export function TreeViewWithDifferentElements() {
             <div>
               Nocturnal birds with distinctive facial discs and silent flight.{' '}
               <Button
-                onClick={event => apiRef.current?.closePopoverManually(event)}
+                onClick={event =>
+                  popoverApiRef.current?.closePopoverManually(event)
+                }
               >
                 Ok
               </Button>
@@ -3512,6 +3524,16 @@ export const VirtualizedLargeTree = {
                 <DropdownMenuItem>Menu item number two</DropdownMenuItem>
               </DropdownContent>
             </Dropdown>
+            <Popover hasPointer={false} focusTrap>
+              <PopoverTrigger aria-label="Open popover">
+                <Button size={ButtonSize.small} color={ButtonColor.subtle}>
+                  This opens a popover
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent>
+                <div>Im a popover.</div>
+              </PopoverContent>
+            </Popover>
           </ButtonGroup>
         </>
       );
@@ -3531,8 +3553,6 @@ export const VirtualizedLargeTree = {
           {...args}
           apiRef={apiRef}
           enableVirtualization={args.enableVirtualization}
-          estimateSize={40}
-          overscan={5}
           style={{ height: '600px', overflow: 'auto' }}
         >
           <TreeItem

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -3408,7 +3408,7 @@ export function CustomExpandIconArrowAndTreeItemStyles() {
 export const VirtualizedLargeTree = {
   render: (args: Partial<TreeViewProps>) => {
     const apiRef = React.useRef<TreeViewApi>();
-    
+
     const treeLabel = () => {
       return (
         <Flex
@@ -3579,7 +3579,6 @@ export const VirtualizedLargeTree = {
                         label={treeLabel()}
                         itemId={`activity${i}-${j}-${k}`}
                         icon={<BookIcon />}
-                        itemSize={120}
                       />
                     ))}
                   </TreeItem>

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -249,6 +249,11 @@ const renderTreeItemsRecursively = (treeItems, depth) => {
   });
 };
 
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
 describe('TreeView', () => {
   it('should find element by testId', () => {
     const { getByTestId } = render(

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -71,8 +71,13 @@ const VirtualItem = styled.div<VirtualItemProps>`
   top: 0;
   left: 0;
   width: 100%;
-  height: ${props => props.height}px;
+  min-height: ${props => props.height}px;
   transform: ${props => `translateY(${props.transform}px)`};
+
+  /* Ensure dropdowns and other floating elements appear above items */
+  &:focus-within {
+    z-index: 1;
+  }
 `;
 
 export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
@@ -107,6 +112,10 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
     );
 
     const parentRef = React.useRef<HTMLUListElement>(null);
+    const itemHeightsRef = React.useRef<Map<number, number>>(new Map());
+    const measurementRefs = React.useRef<Map<number, HTMLDivElement>>(
+      new Map()
+    );
 
     // Flatten tree structure for virtualization
     const flattenedItems = React.useMemo(() => {
@@ -117,7 +126,6 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
         depth: number;
         index: number;
         key: string;
-        itemSize?: number;
       }> = [];
 
       const flatten = (childrenToFlatten: React.ReactNode, depth = 0) => {
@@ -139,8 +147,6 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
             depth,
             index,
             key: itemKey,
-            // HERE need to pass the height of the item!!!
-            itemSize: child.props.itemSize,
           });
 
           // Check if item has children and is expanded
@@ -162,20 +168,55 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       parentRef,
       estimateSize: React.useCallback(
         (index: number) => {
-          // Here we set the height of each item
-          return flattenedItems[index]?.itemSize ?? estimateSize;
+          return itemHeightsRef.current.get(index) ?? estimateSize;
         },
-        [flattenedItems, estimateSize]
+        [itemHeightsRef, estimateSize]
       ),
       overscan,
     });
 
-    // Process children without cloneElement - use context instead
-    const processedChildren = React.useMemo(() => {
-      if (enableVirtualization) {
-        return null; // Handled by virtualizer below
-      }
+    // Measure item heights after render
+    React.useEffect(() => {
+      const measureHeights = () => {
+        let hasChanges = false;
+        measurementRefs.current.forEach((element, index) => {
+          if (element) {
+            const height = element.offsetHeight;
+            const currentHeight = itemHeightsRef.current.get(index);
 
+            if (currentHeight !== height && height > 0) {
+              itemHeightsRef.current.set(index, height);
+              hasChanges = true;
+            }
+          }
+        });
+
+        if (hasChanges) {
+          rowVirtualizer.measure();
+        }
+      };
+
+      const timeoutId = setTimeout(() => {
+        measureHeights();
+      }, 0);
+
+      const resizeObserver = new ResizeObserver(() => {
+        measureHeights();
+      });
+
+      measurementRefs.current.forEach(element => {
+        if (element) {
+          resizeObserver.observe(element);
+        }
+      });
+
+      return () => {
+        clearTimeout(timeoutId);
+        resizeObserver.disconnect();
+      };
+    }, [flattenedItems, rowVirtualizer]);
+
+    const processedChildren = React.useMemo(() => {
       let treeItemIndex = 0;
 
       return React.Children.map(children, child => {
@@ -248,6 +289,16 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
                           key={item.key}
                           height={virtualItem.size}
                           transform={virtualItem.start}
+                          ref={(el: HTMLDivElement) => {
+                            if (el) {
+                              measurementRefs.current.set(
+                                virtualItem.index,
+                                el
+                              );
+                            } else {
+                              measurementRefs.current.delete(virtualItem.index);
+                            }
+                          }}
                         >
                           <TreeItemHierarchyContext.Provider
                             value={hierarchyValue}

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -200,19 +200,25 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
         measureHeights();
       }, 0);
 
-      const resizeObserver = new ResizeObserver(() => {
-        measureHeights();
-      });
+      if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+        const resizeObserver = new (window as any).ResizeObserver(() => {
+          measureHeights();
+        });
 
-      measurementRefs.current.forEach(element => {
-        if (element) {
-          resizeObserver.observe(element);
-        }
-      });
+        measurementRefs.current.forEach(element => {
+          if (element) {
+            resizeObserver.observe(element);
+          }
+        });
+
+        return () => {
+          clearTimeout(timeoutId);
+          resizeObserver.disconnect();
+        };
+      }
 
       return () => {
         clearTimeout(timeoutId);
-        resizeObserver.disconnect();
       };
     }, [flattenedItems, rowVirtualizer]);
 
@@ -246,7 +252,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
 
         return null;
       });
-    }, [children, enableVirtualization]);
+    }, [children]);
 
     return (
       <InverseContext.Provider value={inverseContextValue}>

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -22,16 +22,6 @@ export interface TreeViewProps
    * @default false
    */
   enableVirtualization?: boolean;
-  /**
-   * Estimated size of each tree item in pixels (used for virtualization).
-   * @default 40
-   */
-  estimateSize?: number;
-  /**
-   * Number of items to render above and below the visible area (overscan).
-   * @default 5
-   */
-  overscan?: number;
 }
 
 interface VirtualContainerProps {
@@ -93,8 +83,6 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       testId,
       apiRef,
       enableVirtualization = false,
-      estimateSize = 40,
-      overscan = 5,
       ...rest
     } = props;
 
@@ -172,12 +160,12 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
         (index: number) => {
           const item = flattenedItems[index];
           return item
-            ? (itemHeightsByIdRef.current.get(item.itemId) ?? estimateSize)
-            : estimateSize;
+            ? (itemHeightsByIdRef.current.get(item.itemId) ?? 40)
+            : 40;
         },
-        [flattenedItems, estimateSize]
+        [flattenedItems]
       ),
-      overscan,
+      overscan: 5, // Number of items to render above and below the visible area
     });
 
     // Measure item heights after render

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -112,8 +112,8 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
     );
 
     const parentRef = React.useRef<HTMLUListElement>(null);
-    const itemHeightsRef = React.useRef<Map<number, number>>(new Map());
-    const measurementRefs = React.useRef<Map<number, HTMLDivElement>>(
+    const itemHeightsByIdRef = React.useRef<Map<string, number>>(new Map());
+    const measurementRefs = React.useRef<Map<string, HTMLDivElement>>(
       new Map()
     );
 
@@ -126,6 +126,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
         depth: number;
         index: number;
         key: string;
+        itemId: string;
       }> = [];
 
       const flatten = (childrenToFlatten: React.ReactNode, depth = 0) => {
@@ -134,7 +135,8 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
             return;
           }
 
-          const itemKey = `tree-item-${depth}-${index}-${items.length}`;
+          const itemId = child.props.itemId;
+          const itemKey = `${itemId}-${depth}`;
 
           // Clone the child without its children to prevent double rendering
           const childWithoutNested = React.cloneElement(child, {
@@ -147,10 +149,10 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
             depth,
             index,
             key: itemKey,
+            itemId,
           });
 
           // Check if item has children and is expanded
-          const itemId = child.props.itemId;
           const isExpanded = expansionContextValue.expandedSet?.has(itemId);
 
           if (isExpanded && child.props.children) {
@@ -168,9 +170,12 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       parentRef,
       estimateSize: React.useCallback(
         (index: number) => {
-          return itemHeightsRef.current.get(index) ?? estimateSize;
+          const item = flattenedItems[index];
+          return item
+            ? (itemHeightsByIdRef.current.get(item.itemId) ?? estimateSize)
+            : estimateSize;
         },
-        [itemHeightsRef, estimateSize]
+        [flattenedItems, estimateSize]
       ),
       overscan,
     });
@@ -179,13 +184,14 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
     React.useEffect(() => {
       const measureHeights = () => {
         let hasChanges = false;
-        measurementRefs.current.forEach((element, index) => {
+
+        measurementRefs.current.forEach((element, itemId) => {
           if (element) {
             const height = element.offsetHeight;
-            const currentHeight = itemHeightsRef.current.get(index);
+            const currentHeight = itemHeightsByIdRef.current.get(itemId);
 
             if (currentHeight !== height && height > 0) {
-              itemHeightsRef.current.set(index, height);
+              itemHeightsByIdRef.current.set(itemId, height);
               hasChanges = true;
             }
           }
@@ -254,6 +260,31 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       });
     }, [children]);
 
+    React.useEffect(() => {
+      // Force measurement on children change
+      const timeoutId = setTimeout(() => {
+        let hasChanges = false;
+
+        measurementRefs.current.forEach((element, itemId) => {
+          if (element) {
+            const height = element.offsetHeight;
+            const currentHeight = itemHeightsByIdRef.current.get(itemId);
+
+            if (currentHeight !== height && height > 0) {
+              itemHeightsByIdRef.current.set(itemId, height);
+              hasChanges = true;
+            }
+          }
+        });
+
+        if (hasChanges) {
+          rowVirtualizer.measure();
+        }
+      }, 100); // Small delay to ensure DOM is updated
+
+      return () => clearTimeout(timeoutId);
+    }, [children]);
+
     return (
       <InverseContext.Provider value={inverseContextValue}>
         <TreeViewSelectionContext.Provider value={selectionContextValue}>
@@ -297,12 +328,9 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
                           transform={virtualItem.start}
                           ref={(el: HTMLDivElement) => {
                             if (el) {
-                              measurementRefs.current.set(
-                                virtualItem.index,
-                                el
-                              );
+                              measurementRefs.current.set(item.itemId, el);
                             } else {
-                              measurementRefs.current.delete(virtualItem.index);
+                              measurementRefs.current.delete(item.itemId);
                             }
                           }}
                         >

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -68,6 +68,9 @@ const VirtualItem = styled.div<VirtualItemProps>`
   &:focus-within {
     z-index: 1;
   }
+  &[data-testid='popoverContent'] {
+    z-index: 1;
+  }
 `;
 
 export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
@@ -158,18 +161,26 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       parentRef,
       estimateSize: React.useCallback(
         (index: number) => {
-          const item = flattenedItems[index];
-          return item
-            ? (itemHeightsByIdRef.current.get(item.itemId) ?? 40)
-            : 40;
+          const itemId = flattenedItems[index]?.itemId;
+          if (!itemId) {
+            return 32;
+          }
+
+          return itemHeightsByIdRef.current.get(itemId) ?? 32;
         },
         [flattenedItems]
       ),
-      overscan: 5, // Number of items to render above and below the visible area
+      overscan: 6,
     });
 
     // Measure item heights after render
     React.useEffect(() => {
+      if (!enableVirtualization) {
+        measurementRefs.current.clear();
+        itemHeightsByIdRef.current.clear();
+        return;
+      }
+
       const measureHeights = () => {
         let hasChanges = false;
 
@@ -214,7 +225,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       return () => {
         clearTimeout(timeoutId);
       };
-    }, [flattenedItems, rowVirtualizer]);
+    }, [enableVirtualization, flattenedItems, rowVirtualizer]);
 
     const processedChildren = React.useMemo(() => {
       let treeItemIndex = 0;
@@ -271,7 +282,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       }, 100); // Small delay to ensure DOM is updated
 
       return () => clearTimeout(timeoutId);
-    }, [children]);
+    }, [children, rowVirtualizer]);
 
     return (
       <InverseContext.Provider value={inverseContextValue}>
@@ -307,6 +318,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
                         parentDepth: Math.max(0, item.depth - 1),
                         isTopLevel: item.depth === 0,
                         index: item.index,
+                        isVirtualized: true,
                       };
 
                       return (

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -34,6 +34,15 @@ export interface TreeViewProps
   overscan?: number;
 }
 
+interface VirtualContainerProps {
+  height: number;
+}
+
+interface VirtualItemProps {
+  height: number;
+  transform: number;
+}
+
 const StyledTreeView = styled.ul<TreeViewProps & { isVirtualized?: boolean }>`
   padding: 0;
   margin: 0;
@@ -51,18 +60,19 @@ const StyledTreeView = styled.ul<TreeViewProps & { isVirtualized?: boolean }>`
   }
 `;
 
-const VirtualContainer = styled.div`
+const VirtualContainer = styled.div<VirtualContainerProps>`
   width: 100%;
   position: relative;
+  height: ${props => props.height}px;
 `;
 
-const VirtualItem = styled.div<{ height: number; transform: string }>`
+const VirtualItem = styled.div<VirtualItemProps>`
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: ${props => props.height}px;
-  transform: ${props => props.transform};
+  transform: ${props => `translateY(${props.transform}px)`};
 `;
 
 export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
@@ -110,11 +120,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
         itemSize?: number;
       }> = [];
 
-      const flatten = (
-        childrenToFlatten: React.ReactNode,
-        depth = 0,
-        parentIndex = 0
-      ) => {
+      const flatten = (childrenToFlatten: React.ReactNode, depth = 0) => {
         React.Children.forEach(childrenToFlatten, (child, index) => {
           if (!React.isValidElement(child) || child.type !== TreeItem) {
             return;
@@ -133,6 +139,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
             depth,
             index,
             key: itemKey,
+            // HERE need to pass the height of the item!!!
             itemSize: child.props.itemSize,
           });
 
@@ -141,7 +148,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
           const isExpanded = expansionContextValue.expandedSet?.has(itemId);
 
           if (isExpanded && child.props.children) {
-            flatten(child.props.children, depth + 1, index);
+            flatten(child.props.children, depth + 1);
           }
         });
       };
@@ -155,6 +162,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       parentRef,
       estimateSize: React.useCallback(
         (index: number) => {
+          // Here we set the height of each item
           return flattenedItems[index]?.itemSize ?? estimateSize;
         },
         [flattenedItems, estimateSize]
@@ -199,10 +207,6 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
       });
     }, [children, enableVirtualization]);
 
-    const virtualItems = enableVirtualization
-      ? rowVirtualizer.virtualItems
-      : [];
-
     return (
       <InverseContext.Provider value={inverseContextValue}>
         <TreeViewSelectionContext.Provider value={selectionContextValue}>
@@ -227,20 +231,10 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
                 }}
                 role="tree"
                 theme={theme}
-                style={{
-                  ...rest.style,
-                  ...(enableVirtualization
-                    ? { height: '400px', overflow: 'auto' }
-                    : {}),
-                }}
               >
                 {enableVirtualization ? (
-                  <VirtualContainer
-                    style={{
-                      height: `${rowVirtualizer.totalSize}px`,
-                    }}
-                  >
-                    {virtualItems.map(virtualItem => {
+                  <VirtualContainer height={rowVirtualizer.totalSize}>
+                    {rowVirtualizer.virtualItems.map(virtualItem => {
                       const item = flattenedItems[virtualItem.index];
                       const hierarchyValue = {
                         depth: item.depth,
@@ -253,7 +247,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
                         <VirtualItem
                           key={item.key}
                           height={virtualItem.size}
-                          transform={`translateY(${virtualItem.start}px)`}
+                          transform={virtualItem.start}
                         >
                           <TreeItemHierarchyContext.Provider
                             value={hierarchyValue}

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -27,12 +27,6 @@ export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
    */
   icon?: React.ReactElement<IconProps>;
   /**
-   * Custom height for this item when virtualization is enabled.
-   * If not specified, the TreeView's estimateSize will be used.
-   * @default undefined (uses TreeView's estimateSize)
-   */
-  itemSize?: number;
-  /**
    * If true, element is disabled
    * @default false
    */

--- a/packages/react-magma-dom/src/components/TreeView/utils.ts
+++ b/packages/react-magma-dom/src/components/TreeView/utils.ts
@@ -33,7 +33,8 @@ export function calculateOffset(
   type: TreeNodeType,
   depth = 0,
   labelElem = false,
-  negative = false
+  negative = false,
+  isVirtualized = false
 ) {
   let padding = 0;
 
@@ -45,6 +46,10 @@ export function calculateOffset(
       }
     } else if (depth === 0) {
       padding = 40;
+    } else if (isVirtualized) {
+      // For virtualized items, calculate cumulative padding
+      // Base padding (40px) + (depth * 24px per level after first)
+      padding = 40 + (depth - 1) * 24;
     } else {
       padding = 56;
     }
@@ -56,6 +61,10 @@ export function calculateOffset(
       }
     } else if (depth === 0) {
       padding = 8;
+    } else if (isVirtualized) {
+      // For virtualized items, calculate cumulative padding
+      // Base padding (8px) + (depth * 24px per level after first)
+      padding = 8 + (depth - 1) * 24;
     } else {
       padding = 24;
     }

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -1852,19 +1852,13 @@ For large trees with many items, you can enable virtualization to improve perfor
 
 ### Basic Virtualization
 
-Set `enableVirtualization={true}` and provide a `height` style to enable virtualization:
-
-### Dynamic Item Sizes
-
-TreeItems can have variable heights when they include additional content like due dates or resources. Use the `itemSize` prop on individual TreeItems to specify their height:
-
+Set `enableVirtualization={true}`. The `Treeview` height will be calculated based on the number of items and their heights.
 
 ### Virtualization Props
 
 - `enableVirtualization`: Enable virtualization for better performance (default: `false`)
 - `estimateSize`: Default estimated height in pixels for items without a specific `itemSize` (default: `40`)
 - `overscan`: Number of items to render above and below the visible area (default: `5`)
-- `style.height`: **Required** - Set an explicit height on the TreeView when virtualization is enabled (default: `400`)
 
 ## TreeView Props
 

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -1857,8 +1857,6 @@ Set `enableVirtualization={true}`. The `Treeview` height will be calculated base
 ### Virtualization Props
 
 - `enableVirtualization`: Enable virtualization for better performance (default: `false`)
-- `estimateSize`: Default estimated height in pixels for items without a specific `itemSize` (default: `40`)
-- `overscan`: Number of items to render above and below the visible area (default: `5`)
 
 ## TreeView Props
 


### PR DESCRIPTION
Closes: #1875 

## Screenshots
- Added calculation for every tree item.
- Fixed styles for the Dropdown inside  `Treeview`.
- Deleted hardcoded `height` for `Treeview`
- Deleted redundant props for virtualization
- Updated docs.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Treeview -> Complex with Additional Content -> activate `enableVirtualization` -> check all styles with state, when  `enableVirtualization=false`
Go to Storybook -> Treeview -> Virtualized Large Tree -> check all styles with state, when  `enableVirtualization=false`
