### PR TITLE
fix(Textarea): Fix aria describedby to announce the helper text.

### DIFF
--- a/.changeset/fix-TextArea-helpermessage-is-not-announced.md
+++ b/.changeset/fix-TextArea-helpermessage-is-not-announced.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(TextArea): Add an ARIA announcement helper to inform users how many characters are left.

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
@@ -20,7 +20,7 @@ import { ButtonNext, ButtonPrev } from '../Tabs/TabsScrollButtons';
 import { useTabsMeta } from '../Tabs/utils';
 
 export interface NavTabsProps extends Omit<TabsProps, 'onChange'> {
-  'aria-label': string;
+  'aria-label'?: string;
 }
 
 interface NavTabsContextInterface {

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.stories.tsx
@@ -72,6 +72,7 @@ export const OnClear = {
       <>
         <Textarea
           {...args}
+          maxCount={4}
           labelText="Textarea"
           value={fieldValue}
           onChange={e => {

--- a/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
+++ b/packages/react-magma-dom/src/components/Textarea/Textarea.test.js
@@ -75,22 +75,21 @@ describe('Textarea', () => {
     const labelText = 'test label';
     const testHelperMessage = 'Test helper message';
     const testErrorMessage = 'Test error message';
-    const { getByTestId, getByLabelText, queryByText } = render(
+    const { getByTestId, queryByText } = render(
       <Textarea
+        testId={testId}
         errorMessage={testErrorMessage}
         helperMessage={testHelperMessage}
         labelText={labelText}
       />
     );
 
+    const textarea = getByTestId(testId);
     const errorMessage = getByTestId('inputMessage');
 
     expect(errorMessage).toBeInTheDocument();
 
-    expect(getByLabelText(labelText)).toHaveStyleRule(
-      'border-color',
-      magma.colors.danger
-    );
+    expect(textarea).toHaveStyleRule('border-color', magma.colors.danger);
 
     expect(errorMessage).toHaveStyleRule('color', magma.colors.danger);
 

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -128,7 +128,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       >
         <StyledTextArea
           {...other}
-          aria-describedby={
+          aria-labelledby={
             descriptionId ? descriptionId : props['aria-describedby']
           }
           aria-invalid={!!errorMessage}

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -76,7 +76,10 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const theme = React.useContext(ThemeContext);
 
     const id = useGenerateId(defaultId);
-    const descriptionId = errorMessage || helperMessage ? `${id}__desc` : null;
+    const descriptionId =
+      errorMessage || helperMessage || maxCount || maxLength
+        ? `${id}__desc`
+        : null;
     const maxCharacters = typeof maxCount === 'number' ? maxCount : maxLength;
 
     const maxLengthNum =


### PR DESCRIPTION
Closes: #2112

## What I did
- Added announcement helper message for `Textarea`.
- Add an optional `aria-label` prop for **NavTabs**

## Screenshots
<img width="857" height="647" alt="Screenshot from 2025-12-08 12-23-48" src="https://github.com/user-attachments/assets/8e29f89b-17f5-4d72-9d64-48756e7f4246" />

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> `Textarea` -> `On Clear` -> Turn on NVDA/VO -> Type text -> NVDA/VO should announce helper text
