### PR TITLE
V4/fix/banner docs accessibility issues

### DIFF
--- a/.changeset/fix-Banner-docs-accessibility-issues.md
+++ b/.changeset/fix-Banner-docs-accessibility-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Banner): add the `dismissibleButtonRef` prop to the `Banner` and fix docs page

--- a/packages/react-magma-dom/src/components/Banner/index.tsx
+++ b/packages/react-magma-dom/src/components/Banner/index.tsx
@@ -43,6 +43,10 @@ export interface BannerProps extends AlertProps {
    * @default false
    */
   isDismissible?: boolean;
+  /**
+   * Reference to the dismiss button element
+   */
+  dismissibleButtonRef?: React.Ref<HTMLButtonElement>;
   isInverse?: boolean;
 }
 
@@ -210,6 +214,7 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
       onDismiss,
       testId,
       variant = AlertVariant.info,
+      dismissibleButtonRef,
       ...other
     } = props;
 
@@ -264,6 +269,7 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
               onClick={onDismiss}
               theme={theme}
               variant={ButtonVariant.link}
+              ref={dismissibleButtonRef}
             />
           </ButtonWrapper>
         )}

--- a/website/react-magma-docs/src/pages/api/banner.mdx
+++ b/website/react-magma-docs/src/pages/api/banner.mdx
@@ -67,7 +67,7 @@ export function Example() {
     updateShowBanner(false);
 
     setTimeout(() => {
-      buttonRef.current?.focus();
+      buttonRef.current.focus();
     }, 0);
   }
 
@@ -75,7 +75,7 @@ export function Example() {
     updateShowBanner(true);
 
     setTimeout(() => {
-      dismissibleButtonRef.current?.focus();
+      dismissibleButtonRef.current.focus();
     }, 0);
   }
 

--- a/website/react-magma-docs/src/pages/api/banner.mdx
+++ b/website/react-magma-docs/src/pages/api/banner.mdx
@@ -53,35 +53,52 @@ import {
   Button,
   ButtonColor,
   ButtonSize,
+  Announce,
 } from 'react-magma-dom';
 
 export function Example() {
   const [showBanner, updateShowBanner] = React.useState<boolean>(true);
+  const dismissibleButtonRef = React.useRef<HTMLButtonElement>(null);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  const bannerText = 'Success! You may now dismiss this banner';
 
   function handleBannerDismiss() {
     updateShowBanner(false);
+
+    setTimeout(() => {
+      buttonRef.current?.focus();
+    }, 0);
   }
 
   function handleShowBannerButtonClick() {
     updateShowBanner(true);
+
+    setTimeout(() => {
+      dismissibleButtonRef.current?.focus();
+    }, 0);
   }
 
   return (
     <>
-      {showBanner && (
-        <Banner
-          isDismissible
-          onDismiss={handleBannerDismiss}
-          variant={AlertVariant.success}
-        >
-          Success! You may now dismiss this banner
-        </Banner>
-      )}
+      <Announce aria-label={bannerText}>
+        {showBanner && (
+          <Banner
+            isDismissible
+            onDismiss={handleBannerDismiss}
+            variant={AlertVariant.success}
+            dismissibleButtonRef={dismissibleButtonRef}
+          >
+            {bannerText}
+          </Banner>
+        )}
+      </Announce>
       {!showBanner && (
         <Button
           onClick={handleShowBannerButtonClick}
           size={ButtonSize.small}
           color={ButtonColor.secondary}
+          ref={buttonRef}
         >
           Show Banner Again
         </Button>


### PR DESCRIPTION
Closes: #2040

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add the `dismissibleButtonRef` prop to the `Banner` and fix docs page.
Cherry-pick #2052

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
1. Open Docs -> Banner -> Dismissible section -> Turn on screenreader -> Click on the `Close` button -> Click on the `Show banner again` button -> Observe if the banner content is announced 
2. Open Docs -> Banner -> Dismissible section -> Turn on screenreader -> Click on the `Close` button -> Check that the focus now is on the `Show banner again` button -> Click on the `Show banner again` button -> Check that the focus now is on the `Close` button