### PR TITLE
fix(Select, MultiSelect, Combobox & MultiCombobox): Fix navigation throughth disabled items.

### DIFF
--- a/.changeset/fix-Select-disabled-item.md
+++ b/.changeset/fix-Select-disabled-item.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Select, Multiselect, Combobox & Multicombobox): Fix navigation throughth the disabled items.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
@@ -42,7 +42,7 @@ export const Default = {
     labelText: 'Example',
     defaultItems: [
       { label: 'Red', value: 'red' },
-      { label: 'Blue', value: 'blue' },
+      { label: 'Blue', value: 'blue', disabled: `true` },
       { label: 'Green', value: 'green' },
     ],
     disableCreateItem: false,
@@ -63,10 +63,10 @@ export const Multi = {
         defaultItems={[
           { label: 'Red', value: 'red' },
           { label: 'Blue', value: 'blue' },
-          { label: 'Green', value: 'green' },
+          { label: 'Green', value: 'green', disabled: `true` },
           { label: 'Orange', value: 'orange' },
           { label: 'Aqua', value: 'aqua' },
-          { label: 'Gold', value: 'gold' },
+          { label: 'Gold', value: 'gold', disabled: `true` },
           { label: 'Periwinkle', value: 'periwinkle' },
           { label: 'Lavender', value: 'lavender' },
           { label: 'Marigold', value: 'marigold' },

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -832,6 +832,51 @@ describe('Combobox', () => {
     expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('should skip disabled items and navigate to the next active item', async () => {
+    const customItems = [
+      {
+        label: 'Red',
+        value: 'red',
+        disabled: false,
+      },
+      {
+        label: 'Blue',
+        value: 'blue',
+        disabled: true,
+      },
+      {
+        label: 'Green',
+        value: 'green',
+        disabled: false,
+      },
+    ];
+    const { getByLabelText, getByText } = render(
+      <Combobox labelText={labelText} items={customItems} />
+    );
+
+    const renderedCombobox = getByLabelText(labelText, { selector: 'input' });
+
+    act(() => {
+      renderedCombobox.focus();
+    });
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'false');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{Enter}');
+    expect(renderedCombobox.value).toEqual(customItems[2].label);
+
+    act(() => {
+      renderedCombobox.blur();
+    });
+
+    expect(renderedCombobox.value).toEqual(customItems[2].label);
+  });
+
   describe('events', () => {
     it('onBlur', () => {
       const onBlur = jest.fn();

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
@@ -15,6 +15,7 @@ import { ButtonShape, ButtonSize, ButtonVariant } from '../Button';
 import { defaultComponents } from '../Select/components';
 import { ItemsList } from '../Select/ItemsList';
 import { SelectContainer } from '../Select/SelectContainer';
+import { setFocusedItem } from '../Select/utils';
 
 import { ComboboxProps } from '.';
 
@@ -147,6 +148,14 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
             ? itemToString(changes.selectedItem)
             : '',
         };
+      case useCombobox.stateChangeTypes.InputKeyDownArrowDown:
+      case useCombobox.stateChangeTypes.InputKeyDownArrowUp:
+        // Keep controlled navigation manually via handleOnKeyDown handler
+        return {
+          ...state,
+          highlightedIndex: state.highlightedIndex,
+          isOpen: true,
+        };
       default:
         return changes;
     }
@@ -255,14 +264,26 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
     .replace(/\{labelText\}/g, labelText)
     .replace(/\{selectedItem\}/g, itemToString(selectedItem));
 
-  function handleOnKeyDown(event: any) {
+  function handleOnKeyDown(event: React.KeyboardEvent) {
     const count = document.querySelectorAll('[aria-modal="true"]').length;
 
-    if (event.key === 'Escape') {
-      if (count >= 1 && inputRef.current) {
-        inputRef.current.focus();
-      }
-      event.nativeEvent.stopImmediatePropagation();
+    switch (event.key) {
+      case 'Escape':
+        if (count >= 1 && inputRef.current) {
+          inputRef.current.focus();
+        }
+        event.nativeEvent.stopImmediatePropagation();
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        setFocusedItem(1, highlightedIndex, displayItems, setHighlightedIndex);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setFocusedItem(-1, highlightedIndex, displayItems, setHighlightedIndex);
+        break;
+      default:
+        break;
     }
 
     onInputKeyDown &&

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -1027,6 +1027,45 @@ describe('MultiCombobox', () => {
     expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('should skip disabled items and navigate to the next active item', async () => {
+    const customItems = [
+      {
+        label: 'Red',
+        value: 'red',
+        disabled: false,
+      },
+      {
+        label: 'Blue',
+        value: 'blue',
+        disabled: true,
+      },
+      {
+        label: 'Green',
+        value: 'green',
+        disabled: false,
+      },
+    ];
+
+    const { getByLabelText, getByText } = render(
+      <MultiCombobox isMulti labelText={labelText} items={customItems} />
+    );
+
+    const renderedCombobox = getByLabelText(labelText, {
+      selector: 'input',
+    });
+
+    act(() => {
+      renderedCombobox.focus();
+    });
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'false');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
+  });
+
   describe('events', () => {
     it('onBlur', () => {
       const onBlur = jest.fn();

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -16,6 +16,7 @@ import { defaultComponents } from '../Select/components';
 import { ItemsList } from '../Select/ItemsList';
 import { SelectContainer } from '../Select/SelectContainer';
 import { IconWrapper, SelectedItemButton } from '../Select/shared';
+import { setFocusedItem } from '../Select/utils';
 
 import { MultiComboboxProps } from '.';
 
@@ -180,12 +181,14 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
       onIsOpenChange(changes);
   }
 
+  const filteredItems = getFilteredItems(displayItems);
+
   function stateReducer(state, actionAndChanges) {
     const { type, changes } = actionAndChanges;
     switch (type) {
       case useCombobox.stateChangeTypes.InputKeyDownEnter: {
-        const newSelectedItem =
-          getFilteredItems(displayItems)[state.highlightedIndex];
+        const newSelectedItem = filteredItems[state.highlightedIndex];
+
         return {
           ...changes,
           ...(newSelectedItem && {
@@ -211,6 +214,14 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
         return {
           ...changes,
           isOpen: changes.isOpen,
+        };
+      case useCombobox.stateChangeTypes.InputKeyDownArrowDown:
+      case useCombobox.stateChangeTypes.InputKeyDownArrowUp:
+        // Keep controlled navigation manually via handleOnKeyDown handler
+        return {
+          ...state,
+          highlightedIndex: state.highlightedIndex,
+          isOpen: true,
         };
       default:
         return {
@@ -242,7 +253,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
   } = useCombobox({
     ...comboboxProps,
     itemToString,
-    items: getFilteredItems(displayItems),
+    items: filteredItems,
     onInputValueChange:
       onInputValueChange && typeof onInputValueChange === 'function'
         ? changes => onInputValueChange(changes, setDisplayItems)
@@ -352,14 +363,29 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
       </>
     ) : null;
 
-  function handleOnKeyDown(event: any) {
+  function handleOnKeyDown(event: React.KeyboardEvent) {
     const count = document.querySelectorAll('[aria-modal="true"]').length;
 
-    if (event.key === 'Escape') {
-      if (count >= 1 && inputRef.current) {
-        inputRef.current.focus();
-      }
-      event.nativeEvent.stopImmediatePropagation();
+    switch (event.key) {
+      case 'Escape':
+        if (count >= 1 && inputRef.current) {
+          inputRef.current.focus();
+        }
+        event.nativeEvent.stopImmediatePropagation();
+        break;
+      case 'ArrowDown':
+        setFocusedItem(1, highlightedIndex, filteredItems, setHighlightedIndex);
+        break;
+      case 'ArrowUp':
+        setFocusedItem(
+          -1,
+          highlightedIndex,
+          filteredItems,
+          setHighlightedIndex
+        );
+        break;
+      default:
+        break;
     }
 
     onInputKeyDown &&

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -17,7 +17,7 @@ import {
   SelectComponents,
 } from './components';
 import { StyledCard, StyledItem, StyledList } from './shared';
-import { isItemDisabled } from './utils';
+import { isItemDisabled, setFocusedItem } from './utils';
 
 import { instanceOfToBeCreatedItemObject } from '.';
 
@@ -103,14 +103,10 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
         event.nativeEvent.stopImmediatePropagation();
         break;
       case 'ArrowDown':
-        if (highlightedIndex === items.length - 1) {
-          setHighlightedIndex?.(0);
-        }
+        setFocusedItem(1, highlightedIndex, items, setHighlightedIndex);
         break;
       case 'ArrowUp':
-        if (highlightedIndex === 0) {
-          setHighlightedIndex?.(items.length - 1);
-        }
+        setFocusedItem(-1, highlightedIndex, items, setHighlightedIndex);
         break;
       default:
         break;

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
@@ -622,7 +622,6 @@ describe('Select', () => {
     const renderedSelect = getByLabelText(labelText, { selector: 'div' });
 
     await userEvent.click(renderedSelect);
-    await userEvent.keyboard('{ArrowDown}');
     expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
 
     await userEvent.keyboard('{ArrowDown}');
@@ -637,6 +636,42 @@ describe('Select', () => {
 
     // Looping back to the last item
     await userEvent.keyboard('{ArrowUp}');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('should skip disabled items and navigate to the next active item', async () => {
+    const customItems = [
+      {
+        label: 'Red',
+        value: 'red',
+        disabled: false,
+      },
+      {
+        label: 'Blue',
+        value: 'blue',
+        disabled: true,
+      },
+      {
+        label: 'Green',
+        value: 'green',
+        disabled: false,
+      },
+    ];
+
+    const { getByLabelText, getByText } = render(
+      <MultiSelect isMulti labelText={labelText} items={customItems} />
+    );
+
+    const renderedSelect = getByLabelText(labelText, { selector: 'div' });
+
+    act(() => {
+      renderedSelect.focus();
+    });
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'false');
     expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -89,6 +89,10 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
           )
         );
       }
+    } else {
+      const index = filteredItems.findIndex(item => !isItemDisabled(item));
+
+      setHighlightedIndex(index);
     }
 
     onIsOpenChange &&
@@ -379,7 +383,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
         highlightedIndex={highlightedIndex}
         isOpen={isOpen}
         isInverse={isInverse}
-        items={getFilteredItems(items)}
+        items={filteredItems}
         itemToString={itemToString}
         maxHeight={itemListMaxHeight ?? theme.select.menu.maxHeight}
         menuStyle={menuStyle}

--- a/packages/react-magma-dom/src/components/Select/Select.stories.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.stories.tsx
@@ -243,7 +243,7 @@ export const MultiWithDisabledItems = {
       { label: 'Red', value: 'red' },
       { label: 'Green', value: 'green' },
       { label: 'Blue-Disabled', value: 'blue', disabled: true },
-      { label: 'Purple mountain majesty', value: 'purple' },
+      { label: 'Purple mountain majesty', value: 'purple', disabled: false },
       { label: 'Orange', value: 'orange', disabled: false },
       { label: 'Yellow-Disabled', value: 'Yellow-Disabled', disabled: true },
     ],

--- a/packages/react-magma-dom/src/components/Select/Select.test.js
+++ b/packages/react-magma-dom/src/components/Select/Select.test.js
@@ -539,6 +539,42 @@ describe('Select', () => {
     expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('should skip disabled items and navigate to the next active item', async () => {
+    const customItems = [
+      {
+        label: 'Red',
+        value: 'red',
+        disabled: false,
+      },
+      {
+        label: 'Blue',
+        value: 'blue',
+        disabled: true,
+      },
+      {
+        label: 'Green',
+        value: 'green',
+        disabled: false,
+      },
+    ];
+
+    const { getByLabelText, getByText } = render(
+      <Select labelText={labelText} items={customItems} />
+    );
+
+    const renderedSelect = getByLabelText(labelText, { selector: 'div' });
+
+    act(() => {
+      renderedSelect.focus();
+    });
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'false');
+    expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
+  });
+
   describe('additional content', () => {
     const helpLinkLabel = 'Learn more';
 

--- a/packages/react-magma-dom/src/components/Select/utils.ts
+++ b/packages/react-magma-dom/src/components/Select/utils.ts
@@ -3,3 +3,32 @@ import { instanceOfItemWithOptionalDisabled } from '.';
 export function isItemDisabled(item) {
   return instanceOfItemWithOptionalDisabled(item) && item.disabled;
 }
+
+export const setFocusedItem = (
+  step: number,
+  highlightedIndex: number,
+  items: any[],
+  setHighlightedIndex: (index: number) => void
+) => {
+  if (!items || items.length === 0) return;
+
+  let nextIndex = highlightedIndex ?? 0;
+
+  if (nextIndex === -1 && step < 0) {
+    nextIndex = 0;
+  }
+
+  let iterations = 0;
+
+  while (iterations < items.length) {
+    nextIndex = (nextIndex + step + items.length) % items.length;
+
+    if (!isItemDisabled(items[nextIndex])) {
+      setHighlightedIndex?.(nextIndex);
+
+      return;
+    }
+
+    iterations++;
+  }
+};


### PR DESCRIPTION
Closes: #1923 

Copy of [this](https://github.com/cengage/react-magma/pull/2055) PR into the `v4/dev` branch.

## What I did
- Restricted navigation across disabled items for `Select`, `MultiSelect`, `Combobox`, and `MultiCombobox`.
- Added focusing for `MultiSelect` when the user first presses either the `ArrowDown` or `ArrowUp` button.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to **Storybook** -> **Select** -> **Default** -> navigation across items, skip the disabled item, and the user can't choose this item.
Go to **Storybook** -> **Select** -> **Full with disabled items** -> navigation across items, skip the disabled item, and the user can't choose this item + pressing either the `ArrowDown` or `ArrowUp` button also forces focus to the first or last item.

Go to **Storybook** -> **Combobox** -> **Default** -> navigation across items, skip the disabled item, and the user can't choose this item.
Go to **Storybook** -> **Combobox** -> **Multi** -> navigation across items, skip the disabled item, and the user can't choose this item.