### PR TITLE
fix(Radiobutton): Label is not announced with a helper or error message.

### DIFF
--- a/.changeset/fix-RadioButton-label-is-not-annouced-with-helper-message.md
+++ b/.changeset/fix-RadioButton-label-is-not-annouced-with-helper-message.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(RadioButton): Fix announcing label text with error or helper message.

--- a/packages/react-magma-dom/src/components/Radio/index.tsx
+++ b/packages/react-magma-dom/src/components/Radio/index.tsx
@@ -170,7 +170,7 @@ export const Radio = React.forwardRef<HTMLInputElement, RadioProps>(
       <StyledContainer style={containerStyle}>
         <HiddenInput
           {...other}
-          aria-labelledby={context.descriptionId}
+          aria-describedby={context.descriptionId}
           id={id}
           ref={ref}
           checked={context.selectedValue === value}


### PR DESCRIPTION
Closes: #1928 

Copy of [this](https://github.com/cengage/react-magma/pull/2138) PR into the `v4/dev` branch.

## What I did
- Fixed announcing `label` with helper or error message.

## Screenshots

<img width="869" height="534" alt="Screenshot from 2025-12-17 15-50-53" src="https://github.com/user-attachments/assets/df825458-4382-4ff8-bb52-463662eb8416" />
<img width="869" height="534" alt="Screenshot from 2025-12-17 15-51-40" src="https://github.com/user-attachments/assets/e074a997-1170-46bf-9b4c-c9a319337bc1" />

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Radio -> Default -> Turn on VO/NVDA -> label text should be announced with helper or error message.
