### PR TITLE
fix(Modal & Drawer): Fix focus order for header and close button.

### DIFF
--- a/.changeset/fix-Modal-fix-focus-order.md
+++ b/.changeset/fix-Modal-fix-focus-order.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal & Drawer): Fix focus order for header, close button, and content.

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import { Button } from '../Button';
-import { Container } from '../Container/Container';
-import { VisuallyHidden } from '../VisuallyHidden';
 import { DrawerPosition, DrawerProps } from './Drawer';
+import { Container } from '../Container/Container';
 import { NavTab, NavTabs } from '../NavTabs';
 import { Paragraph } from '../Paragraph/index';
 import { TabsOrientation } from '../Tabs/shared';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 import { Drawer } from '.';
 

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 
-import { Modal, ModalSize, NativeSelect, Toggle, VisuallyHidden } from '../..';
+import { Meta } from '@storybook/react';
+
+import {
+  Modal,
+  ModalProps,
+  ModalSize,
+  NativeSelect,
+  Toggle,
+  VisuallyHidden,
+} from '../..';
 import { Button, ButtonColor } from '../Button';
 import { ButtonGroup, ButtonGroupAlignment } from '../ButtonGroup';
 import { Combobox } from '../Combobox';
@@ -21,40 +30,56 @@ import { Spacer } from '../Spacer';
 const info = {
   component: Modal,
   title: 'Modal',
+  argTypes: {
+    isCloseButtonHidden: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
 };
 
 export default info;
 
-export const Default = () => {
-  const [showModal, setShowModal] = React.useState(false);
-  const buttonRef = React.useRef<HTMLButtonElement>();
+export const Default = {
+  render: (
+    args: React.JSX.IntrinsicAttributes &
+      ModalProps &
+      React.RefAttributes<HTMLDivElement>
+  ) => {
+    const [showModal, setShowModal] = React.useState(false);
+    const buttonRef = React.useRef<HTMLButtonElement>();
 
-  return (
-    <>
-      <Modal
-        header="Modal Title"
-        onClose={() => {
-          setShowModal(false);
-          buttonRef.current.focus();
-        }}
-        isOpen={showModal}
-      >
-        <Paragraph noTopMargin>This is a modal, doing modal things.</Paragraph>
-        <ButtonGroup alignment={ButtonGroupAlignment.right}>
-          <Button color={ButtonColor.secondary}>Cancel</Button>
-          <Button>Save</Button>
-        </ButtonGroup>
-      </Modal>
-      <Button
-        aria-haspopup="dialog"
-        onClick={() => setShowModal(true)}
-        ref={buttonRef}
-      >
-        Show Modal
-        <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
-      </Button>
-    </>
-  );
+    return (
+      <>
+        <Modal
+          {...args}
+          header="Modal Title"
+          onClose={() => {
+            setShowModal(false);
+            buttonRef.current.focus();
+          }}
+          isOpen={showModal}
+        >
+          <Paragraph noTopMargin>
+            This is a modal, doing modal things.
+          </Paragraph>
+          <ButtonGroup alignment={ButtonGroupAlignment.right}>
+            <Button color={ButtonColor.secondary}>Cancel</Button>
+            <Button>Save</Button>
+          </ButtonGroup>
+        </Modal>
+        <Button
+          aria-haspopup="dialog"
+          onClick={() => setShowModal(true)}
+          ref={buttonRef}
+        >
+          Show Modal
+          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+        </Button>
+      </>
+    );
+  },
 };
 
 export const BackgroundCickDisabled = () => {

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -835,12 +835,12 @@ describe('Modal', () => {
       expect(getByText('Hello')).toHaveFocus();
     });
 
-    it('should focus the first actionable element element upon opening the modal if there is no header', () => {
-      const { rerender, getByText, getByTestId } = render(
+    it('should focus the close button upon opening the modal when the modal if there is no header', () => {
+      const { rerender, getByTestId, getByText } = render(
         <>
           <button>Open</button>
           <Modal isOpen={false} onClose={jest.fn()}>
-            <button data-testid="closeButton">Close</button>
+            Modal Content
           </Modal>
         </>
       );
@@ -851,6 +851,30 @@ describe('Modal', () => {
         <>
           <button>Open</button>
           <Modal isOpen onClose={jest.fn()}>
+            Modal Content
+          </Modal>
+        </>
+      );
+
+      expect(getByTestId('modal-closebtn')).toHaveFocus();
+    });
+
+    it('should focus the first actionable element element upon opening the modal if there is no header and close button', () => {
+      const { rerender, getByText, getByTestId } = render(
+        <>
+          <button>Open</button>
+          <Modal isOpen={false} onClose={jest.fn()} isCloseButtonHidden>
+            <button data-testid="closeButton">Close</button>
+          </Modal>
+        </>
+      );
+
+      getByText('Open').focus();
+
+      rerender(
+        <>
+          <button>Open</button>
+          <Modal isOpen onClose={jest.fn()} isCloseButtonHidden>
             <button data-testid="closeButton">Close</button>
           </Modal>
         </>

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -438,9 +438,6 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                     )}
                   </ModalHeader>
                 )}
-                <ModalWrapper ref={bodyRef} theme={theme}>
-                  {children}
-                </ModalWrapper>
                 {!isCloseButtonHidden && (
                   <CloseBtn theme={theme}>
                     <IconButton
@@ -458,6 +455,9 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                     />
                   </CloseBtn>
                 )}
+                <ModalWrapper ref={bodyRef} theme={theme}>
+                  {children}
+                </ModalWrapper>
               </ModalContent>
             </ModalContainer>
             {showBackgroundOverlay && (

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -241,6 +241,30 @@ export function Example() {
       </Modal>
 
       <Modal
+        header={
+          <Flex
+            behavior={FlexBehavior.container}
+            direction={FlexDirection.column}
+            alignItems={FlexAlignItems.center}
+            justify={FlexJustify.center}
+            style={{ marginLeft: '30px' }}
+          >
+            <CheckIcon
+              style={{
+                background: magma.colors.success,
+                color: magma.colors.neutral100,
+                width: '36px',
+                height: '36px',
+                padding: '8px',
+                borderRadius: '50%',
+                marginBottom: '20px',
+              }}
+            />
+            <h3 ref={customHeadingRef} tabIndex={-1} style={{ margin: 0 }}>
+              Confirmation header
+            </h3>
+          </Flex>
+        }
         onClose={() => {
           setShowModalHeaderRef(false);
           headerRefButtonRef.current.focus();
@@ -257,19 +281,6 @@ export function Example() {
           spacing={2}
           wrap={FlexWrap.nowrap}
         >
-          <CheckIcon
-            style={{
-              background: magma.colors.success,
-              color: magma.colors.neutral100,
-              width: '36px',
-              height: '36px',
-              padding: '8px',
-              borderRadius: '50%',
-            }}
-          />
-          <h2 ref={customHeadingRef} tabIndex={-1}>
-            Confirmation header
-          </h2>
           <Paragraph>
             With watermelon ostriches. Gourds utters at welding equipment a oink
             oink haybine. Goose hammers cattle rats in crows. Blue berries


### PR DESCRIPTION
Closes: #2110
Closes: #2080

## What I did
- Fixed focus order for `Modal` and `Drawer` components.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to **Storybook** -> Modal -> Default -> Open Modal -> header should be focused -> press `Tab` -> `X` button should be focused ->  press `Tab` -> inner modal content should be focused.

Go to **Storybook** -> Modal -> Default -> Controls -> switch `isCloseButtonHidden` to `true` ->  Open Modal -> header should be focused -> press `Tab` -> ` -> inner modal content should be focused `Cancel` button.

Go to **Docs** -> Components -> Modal -> Modal Header -> Modal with no header -> `X` button should be focused 
