### PR TITLE
fix(Dropdown): Add `role=menu` to DropdownContent for DropdownMenuNavItem children.

### DIFF
--- a/.changeset/fix-Dropdown-accessibility-issues.md
+++ b/.changeset/fix-Dropdown-accessibility-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Remove `aria-label` from DropdownMenuItem icon. Add `role=menu` to DropdownContent for DropdownMenuNavItem children. Fix docs examples.

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownContent.tsx
@@ -80,7 +80,8 @@ export const DropdownContent = React.forwardRef<
   React.Children.forEach(children, (child: any) => {
     if (
       child?.type?.displayName === 'DropdownMenuItem' ||
-      child?.type?.displayName === 'DropdownMenuGroup'
+      child?.type?.displayName === 'DropdownMenuGroup' ||
+      child?.type?.displayName === 'DropdownMenuNavItem'
     ) {
       hasItemChildren = true;
     }

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
@@ -210,7 +210,7 @@ export const DropdownMenuItem = React.forwardRef<
       )}
       {isActive && (
         <IconWrapper isInverse={context.isInverse} theme={theme}>
-          <CheckIcon aria-label={i18n.dropdown.menuItemSelectedAriaLabel} />
+          <CheckIcon />
         </IconWrapper>
       )}
       {children}

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
@@ -6,7 +6,6 @@ import { transparentize } from 'polished';
 import { IconProps, CheckIcon } from 'react-magma-icons';
 
 import { DropdownContext } from './Dropdown';
-import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { Omit, useForkedRef } from '../../utils';
 
@@ -183,8 +182,6 @@ export const DropdownMenuItem = React.forwardRef<
     if (!disabled)
       context.registerDropdownMenuItem(context.itemRefArray, ownRef);
   }, []);
-
-  const i18n = React.useContext(I18nContext);
 
   return (
     <StyledItem

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -156,7 +156,6 @@ export const defaultI18n: I18nInterface = {
   },
   dateTimePickerLabel: 'Pick a date and time',
   dropdown: {
-    menuItemSelectedAriaLabel: '(selected)',
     toggleMenuAriaLabel: 'Toggle menu',
   },
   dropzone: {

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -164,7 +164,6 @@ export interface I18nInterface {
   };
   dateTimePickerLabel: string;
   dropdown: {
-    menuItemSelectedAriaLabel: string;
     toggleMenuAriaLabel: string;
   };
   dropzone: {

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -735,7 +735,7 @@ export function Example() {
           size={ButtonSize.large}
           variant={ButtonVariant.solid}
           color={ButtonColor.danger}
-          aria-label={'Custom Button Example'}
+          aria-label={'Extra Props Split'}
         >
           Extra Props Split
         </DropdownSplitButton>


### PR DESCRIPTION
Closes: #2098 

## What I did
- Removed `aria-label` from DropdownMenuItem icon.
-  Add `role=menu` to DropdownContent for DropdownMenuNavItem children. 
- Fixed docs examples.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been

Go to Storybook -> Dropdown -> Link Menu -> DropdownMenuNavItem should be the children inside a container with role="menu".

Go to Docs -> Components -> Dropdown -> Active Item Index -> aria-label="(selected)" should be removed for selected DropdownMenuItem.

Go to Docs -> Components -> Dropdown -> Custom button -> the visual label "Extra Props Split" matches with aria-label="Extra Props Split".
