### PR TITLE
fix(Alert): Add margin right.

### DIFF
--- a/.changeset/fix-Alert-right-padding-missing.md
+++ b/.changeset/fix-Alert-right-padding-missing.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Alert): Add margin right for alert content.

--- a/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/react-magma-dom/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -381,6 +381,7 @@ exports[`Alert Variants should render an alert with danger variant 1`] = `
   flex-grow: 1;
   font-family: "Work Sans",Helvetica,sans-serif;
   padding: 12px 0;
+  margin-right: 8px;
 }
 
 @media (max-width: 600px) {
@@ -488,6 +489,7 @@ exports[`Alert Variants should render an alert with danger variant 1`] = `
   flex-grow: 1;
   font-family: "Work Sans",Helvetica,sans-serif;
   padding: 12px 0;
+  margin-right: 8px;
 }
 
 @media (max-width: 600px) {
@@ -638,6 +640,7 @@ exports[`Alert Variants should render an alert with info variant 1`] = `
   flex-grow: 1;
   font-family: "Work Sans",Helvetica,sans-serif;
   padding: 12px 0;
+  margin-right: 8px;
 }
 
 @media (max-width: 600px) {
@@ -745,6 +748,7 @@ exports[`Alert Variants should render an alert with info variant 1`] = `
   flex-grow: 1;
   font-family: "Work Sans",Helvetica,sans-serif;
   padding: 12px 0;
+  margin-right: 8px;
 }
 
 @media (max-width: 600px) {
@@ -895,6 +899,7 @@ exports[`Alert Variants should render an alert with warning variant 1`] = `
   flex-grow: 1;
   font-family: "Work Sans",Helvetica,sans-serif;
   padding: 12px 0;
+  margin-right: 8px;
 }
 
 @media (max-width: 600px) {
@@ -1002,6 +1007,7 @@ exports[`Alert Variants should render an alert with warning variant 1`] = `
   flex-grow: 1;
   font-family: "Work Sans",Helvetica,sans-serif;
   padding: 12px 0;
+  margin-right: 8px;
 }
 
 @media (max-width: 600px) {
@@ -1152,6 +1158,7 @@ exports[`Alert should render an alert with default variant 1`] = `
   flex-grow: 1;
   font-family: "Work Sans",Helvetica,sans-serif;
   padding: 12px 0;
+  margin-right: 8px;
 }
 
 @media (max-width: 600px) {
@@ -1259,6 +1266,7 @@ exports[`Alert should render an alert with default variant 1`] = `
   flex-grow: 1;
   font-family: "Work Sans",Helvetica,sans-serif;
   padding: 12px 0;
+  margin-right: 8px;
 }
 
 @media (max-width: 600px) {

--- a/packages/react-magma-dom/src/components/AlertBase/index.tsx
+++ b/packages/react-magma-dom/src/components/AlertBase/index.tsx
@@ -293,9 +293,7 @@ const AlertContents = styled.div<{
   padding: ${props => props.theme.spaceScale.spacing04} 0;
   display: ${props => (props.additionalContent ? 'flex' : '')};
   margin-right: ${props =>
-    props.additionalContent && !props.isDismissible
-      ? props.theme.spaceScale.spacing03
-      : ''};
+    !props.isDismissible ? props.theme.spaceScale.spacing03 : ''};
   @media (max-width: ${props => props.theme.breakpoints.small}px) {
     padding-left: 0;
   }


### PR DESCRIPTION
Closes: #2149 

Duplicate of [this](https://github.com/cengage/react-magma/pull/2150) PR into `v4/dev` branch

## What I did
- Added margin right for Alert content.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Alert -> Default -> all NOT dismissible alerts should have `margin-right=8px`.
