### PR TITLE
fix(Tooltip): Supports keeping the tooltip content visible on hover.

### DIFF
--- a/.changeset/fix-Tooltip-Loading-indicator-issues.md
+++ b/.changeset/fix-Tooltip-Loading-indicator-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tooltip & Loading Indicator): Force visibility tooltip content when user hover it. Fix announcing `Loading` twice for Loading indicator.

--- a/packages/react-magma-dom/src/components/LoadingIndicator/index.tsx
+++ b/packages/react-magma-dom/src/components/LoadingIndicator/index.tsx
@@ -139,7 +139,7 @@ export const LoadingIndicator = React.forwardRef<
           isLoadingIndicator
         />
       ) : (
-        <Spinner {...other} size={theme.spaceScale.spacing10} />
+        <Spinner {...other} size={theme.spaceScale.spacing10} hasMessage />
       )}
 
       <MessageContainer theme={theme}>

--- a/packages/react-magma-dom/src/components/LoadingIndicator/index.tsx
+++ b/packages/react-magma-dom/src/components/LoadingIndicator/index.tsx
@@ -15,12 +15,12 @@ export interface LoadingIndicatorProps
    */
   css?: any; // Adding css prop to fix emotion error
   /**
-   * Message displayed for the first five seconds
+   * Message displayed for the first 5 seconds
    * @default "Loading..."
    */
   message1?: string;
   /**
-   * Message displayed for the first five seconds
+   * Message displayed after 5 seconds
    * @default "Thank you for your patience. Still loading..."
    */
   message2?: string;
@@ -30,7 +30,7 @@ export interface LoadingIndicatorProps
    */
   message3?: string;
   /**
-   * Message displayed for the first five seconds
+   * Value between 0 and 100 representing the percentage of progress
    * @default 0
    */
   percentage?: number;

--- a/packages/react-magma-dom/src/components/Spinner/index.tsx
+++ b/packages/react-magma-dom/src/components/Spinner/index.tsx
@@ -32,6 +32,10 @@ export interface SpinnerProps extends React.HTMLAttributes<HTMLSpanElement> {
    * @internal
    */
   testId?: string;
+  /**
+   * @internal
+   */
+  hasMessage?: boolean;
 }
 
 const StyledSpinner = styled.span<SpinnerProps>`
@@ -58,6 +62,7 @@ export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
       noRole,
       size,
       testId,
+      hasMessage,
       ...other
     } = props;
 
@@ -74,6 +79,7 @@ export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
     return (
       <StyledSpinner
         {...other}
+        aria-hidden={hasMessage ? true : noRole}
         aria-label={ariaLabel ? ariaLabel : i18n.spinner.ariaLabel}
         color={
           color
@@ -85,7 +91,6 @@ export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
         data-testid={testId}
         ref={ref}
         role={noRole ? undefined : 'img'}
-        aria-hidden={noRole}
         size={sizeString}
       />
     );

--- a/packages/react-magma-dom/src/components/Tooltip/Tooltip.test.js
+++ b/packages/react-magma-dom/src/components/Tooltip/Tooltip.test.js
@@ -135,7 +135,7 @@ describe('Tooltip', () => {
     expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
   });
 
-  it('should show the tooltip on mouseenter and hide it on mouseleave', () => {
+  it('should show the tooltip on mouseenter and hide it on mouseleave trigger button', () => {
     const { container } = render(
       <Tooltip content={CONTENT_TEXT}>{TRIGGER_ELEMENT}</Tooltip>
     );
@@ -150,6 +150,30 @@ describe('Tooltip', () => {
     expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
 
     fireEvent.mouseLeave(tooltipTrigger);
+
+    expect(
+      container.querySelector('div[role="tooltip"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show the tooltip content on mouseenter and hide it on mouseleave tooltip content', () => {
+    const { container } = render(
+      <Tooltip content={CONTENT_TEXT}>{TRIGGER_ELEMENT}</Tooltip>
+    );
+    const tooltipTrigger = container.querySelector('button');
+
+    expect(
+      container.querySelector('div[role="tooltip"]')
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(tooltipTrigger);
+
+    expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
+
+    fireEvent.mouseEnter(container.querySelector('div[role="tooltip"]'));
+
+    expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
+    fireEvent.mouseLeave(container.querySelector('div[role="tooltip"]'));
 
     expect(
       container.querySelector('div[role="tooltip"]')

--- a/packages/react-magma-dom/src/components/Tooltip/index.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/index.tsx
@@ -10,6 +10,11 @@ import {
   shift,
   useFloating,
   FloatingArrow,
+  useHover,
+  useFocus,
+  useDismiss,
+  useInteractions,
+  safePolygon,
 } from '@floating-ui/react';
 
 import { useIsInverse } from '../../inverse';
@@ -124,6 +129,7 @@ export const StyledTooltip = styled.div<{
 
 // Using any for the ref because it is put on the passed in children which does not have a specific type
 export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
+  const isOpen = props.open !== undefined;
   const [isVisible, setIsVisible] = React.useState<boolean>(props.open);
   const arrowElement = React.useRef(null);
 
@@ -153,6 +159,8 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
 
   const { refs, floatingStyles, placement, context, elements, update } =
     useFloating({
+      open: isVisible,
+      onOpenChange: setIsVisible,
       //flip() - Changes the placement of the floating element to keep it in view.
       //offset() - Translates the floating element along the specified axes. (Space between the Trigger and the Content).
       //shift() - Shifts the floating element along the specified axes to keep it in view within the clipping context or viewport.
@@ -168,6 +176,23 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
       whileElementsMounted: autoUpdate,
     });
 
+  const hover = useHover(context, {
+    enabled: !isOpen,
+    handleClose: safePolygon(),
+  });
+
+  const focus = useFocus(context, {
+    enabled: !isOpen,
+  });
+
+  const dismiss = useDismiss(context);
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    hover,
+    focus,
+    dismiss,
+  ]);
+
   React.useEffect(() => {
     const referenceElement = elements.reference;
     const floatingTooltipContent = elements.floating;
@@ -180,35 +205,10 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
   const combinedRef = useForkedRef(ref, refs.setReference);
 
   React.useEffect(() => {
-    const handleEsc = event => {
-      if (event.key === 'Escape') {
-        hideTooltip();
-      }
-    };
-
-    window.addEventListener('keydown', handleEsc);
-
-    return () => {
-      window.removeEventListener('keydown', handleEsc);
-    };
-  }, []);
-
-  function handleKeyDown(event: React.KeyboardEvent) {
-    if (event.key === 'Escape') {
-      if (isVisible) {
-        event.stopPropagation();
-      }
-      hideTooltip();
+    if (isOpen) {
+      setIsVisible(props.open);
     }
-  }
-
-  function showTooltip() {
-    setIsVisible(true);
-  }
-
-  function hideTooltip() {
-    setIsVisible(props.open);
-  }
+  }, [isOpen, props.open]);
 
   const id = useGenerateId(defaultId);
   const theme = React.useContext(ThemeContext);
@@ -217,12 +217,25 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
     throw new Error('Tooltip children can only be one element.');
   }
 
-  const tooltipTrigger = React.cloneElement(children, {
-    'aria-describedby': isVisible ? id : null,
-    onBlur: hideTooltip,
-    onFocus: showTooltip,
-    ref: combinedRef,
-  });
+  const tooltipTrigger = React.cloneElement(
+    children,
+    getReferenceProps({
+      'aria-describedby': isVisible ? id : null,
+      ref: combinedRef,
+      onFocus: event => {
+        children.props.onFocus?.(event);
+        if (!isOpen) {
+          setIsVisible(true);
+        }
+      },
+      onBlur: event => {
+        children.props.onBlur?.(event);
+        if (!isOpen) {
+          setIsVisible(false);
+        }
+      },
+    })
+  );
 
   const combinedTooltipStyles = {
     zIndex: theme.tooltip.zIndex,
@@ -236,14 +249,26 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
     <TooltipContainer
       {...other}
       data-testid={testId ?? 'tooltip'}
-      onKeyDown={handleKeyDown}
-      onMouseLeave={hideTooltip}
-      onMouseEnter={showTooltip}
       style={containerStyle}
     >
       {tooltipTrigger}
       {isVisible && (
-        <div ref={refs.setFloating} style={combinedTooltipStyles}>
+        <div
+          ref={refs.setFloating}
+          style={combinedTooltipStyles}
+          {...getFloatingProps({
+            onMouseEnter: () => {
+              if (!isOpen) {
+                setIsVisible(true);
+              }
+            },
+            onMouseLeave: () => {
+              if (!isOpen) {
+                setIsVisible(false);
+              }
+            },
+          })}
+        >
           <FloatingArrow
             ref={arrowElement}
             data-testid={testId ? `${testId}-arrow` : 'tooltip-arrow'}


### PR DESCRIPTION
Closes: #2111

## What I did
- Added supporting visibility when the user hovers over it with the mouse pointer.
- Removed image `aria-label` for Loading Indicator.component

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Loading Indicator -> Default ->  Turn on VO/NVDA -> `Loading` should be announced only for text, not for image.

Go to Storybook -> Tooltip -> Default -> click on `Tooltip trigger` -> tooltip content is visible -> hover on tooltip content -> it is still visible. 