### PR TITLE
fix(Pagination):  Add `aria-hidden=true` for ellipsis.

### DIFF
--- a/.changeset/fix-Pagination-aria-hidden-dots.md
+++ b/.changeset/fix-Pagination-aria-hidden-dots.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Pagination): Add `aria-hidden=true` for ellipsis.

--- a/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
@@ -4,11 +4,11 @@ import styled from '@emotion/styled';
 import { ArrowBackIcon, ArrowForwardIcon } from 'react-magma-icons';
 
 import { I18nContext } from '../../i18n';
+import { ThemeContext } from '../../theme/ThemeContext';
 import { ButtonColor, ButtonShape, ButtonSize, ButtonVariant } from '../Button';
 import { IconButton } from '../IconButton';
 import { PageButton, pageButtonTypeSize } from './PageButton';
 import { usePagination } from './usePagination';
-import { ThemeContext } from '../../theme/ThemeContext';
 import { SimplePagination } from '../Pagination/SimplePagination';
 
 export interface BasePaginationProps
@@ -224,6 +224,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
                     return (
                       <StyledEllipsis
                         aria-current={Boolean(ariaCurrent)}
+                        aria-hidden="true"
                         key={index}
                         isInverse={isInverse}
                         size={size}


### PR DESCRIPTION
Closes: #2068

## What I did
-  Added `aria-hidden=true` for ellipsis.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Pagination -> Default -> Turn on VO/NVDA -> ellipsis should not be announced.
