### PR TITLE
fix(Treeview): Fix visibility content inside treeitem.

### DIFF
--- a/.changeset/fix-Treeview-showing-inner-content.md
+++ b/.changeset/fix-Treeview-showing-inner-content.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Treeview): Fix showing content inside `Treeitem`.

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -118,7 +118,7 @@ export default {
     },
     height: {
       control: 'number',
-      defaultValue: 800,
+      defaultValue: 0,
     },
   },
 } as Meta;

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -137,10 +137,24 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
           const itemId = child.props.itemId;
           const itemKey = `${itemId}-${depth}`;
 
-          // Clone the child without its children to prevent double rendering
+          // Filter children to separate TreeItem elements from other content
+          // Keep non-TreeItem children (like Tag, text, etc.) but remove nested TreeItems
+          const nonTreeItemChildren: React.ReactNode[] = [];
+
+          React.Children.forEach(child.props.children, childNode => {
+            if (
+              !React.isValidElement(childNode) ||
+              childNode.type !== TreeItem
+            ) {
+              nonTreeItemChildren.push(childNode);
+            }
+          });
+
+          // Clone the child with only non-TreeItem children to prevent double rendering
           const childWithoutNested = React.cloneElement(child, {
             ...child.props,
-            children: null,
+            children:
+              nonTreeItemChildren.length > 0 ? nonTreeItemChildren : null,
           });
 
           items.push({

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.tsx
@@ -140,6 +140,7 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
           // Filter children to separate TreeItem elements from other content
           // Keep non-TreeItem children (like Tag, text, etc.) but remove nested TreeItems
           const nonTreeItemChildren: React.ReactNode[] = [];
+          let hasTreeItemChildren = false;
 
           React.Children.forEach(child.props.children, childNode => {
             if (
@@ -147,12 +148,15 @@ export const TreeView = React.forwardRef<HTMLUListElement, TreeViewProps>(
               childNode.type !== TreeItem
             ) {
               nonTreeItemChildren.push(childNode);
+            } else {
+              hasTreeItemChildren = true;
             }
           });
 
           // Clone the child with only non-TreeItem children to prevent double rendering
           const childWithoutNested = React.cloneElement(child, {
             ...child.props,
+            hasTreeItemChildren,
             children:
               nonTreeItemChildren.length > 0 ? nonTreeItemChildren : null,
           });

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -73,6 +73,11 @@ export interface UseTreeItemProps extends React.HTMLAttributes<HTMLLIElement> {
    * Style properties for the tree item
    */
   treeItemStyles?: React.CSSProperties;
+  /**
+   * @internal
+   * Used in virtualization to indicate this item has TreeItem children.
+   */
+  hasTreeItemChildren?: boolean;
 }
 
 export const checkedStatusToBoolean = (
@@ -80,7 +85,15 @@ export const checkedStatusToBoolean = (
 ): boolean => status === IndeterminateCheckboxStatus.checked;
 
 export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
-  const { children, itemDepth, itemId, onClick, parentDepth, topLevel } = props;
+  const {
+    children,
+    itemDepth,
+    itemId,
+    onClick,
+    parentDepth,
+    topLevel,
+    hasTreeItemChildren,
+  } = props;
 
   // Consume split contexts for reduced re-render scope
   const { items, selectedItems, selectItem } = React.useContext(
@@ -128,8 +141,12 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   );
 
   const hasOwnTreeItems = React.useMemo(() => {
-    return treeViewItemData?.hasOwnTreeItems || treeItemChildren.length > 0;
-  }, [treeViewItemData, treeItemChildren.length]);
+    return (
+      treeViewItemData?.hasOwnTreeItems ||
+      treeItemChildren.length > 0 ||
+      hasTreeItemChildren
+    );
+  }, [treeViewItemData, treeItemChildren.length, hasTreeItemChildren]);
 
   const expanded = React.useMemo(() => {
     return expandedSet.has(itemId);


### PR DESCRIPTION
Closes: #1875 

## What I did
- Fix showing content inside `TreeItem`.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Treeview -> Invalid Tree Items -> Open Node 1 > Open Grandchild 1 - has tag content -> `This is a tag as a child of Grandchild 1` should be visible -> enableVirtualization -> ` This is a tag as a child of Grandchild 1` content should be still vivisble


The original issue:
https://storybook-preview-v4-dev--upbeat-sinoussi-f675aa.netlify.app/?path=/story/treeview--invalid-tree-items&args=enableVirtualization:true