### PR TITLE
fix(DatePicker): Add focus after clearing date.

### DIFF
--- a/.changeset/fix-DatePicker-clear-focus-input.md
+++ b/.changeset/fix-DatePicker-clear-focus-input.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Fix focusing input field after clearing date and when `isDateFieldInput=true`.

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -224,6 +224,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
     onClear();
     handleDateChange?.(null, null);
     onClearDate?.();
+    firstFieldRef?.focus();
   };
 
   const focusInputContainer = (e: React.MouseEvent | React.FocusEvent) => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.stories.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { isValid } from 'date-fns';
 
+import { getDateFromString, inDateRange } from './utils';
 import { I18nContext } from '../../i18n';
 import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
-import { LabelPosition } from '../Label';
-import { getDateFromString, inDateRange } from './utils';
 import { Button } from '../Button';
+import { LabelPosition } from '../Label';
 
 import { DatePicker } from '.';
 

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -1914,6 +1914,7 @@ describe('Date Picker', () => {
           expect(monthInput.value).toBe('');
           expect(dayInput.value).toBe('');
           expect(yearInput.value).toBe('');
+          expect(monthInput).toHaveFocus();
         });
       });
 


### PR DESCRIPTION
Closes: #1179 
Fix for [this](https://github.com/cengage/react-magma/issues/1179#:~:text=olehnoskov%2Dcengage%2C-,when,-isDateFieldInput%20and%20isClearable) comment.

## What I did
- Added focus after clearing the date.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> DatePicker -> Date Field Default -> set up a new date -> click on `Clear` button -> focus should move to input.
