### PR TITLE
fix(Pagination): Add announcement when selected page updates.

### DIFF
--- a/.changeset/fix-Pagination-add-announcement-selected-page.md
+++ b/.changeset/fix-Pagination-add-announcement-selected-page.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Pagination): Add announcement when selected page updates.

--- a/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
@@ -9,7 +9,10 @@ import { ButtonColor, ButtonShape, ButtonSize, ButtonVariant } from '../Button';
 import { IconButton } from '../IconButton';
 import { PageButton, pageButtonTypeSize } from './PageButton';
 import { usePagination } from './usePagination';
+import { Announce, AnnouncePoliteness } from '../Announce';
 import { SimplePagination } from '../Pagination/SimplePagination';
+import { VisuallyHidden } from '../VisuallyHidden';
+import { pageAriaLabel } from './utils';
 
 export interface BasePaginationProps
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -190,6 +193,28 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
     });
 
     const i18n = React.useContext(I18nContext);
+    const [focusedPage, setFocusedPage] = React.useState<number | null>(null);
+    const pageButtonRefs = React.useRef<Map<number, HTMLButtonElement>>(
+      new Map()
+    );
+
+    React.useEffect(() => {
+      if (focusedPage !== null && pageButtonRefs.current.has(focusedPage)) {
+        const button = pageButtonRefs.current.get(focusedPage);
+
+        button?.focus();
+        setFocusedPage(null);
+      }
+    }, [focusedPage, pageButtons]);
+
+    const setPageButtonRef =
+      (pageNumber: number) => (el: HTMLButtonElement | null) => {
+        if (el) {
+          pageButtonRefs.current.set(pageNumber, el);
+        } else {
+          pageButtonRefs.current.delete(pageNumber);
+        }
+      };
 
     return (
       <>
@@ -217,7 +242,13 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
             <StyledList>
               {pageButtons.map(
                 (
-                  { 'aria-current': ariaCurrent, page, type, ...other },
+                  {
+                    'aria-current': ariaCurrent,
+                    page,
+                    type,
+                    isSelected,
+                    ...other
+                  },
                   index
                 ) => {
                   if (type === 'start-ellipsis' || type === 'end-ellipsis') {
@@ -242,12 +273,23 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
                         key={index}
                       >
                         <PageButton
+                          ref={setPageButtonRef(page)}
                           isInverse={isInverse}
+                          isSelected={isSelected}
                           size={buttonSize}
                           {...other}
+                          onClick={event => {
+                            setFocusedPage(page);
+                            other.onClick?.(event);
+                          }}
                         >
                           {page}
                         </PageButton>
+                        <VisuallyHidden>
+                          <Announce
+                            politeness={AnnouncePoliteness.assertive}
+                          >{`${isSelected ? pageAriaLabel(page, count, i18n.simplePagination) : ''}`}</Announce>
+                        </VisuallyHidden>
                       </StyledListItem>
                     );
                   } else if (type === 'previous' || type === 'next') {

--- a/packages/react-magma-dom/src/components/Pagination/SimplePagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/SimplePagination.tsx
@@ -13,6 +13,7 @@ import { ButtonColor, ButtonShape, ButtonVariant } from '../Button';
 import { Spacer } from '../Spacer';
 import { Tooltip } from '../Tooltip';
 import { VisuallyHidden } from '../VisuallyHidden';
+import { pageAriaLabel, paginationLabel } from './utils';
 
 import { NavButton, PaginationProps } from './';
 
@@ -78,7 +79,9 @@ export const SimplePagination = React.forwardRef<
 
   const id = useGenerateId(defaultId);
 
-  let [selectedPage, setSelectedPage] = React.useState(page || defaultPage);
+  let [selectedPage, setSelectedPage] = React.useState(
+    page || defaultPage || 1
+  );
 
   React.useEffect(() => {
     setSelectedPage(page);
@@ -115,33 +118,23 @@ export const SimplePagination = React.forwardRef<
       onPageChange(event, selectedPage);
   }
 
-  function paginationLabel() {
-    return `${i18n.simplePagination.ofLabel}
-        ${count}
-        ${
-          count <= 1
-            ? i18n.simplePagination.pageLabel
-            : i18n.simplePagination.pagesLabel
-        }`;
-  }
-
-  const pageAriaLabel = `${i18n.simplePagination.pageNumberLabel}
-    ${selectedPage}
-    ${paginationLabel()}
-    ${i18n.simplePagination.selectedLabel}`;
-
   const disabledPrevTooltip =
-    disabled || selectedPage <= 1 || count <= 0 || count == null;
+    disabled || selectedPage <= 1 || count <= 0 || count === null;
 
   const disabledNextTooltip =
-    disabled || selectedPage >= count || count == null;
+    disabled || selectedPage >= count || count === null;
 
   const prevTooltipContent = i18n.pagination.previousButtonLabel;
   const nextTooltipContent = i18n.pagination.nextButtonLabel;
+  const pageAriaLabelText = pageAriaLabel(
+    selectedPage,
+    count,
+    i18n.simplePagination
+  );
 
   const PrevButton = (
     <NavButton
-      aria-label={i18n.pagination.previousButtonLabel}
+      aria-label={prevTooltipContent}
       variant={ButtonVariant.link}
       color={ButtonColor.secondary}
       disabled={disabledPrevTooltip}
@@ -204,7 +197,7 @@ export const SimplePagination = React.forwardRef<
           >
             {Array.from({ length: count }, (_, i) => (
               <option
-                aria-label={pageAriaLabel}
+                aria-label={pageAriaLabelText}
                 data-testid={testId ? `${testId}-option-${i}` : `option-${i}`}
                 key={i}
                 onChange={handleChange}
@@ -219,10 +212,10 @@ export const SimplePagination = React.forwardRef<
             aria-hidden="true"
             data-testid={testId ? `${testId}-label` : `label`}
           >
-            {paginationLabel()}
+            {paginationLabel(count, i18n.simplePagination)}
           </label>
           <VisuallyHidden>
-            <Announce>{pageAriaLabel}</Announce>
+            <Announce>{pageAriaLabelText}</Announce>
           </VisuallyHidden>
         </>
       )}

--- a/packages/react-magma-dom/src/components/Pagination/utils.ts
+++ b/packages/react-magma-dom/src/components/Pagination/utils.ts
@@ -1,0 +1,19 @@
+interface PaginationI18n {
+  ofLabel: string;
+  pageNumberLabel: string;
+  pageLabel: string;
+  pagesLabel: string;
+  selectedLabel: string;
+}
+
+export const paginationLabel = (count: number, pagination: PaginationI18n) => {
+  return `${pagination.ofLabel} ${count} ${count <= 1 ? pagination.pageLabel : pagination.pagesLabel}`;
+};
+
+export const pageAriaLabel = (
+  selectedPage: number,
+  count: number,
+  pagination: PaginationI18n
+) => {
+  return `${pagination.pageNumberLabel} ${selectedPage} ${paginationLabel(count, pagination)} ${pagination.selectedLabel}`;
+};


### PR DESCRIPTION
Closes: #2025 

Copy of [this](https://github.com/cengage/react-magma/pull/2037) PR into `v4/dev` branch.

## What I did
- Added announcement for `Pagination` when the selected page changes.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Pagination -> Default -> Turn on VO/NVDA -> when the selected page changes -> screen reader announces the selected page number.

Go to Storybook -> Pagination -> Simple Pagination -> behaviour should work as before.