### PR TITLE
fix(Date Picker): Automatically focus today or min date on open state.

### DIFF
--- a/.changeset/fix-DatePicker-focus-today-calendar.md
+++ b/.changeset/fix-DatePicker-focus-today-calendar.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Automatically focus today or min date on open state.

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
@@ -13,9 +13,6 @@ import { ThemeContext } from '../../theme/ThemeContext';
 
 interface CalendarDayProps {
   day: Date;
-  dayFocusable?: boolean;
-  isInverse?: boolean;
-  onDateChange?: (day: Date, event: React.SyntheticEvent) => void;
 }
 
 type CalendarDayState = {
@@ -33,6 +30,7 @@ function getCalendarDayBackground(
   if (isInverse) {
     return isChosen ? theme.colors.tertiary : theme.colors.primary;
   }
+
   return isChosen ? theme.colors.primary : theme.colors.neutral100;
 }
 
@@ -40,6 +38,7 @@ const getTodayColor = (isChosen: boolean, isInverse: boolean, theme: Theme) => {
   if (isInverse) {
     return isChosen ? theme.colors.primary600 : theme.colors.secondary500;
   }
+
   return isChosen ? theme.colors.neutral100 : theme.colors.primary500;
 };
 
@@ -81,6 +80,7 @@ const getCalendarDayColor = (
   if (state.isChosen) return getChosenDayColor(isInverse, theme);
   if (!state.isDayInCurrentMonth && !state.disabled)
     return getNotCurrentMonthColor(isInverse, theme);
+
   return getCurrentMonthColor(isInverse, theme);
 };
 
@@ -110,6 +110,7 @@ function getChosenDayHover(
 
 const getCalendarDayFontSize = (state: CalendarDayState) => {
   if (state.isToday) return 700;
+
   return !state.isDayInCurrentMonth || state.disabled ? 400 : 500;
 };
 
@@ -227,27 +228,26 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
     setFocusedDate,
     isInverse,
   } = React.useContext(CalendarContext);
-  const [focused, setFocused] = React.useState<boolean>(false);
   const { day } = props;
 
   React.useEffect(() => {
     if (dateFocused && isSameDay(day, focusedDate)) {
       dayRef.current.focus();
-      setFocused(true);
-    } else {
-      if (focused) {
-        setFocused(false);
-      }
     }
-  }, [focusedDate, dateFocused]);
+  }, [focusedDate, dateFocused, day]);
 
   function onCalendarDayFocus() {
     setDateFocused(true);
   }
 
+  const disabled: boolean =
+    (maxDate ? isAfter(day, maxDate) : false) ||
+    (minDate ? isBefore(day, minDate) : false);
+
   function onDayClick(event: React.SyntheticEvent) {
     if (disabled) {
       event.preventDefault();
+
       return;
     }
 
@@ -261,10 +261,6 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
     }
     setFocusedDate(day);
   }
-
-  const disabled: boolean =
-    (maxDate ? isAfter(props.day, maxDate) : false) ||
-    (minDate ? isBefore(props.day, minDate) : false);
 
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -156,7 +156,6 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
   const lastFocus = React.useRef<any>();
   const helperButtonRef = React.useRef<any>();
   const context = React.useContext(CalendarContext);
-  const [dayFocusable, setDayFocusable] = React.useState<boolean>(false);
   const prevCalendarOpened = usePrevious(props.calendarOpened);
   const focusTrapElement = useFocusLock(props.calendarOpened);
   const monthContainerRef = React.useRef<HTMLDivElement>(null);
@@ -166,7 +165,6 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
       lastFocus.current = document.activeElement;
 
       if (props.focusOnOpen) {
-        setDayFocusable(true);
         context.setDateFocused(true);
       }
     }
@@ -178,12 +176,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
     }
   }, [context.helperInformationShown]);
 
-  function onCalendarTableFocus() {
-    setDayFocusable(true);
-  }
-
   function onCalendarTableBlur() {
-    setDayFocusable(false);
     context.setDateFocused(false);
   }
 
@@ -245,7 +238,6 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
 
             <Table
               onBlur={onCalendarTableBlur}
-              onFocus={onCalendarTableFocus}
               theme={theme}
               role="application"
               dateTimePickerContent={!!props.dateTimePickerContent}
@@ -257,13 +249,7 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
                   .map((week, i) => (
                     <tr key={i}>
                       {week.map((day, dayOfWeek) => (
-                        <CalendarDay
-                          key={dayOfWeek}
-                          isInverse={context.isInverse}
-                          day={day}
-                          dayFocusable={dayFocusable}
-                          onDateChange={context.onDateChange}
-                        />
+                        <CalendarDay key={dayOfWeek} day={day} />
                       ))}
                     </tr>
                   ))}

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.stories.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
 import { isValid } from 'date-fns';
 
+import { getDateFromString, inDateRange } from './utils';
 import { I18nContext } from '../../i18n';
 import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
-import { LabelPosition } from '../Label';
-import { getDateFromString, inDateRange } from './utils';
 import { Button } from '../Button';
+import { LabelPosition } from '../Label';
 
 import { DatePicker } from '.';
 
@@ -54,12 +54,18 @@ export default {
 
 export const Default = {
   render: args => {
-    return <DatePicker {...args} />;
+    return (
+      <DatePicker
+        minDate={
+          new Date(today.getFullYear(), today.getMonth(), today.getDate())
+        }
+        {...args}
+      />
+    );
   },
 
   args: {
     labelText: 'Date',
-    minDate: today,
     errorMessage: '',
     helperMessage: '',
   },

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -57,6 +57,8 @@ const ClearingTheDate = args => {
   );
 };
 
+const labelText = 'Date Picker Label';
+
 const errorMessage = 'Error message';
 const helperMessage = 'Helper message';
 
@@ -104,7 +106,6 @@ describe('Date Picker', () => {
   });
 
   it('should clear input and Chosen Date value after clicking on isClearable X button', () => {
-    const labelText = 'Date Picker Label';
     const valueDate = new Date(2025, 8, 1);
     const day =
       format(valueDate, 'dd')[0] === '0'
@@ -132,7 +133,6 @@ describe('Date Picker', () => {
   });
 
   it('should clear input and Chosen Date value after clicking on Clear Date button', () => {
-    const labelText = 'Date Picker Label';
     const valueDate = new Date(2025, 6, 1);
     const day =
       format(valueDate, 'dd')[0] === '0'
@@ -279,7 +279,6 @@ describe('Date Picker', () => {
   });
 
   it('should keep the user inputted date in the input even if it is before the minDate', () => {
-    const labelText = 'Date Picker Label';
     const valueDate = '01/20/2020';
     const minDate = '02/02/2020';
     const defaultDate = '02/20/2020';
@@ -308,7 +307,6 @@ describe('Date Picker', () => {
   });
 
   it('should keep the user inputted date in the input even if it is before the maxDate', () => {
-    const labelText = 'Date Picker Label';
     const valueDate = '03/20/2020';
     const maxDate = '02/02/2020';
     const defaultDate = '01/20/2020';
@@ -386,7 +384,6 @@ describe('Date Picker', () => {
   });
 
   it('should require the date picker input', () => {
-    const labelText = 'Date Picker Label';
     const { getByLabelText } = render(
       <DatePicker labelText={labelText} required />
     );
@@ -397,7 +394,6 @@ describe('Date Picker', () => {
   it('should watch for input change', () => {
     const onChange = jest.fn();
     const onInputChange = jest.fn();
-    const labelText = 'Date Picker Label';
     const { getByLabelText } = render(
       <DatePicker
         labelText={labelText}
@@ -416,7 +412,6 @@ describe('Date Picker', () => {
 
   it('should call passed in handle focus function', () => {
     const onInputFocus = jest.fn();
-    const labelText = 'Date Picker Label';
     const { getByLabelText } = render(
       <DatePicker labelText={labelText} onInputFocus={onInputFocus} />
     );
@@ -428,7 +423,6 @@ describe('Date Picker', () => {
 
   it('should call passed in handle blur function', () => {
     const onInputBlur = jest.fn();
-    const labelText = 'Date Picker Label';
     const { getByLabelText } = render(
       <DatePicker labelText={labelText} onInputBlur={onInputBlur} />
     );
@@ -442,7 +436,6 @@ describe('Date Picker', () => {
 
   it('should change the focused date and call on change on blur if the typed in date is a valid date', () => {
     const onChange = jest.fn();
-    const labelText = 'Date Picker Label';
     const { getByLabelText, getAllByText } = render(
       <DatePicker labelText={labelText} onChange={onChange} />
     );
@@ -466,7 +459,6 @@ describe('Date Picker', () => {
 
   it('should handle a date lower than the year 1000', () => {
     const onChange = jest.fn();
-    const labelText = 'Date Picker Label';
     const { getByLabelText, getAllByText } = render(
       <DatePicker labelText={labelText} onChange={onChange} />
     );
@@ -531,7 +523,7 @@ describe('Date Picker', () => {
     expect(getByText('17')).toBe(document.activeElement);
   });
 
-  it('should take focus off of chosen date when none valid date in input', () => {
+  it('should focus on today when none valid date in input', () => {
     const defaultDate = new Date(2019, 0, 17);
     const now = new Date();
     const [month, year] = format(now, 'MMMM yyyy').split(' ');
@@ -552,12 +544,25 @@ describe('Date Picker', () => {
 
     expect(getByText(month)).not.toBeNull();
     expect(getByText(year)).not.toBeNull();
-    expect(getAllByText(format(now, 'd'))[0]).not.toBe(document.activeElement);
+    expect(getAllByText(format(now, 'd'))[0]).toHaveFocus();
+  });
+
+  it('should focus on min date when it min date after today', () => {
+    const minDate = new Date(2030, 0, 17);
+    const focusedDay = minDate.getDate();
+    const { getByLabelText, getByText } = render(
+      <DatePicker minDate={minDate} labelText={labelText} />
+    );
+
+    getByLabelText('Toggle Calendar Widget').focus();
+
+    fireEvent.click(getByLabelText('Toggle Calendar Widget'));
+
+    expect(getByText(focusedDay)).toHaveFocus();
   });
 
   it('should go to the previous month when the previous month button is clicked', () => {
     const defaultDate = new Date(2019, 0, 17);
-    const labelText = 'Date Picker Label';
     const { getByLabelText, getAllByText } = render(
       <DatePicker defaultDate={defaultDate} labelText={labelText} />
     );
@@ -573,7 +578,6 @@ describe('Date Picker', () => {
 
   it('should go to the next month when the next month button is clicked', () => {
     const defaultDate = new Date(2019, 0, 17);
-    const labelText = 'Date Picker Label';
     const { getByLabelText, getAllByText } = render(
       <DatePicker defaultDate={defaultDate} labelText={labelText} />
     );
@@ -713,7 +717,6 @@ describe('Date Picker', () => {
     const onChange = jest.fn();
     const onDateChange = jest.fn();
     const defaultDate = new Date();
-    const labelText = 'Date picker label';
     const { getAllByText, container } = render(
       <DatePicker
         defaultDate={defaultDate}
@@ -734,7 +737,6 @@ describe('Date Picker', () => {
   describe('on key down press', () => {
     it('types in the input if you type anything other than the question mark key', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getByLabelText, queryByRole } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -751,7 +753,6 @@ describe('Date Picker', () => {
 
     it('does not update focused date if date is not focused', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getByLabelText, getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -773,7 +774,6 @@ describe('Date Picker', () => {
 
     it('ArrowUp', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -794,7 +794,6 @@ describe('Date Picker', () => {
 
     it('ArrowLeft', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -815,7 +814,6 @@ describe('Date Picker', () => {
 
     it('Home', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -836,7 +834,6 @@ describe('Date Picker', () => {
 
     it('PageUp', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -857,7 +854,6 @@ describe('Date Picker', () => {
 
     it('PageDown', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -878,7 +874,6 @@ describe('Date Picker', () => {
 
     it('ArrowDown', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -899,7 +894,6 @@ describe('Date Picker', () => {
 
     it('ArrowRight', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -920,7 +914,6 @@ describe('Date Picker', () => {
 
     it('End', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -971,7 +964,6 @@ describe('Date Picker', () => {
 
     it('Escape without focus', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -987,7 +979,6 @@ describe('Date Picker', () => {
 
     it('Enter', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -1008,7 +999,6 @@ describe('Date Picker', () => {
 
     it('Spacebar', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -1029,7 +1019,6 @@ describe('Date Picker', () => {
 
     it('does not update the focused date if a bad key press occurs', () => {
       const defaultDate = new Date();
-      const labelText = 'Date picker label';
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );
@@ -1302,7 +1291,6 @@ describe('Date Picker', () => {
     it('should move focus on the previous month button when maxDate is reached', () => {
       const defaultDate = new Date(2019, 0, 17);
       const maxDate = new Date(2019, 2, 17);
-      const labelText = 'Date Picker Label';
       const { getByLabelText, getAllByText } = render(
         <DatePicker
           defaultDate={defaultDate}
@@ -1329,7 +1317,6 @@ describe('Date Picker', () => {
     it('should move focus on the next month button when minDate is reached', () => {
       const defaultDate = new Date(2019, 2, 17);
       const minDate = new Date(2019, 0, 1);
-      const labelText = 'Date Picker Label';
       const { getByLabelText, getAllByText } = render(
         <DatePicker
           defaultDate={defaultDate}

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -203,6 +203,12 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
     const inputRef = React.useRef<HTMLInputElement>();
     const lastFocus = React.useRef<any>();
     const id: string = useGenerateId(props.id);
+    const isInverse = useIsInverse(props.isInverse);
+
+    const minDate = getDateFromString(props.minDate);
+    const maxDate = getDateFromString(props.maxDate);
+    const dateFormat = i18n.dateFormat;
+
     const [helperInformationShown, setHelperInformationShown] =
       React.useState<boolean>(false);
     const [calendarOpened, setCalendarOpened] = React.useState<boolean>(false);
@@ -266,6 +272,15 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       previousIconRef.current = iconRef.current;
     }, []);
 
+    React.useEffect(() => {
+      if (!focusedDate || !minDate) return;
+
+      if (isBefore(focusedDate, minDate) && !chosenDate) {
+        setFocusedDate(minDate);
+        setDateFocused(true);
+      }
+    }, [focusedDate, minDate, chosenDate]);
+
     function showHelperInformation() {
       lastFocus.current = document.activeElement;
       setHelperInformationShown(true);
@@ -293,13 +308,14 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       ) {
         event.preventDefault();
         setFocusedDate(setDefaultFocusedDate());
+        setDateFocused(true);
       }
     };
 
     function setDateFromConsumer(date: Date): Date {
       const convertedDate = getDateFromString(date);
-      const convertedMinDate = getDateFromString(props.minDate);
-      const convertedMaxDate = getDateFromString(props.maxDate);
+      const convertedMinDate = getDateFromString(minDate);
+      const convertedMaxDate = getDateFromString(maxDate);
 
       return date &&
         inDateRange(convertedDate, convertedMinDate, convertedMaxDate)
@@ -309,8 +325,8 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
 
     function setDefaultFocusedDate(): Date {
       const newDate = new Date();
-      const convertedMinDate = getDateFromString(props.minDate);
-      const convertedMaxDate = getDateFromString(props.maxDate);
+      const convertedMinDate = getDateFromString(minDate);
+      const convertedMaxDate = getDateFromString(maxDate);
 
       if (inDateRange(newDate, convertedMinDate, convertedMaxDate)) {
         if (isBefore(startOfDay(newDate), convertedMinDate)) {
@@ -560,7 +576,15 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
     }
 
     function toggleCalendarOpened() {
-      setCalendarOpened(opened => !opened);
+      setCalendarOpened(opened => {
+        // Focus on today when opening calendar without a chosen date
+        if (!opened && !chosenDate) {
+          setFocusedDate(setDefaultFocusedDate());
+          setDateFocused(true);
+        }
+
+        return !opened;
+      });
     }
 
     const { placeholder, testId, dateTimePickerContent, ...rest } = props;
@@ -568,13 +592,6 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       ['onDateChange', 'onInputChange', 'onInputBlur', 'onInputFocus'],
       rest
     );
-
-    const isInverse = useIsInverse(props.isInverse);
-
-    const minDate = getDateFromString(props.minDate);
-    const maxDate = getDateFromString(props.maxDate);
-
-    const dateFormat = i18n.dateFormat;
 
     const dateFieldValue =
       dateFormat === 'MMMM d, yyyy' && chosenDate
@@ -685,11 +702,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
                 theme={theme}
               >
                 <CalendarMonth
-                  focusOnOpen={
-                    calendarOpened &&
-                    Boolean(focusedDate) &&
-                    Boolean(chosenDate)
-                  }
+                  focusOnOpen={calendarOpened && Boolean(focusedDate)}
                   isInverse={isInverse}
                   handleCloseButtonClick={handleCloseButtonClick}
                   calendarOpened={calendarOpened}

--- a/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
+++ b/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
@@ -368,13 +368,14 @@ describe('DateTimePicker', () => {
     it('should respect minDate when provided', () => {
       const minDate = new Date('2024-01-01');
 
-      const { getByTestId, getByText, getByPlaceholderText, getByLabelText } =
-        render(
-          <DateTimePicker
-            labelText="Date Time Picker Label"
-            minDate={minDate}
-          />
-        );
+      const {
+        getByTestId,
+        getAllByText,
+        getByPlaceholderText,
+        getByLabelText,
+      } = render(
+        <DateTimePicker labelText="Date Time Picker Label" minDate={minDate} />
+      );
 
       const input = getByPlaceholderText('mm/dd/yyyy hh:mm AM');
 
@@ -383,10 +384,11 @@ describe('DateTimePicker', () => {
       userEvent.click(getByLabelText('Toggle Calendar Widget'));
 
       const calendar = getByTestId('calendarMonthContainer');
+      const disabledDay = getAllByText('31')[0];
 
       expect(calendar).toBeVisible();
-      expect(getByText('31')).toBeVisible();
-      expect(getByText('31')).toHaveAttribute('aria-disabled', 'true');
+      expect(getAllByText('31')[0]).toBeVisible();
+      expect(getAllByText('31')[0]).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('should respect maxDate when provided', () => {


### PR DESCRIPTION
Closes: #2117 

Copy of [this](https://github.com/cengage/react-magma/pull/2147) PR into `v4/dev` branch.

## What I did
- Added automatic focus on today.
- Added automatic focus on min date.
- Pressing on the `Today` button forces focus on today.
- Refactor code, fix extra focus on the month wrapper.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Date Picker -> Default -> open Calendar -> current day should be focused
Go to Storybook -> Date Picker -> Default -> Open Calendar -> change the month or year ->  click on the `Today` button -> the current day should be focused.

Go to Storybook -> Date Picker -> Default -> set min date like `11/11/2025` ->  Open Calendar -> go to `November` -> min date should be focused
Go to Storybook -> Date Picker -> Default -> type date like `11/11/2022` -> set min date like `11/11/2025` ->  Open Calendar -> go to `November` -> chosen date should be focused but disabled.
