### PR TITLE
fix(Select): add aria-disabled attribute to disabled select elements

### DIFF
--- a/.changeset/fix-select-disabled-aria-label.md
+++ b/.changeset/fix-select-disabled-aria-label.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Select): add aria-disabled attribute to disabled select elements.

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
@@ -453,6 +453,7 @@ describe('Select', () => {
 
     await waitFor(() => {
       expect(renderedSelect).toHaveAttribute('disabled');
+      expect(renderedSelect).toHaveAttribute('aria-disabled', 'true');
     });
   });
 

--- a/packages/react-magma-dom/src/components/Select/Select.test.js
+++ b/packages/react-magma-dom/src/components/Select/Select.test.js
@@ -313,6 +313,7 @@ describe('Select', () => {
 
     await waitFor(() => {
       expect(renderedSelect).toHaveAttribute('disabled');
+      expect(renderedSelect).toHaveAttribute('aria-disabled', 'true');
     });
   });
 

--- a/packages/react-magma-dom/src/components/Select/SelectTriggerButton.tsx
+++ b/packages/react-magma-dom/src/components/Select/SelectTriggerButton.tsx
@@ -72,6 +72,7 @@ export function SelectTriggerButton<T>(props: SelectTriggerButtonInterface<T>) {
       <StyledButton
         {...toggleButtonProps}
         aria-describedby={ariaDescribedBy}
+        aria-disabled={disabled}
         data-testid="selectTriggerButton"
         disabled={disabled}
         hasError={hasError}


### PR DESCRIPTION
Closes: #2181

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Select -> Disabled 
MultiSelect-> Disabled 
Check SR behaviour and verify that `aria-disabled="true"