### PR TITLE
fix(DatePicker): Add focus after clearing date.

### DIFF
--- a/.changeset/fix-DatePicker-clear-focus-input.md
+++ b/.changeset/fix-DatePicker-clear-focus-input.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Fix focusing input field after clearing date and when `isDateFieldInput=true`.

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -224,6 +224,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
     onClear();
     handleDateChange?.(null, null);
     onClearDate?.();
+    firstFieldRef?.focus();
   };
 
   const focusInputContainer = (e: React.MouseEvent | React.FocusEvent) => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -1836,6 +1836,7 @@ describe('Date Picker', () => {
         expect(monthInput.value).toBe('');
         expect(dayInput.value).toBe('');
         expect(yearInput.value).toBe('');
+        expect(monthInput).toHaveFocus();
       });
 
       it('should call handleDateChange to parent when all fields are cleared with default format', () => {


### PR DESCRIPTION
Closes: #1179 
Fix for [this](https://github.com/cengage/react-magma/issues/1179#:~:text=olehnoskov%2Dcengage%2C-,when,-isDateFieldInput%20and%20isClearable) comment.

Copy of [this](url) PR into `v4/dev` branch

## What I did
- Added focus after clearing the date.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> DatePicker -> Date Field Default -> set up a new date -> click on `Clear` button -> focus should move to input.
