### PR TITLE
fix(Tooltip): Supports keeping the tooltip content visible on hover.

### DIFF
--- a/.changeset/fix-Tooltip-Loading-indicator-issues.md
+++ b/.changeset/fix-Tooltip-Loading-indicator-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tooltip & Loading Indicator): Force visibility tooltip content when user hover it. Fix announcing `Loading` twice for Loading indicator.

--- a/packages/react-magma-dom/src/components/LoadingIndicator/index.tsx
+++ b/packages/react-magma-dom/src/components/LoadingIndicator/index.tsx
@@ -15,12 +15,12 @@ export interface LoadingIndicatorProps
    */
   css?: any; // Adding css prop to fix emotion error
   /**
-   * Message displayed for the first five seconds
+   * Message displayed for the first 5 seconds
    * @default "Loading..."
    */
   message1?: string;
   /**
-   * Message displayed for the first five seconds
+   * Message displayed after 5 seconds
    * @default "Thank you for your patience. Still loading..."
    */
   message2?: string;
@@ -30,7 +30,7 @@ export interface LoadingIndicatorProps
    */
   message3?: string;
   /**
-   * Message displayed for the first five seconds
+   * Value between 0 and 100 representing the percentage of progress
    * @default 0
    */
   percentage?: number;
@@ -139,7 +139,7 @@ export const LoadingIndicator = React.forwardRef<
           isLoadingIndicator
         />
       ) : (
-        <Spinner {...other} size={theme.spaceScale.spacing10} />
+        <Spinner {...other} size={theme.spaceScale.spacing10} hasMessage />
       )}
 
       <MessageContainer theme={theme}>

--- a/packages/react-magma-dom/src/components/Spinner/index.tsx
+++ b/packages/react-magma-dom/src/components/Spinner/index.tsx
@@ -32,6 +32,10 @@ export interface SpinnerProps extends React.HTMLAttributes<HTMLSpanElement> {
    * @internal
    */
   testId?: string;
+  /**
+   * @internal
+   */
+  hasMessage?: boolean;
 }
 
 const StyledSpinner = styled.span<SpinnerProps>`
@@ -58,6 +62,7 @@ export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
       noRole,
       size,
       testId,
+      hasMessage,
       ...other
     } = props;
 
@@ -74,6 +79,7 @@ export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
     return (
       <StyledSpinner
         {...other}
+        aria-hidden={hasMessage ? true : noRole}
         aria-label={ariaLabel ? ariaLabel : i18n.spinner.ariaLabel}
         color={
           color
@@ -85,7 +91,6 @@ export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
         data-testid={testId}
         ref={ref}
         role={noRole ? undefined : 'img'}
-        aria-hidden={noRole}
         size={sizeString}
       />
     );

--- a/packages/react-magma-dom/src/components/Tooltip/Tooltip.test.js
+++ b/packages/react-magma-dom/src/components/Tooltip/Tooltip.test.js
@@ -135,7 +135,7 @@ describe('Tooltip', () => {
     expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
   });
 
-  it('should show the tooltip on mouseenter and hide it on mouseleave', () => {
+  it('should show the tooltip on mouseenter and hide it on mouseleave trigger button', () => {
     const { container } = render(
       <Tooltip content={CONTENT_TEXT}>{TRIGGER_ELEMENT}</Tooltip>
     );
@@ -150,6 +150,30 @@ describe('Tooltip', () => {
     expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
 
     fireEvent.mouseLeave(tooltipTrigger);
+
+    expect(
+      container.querySelector('div[role="tooltip"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show the tooltip content on mouseenter and hide it on mouseleave tooltip content', () => {
+    const { container } = render(
+      <Tooltip content={CONTENT_TEXT}>{TRIGGER_ELEMENT}</Tooltip>
+    );
+    const tooltipTrigger = container.querySelector('button');
+
+    expect(
+      container.querySelector('div[role="tooltip"]')
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(tooltipTrigger);
+
+    expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
+
+    fireEvent.mouseEnter(container.querySelector('div[role="tooltip"]'));
+
+    expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
+    fireEvent.mouseLeave(container.querySelector('div[role="tooltip"]'));
 
     expect(
       container.querySelector('div[role="tooltip"]')

--- a/packages/react-magma-dom/src/components/Tooltip/Tooltip.test.js
+++ b/packages/react-magma-dom/src/components/Tooltip/Tooltip.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React from 'react';
 
-import { act, render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent, waitFor } from '@testing-library/react';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
@@ -135,7 +135,7 @@ describe('Tooltip', () => {
     expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
   });
 
-  it('should show the tooltip on mouseenter and hide it on mouseleave trigger button', () => {
+  it('should show the tooltip on mouseenter and hide it on mouseleave trigger button', async () => {
     const { container } = render(
       <Tooltip content={CONTENT_TEXT}>{TRIGGER_ELEMENT}</Tooltip>
     );
@@ -151,12 +151,14 @@ describe('Tooltip', () => {
 
     fireEvent.mouseLeave(tooltipTrigger);
 
-    expect(
-      container.querySelector('div[role="tooltip"]')
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        container.querySelector('div[role="tooltip"]')
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('should show the tooltip content on mouseenter and hide it on mouseleave tooltip content', () => {
+  it('should show the tooltip content on mouseenter and hide it on mouseleave tooltip content', async () => {
     const { container } = render(
       <Tooltip content={CONTENT_TEXT}>{TRIGGER_ELEMENT}</Tooltip>
     );
@@ -175,12 +177,14 @@ describe('Tooltip', () => {
     expect(container.querySelector('div[role="tooltip"]')).toBeInTheDocument();
     fireEvent.mouseLeave(container.querySelector('div[role="tooltip"]'));
 
-    expect(
-      container.querySelector('div[role="tooltip"]')
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        container.querySelector('div[role="tooltip"]')
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('should hide the tooltip when the escape key is pressed', () => {
+  it('should hide the tooltip when the escape key is pressed', async () => {
     const { container } = render(
       <Tooltip content={CONTENT_TEXT}>{TRIGGER_ELEMENT}</Tooltip>
     );
@@ -204,7 +208,9 @@ describe('Tooltip', () => {
       keyCode: 27,
     });
 
-    expect(tooltip).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(tooltip).not.toBeInTheDocument();
+    });
   });
 
   it('should render the tooltip component with the correct styles for the inverse prop, position top', async () => {

--- a/packages/react-magma-dom/src/components/Tooltip/index.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/index.tsx
@@ -10,6 +10,11 @@ import {
   shift,
   useFloating,
   FloatingArrow,
+  useHover,
+  useFocus,
+  useDismiss,
+  useInteractions,
+  safePolygon,
 } from '@floating-ui/react';
 
 import { useIsInverse } from '../../inverse';
@@ -124,6 +129,7 @@ export const StyledTooltip = styled.div<{
 
 // Using any for the ref because it is put on the passed in children which does not have a specific type
 export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
+  const isOpen = props.open !== undefined;
   const [isVisible, setIsVisible] = React.useState<boolean>(props.open);
   const arrowElement = React.useRef(null);
 
@@ -153,6 +159,12 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
 
   const { refs, floatingStyles, placement, context, elements, update } =
     useFloating({
+      open: isVisible,
+      onOpenChange: open => {
+        if (mountedRef.current) {
+          setIsVisible(open);
+        }
+      },
       //flip() - Changes the placement of the floating element to keep it in view.
       //offset() - Translates the floating element along the specified axes. (Space between the Trigger and the Content).
       //shift() - Shifts the floating element along the specified axes to keep it in view within the clipping context or viewport.
@@ -163,50 +175,44 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
         offset(isArrowVisible ? 14 : 0),
         ...(isArrowVisible ? [arrow({ element: arrowElement })] : []),
       ],
-      placement: props.position || (TooltipPosition.top as AlignedPlacement),
+      placement: (position ??
+        TooltipPosition.top) as unknown as AlignedPlacement,
       whileElementsMounted: autoUpdate,
     });
 
-  React.useEffect(() => {
-    const referenceElement = elements.reference;
-    const floatingTooltipContent = elements.floating;
+  const hover = useHover(context, {
+    enabled: !isOpen,
+    handleClose: safePolygon(),
+  });
 
-    if (isVisible && referenceElement && floatingTooltipContent) {
-      return autoUpdate(referenceElement, floatingTooltipContent, update);
-    }
-  }, [isVisible, elements, update]);
+  const focus = useFocus(context, {
+    enabled: !isOpen,
+  });
+
+  const dismiss = useDismiss(context);
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    hover,
+    focus,
+    dismiss,
+  ]);
 
   const combinedRef = useForkedRef(ref, refs.setReference);
+  const mountedRef = React.useRef(false);
 
+  // Fix to avoid setting state on unmounted component in test environments
   React.useEffect(() => {
-    const handleEsc = event => {
-      if (event.key === 'Escape') {
-        hideTooltip();
-      }
-    };
-    window.addEventListener('keydown', handleEsc);
-
+    mountedRef.current = true;
     return () => {
-      window.removeEventListener('keydown', handleEsc);
+      mountedRef.current = false;
     };
   }, []);
 
-  function handleKeyDown(event: React.KeyboardEvent) {
-    if (event.key === 'Escape') {
-      if (isVisible) {
-        event.stopPropagation();
-      }
-      hideTooltip();
+  React.useEffect(() => {
+    if (isOpen) {
+      setIsVisible(props.open);
     }
-  }
-
-  function showTooltip() {
-    setIsVisible(true);
-  }
-
-  function hideTooltip() {
-    setIsVisible(props.open);
-  }
+  }, [isOpen, props.open]);
 
   const id = useGenerateId(defaultId);
   const theme = React.useContext(ThemeContext);
@@ -215,12 +221,25 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
     throw new Error('Tooltip children can only be one element.');
   }
 
-  const tooltipTrigger = React.cloneElement(children, {
-    'aria-describedby': isVisible ? id : null,
-    onBlur: hideTooltip,
-    onFocus: showTooltip,
-    ref: combinedRef,
-  });
+  const tooltipTrigger = React.cloneElement(
+    children,
+    getReferenceProps({
+      'aria-describedby': isVisible ? id : null,
+      ref: combinedRef,
+      onFocus: event => {
+        children.props.onFocus?.(event);
+        if (!isOpen && mountedRef.current) {
+          setIsVisible(true);
+        }
+      },
+      onBlur: event => {
+        children.props.onBlur?.(event);
+        if (!isOpen && mountedRef.current) {
+          setIsVisible(false);
+        }
+      },
+    })
+  );
 
   const combinedTooltipStyles = {
     zIndex: theme.tooltip.zIndex,
@@ -233,15 +252,27 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
   return (
     <TooltipContainer
       {...other}
-      data-testid={testId || 'tooltip'}
-      onKeyDown={handleKeyDown}
-      onMouseLeave={hideTooltip}
-      onMouseEnter={showTooltip}
+      data-testid={testId ?? 'tooltip'}
       style={containerStyle}
     >
       {tooltipTrigger}
       {isVisible && (
-        <div ref={refs.setFloating} style={combinedTooltipStyles}>
+        <div
+          ref={refs.setFloating}
+          style={combinedTooltipStyles}
+          {...getFloatingProps({
+            onMouseEnter: () => {
+              if (!isOpen && mountedRef.current) {
+                setIsVisible(true);
+              }
+            },
+            onMouseLeave: () => {
+              if (!isOpen && mountedRef.current) {
+                setIsVisible(false);
+              }
+            },
+          })}
+        >
           <FloatingArrow
             ref={arrowElement}
             data-testid={testId ? `${testId}-arrow` : 'tooltip-arrow'}

--- a/packages/react-magma-dom/src/components/Tooltip/index.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/index.tsx
@@ -124,8 +124,12 @@ export const StyledTooltip = styled.div<{
 
 // Using any for the ref because it is put on the passed in children which does not have a specific type
 export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
-  const [isVisible, setIsVisible] = React.useState<boolean>(props.open);
+  const [isVisible, setIsVisible] = React.useState<boolean>(
+    props.open ?? false
+  );
   const arrowElement = React.useRef(null);
+  const hideTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+  const isMountedRef = React.useRef<boolean>(true);
 
   const {
     arrowStyle,
@@ -188,7 +192,11 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
     window.addEventListener('keydown', handleEsc);
 
     return () => {
+      isMountedRef.current = false;
       window.removeEventListener('keydown', handleEsc);
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+      }
     };
   }, []);
 
@@ -202,11 +210,23 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
   }
 
   function showTooltip() {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
     setIsVisible(true);
   }
 
   function hideTooltip() {
-    setIsVisible(props.open);
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+    }
+    hideTimeoutRef.current = setTimeout(() => {
+      if (isMountedRef.current) {
+        setIsVisible(props.open ?? false);
+      }
+      hideTimeoutRef.current = null;
+    }, 50);
   }
 
   const id = useGenerateId(defaultId);

--- a/packages/react-magma-dom/src/components/Tooltip/index.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/index.tsx
@@ -157,28 +157,26 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
     }
   }, [arrowStyle, arrowElement, arrowElement.current]);
 
-  const { refs, floatingStyles, placement, context, elements, update } =
-    useFloating({
-      open: isVisible,
-      onOpenChange: open => {
-        if (mountedRef.current) {
-          setIsVisible(open);
-        }
-      },
-      //flip() - Changes the placement of the floating element to keep it in view.
-      //offset() - Translates the floating element along the specified axes. (Space between the Trigger and the Content).
-      //shift() - Shifts the floating element along the specified axes to keep it in view within the clipping context or viewport.
-      //arrow() - Positions an arrow element pointing at the reference element, ensuring proper alignment.
-      middleware: [
-        flip(),
-        shift(),
-        offset(isArrowVisible ? 14 : 0),
-        ...(isArrowVisible ? [arrow({ element: arrowElement })] : []),
-      ],
-      placement: (position ??
-        TooltipPosition.top) as unknown as AlignedPlacement,
-      whileElementsMounted: autoUpdate,
-    });
+  const { refs, floatingStyles, placement, context } = useFloating({
+    open: isVisible,
+    onOpenChange: open => {
+      if (mountedRef.current) {
+        setIsVisible(open);
+      }
+    },
+    //flip() - Changes the placement of the floating element to keep it in view.
+    //offset() - Translates the floating element along the specified axes. (Space between the Trigger and the Content).
+    //shift() - Shifts the floating element along the specified axes to keep it in view within the clipping context or viewport.
+    //arrow() - Positions an arrow element pointing at the reference element, ensuring proper alignment.
+    middleware: [
+      flip(),
+      shift(),
+      offset(isArrowVisible ? 14 : 0),
+      ...(isArrowVisible ? [arrow({ element: arrowElement })] : []),
+    ],
+    placement: (position ?? TooltipPosition.top) as unknown as AlignedPlacement,
+    whileElementsMounted: autoUpdate,
+  });
 
   const hover = useHover(context, {
     enabled: !isOpen,

--- a/packages/react-magma-dom/src/components/Tooltip/index.tsx
+++ b/packages/react-magma-dom/src/components/Tooltip/index.tsx
@@ -10,11 +10,6 @@ import {
   shift,
   useFloating,
   FloatingArrow,
-  useHover,
-  useFocus,
-  useDismiss,
-  useInteractions,
-  safePolygon,
 } from '@floating-ui/react';
 
 import { useIsInverse } from '../../inverse';
@@ -129,7 +124,6 @@ export const StyledTooltip = styled.div<{
 
 // Using any for the ref because it is put on the passed in children which does not have a specific type
 export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
-  const isOpen = props.open !== undefined;
   const [isVisible, setIsVisible] = React.useState<boolean>(props.open);
   const arrowElement = React.useRef(null);
 
@@ -157,60 +151,63 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
     }
   }, [arrowStyle, arrowElement, arrowElement.current]);
 
-  const { refs, floatingStyles, placement, context } = useFloating({
-    open: isVisible,
-    onOpenChange: open => {
-      if (mountedRef.current) {
-        setIsVisible(open);
-      }
-    },
-    //flip() - Changes the placement of the floating element to keep it in view.
-    //offset() - Translates the floating element along the specified axes. (Space between the Trigger and the Content).
-    //shift() - Shifts the floating element along the specified axes to keep it in view within the clipping context or viewport.
-    //arrow() - Positions an arrow element pointing at the reference element, ensuring proper alignment.
-    middleware: [
-      flip(),
-      shift(),
-      offset(isArrowVisible ? 14 : 0),
-      ...(isArrowVisible ? [arrow({ element: arrowElement })] : []),
-    ],
-    placement: (position ?? TooltipPosition.top) as unknown as AlignedPlacement,
-    whileElementsMounted: autoUpdate,
-  });
+  const { refs, floatingStyles, placement, context, elements, update } =
+    useFloating({
+      //flip() - Changes the placement of the floating element to keep it in view.
+      //offset() - Translates the floating element along the specified axes. (Space between the Trigger and the Content).
+      //shift() - Shifts the floating element along the specified axes to keep it in view within the clipping context or viewport.
+      //arrow() - Positions an arrow element pointing at the reference element, ensuring proper alignment.
+      middleware: [
+        flip(),
+        shift(),
+        offset(isArrowVisible ? 14 : 0),
+        ...(isArrowVisible ? [arrow({ element: arrowElement })] : []),
+      ],
+      placement: (position ??
+        TooltipPosition.top) as unknown as AlignedPlacement,
+      whileElementsMounted: autoUpdate,
+    });
 
-  const hover = useHover(context, {
-    enabled: !isOpen,
-    handleClose: safePolygon(),
-  });
+  React.useEffect(() => {
+    const referenceElement = elements.reference;
+    const floatingTooltipContent = elements.floating;
 
-  const focus = useFocus(context, {
-    enabled: !isOpen,
-  });
-
-  const dismiss = useDismiss(context);
-
-  const { getReferenceProps, getFloatingProps } = useInteractions([
-    hover,
-    focus,
-    dismiss,
-  ]);
+    if (isVisible && referenceElement && floatingTooltipContent) {
+      return autoUpdate(referenceElement, floatingTooltipContent, update);
+    }
+  }, [isVisible, elements, update]);
 
   const combinedRef = useForkedRef(ref, refs.setReference);
-  const mountedRef = React.useRef(false);
 
-  // Fix to avoid setting state on unmounted component in test environments
   React.useEffect(() => {
-    mountedRef.current = true;
+    const handleEsc = event => {
+      if (event.key === 'Escape') {
+        hideTooltip();
+      }
+    };
+    window.addEventListener('keydown', handleEsc);
+
     return () => {
-      mountedRef.current = false;
+      window.removeEventListener('keydown', handleEsc);
     };
   }, []);
 
-  React.useEffect(() => {
-    if (isOpen) {
-      setIsVisible(props.open);
+  function handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Escape') {
+      if (isVisible) {
+        event.stopPropagation();
+      }
+      hideTooltip();
     }
-  }, [isOpen, props.open]);
+  }
+
+  function showTooltip() {
+    setIsVisible(true);
+  }
+
+  function hideTooltip() {
+    setIsVisible(props.open);
+  }
 
   const id = useGenerateId(defaultId);
   const theme = React.useContext(ThemeContext);
@@ -219,25 +216,12 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
     throw new Error('Tooltip children can only be one element.');
   }
 
-  const tooltipTrigger = React.cloneElement(
-    children,
-    getReferenceProps({
-      'aria-describedby': isVisible ? id : null,
-      ref: combinedRef,
-      onFocus: event => {
-        children.props.onFocus?.(event);
-        if (!isOpen && mountedRef.current) {
-          setIsVisible(true);
-        }
-      },
-      onBlur: event => {
-        children.props.onBlur?.(event);
-        if (!isOpen && mountedRef.current) {
-          setIsVisible(false);
-        }
-      },
-    })
-  );
+  const tooltipTrigger = React.cloneElement(children, {
+    'aria-describedby': isVisible ? id : null,
+    onBlur: hideTooltip,
+    onFocus: showTooltip,
+    ref: combinedRef,
+  });
 
   const combinedTooltipStyles = {
     zIndex: theme.tooltip.zIndex,
@@ -250,27 +234,15 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
   return (
     <TooltipContainer
       {...other}
-      data-testid={testId ?? 'tooltip'}
+      data-testid={testId || 'tooltip'}
+      onKeyDown={handleKeyDown}
+      onMouseLeave={hideTooltip}
+      onMouseEnter={showTooltip}
       style={containerStyle}
     >
       {tooltipTrigger}
       {isVisible && (
-        <div
-          ref={refs.setFloating}
-          style={combinedTooltipStyles}
-          {...getFloatingProps({
-            onMouseEnter: () => {
-              if (!isOpen && mountedRef.current) {
-                setIsVisible(true);
-              }
-            },
-            onMouseLeave: () => {
-              if (!isOpen && mountedRef.current) {
-                setIsVisible(false);
-              }
-            },
-          })}
-        >
+        <div ref={refs.setFloating} style={combinedTooltipStyles}>
           <FloatingArrow
             ref={arrowElement}
             data-testid={testId ? `${testId}-arrow` : 'tooltip-arrow'}
@@ -288,7 +260,9 @@ export const Tooltip = React.forwardRef<any, TooltipProps>((props, ref) => {
             id={id}
             isInverse={isInverse}
             position={
-              placement ? (placement as AlignedPlacement) : TooltipPosition.top
+              (placement
+                ? (placement as unknown)
+                : TooltipPosition.top) as TooltipPosition
             }
             theme={theme}
             role="tooltip"


### PR DESCRIPTION
Closes: #2111

Copy of [this](https://github.com/cengage/react-magma/pull/2162) PR into `v4/dev` branch.

## What I did
- Added supporting visibility when the user hovers over it with the mouse pointer.
- Removed image `aria-label` for Loading Indicator.component

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Loading Indicator -> Default ->  Turn on VO/NVDA -> `Loading` should be announced only for text, not for image.

Go to Storybook -> Tooltip -> Default -> click on `Tooltip trigger` -> tooltip content is visible -> hover on tooltip content -> it is still visible. 