### PR TITLE
fix(Native Select & Radio Button & Table & Spinner & Table): Fix accessibility issues in docs.

### DIFF
--- a/.changeset/fix-doc-examples.md
+++ b/.changeset/fix-doc-examples.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Progress Bar & Radio Button & Native Select & Spinner): Fix various accessibility issues in example components.

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -211,7 +211,9 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
         >
           <StyledNativeSelect
             data-testid={testId}
-            aria-describedby={`${id}__desc`}
+            aria-describedby={
+              errorMessage || helperMessage ? `${id}__desc` : undefined
+            }
             hasError={!!errorMessage}
             disabled={disabled}
             id={id}

--- a/packages/react-magma-dom/src/components/ProgressBar/index.tsx
+++ b/packages/react-magma-dom/src/components/ProgressBar/index.tsx
@@ -204,8 +204,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
           theme={theme}
         >
           <Bar
-            aria-labelledby={labelId}
-            aria-valuenow={percentageValue}
+            aria-label="Progress bar"
             aria-valuemin={0}
             aria-valuemax={100}
             color={color}
@@ -221,7 +220,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
             {percentageValue}%
           </Percentage>
         ) : (
-          <VisuallyHidden id={labelId}>{percentageValue}%</VisuallyHidden>
+          <VisuallyHidden id={labelId}>{`${percentageValue}%`}</VisuallyHidden>
         )}
       </Container>
     );

--- a/website/react-magma-docs/src/pages/api/progress-bar.mdx
+++ b/website/react-magma-docs/src/pages/api/progress-bar.mdx
@@ -47,7 +47,7 @@ export function Example() {
 
   return (
     <>
-      <ProgressBar percentage={percentage} />
+      <ProgressBar percentage={percentage} aria-live="polite" />
       <Spacer size={12} />
       <ButtonGroup>
         <Button disabled={percentage >= 100} onClick={handleIncrease}>

--- a/website/react-magma-docs/src/pages/api/radio.mdx
+++ b/website/react-magma-docs/src/pages/api/radio.mdx
@@ -488,19 +488,25 @@ import {
   Button,
   ButtonColor,
   ButtonGroup,
+  Announce,
+  VisuallyHidden,
 } from 'react-magma-dom';
 
 export function Example() {
   const radioRef = React.useRef();
   const [radioGroupVal, setRadioGroupVal] = React.useState(null);
+  const [announcement, setAnnouncement] = React.useState('');
 
   function handleSelectOne() {
     if (!radioRef.current) {
       setRadioGroupVal(null);
+      setAnnouncement('');
     } else if (radioRef.current.checked) {
       setRadioGroupVal('');
+      setAnnouncement('Option one deselected');
     } else if (!radioRef.current.checked) {
       setRadioGroupVal('1');
+      setAnnouncement('Option one selected');
     }
   }
 
@@ -532,6 +538,9 @@ export function Example() {
           Focus option 1
         </Button>
       </ButtonGroup>
+      <Announce>
+        <VisuallyHidden>{announcement}</VisuallyHidden>
+      </Announce>
     </>
   );
 }

--- a/website/react-magma-docs/src/pages/api/spinner.mdx
+++ b/website/react-magma-docs/src/pages/api/spinner.mdx
@@ -35,7 +35,7 @@ import React from 'react';
 import { Spinner } from 'react-magma-dom';
 
 export function Example() {
-  return <Spinner aria-label="Custom aria label" />;
+  return <Spinner aria-label="Page loading. Please wait" />;
 }
 ```
 

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -840,7 +840,7 @@ export function Example() {
         <TableRow>
           <TableCell>Lorem ipsum dolor sit amet consectetur</TableCell>
           <TableCell>
-            <Input label="Table input" isLabelVisuallyHidden />
+            <Input aria-label="Table input row 1" isLabelVisuallyHidden />
           </TableCell>
           <TableCell>Lorem ipsum dolor</TableCell>
           <TableCell>
@@ -850,7 +850,7 @@ export function Example() {
         <TableRow>
           <TableCell>Lorem ipsum dolor sit amet</TableCell>
           <TableCell>
-            <Input label="Table input" isLabelVisuallyHidden />
+            <Input aria-label="Table input row 2" isLabelVisuallyHidden />
           </TableCell>
           <TableCell>Lorem ipsum dolor</TableCell>
           <TableCell>


### PR DESCRIPTION
Closes: #2101 
Closes: #2102 

Copy of [this](https://github.com/cengage/react-magma/pull/2153) PR into `v4/dev`.

## What I did
- Fixed accessibility issues in the docs for these components: `Native Select` & `Radio Button` & `Table` & `Spinner`, and `Table`.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Native Select -> Basic Usage -> should not have `aria-describedby` attribute when errorMessage or helperMessage is not provided, and vice versa.

Go to Docs -> Components -> Progress Bar -> Percentage -> Turn on VO/NVDA -> press on `Increase` or `Decrease` button -> Progress Bar value should be announced.

Go to Docs -> Components -> Radio Button ->Forward Ref -> Turn on VO/NVDA -> press on `Toggle option 1 selection` -> changing state of `Option one label` Radio button should be announced.

Go to Docs -> Components -> Spinner -> Aria-Label-> Turn on VO/NVDA -> check new aria-label text.

Go to Docs -> Components -> Table -> Other Content-> Scan full page via AXE -> aria-label should be provided for inputs.
