### PR TITLE
fix(Datepicker): Add leading zero for year and fix updating values.

### DIFF
--- a/.changeset/fix-DatePicker-prerelease-bugs.md
+++ b/.changeset/fix-DatePicker-prerelease-bugs.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Improve updating values in input when `isDateFieldInput=true`

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarHeader.tsx
@@ -10,7 +10,12 @@ import {
 } from 'react-magma-icons';
 
 import { CalendarContext } from './CalendarContext';
-import { i18nFormat as format, getCurrentMonthAndYear } from './utils';
+import {
+  i18nFormat as format,
+  getCurrentMonthAndYear,
+  MAX_YEAR,
+  MIN_YEAR,
+} from './utils';
 import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { ButtonColor, ButtonType, ButtonVariant } from '../Button';
@@ -76,8 +81,8 @@ export const CalendarHeader: React.FunctionComponent<
   const i18n = React.useContext(I18nContext);
   const locale = i18n.locale || enUS;
   const monthAndYear = getCurrentMonthAndYear(focusedDate, locale);
-  const minDateOrDefault = minDate ?? new Date(1900, 0, 1);
-  const maxDateOrDefault = maxDate ?? new Date(2099, 11, 31);
+  const minDateOrDefault = minDate ?? new Date(MIN_YEAR, 0, 1);
+  const maxDateOrDefault = maxDate ?? new Date(MAX_YEAR, 11, 31);
   const previousMonthRef = React.useRef<HTMLButtonElement>();
   const nextMonthRef = React.useRef<HTMLButtonElement>();
 

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -127,7 +127,6 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
         return (
           <StyledNumInput
             aria-label={datePicker.day}
-            aria-describedby={dayId}
             aria-valuemin={1}
             aria-valuemax={31}
             aria-valuenow={Number(day)}
@@ -154,7 +153,6 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
         return (
           <StyledNumInput
             aria-label={datePicker.month}
-            aria-describedby={monthId}
             aria-valuemax={12}
             aria-valuemin={1}
             aria-valuenow={
@@ -193,7 +191,6 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
         return (
           <StyledNumInput
             aria-label={datePicker.year}
-            aria-describedby={yearId}
             aria-valuemin={MIN_YEAR}
             aria-valuemax={MAX_YEAR}
             aria-valuenow={Number(year)}

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -28,6 +28,7 @@ import {
 import { IconButton } from '../../IconButton';
 import { IconButtonContainer } from '../../InputBase';
 import { Divider, StyledNumInput } from '../../TimePicker';
+import { MAX_YEAR, MIN_YEAR } from '../utils';
 
 export interface DateFieldInputProps
   extends Omit<FormFieldContainerBaseProps, 'inputSize' | 'fieldId'> {
@@ -193,8 +194,8 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
           <StyledNumInput
             aria-label={datePicker.year}
             aria-describedby={yearId}
-            aria-valuemin={1900}
-            aria-valuemax={2099}
+            aria-valuemin={MIN_YEAR}
+            aria-valuemax={MAX_YEAR}
             aria-valuenow={Number(year)}
             aria-valuetext={year}
             data-testid="year-input"
@@ -253,7 +254,12 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       return;
     }
 
-    const isCompletedDate = month && day && year;
+    const isCompletedDate =
+      month &&
+      day &&
+      year &&
+      Number(year) >= MIN_YEAR &&
+      Number(year) <= MAX_YEAR;
 
     if (!isCompletedDate) return;
     const newDate = hasMonthLongFormat

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/useDateField.ts
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/useDateField.ts
@@ -3,6 +3,8 @@ import * as React from 'react';
 import { enUS } from 'date-fns/locale';
 import { isEmpty } from 'lodash';
 
+import { MAX_YEAR, MIN_YEAR } from '../utils';
+
 export interface UseDateFieldProps {
   dateFormat: string;
 }
@@ -42,10 +44,20 @@ export function useDateField(props: UseDateFieldProps) {
     setMonthTypingBuffer('');
   };
 
-  const formatWithLeadingZero = (value: number, maxValue?: number): string => {
+  const formatWithLeadingZero = (
+    value: number,
+    maxValue?: number,
+    isYearField?: boolean
+  ): string => {
+    if (isYearField) {
+      return String(value).padStart(4, '0');
+    }
+
     if (value < 10) {
       return `0${value}`;
-    } else if (maxValue && value > maxValue) {
+    }
+
+    if (maxValue && value > maxValue) {
       return `0${String(value).substring(0, 1)}`;
     }
 
@@ -61,44 +73,46 @@ export function useDateField(props: UseDateFieldProps) {
     return daysInMonth;
   };
 
+  const sanitizeInputValue = (input: string): string => {
+    return input.replace(/\s/g, '');
+  };
+
   const sanitizeMonth = (
     newMonth: string,
     hasMonthLongFormat?: boolean
   ): number => {
-    const monthNum = Number(newMonth);
+    const cleanedMonth = sanitizeInputValue(newMonth);
+    const monthNum = Number(cleanedMonth);
 
     if (monthNum > 12) {
-      return Number(newMonth.slice(hasMonthLongFormat ? 1 : 2));
+      return Number(cleanedMonth.slice(hasMonthLongFormat ? 1 : 2));
     }
-    if (monthNum < 1) {
-      return 1;
-    }
-    if (newMonth.length > 2) {
-      return Number(newMonth.slice(-2));
+    if (cleanedMonth.length > 2) {
+      return Number(cleanedMonth.slice(-2));
     }
 
     return monthNum;
   };
 
   const sanitizeDay = (newDay: string, daysInMonth: number): string => {
-    const dayNum = Number(newDay);
+    const cleanedDay = sanitizeInputValue(newDay);
+    const dayNum = Number(cleanedDay);
 
     if (dayNum > daysInMonth) {
-      return newDay.slice(2);
+      return cleanedDay.slice(2);
+    }
+    if (cleanedDay.length > 2) {
+      return cleanedDay.slice(-2);
     }
 
-    if (newDay.length > 2) {
-      return newDay.slice(-2);
-    }
-
-    return newDay;
+    return cleanedDay;
   };
 
   const sanitizeYear = (newYear: string): number => {
     const yearNum = Number(newYear);
 
-    if (newYear.length > 4) {
-      return Number(newYear.slice(-4));
+    if (yearNum.toString().length > 4) {
+      return Number(newYear.slice(-1));
     }
 
     return yearNum;
@@ -191,7 +205,7 @@ export function useDateField(props: UseDateFieldProps) {
   const handleYearChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const sanitizedYear = sanitizeYear(event.target.value);
 
-    setYearValue(formatWithLeadingZero(sanitizedYear));
+    setYearValue(formatWithLeadingZero(sanitizedYear, undefined, true));
   };
 
   const changeDay = (direction: ChangeDirection) => {
@@ -263,9 +277,9 @@ export function useDateField(props: UseDateFieldProps) {
       const currentYear = Number(year);
 
       if (direction === ChangeDirection.Increment) {
-        newYear = Math.min(2099, currentYear + 1);
+        newYear = Math.min(MAX_YEAR, currentYear + 1);
       } else {
-        newYear = Math.max(1900, currentYear - 1);
+        newYear = Math.max(MIN_YEAR, currentYear - 1);
       }
     }
 

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -1578,6 +1578,32 @@ describe('Date Picker', () => {
       expect(onInputBlur).toHaveBeenCalled();
     });
 
+    it('should render date with leading zero', async () => {
+      const user = userEvent.setup();
+      const { getByTestId } = render(<DatePicker isDateFieldInput />);
+
+      const monthInput = getByTestId('month-input');
+      const dayInput = getByTestId('day-input');
+      const yearInput = getByTestId('year-input');
+
+      await user.type(monthInput, '1');
+      await user.type(dayInput, '5');
+      await user.type(yearInput, '2');
+
+      expect(monthInput).toHaveValue('01');
+      expect(dayInput).toHaveValue('05');
+      expect(yearInput).toHaveValue('0002');
+
+      await user.type(yearInput, '0');
+      expect(yearInput).toHaveValue('0020');
+
+      await user.type(yearInput, '2');
+      expect(yearInput).toHaveValue('0202');
+
+      await user.type(yearInput, '6');
+      expect(yearInput).toHaveValue('2026');
+    });
+
     describe('Focus behavior', () => {
       it('should handle input focus behavior via tabbing', async () => {
         const user = userEvent.setup();

--- a/packages/react-magma-dom/src/components/DatePicker/YearPicker.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/YearPicker.tsx
@@ -4,6 +4,7 @@ import { getYear } from 'date-fns';
 
 import { CalendarContext } from './CalendarContext';
 import { StyledSelect } from './StyledSelect';
+import { MAX_YEAR, MIN_YEAR } from './utils';
 import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { NativeSelect } from '../NativeSelect';
@@ -18,8 +19,8 @@ export const YearPicker: React.FunctionComponent<YearPickerProps> = (
 ) => {
   const { currentYear, isInverse } = props;
   const { minDate, maxDate } = React.useContext(CalendarContext);
-  const minYear = minDate ? getYear(minDate) : 1900;
-  const maxYear = maxDate ? getYear(maxDate) : 2099;
+  const minYear = minDate ? getYear(minDate) : MIN_YEAR;
+  const maxYear = maxDate ? getYear(maxDate) : MAX_YEAR;
   const theme = React.useContext(ThemeContext);
   const { setYearFocusedDate } = React.useContext(CalendarContext);
   const i18n = React.useContext(I18nContext);

--- a/packages/react-magma-dom/src/components/DatePicker/utils.ts
+++ b/packages/react-magma-dom/src/components/DatePicker/utils.ts
@@ -180,3 +180,7 @@ export function setMonthForDate(prevDate, numberMonth: number) {
 export function setYearForDate(prevDate, numberYear: number) {
   return setYear(prevDate, numberYear);
 }
+
+export const MAX_YEAR = 2099;
+
+export const MIN_YEAR = 1900;


### PR DESCRIPTION
Closes: #2203 

## What I did
- Added leading zero for `year` field.
- Fixed a bug with pressing `Space` on input.
- Fixed double announcing for `day`, `month`, and `year` fields.
- Refactored existing code.

## Screenshots
<img width="1522" height="125" alt="Screenshot from 2026-01-23 16-19-47" src="https://github.com/user-attachments/assets/a1e55297-6ed4-4a65-91c2-da37f3ec41f7" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Date Picker -> Default -> `isDateFieldInput=true` -> focus on `day`,  `month`, `year` field -> type `11` > press `Space` -> value should be the same.
 
Go to Storybook -> Date Picker -> Default -> `isDateFieldInput=true` -> focus on `year` field -> type `2` > `0002` -> type `0` > `0020` -> type `2` > `00202` -> type `6` > `2026` ->   type `2` > `0002` -> 

Go to Storybook -> Date Picker -> Default -> `isDateFieldInput=true` -> Turn on NVDA/VO -> values in input should be announced once. 

**Any date earlier than 1900 or later than 2099 is ignored.**
