### PR TITLE
fix(charts): fix magma styles not applied to carbon charts

### DIFF
--- a/.changeset/fix-Combobox-accessibility copy.md
+++ b/.changeset/fix-Combobox-accessibility copy.md
@@ -1,0 +1,5 @@
+---
+'@react-magma/charts': patch
+---
+
+fix(Charts): Fix magma styles not applied to carbon charts.

--- a/packages/charts/src/components/CarbonChart/CarbonChart.test.js
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
+import { ThemeContext, magma } from 'react-magma-dom';
 
 import { CarbonChart, CarbonChartType } from '.';
 
@@ -72,5 +73,510 @@ describe('CarbonChart', () => {
     );
 
     expect(getByTestId(testId)).toBeInTheDocument();
+  });
+
+  describe('Magma Theme Values Applied to Styles', () => {
+    it('should apply theme.colors.neutral700 to data table cells', () => {
+      const testId = 'table-color-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.neutral700 to .cds--data-table td
+      expect(wrapper).toHaveStyleRule('color', magma.colors.neutral700, {
+        target: '.cds--data-table td',
+      });
+    });
+
+    it('should apply theme.colors.primary for button background in non-inverse mode', () => {
+      const testId = 'button-color-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse={false}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.primary to .cds--btn--primary
+      expect(wrapper).toHaveStyleRule('background', magma.colors.primary, {
+        target: '.chart-holder .cds--btn--primary',
+      });
+    });
+
+    it('should apply theme.colors.tertiary500 for button background when isInverse is true', () => {
+      const testId = 'button-inverse-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.tertiary500 to .cds--btn--primary when inverse
+      expect(wrapper).toHaveStyleRule('background', magma.colors.tertiary500, {
+        target: '.chart-holder .cds--btn--primary',
+      });
+    });
+
+    it('should apply theme.colors.primary700 for inverse table header background', () => {
+      const testId = 'table-inverse-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.primary700 to table header when inverse
+      expect(wrapper).toHaveStyleRule(
+        'background',
+        `${magma.colors.primary700}!important`,
+        {
+          target: '.cds--data-table thead tr th',
+        }
+      );
+    });
+
+    it('should apply theme.colors.neutral100 for inverse text color', () => {
+      const testId = 'text-inverse-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.neutral100 to text when inverse
+      expect(wrapper).toHaveStyleRule('color', magma.colors.neutral100, {
+        target: 'p',
+      });
+    });
+
+    it('should apply theme.bodyFont to chart text elements', () => {
+      const testId = 'font-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.bodyFont to various text elements
+      expect(wrapper).toHaveStyleRule(
+        'font-family',
+        `${magma.bodyFont}!important`,
+        {
+          target: 'p',
+        }
+      );
+    });
+
+    it('should apply theme.typeScale.size02.fontSize to tooltip text', () => {
+      const testId = 'font-size-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.typeScale.size02.fontSize to tooltips
+      expect(wrapper).toHaveStyleRule(
+        'font-size',
+        magma.typeScale.size02.fontSize,
+        {
+          target: '.cds--cc--tooltip .content-box .datapoint-tooltip p',
+        }
+      );
+    });
+
+    it('should apply theme.typeScale.size03.fontSize to legend text', () => {
+      const testId = 'legend-font-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.typeScale.size03.fontSize to legend
+      expect(wrapper).toHaveStyleRule(
+        'font-size',
+        magma.typeScale.size03.fontSize,
+        {
+          target: 'div.cds--cc--legend div.legend-item p',
+        }
+      );
+    });
+
+    it('should apply theme.borderRadius to modal container', () => {
+      const testId = 'border-radius-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.borderRadius in clip-path
+      expect(wrapper).toHaveStyleRule(
+        'clip-path',
+        `inset(0% 0% 0% 0% round ${magma.borderRadius})`,
+        {
+          target: '.cds--modal-container',
+        }
+      );
+    });
+
+    it('should apply theme.colors.focus for focus outline', () => {
+      const testId = 'focus-color-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.focus to outline
+      expect(wrapper).toHaveStyleRule(
+        'outline',
+        `2px solid ${magma.colors.focus}!important`,
+        {
+          target: '.chart-holder *:focus',
+        }
+      );
+    });
+
+    it('should apply theme.colors.focusInverse for focus outline when isInverse is true', () => {
+      const testId = 'focus-inverse-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.focusInverse to outline when inverse
+      expect(wrapper).toHaveStyleRule(
+        'outline',
+        `2px solid ${magma.colors.focusInverse}!important`,
+        {
+          target: '.chart-holder *:focus',
+        }
+      );
+    });
+
+    it('should apply theme.spaceScale.spacing05 to legend checkbox dimensions', () => {
+      const testId = 'spacing-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.spaceScale.spacing05 to checkbox width
+      expect(wrapper).toHaveStyleRule('width', magma.spaceScale.spacing05, {
+        target: 'div.cds--cc--legend div.legend-item div.checkbox',
+      });
+
+      // And height
+      expect(wrapper).toHaveStyleRule('height', magma.spaceScale.spacing05, {
+        target: 'div.cds--cc--legend div.legend-item div.checkbox',
+      });
+    });
+
+    it('should apply theme.colors.neutral900 to legend checkbox background when isInverse', () => {
+      const testId = 'legend-bg-inverse-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.neutral900 to checkbox background when inverse
+      expect(wrapper).toHaveStyleRule('background', magma.colors.neutral900, {
+        target: 'div.cds--cc--legend div.legend-item div.checkbox',
+      });
+    });
+
+    it('should apply theme.colors.neutral100 to legend checkbox background in normal mode', () => {
+      const testId = 'legend-bg-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse={false}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.neutral100 to checkbox background
+      expect(wrapper).toHaveStyleRule('background', magma.colors.neutral100, {
+        target: 'div.cds--cc--legend div.legend-item div.checkbox',
+      });
+    });
+
+    it('should apply theme.colors.neutral100 to modal header background in normal mode', () => {
+      const testId = 'modal-header-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse={false}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.neutral100 to modal header background
+      expect(wrapper).toHaveStyleRule('background', magma.colors.neutral100, {
+        target: '.chart-holder .cds--modal-header',
+      });
+    });
+
+    it('should apply theme.colors.primary600 to modal header background when isInverse', () => {
+      const testId = 'modal-header-inverse-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.primary600 to modal header when inverse
+      expect(wrapper).toHaveStyleRule('background', magma.colors.primary600, {
+        target: '.chart-holder .cds--modal-header',
+      });
+    });
+
+    it('should apply font-weight 600 to modal header heading', () => {
+      const testId = 'modal-heading-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies font-weight to modal header heading
+      expect(wrapper).toHaveStyleRule('font-weight', '600', {
+        target: '.chart-holder .cds--modal-header__heading',
+      });
+    });
+
+    it('should apply theme.colors.neutral100 to modal footer background in normal mode', () => {
+      const testId = 'modal-footer-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse={false}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.neutral100 to modal footer background
+      expect(wrapper).toHaveStyleRule(
+        'background',
+        `${magma.colors.neutral100}!important`,
+        {
+          target: '.cds--modal-footer.cds--modal-footer',
+        }
+      );
+    });
+
+    it('should apply theme.colors.primary600 to modal footer background when isInverse', () => {
+      const testId = 'modal-footer-inverse-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.primary600 to modal footer when inverse
+      expect(wrapper).toHaveStyleRule(
+        'background',
+        `${magma.colors.primary600}!important`,
+        {
+          target: '.cds--modal-footer.cds--modal-footer',
+        }
+      );
+    });
+
+    it('should apply theme.colors.neutral300 border to modal header in normal mode', () => {
+      const testId = 'modal-header-border-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse={false}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.neutral300 border to modal header
+      expect(wrapper).toHaveStyleRule(
+        'border-bottom',
+        `1px solid ${magma.colors.neutral300}`,
+        {
+          target: '.chart-holder .cds--modal-header',
+        }
+      );
+    });
+
+    it('should apply theme.colors.neutral300 border to modal footer in normal mode', () => {
+      const testId = 'modal-footer-border-test';
+      const { getByTestId } = render(
+        <ThemeContext.Provider value={magma}>
+          <CarbonChart
+            testId={testId}
+            dataSet={dataSet}
+            options={chartOptions}
+            type={CarbonChartType.bar}
+            isInverse={false}
+          />
+        </ThemeContext.Provider>
+      );
+
+      const wrapper = getByTestId(testId);
+
+      // CarbonChartWrapper applies theme.colors.neutral300 border to modal footer
+      expect(wrapper).toHaveStyleRule(
+        'border-top',
+        `1px solid ${magma.colors.neutral300}`,
+        {
+          target: '.cds--modal-footer.cds--modal-footer',
+        }
+      );
+    });
   });
 });

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -220,33 +220,33 @@ const CarbonChartWrapper = styled.div<{
     }
     .cds--cc--scatter circle.dot {
       filter: drop-shadow(
-            1px 0px 0px
-              ${props =>
-                props.isInverse
-                  ? props.theme.colors.primary600
-                  : props.theme.colors.neutral100}
-          )
-          drop-shadow(
-            -1px 0px 0px
-              ${props =>
-                props.isInverse
-                  ? props.theme.colors.primary600
-                  : props.theme.colors.neutral100}
-          )
-          drop-shadow(
-            0px 1px 0px
-              ${props =>
-                props.isInverse
-                  ? props.theme.colors.primary600
-                  : props.theme.colors.neutral100}
-          )
-          drop-shadow(
-            0px -1px 0px
-              ${props =>
-                props.isInverse
-                  ? props.theme.colors.primary600
-                  : props.theme.colors.neutral100}
-          );
+          1px 0px 0px
+            ${props =>
+              props.isInverse
+                ? props.theme.colors.primary600
+                : props.theme.colors.neutral100}
+        )
+        drop-shadow(
+          -1px 0px 0px
+            ${props =>
+              props.isInverse
+                ? props.theme.colors.primary600
+                : props.theme.colors.neutral100}
+        )
+        drop-shadow(
+          0px 1px 0px
+            ${props =>
+              props.isInverse
+                ? props.theme.colors.primary600
+                : props.theme.colors.neutral100}
+        )
+        drop-shadow(
+          0px -1px 0px
+            ${props =>
+              props.isInverse
+                ? props.theme.colors.primary600
+                : props.theme.colors.neutral100}
+        );
     }
     .cds--cc--scatter circle.dot.hovered {
       stroke-width: 0.5em;
@@ -326,22 +326,23 @@ const CarbonChartWrapper = styled.div<{
       transition: 0.1s all linear;
       stroke-width: 1.1em;
     }
-    
+
     .cds--cc--tooltip {
-    ${props => {
-      const chartColors =
-        (props.isInverse
-          ? props.theme.chartColorsInverse
-          : props.theme.chartColors) || [];
+      ${props => {
+        const chartColors =
+          (props.isInverse
+            ? props.theme.chartColorsInverse
+            : props.theme.chartColors) || [];
 
-      return chartColors.reduce((result, color, index) => {
-        const indexNum = index + 1;
+        return chartColors.reduce((result, color, index) => {
+          const indexNum = index + 1;
 
-        result += `.tooltip-${props.groupsLength}-1-${indexNum} { background-color: ${color}; }`;
+          result += `.tooltip-${props.groupsLength}-1-${indexNum} { background-color: ${color}; }`;
 
-        return result;
-      }, '');
-    }}
+          return result;
+        }, '');
+      }}
+    }
 
     .cds--overflow-menu-options__btn:focus {
       outline-color: ${props =>

--- a/packages/charts/src/components/CarbonChart/carbon-charts.css
+++ b/packages/charts/src/components/CarbonChart/carbon-charts.css
@@ -1,6499 +1,2118 @@
-.cds--chart-holder {
-  --cds-charts-1-1-1: #6929c4;
-  --cds-charts-1-1-1-hovered: rgb(89.1835443038, 34.8240506329, 166.4759493671);
-  --cds-charts-1-2-1: #002d9c;
-  --cds-charts-1-2-1-hovered: rgb(0, 34.7019230769, 120.3);
-  --cds-charts-1-3-1: #1192e8;
-  --cds-charts-1-3-1-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-1-4-1: #007d79;
-  --cds-charts-1-4-1-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-2-1-1: #6929c4;
-  --cds-charts-2-1-1-hovered: rgb(89.1835443038, 34.8240506329, 166.4759493671);
-  --cds-charts-2-1-2: #009d9a;
-  --cds-charts-2-1-2-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-2-2-1: #8a3ffc;
-  --cds-charts-2-2-1-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-2-2-2: #520408;
-  --cds-charts-2-2-2-hovered: rgb(47.9604651163, 2.3395348837, 4.6790697674);
-  --cds-charts-2-3-1: #9f1853;
-  --cds-charts-2-3-1-hovered: rgb(127.9819672131, 19.3180327869, 66.8081967213);
-  --cds-charts-2-3-2: #520408;
-  --cds-charts-2-3-2-hovered: rgb(47.9604651163, 2.3395348837, 4.6790697674);
-  --cds-charts-2-4-1: #1192e8;
-  --cds-charts-2-4-1-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-2-4-2: #005d5d;
-  --cds-charts-2-4-2-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-2-5-1: #009d9a;
-  --cds-charts-2-5-1-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-2-5-2: #002d9c;
-  --cds-charts-2-5-2-hovered: rgb(0, 34.7019230769, 120.3);
-  --cds-charts-3-1-1: #ee5396;
-  --cds-charts-3-1-1-hovered: rgb(
-    234.7888888889,
-    50.5111111111,
-    130.1666666667
-  );
-  --cds-charts-3-1-2: #1192e8;
-  --cds-charts-3-1-2-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-3-1-3: #6929c4;
-  --cds-charts-3-1-3-hovered: rgb(89.1835443038, 34.8240506329, 166.4759493671);
-  --cds-charts-3-2-1: #9f1853;
-  --cds-charts-3-2-1-hovered: rgb(127.9819672131, 19.3180327869, 66.8081967213);
-  --cds-charts-3-2-2: #fa4d56;
-  --cds-charts-3-2-2-hovered: rgb(249.0245901639, 42.2754098361, 53.031147541);
-  --cds-charts-3-2-3: #520408;
-  --cds-charts-3-2-3-hovered: rgb(47.9604651163, 2.3395348837, 4.6790697674);
-  --cds-charts-3-3-1: #a56eff;
-  --cds-charts-3-3-1-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-3-3-2: #005d5d;
-  --cds-charts-3-3-2-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-3-3-3: #002d9c;
-  --cds-charts-3-3-3-hovered: rgb(0, 34.7019230769, 120.3);
-  --cds-charts-3-4-1: #a56eff;
-  --cds-charts-3-4-1-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-3-4-2: #005d5d;
-  --cds-charts-3-4-2-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-3-4-3: #9f1853;
-  --cds-charts-3-4-3-hovered: rgb(127.9819672131, 19.3180327869, 66.8081967213);
-  --cds-charts-3-5-1: #012749;
-  --cds-charts-3-5-1-hovered: rgb(0.5175675676, 20.1851351351, 37.7824324324);
-  --cds-charts-3-5-2: #6929c4;
-  --cds-charts-3-5-2-hovered: rgb(89.1835443038, 34.8240506329, 166.4759493671);
-  --cds-charts-3-5-3: #009d9a;
-  --cds-charts-3-5-3-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-4-1-1: #6929c4;
-  --cds-charts-4-1-1-hovered: rgb(89.1835443038, 34.8240506329, 166.4759493671);
-  --cds-charts-4-1-2: #012749;
-  --cds-charts-4-1-2-hovered: rgb(0.5175675676, 20.1851351351, 37.7824324324);
-  --cds-charts-4-1-3: #009d9a;
-  --cds-charts-4-1-3-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-4-1-4: #ee5396;
-  --cds-charts-4-1-4-hovered: rgb(
-    234.7888888889,
-    50.5111111111,
-    130.1666666667
-  );
-  --cds-charts-4-2-1: #9f1853;
-  --cds-charts-4-2-1-hovered: rgb(127.9819672131, 19.3180327869, 66.8081967213);
-  --cds-charts-4-2-2: #fa4d56;
-  --cds-charts-4-2-2-hovered: rgb(249.0245901639, 42.2754098361, 53.031147541);
-  --cds-charts-4-2-3: #520408;
-  --cds-charts-4-2-3-hovered: rgb(47.9604651163, 2.3395348837, 4.6790697674);
-  --cds-charts-4-2-4: #a56eff;
-  --cds-charts-4-2-4-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-4-3-1: #009d9a;
-  --cds-charts-4-3-1-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-4-3-2: #002d9c;
-  --cds-charts-4-3-2-hovered: rgb(0, 34.7019230769, 120.3);
-  --cds-charts-4-3-3: #a56eff;
-  --cds-charts-4-3-3-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-4-3-4: #9f1853;
-  --cds-charts-4-3-4-hovered: rgb(127.9819672131, 19.3180327869, 66.8081967213);
-  --cds-charts-5-1-1: #6929c4;
-  --cds-charts-5-1-1-hovered: rgb(89.1835443038, 34.8240506329, 166.4759493671);
-  --cds-charts-5-1-2: #1192e8;
-  --cds-charts-5-1-2-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-5-1-3: #005d5d;
-  --cds-charts-5-1-3-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-5-1-4: #9f1853;
-  --cds-charts-5-1-4-hovered: rgb(127.9819672131, 19.3180327869, 66.8081967213);
-  --cds-charts-5-1-5: #520408;
-  --cds-charts-5-1-5-hovered: rgb(47.9604651163, 2.3395348837, 4.6790697674);
-  --cds-charts-5-2-1: #002d9c;
-  --cds-charts-5-2-1-hovered: rgb(0, 34.7019230769, 120.3);
-  --cds-charts-5-2-2: #009d9a;
-  --cds-charts-5-2-2-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-5-2-3: #9f1853;
-  --cds-charts-5-2-3-hovered: rgb(127.9819672131, 19.3180327869, 66.8081967213);
-  --cds-charts-5-2-4: #520408;
-  --cds-charts-5-2-4-hovered: rgb(47.9604651163, 2.3395348837, 4.6790697674);
-  --cds-charts-5-2-5: #a56eff;
-  --cds-charts-5-2-5-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-14-1-1: #6929c4;
-  --cds-charts-14-1-1-hovered: rgb(
-    89.1835443038,
-    34.8240506329,
-    166.4759493671
-  );
-  --cds-charts-14-1-2: #1192e8;
-  --cds-charts-14-1-2-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-14-1-3: #005d5d;
-  --cds-charts-14-1-3-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-14-1-4: #9f1853;
-  --cds-charts-14-1-4-hovered: rgb(
-    127.9819672131,
-    19.3180327869,
-    66.8081967213
-  );
-  --cds-charts-14-1-5: #fa4d56;
-  --cds-charts-14-1-5-hovered: rgb(249.0245901639, 42.2754098361, 53.031147541);
-  --cds-charts-14-1-6: #520408;
-  --cds-charts-14-1-6-hovered: rgb(47.9604651163, 2.3395348837, 4.6790697674);
-  --cds-charts-14-1-7: #198038;
-  --cds-charts-14-1-7-hovered: rgb(19.1666666667, 98.1333333333, 42.9333333333);
-  --cds-charts-14-1-8: #002d9c;
-  --cds-charts-14-1-8-hovered: rgb(0, 34.7019230769, 120.3);
-  --cds-charts-14-1-9: #ee5396;
-  --cds-charts-14-1-9-hovered: rgb(
-    234.7888888889,
-    50.5111111111,
-    130.1666666667
-  );
-  --cds-charts-14-1-10: #b28600;
-  --cds-charts-14-1-10-hovered: rgb(142.3, 107.1247191011, 0);
-  --cds-charts-14-1-11: #009d9a;
-  --cds-charts-14-1-11-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-14-1-12: #012749;
-  --cds-charts-14-1-12-hovered: rgb(0.5175675676, 20.1851351351, 37.7824324324);
-  --cds-charts-14-1-13: #8a3800;
-  --cds-charts-14-1-13-hovered: rgb(102.3, 41.5130434783, 0);
-  --cds-charts-14-1-14: #a56eff;
-  --cds-charts-14-1-14-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-mono-1-1: #ffffff;
-  --cds-charts-mono-1-1-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-mono-1-2: #f6f2ff;
-  --cds-charts-mono-1-2-hovered: rgb(221.2846153846, 206.3, 255);
-  --cds-charts-mono-1-3: #e8daff;
-  --cds-charts-mono-1-3-hovered: rgb(209.8081081081, 182.3, 255);
-  --cds-charts-mono-1-4: #d4bbff;
-  --cds-charts-mono-1-4-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-mono-1-5: #be95ff;
-  --cds-charts-mono-1-5-hovered: rgb(168.108490566, 113.3, 255);
-  --cds-charts-mono-1-6: #a56eff;
-  --cds-charts-mono-1-6-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-mono-1-7: #8a3ffc;
-  --cds-charts-mono-1-7-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-mono-1-8: #6929c4;
-  --cds-charts-mono-1-8-hovered: rgb(
-    89.1835443038,
-    34.8240506329,
-    166.4759493671
-  );
-  --cds-charts-mono-1-9: #491d8b;
-  --cds-charts-mono-1-9-hovered: rgb(57.4875, 22.8375, 109.4625);
-  --cds-charts-mono-1-10: #31135e;
-  --cds-charts-mono-1-10-hovered: rgb(
-    33.5194690265,
-    12.9973451327,
-    64.3026548673
-  );
-  --cds-charts-mono-1-11: #1c0f30;
-  --cds-charts-mono-1-11-hovered: rgb(12.1333333333, 6.5, 20.8);
-  --cds-charts-mono-2-1: #ffffff;
-  --cds-charts-mono-2-1-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-mono-2-2: #edf5ff;
-  --cds-charts-mono-2-2-hovered: rgb(201.3, 225.1666666667, 255);
-  --cds-charts-mono-2-3: #d0e2ff;
-  --cds-charts-mono-2-3-hovered: rgb(172.3, 203.9723404255, 255);
-  --cds-charts-mono-2-4: #a6c8ff;
-  --cds-charts-mono-2-4-hovered: rgb(130.3, 177.9382022472, 255);
-  --cds-charts-mono-2-5: #78a9ff;
-  --cds-charts-mono-2-5-hovered: rgb(84.3, 146.2577777778, 255);
-  --cds-charts-mono-2-6: #4589ff;
-  --cds-charts-mono-2-6-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-mono-2-7: #0f62fe;
-  --cds-charts-mono-2-7-hovered: rgb(
-    0.9680497925,
-    81.3161825726,
-    232.3319502075
-  );
-  --cds-charts-mono-2-8: #0043ce;
-  --cds-charts-mono-2-8-hovered: rgb(0, 55.3888349515, 170.3);
-  --cds-charts-mono-2-9: #002d9c;
-  --cds-charts-mono-2-9-hovered: rgb(0, 34.7019230769, 120.3);
-  --cds-charts-mono-2-10: #001d6c;
-  --cds-charts-mono-2-10-hovered: rgb(0, 19.4138888889, 72.3);
-  --cds-charts-mono-2-11: #001141;
-  --cds-charts-mono-2-11-hovered: rgb(0, 7.6630769231, 29.3);
-  --cds-charts-mono-3-1: #ffffff;
-  --cds-charts-mono-3-1-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-mono-3-2: #e5f6ff;
-  --cds-charts-mono-3-2-hovered: rgb(193.3, 233.6423076923, 255);
-  --cds-charts-mono-3-3: #bae6ff;
-  --cds-charts-mono-3-3-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-mono-3-4: #82cfff;
-  --cds-charts-mono-3-4-hovered: rgb(94.3, 193.2912, 255);
-  --cds-charts-mono-3-5: #33b1ff;
-  --cds-charts-mono-3-5-hovered: rgb(15.3, 163.35, 255);
-  --cds-charts-mono-3-6: #1192e8;
-  --cds-charts-mono-3-6-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-mono-3-7: #0072c3;
-  --cds-charts-mono-3-7-hovered: rgb(0, 93.1292307692, 159.3);
-  --cds-charts-mono-3-8: #00539a;
-  --cds-charts-mono-3-8-hovered: rgb(0, 63.7590909091, 118.3);
-  --cds-charts-mono-3-9: #003a6d;
-  --cds-charts-mono-3-9-hovered: rgb(0, 39.0036697248, 73.3);
-  --cds-charts-mono-3-10: #012749;
-  --cds-charts-mono-3-10-hovered: rgb(
-    0.5175675676,
-    20.1851351351,
-    37.7824324324
-  );
-  --cds-charts-mono-3-11: #061727;
-  --cds-charts-mono-3-11-hovered: rgb(1.24, 4.7533333333, 8.06);
-  --cds-charts-mono-4-1: #ffffff;
-  --cds-charts-mono-4-1-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-mono-4-2: #d9fbfb;
-  --cds-charts-mono-4-2-hovered: rgb(184.7, 247.6, 247.6);
-  --cds-charts-mono-4-3: #9ef0f0;
-  --cds-charts-mono-4-3-hovered: rgb(127.08125, 235.21875, 235.21875);
-  --cds-charts-mono-4-4: #3ddbd9;
-  --cds-charts-mono-4-4-hovered: rgb(
-    38.2382608696,
-    206.0617391304,
-    203.9373913043
-  );
-  --cds-charts-mono-4-5: #08bdba;
-  --cds-charts-mono-4-5-hovered: rgb(
-    6.5502538071,
-    154.7497461929,
-    152.2934010152
-  );
-  --cds-charts-mono-4-6: #009d9a;
-  --cds-charts-mono-4-6-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-mono-4-7: #007d79;
-  --cds-charts-mono-4-7-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-mono-4-8: #005d5d;
-  --cds-charts-mono-4-8-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-mono-4-9: #004144;
-  --cds-charts-mono-4-9-hovered: rgb(0, 30.875, 32.3);
-  --cds-charts-mono-4-10: #022b30;
-  --cds-charts-mono-4-10-hovered: rgb(0.572, 12.298, 13.728);
-  --cds-charts-mono-4-11: #081a1c;
-  --cds-charts-mono-4-11-hovered: rgb(0.0666666667, 0.2166666667, 0.2333333333);
-  --cds-charts-diverge-1-1: #750e13;
-  --cds-charts-diverge-1-1-hovered: rgb(
-    85.1152671756,
-    10.1847328244,
-    13.8221374046
-  );
-  --cds-charts-diverge-1-2: #a2191f;
-  --cds-charts-diverge-1-2-hovered: rgb(
-    131.0727272727,
-    20.2272727273,
-    25.0818181818
-  );
-  --cds-charts-diverge-1-3: #da1e28;
-  --cds-charts-diverge-1-3-hovered: rgb(
-    186.6185483871,
-    25.6814516129,
-    34.2419354839
-  );
-  --cds-charts-diverge-1-4: #fa4d56;
-  --cds-charts-diverge-1-4-hovered: rgb(
-    249.0245901639,
-    42.2754098361,
-    53.031147541
-  );
-  --cds-charts-diverge-1-5: #ff8389;
-  --cds-charts-diverge-1-5-hovered: rgb(255, 95.3, 103.0274193548);
-  --cds-charts-diverge-1-6: #ffb3b8;
-  --cds-charts-diverge-1-6-hovered: rgb(255, 143.3, 150.6486842105);
-  --cds-charts-diverge-1-7: #ffd7d9;
-  --cds-charts-diverge-1-7-hovered: rgb(255, 179.3, 183.085);
-  --cds-charts-diverge-1-8: #fff1f1;
-  --cds-charts-diverge-1-8-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-diverge-1-9: #ffffff;
-  --cds-charts-diverge-1-9-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-diverge-1-10: #e5f6ff;
-  --cds-charts-diverge-1-10-hovered: rgb(193.3, 233.6423076923, 255);
-  --cds-charts-diverge-1-11: #bae6ff;
-  --cds-charts-diverge-1-11-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-diverge-1-12: #82cfff;
-  --cds-charts-diverge-1-12-hovered: rgb(94.3, 193.2912, 255);
-  --cds-charts-diverge-1-13: #33b1ff;
-  --cds-charts-diverge-1-13-hovered: rgb(15.3, 163.35, 255);
-  --cds-charts-diverge-1-14: #1192e8;
-  --cds-charts-diverge-1-14-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-diverge-1-15: #0072c3;
-  --cds-charts-diverge-1-15-hovered: rgb(0, 93.1292307692, 159.3);
-  --cds-charts-diverge-1-16: #00539a;
-  --cds-charts-diverge-1-16-hovered: rgb(0, 63.7590909091, 118.3);
-  --cds-charts-diverge-1-17: #003a6d;
-  --cds-charts-diverge-1-17-hovered: rgb(0, 39.0036697248, 73.3);
-  --cds-charts-diverge-2-1: #491d8b;
-  --cds-charts-diverge-2-1-hovered: rgb(57.4875, 22.8375, 109.4625);
-  --cds-charts-diverge-2-2: #6929c4;
-  --cds-charts-diverge-2-2-hovered: rgb(
-    89.1835443038,
-    34.8240506329,
-    166.4759493671
-  );
-  --cds-charts-diverge-2-3: #8a3ffc;
-  --cds-charts-diverge-2-3-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-diverge-2-4: #a56eff;
-  --cds-charts-diverge-2-4-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-diverge-2-5: #be95ff;
-  --cds-charts-diverge-2-5-hovered: rgb(168.108490566, 113.3, 255);
-  --cds-charts-diverge-2-6: #d4bbff;
-  --cds-charts-diverge-2-6-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-diverge-2-7: #e8daff;
-  --cds-charts-diverge-2-7-hovered: rgb(209.8081081081, 182.3, 255);
-  --cds-charts-diverge-2-8: #f6f2ff;
-  --cds-charts-diverge-2-8-hovered: rgb(221.2846153846, 206.3, 255);
-  --cds-charts-diverge-2-9: #ffffff;
-  --cds-charts-diverge-2-9-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-diverge-2-10: #d9fbfb;
-  --cds-charts-diverge-2-10-hovered: rgb(184.7, 247.6, 247.6);
-  --cds-charts-diverge-2-11: #9ef0f0;
-  --cds-charts-diverge-2-11-hovered: rgb(127.08125, 235.21875, 235.21875);
-  --cds-charts-diverge-2-12: #3ddbd9;
-  --cds-charts-diverge-2-12-hovered: rgb(
-    38.2382608696,
-    206.0617391304,
-    203.9373913043
-  );
-  --cds-charts-diverge-2-13: #08bdba;
-  --cds-charts-diverge-2-13-hovered: rgb(
-    6.5502538071,
-    154.7497461929,
-    152.2934010152
-  );
-  --cds-charts-diverge-2-14: #009d9a;
-  --cds-charts-diverge-2-14-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-diverge-2-15: #007d79;
-  --cds-charts-diverge-2-15-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-diverge-2-16: #005d5d;
-  --cds-charts-diverge-2-16-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-diverge-2-17: #004144;
-  --cds-charts-diverge-2-17-hovered: rgb(0, 30.875, 32.3);
-}
-
-.cds--chart-holder[data-carbon-theme='g90'],
-.cds--chart-holder[data-carbon-theme='g100'] {
-  --cds-charts-1-1-1: #d4bbff;
-  --cds-charts-1-1-1-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-1-2-1: #4589ff;
-  --cds-charts-1-2-1-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-1-3-1: #33b1ff;
-  --cds-charts-1-3-1-hovered: rgb(15.3, 163.35, 255);
-  --cds-charts-1-4-1: #08bdba;
-  --cds-charts-1-4-1-hovered: rgb(6.5502538071, 154.7497461929, 152.2934010152);
-  --cds-charts-2-1-1: #8a3ffc;
-  --cds-charts-2-1-1-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-2-1-2: #08bdba;
-  --cds-charts-2-1-2-hovered: rgb(6.5502538071, 154.7497461929, 152.2934010152);
-  --cds-charts-2-2-1: #8a3ffc;
-  --cds-charts-2-2-1-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-2-2-2: #ff7eb6;
-  --cds-charts-2-2-2-hovered: rgb(255, 90.3, 161.7976744186);
-  --cds-charts-2-3-1: #ff7eb6;
-  --cds-charts-2-3-1-hovered: rgb(255, 90.3, 161.7976744186);
-  --cds-charts-2-3-2: #fff1f1;
-  --cds-charts-2-3-2-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-2-4-1: #4589ff;
-  --cds-charts-2-4-1-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-2-4-2: #bae6ff;
-  --cds-charts-2-4-2-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-2-5-1: #007d79;
-  --cds-charts-2-5-1-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-2-5-2: #6fdc8c;
-  --cds-charts-2-5-2-hovered: rgb(
-    82.2804469274,
-    213.0195530726,
-    117.0642458101
-  );
-  --cds-charts-3-1-1: #8a3ffc;
-  --cds-charts-3-1-1-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-3-1-2: #08bdba;
-  --cds-charts-3-1-2-hovered: rgb(6.5502538071, 154.7497461929, 152.2934010152);
-  --cds-charts-3-1-3: #bae6ff;
-  --cds-charts-3-1-3-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-3-2-1: #8a3ffc;
-  --cds-charts-3-2-1-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-3-2-2: #ff7eb6;
-  --cds-charts-3-2-2-hovered: rgb(255, 90.3, 161.7976744186);
-  --cds-charts-3-2-3: #fff1f1;
-  --cds-charts-3-2-3-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-3-3-1: #4589ff;
-  --cds-charts-3-3-1-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-3-3-2: #08bdba;
-  --cds-charts-3-3-2-hovered: rgb(6.5502538071, 154.7497461929, 152.2934010152);
-  --cds-charts-3-3-3: #d4bbff;
-  --cds-charts-3-3-3-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-3-4-1: #4589ff;
-  --cds-charts-3-4-1-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-3-4-2: #6fdc8c;
-  --cds-charts-3-4-2-hovered: rgb(
-    82.2804469274,
-    213.0195530726,
-    117.0642458101
-  );
-  --cds-charts-3-4-3: #fff1f1;
-  --cds-charts-3-4-3-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-3-5-1: #007d79;
-  --cds-charts-3-5-1-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-3-5-2: #6fdc8c;
-  --cds-charts-3-5-2-hovered: rgb(
-    82.2804469274,
-    213.0195530726,
-    117.0642458101
-  );
-  --cds-charts-3-5-3: #bae6ff;
-  --cds-charts-3-5-3-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-4-1-1: #8a3ffc;
-  --cds-charts-4-1-1-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-4-1-2: #08bdba;
-  --cds-charts-4-1-2-hovered: rgb(6.5502538071, 154.7497461929, 152.2934010152);
-  --cds-charts-4-1-3: #bae6ff;
-  --cds-charts-4-1-3-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-4-1-4: #4589ff;
-  --cds-charts-4-1-4-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-4-2-1: #4589ff;
-  --cds-charts-4-2-1-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-4-2-2: #08bdba;
-  --cds-charts-4-2-2-hovered: rgb(6.5502538071, 154.7497461929, 152.2934010152);
-  --cds-charts-4-2-3: #d4bbff;
-  --cds-charts-4-2-3-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-4-2-4: #fff1f1;
-  --cds-charts-4-2-4-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-4-3-1: #007d79;
-  --cds-charts-4-3-1-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-4-3-2: #fff1f1;
-  --cds-charts-4-3-2-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-4-3-3: #33b1ff;
-  --cds-charts-4-3-3-hovered: rgb(15.3, 163.35, 255);
-  --cds-charts-4-3-4: #6fdc8c;
-  --cds-charts-4-3-4-hovered: rgb(
-    82.2804469274,
-    213.0195530726,
-    117.0642458101
-  );
-  --cds-charts-5-1-1: #8a3ffc;
-  --cds-charts-5-1-1-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-5-1-2: #08bdba;
-  --cds-charts-5-1-2-hovered: rgb(6.5502538071, 154.7497461929, 152.2934010152);
-  --cds-charts-5-1-3: #bae6ff;
-  --cds-charts-5-1-3-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-5-1-4: #4589ff;
-  --cds-charts-5-1-4-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-5-1-5: #ff7eb6;
-  --cds-charts-5-1-5-hovered: rgb(255, 90.3, 161.7976744186);
-  --cds-charts-5-2-1: #4589ff;
-  --cds-charts-5-2-1-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-5-2-2: #08bdba;
-  --cds-charts-5-2-2-hovered: rgb(6.5502538071, 154.7497461929, 152.2934010152);
-  --cds-charts-5-2-3: #d4bbff;
-  --cds-charts-5-2-3-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-5-2-4: #fff1f1;
-  --cds-charts-5-2-4-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-5-2-5: #6fdc8c;
-  --cds-charts-5-2-5-hovered: rgb(
-    82.2804469274,
-    213.0195530726,
-    117.0642458101
-  );
-  --cds-charts-14-1-1: #8a3ffc;
-  --cds-charts-14-1-1-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-14-1-2: #33b1ff;
-  --cds-charts-14-1-2-hovered: rgb(15.3, 163.35, 255);
-  --cds-charts-14-1-3: #007d79;
-  --cds-charts-14-1-3-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-14-1-4: #ff7eb6;
-  --cds-charts-14-1-4-hovered: rgb(255, 90.3, 161.7976744186);
-  --cds-charts-14-1-5: #fa4d56;
-  --cds-charts-14-1-5-hovered: rgb(249.0245901639, 42.2754098361, 53.031147541);
-  --cds-charts-14-1-6: #fff1f1;
-  --cds-charts-14-1-6-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-14-1-7: #6fdc8c;
-  --cds-charts-14-1-7-hovered: rgb(
-    82.2804469274,
-    213.0195530726,
-    117.0642458101
-  );
-  --cds-charts-14-1-8: #4589ff;
-  --cds-charts-14-1-8-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-14-1-9: #d02670;
-  --cds-charts-14-1-9-hovered: rgb(
-    177.8146341463,
-    32.4853658537,
-    95.7463414634
-  );
-  --cds-charts-14-1-10: #d2a106;
-  --cds-charts-14-1-10-hovered: rgb(
-    175.2916666667,
-    134.3902777778,
-    5.0083333333
-  );
-  --cds-charts-14-1-11: #08bdba;
-  --cds-charts-14-1-11-hovered: rgb(
-    6.5502538071,
-    154.7497461929,
-    152.2934010152
-  );
-  --cds-charts-14-1-12: #bae6ff;
-  --cds-charts-14-1-12-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-14-1-13: #ba4e00;
-  --cds-charts-14-1-13-hovered: rgb(150.3, 63.0290322581, 0);
-  --cds-charts-14-1-14: #d4bbff;
-  --cds-charts-14-1-14-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-mono-1-1: #ffffff;
-  --cds-charts-mono-1-1-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-mono-1-2: #f6f2ff;
-  --cds-charts-mono-1-2-hovered: rgb(221.2846153846, 206.3, 255);
-  --cds-charts-mono-1-3: #e8daff;
-  --cds-charts-mono-1-3-hovered: rgb(209.8081081081, 182.3, 255);
-  --cds-charts-mono-1-4: #d4bbff;
-  --cds-charts-mono-1-4-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-mono-1-5: #be95ff;
-  --cds-charts-mono-1-5-hovered: rgb(168.108490566, 113.3, 255);
-  --cds-charts-mono-1-6: #a56eff;
-  --cds-charts-mono-1-6-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-mono-1-7: #8a3ffc;
-  --cds-charts-mono-1-7-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-mono-1-8: #6929c4;
-  --cds-charts-mono-1-8-hovered: rgb(
-    89.1835443038,
-    34.8240506329,
-    166.4759493671
-  );
-  --cds-charts-mono-1-9: #491d8b;
-  --cds-charts-mono-1-9-hovered: rgb(57.4875, 22.8375, 109.4625);
-  --cds-charts-mono-1-10: #31135e;
-  --cds-charts-mono-1-10-hovered: rgb(
-    33.5194690265,
-    12.9973451327,
-    64.3026548673
-  );
-  --cds-charts-mono-1-11: #1c0f30;
-  --cds-charts-mono-1-11-hovered: rgb(12.1333333333, 6.5, 20.8);
-  --cds-charts-mono-2-1: #ffffff;
-  --cds-charts-mono-2-1-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-mono-2-2: #edf5ff;
-  --cds-charts-mono-2-2-hovered: rgb(201.3, 225.1666666667, 255);
-  --cds-charts-mono-2-3: #d0e2ff;
-  --cds-charts-mono-2-3-hovered: rgb(172.3, 203.9723404255, 255);
-  --cds-charts-mono-2-4: #a6c8ff;
-  --cds-charts-mono-2-4-hovered: rgb(130.3, 177.9382022472, 255);
-  --cds-charts-mono-2-5: #78a9ff;
-  --cds-charts-mono-2-5-hovered: rgb(84.3, 146.2577777778, 255);
-  --cds-charts-mono-2-6: #4589ff;
-  --cds-charts-mono-2-6-hovered: rgb(33.3, 114.3516129032, 255);
-  --cds-charts-mono-2-7: #0f62fe;
-  --cds-charts-mono-2-7-hovered: rgb(
-    0.9680497925,
-    81.3161825726,
-    232.3319502075
-  );
-  --cds-charts-mono-2-8: #0043ce;
-  --cds-charts-mono-2-8-hovered: rgb(0, 55.3888349515, 170.3);
-  --cds-charts-mono-2-9: #002d9c;
-  --cds-charts-mono-2-9-hovered: rgb(0, 34.7019230769, 120.3);
-  --cds-charts-mono-2-10: #001d6c;
-  --cds-charts-mono-2-10-hovered: rgb(0, 19.4138888889, 72.3);
-  --cds-charts-mono-2-11: #001141;
-  --cds-charts-mono-2-11-hovered: rgb(0, 7.6630769231, 29.3);
-  --cds-charts-mono-3-1: #ffffff;
-  --cds-charts-mono-3-1-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-mono-3-2: #e5f6ff;
-  --cds-charts-mono-3-2-hovered: rgb(193.3, 233.6423076923, 255);
-  --cds-charts-mono-3-3: #bae6ff;
-  --cds-charts-mono-3-3-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-mono-3-4: #82cfff;
-  --cds-charts-mono-3-4-hovered: rgb(94.3, 193.2912, 255);
-  --cds-charts-mono-3-5: #33b1ff;
-  --cds-charts-mono-3-5-hovered: rgb(15.3, 163.35, 255);
-  --cds-charts-mono-3-6: #1192e8;
-  --cds-charts-mono-3-6-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-mono-3-7: #0072c3;
-  --cds-charts-mono-3-7-hovered: rgb(0, 93.1292307692, 159.3);
-  --cds-charts-mono-3-8: #00539a;
-  --cds-charts-mono-3-8-hovered: rgb(0, 63.7590909091, 118.3);
-  --cds-charts-mono-3-9: #003a6d;
-  --cds-charts-mono-3-9-hovered: rgb(0, 39.0036697248, 73.3);
-  --cds-charts-mono-3-10: #012749;
-  --cds-charts-mono-3-10-hovered: rgb(
-    0.5175675676,
-    20.1851351351,
-    37.7824324324
-  );
-  --cds-charts-mono-3-11: #061727;
-  --cds-charts-mono-3-11-hovered: rgb(1.24, 4.7533333333, 8.06);
-  --cds-charts-mono-4-1: #ffffff;
-  --cds-charts-mono-4-1-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-mono-4-2: #d9fbfb;
-  --cds-charts-mono-4-2-hovered: rgb(184.7, 247.6, 247.6);
-  --cds-charts-mono-4-3: #9ef0f0;
-  --cds-charts-mono-4-3-hovered: rgb(127.08125, 235.21875, 235.21875);
-  --cds-charts-mono-4-4: #3ddbd9;
-  --cds-charts-mono-4-4-hovered: rgb(
-    38.2382608696,
-    206.0617391304,
-    203.9373913043
-  );
-  --cds-charts-mono-4-5: #08bdba;
-  --cds-charts-mono-4-5-hovered: rgb(
-    6.5502538071,
-    154.7497461929,
-    152.2934010152
-  );
-  --cds-charts-mono-4-6: #009d9a;
-  --cds-charts-mono-4-6-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-mono-4-7: #007d79;
-  --cds-charts-mono-4-7-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-mono-4-8: #005d5d;
-  --cds-charts-mono-4-8-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-mono-4-9: #004144;
-  --cds-charts-mono-4-9-hovered: rgb(0, 30.875, 32.3);
-  --cds-charts-mono-4-10: #022b30;
-  --cds-charts-mono-4-10-hovered: rgb(0.572, 12.298, 13.728);
-  --cds-charts-mono-4-11: #081a1c;
-  --cds-charts-mono-4-11-hovered: rgb(0.0666666667, 0.2166666667, 0.2333333333);
-  --cds-charts-diverge-1-1: #750e13;
-  --cds-charts-diverge-1-1-hovered: rgb(
-    85.1152671756,
-    10.1847328244,
-    13.8221374046
-  );
-  --cds-charts-diverge-1-2: #a2191f;
-  --cds-charts-diverge-1-2-hovered: rgb(
-    131.0727272727,
-    20.2272727273,
-    25.0818181818
-  );
-  --cds-charts-diverge-1-3: #da1e28;
-  --cds-charts-diverge-1-3-hovered: rgb(
-    186.6185483871,
-    25.6814516129,
-    34.2419354839
-  );
-  --cds-charts-diverge-1-4: #fa4d56;
-  --cds-charts-diverge-1-4-hovered: rgb(
-    249.0245901639,
-    42.2754098361,
-    53.031147541
-  );
-  --cds-charts-diverge-1-5: #ff8389;
-  --cds-charts-diverge-1-5-hovered: rgb(255, 95.3, 103.0274193548);
-  --cds-charts-diverge-1-6: #ffb3b8;
-  --cds-charts-diverge-1-6-hovered: rgb(255, 143.3, 150.6486842105);
-  --cds-charts-diverge-1-7: #ffd7d9;
-  --cds-charts-diverge-1-7-hovered: rgb(255, 179.3, 183.085);
-  --cds-charts-diverge-1-8: #fff1f1;
-  --cds-charts-diverge-1-8-hovered: rgb(255, 205.3, 205.3);
-  --cds-charts-diverge-1-9: #ffffff;
-  --cds-charts-diverge-1-9-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-diverge-1-10: #e5f6ff;
-  --cds-charts-diverge-1-10-hovered: rgb(193.3, 233.6423076923, 255);
-  --cds-charts-diverge-1-11: #bae6ff;
-  --cds-charts-diverge-1-11-hovered: rgb(150.3, 217.0652173913, 255);
-  --cds-charts-diverge-1-12: #82cfff;
-  --cds-charts-diverge-1-12-hovered: rgb(94.3, 193.2912, 255);
-  --cds-charts-diverge-1-13: #33b1ff;
-  --cds-charts-diverge-1-13-hovered: rgb(15.3, 163.35, 255);
-  --cds-charts-diverge-1-14: #1192e8;
-  --cds-charts-diverge-1-14-hovered: rgb(
-    14.5626506024,
-    125.0674698795,
-    198.7373493976
-  );
-  --cds-charts-diverge-1-15: #0072c3;
-  --cds-charts-diverge-1-15-hovered: rgb(0, 93.1292307692, 159.3);
-  --cds-charts-diverge-1-16: #00539a;
-  --cds-charts-diverge-1-16-hovered: rgb(0, 63.7590909091, 118.3);
-  --cds-charts-diverge-1-17: #003a6d;
-  --cds-charts-diverge-1-17-hovered: rgb(0, 39.0036697248, 73.3);
-  --cds-charts-diverge-2-1: #491d8b;
-  --cds-charts-diverge-2-1-hovered: rgb(57.4875, 22.8375, 109.4625);
-  --cds-charts-diverge-2-2: #6929c4;
-  --cds-charts-diverge-2-2-hovered: rgb(
-    89.1835443038,
-    34.8240506329,
-    166.4759493671
-  );
-  --cds-charts-diverge-2-3: #8a3ffc;
-  --cds-charts-diverge-2-3-hovered: rgb(116.58, 27.8492307692, 251.4507692308);
-  --cds-charts-diverge-2-4: #a56eff;
-  --cds-charts-diverge-2-4-hovered: rgb(142.8413793103, 74.3, 255);
-  --cds-charts-diverge-2-5: #be95ff;
-  --cds-charts-diverge-2-5-hovered: rgb(168.108490566, 113.3, 255);
-  --cds-charts-diverge-2-6: #d4bbff;
-  --cds-charts-diverge-2-6-hovered: rgb(189.425, 151.3, 255);
-  --cds-charts-diverge-2-7: #e8daff;
-  --cds-charts-diverge-2-7-hovered: rgb(209.8081081081, 182.3, 255);
-  --cds-charts-diverge-2-8: #f6f2ff;
-  --cds-charts-diverge-2-8-hovered: rgb(221.2846153846, 206.3, 255);
-  --cds-charts-diverge-2-9: #ffffff;
-  --cds-charts-diverge-2-9-hovered: rgb(237.15, 237.15, 237.15);
-  --cds-charts-diverge-2-10: #d9fbfb;
-  --cds-charts-diverge-2-10-hovered: rgb(184.7, 247.6, 247.6);
-  --cds-charts-diverge-2-11: #9ef0f0;
-  --cds-charts-diverge-2-11-hovered: rgb(127.08125, 235.21875, 235.21875);
-  --cds-charts-diverge-2-12: #3ddbd9;
-  --cds-charts-diverge-2-12-hovered: rgb(
-    38.2382608696,
-    206.0617391304,
-    203.9373913043
-  );
-  --cds-charts-diverge-2-13: #08bdba;
-  --cds-charts-diverge-2-13-hovered: rgb(
-    6.5502538071,
-    154.7497461929,
-    152.2934010152
-  );
-  --cds-charts-diverge-2-14: #009d9a;
-  --cds-charts-diverge-2-14-hovered: rgb(0, 121.3, 118.9821656051);
-  --cds-charts-diverge-2-15: #007d79;
-  --cds-charts-diverge-2-15-hovered: rgb(0, 89.3, 86.4424);
-  --cds-charts-diverge-2-16: #005d5d;
-  --cds-charts-diverge-2-16-hovered: rgb(0, 57.3, 57.3);
-  --cds-charts-diverge-2-17: #004144;
-  --cds-charts-diverge-2-17-hovered: rgb(0, 30.875, 32.3);
-}
-
-.cds--cc--chart-wrapper .fill-1-1-1 {
-  fill: var(--cds-charts-1-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-1-1-1.hovered {
-  fill: var(--cds-charts-1-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-1-1-1 {
-  background-color: var(--cds-charts-1-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .background-1-1-1.hovered {
-  background-color: var(--cds-charts-1-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-1-1-1 {
-  stroke: var(--cds-charts-1-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-1-1-1 {
-  stop-color: var(--cds-charts-1-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-1-2-1 {
-  fill: var(--cds-charts-1-2-1, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-1-2-1.hovered {
-  fill: var(--cds-charts-1-2-1-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-1-2-1 {
-  background-color: var(--cds-charts-1-2-1, #002d9c);
-}
-.cds--cc--chart-wrapper .background-1-2-1.hovered {
-  background-color: var(--cds-charts-1-2-1-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-1-2-1 {
-  stroke: var(--cds-charts-1-2-1, #002d9c);
-}
-.cds--cc--chart-wrapper .stop-color-1-2-1 {
-  stop-color: var(--cds-charts-1-2-1, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-1-3-1 {
-  fill: var(--cds-charts-1-3-1, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-1-3-1.hovered {
-  fill: var(--cds-charts-1-3-1-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-1-3-1 {
-  background-color: var(--cds-charts-1-3-1, #1192e8);
-}
-.cds--cc--chart-wrapper .background-1-3-1.hovered {
-  background-color: var(--cds-charts-1-3-1-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-1-3-1 {
-  stroke: var(--cds-charts-1-3-1, #1192e8);
-}
-.cds--cc--chart-wrapper .stop-color-1-3-1 {
-  stop-color: var(--cds-charts-1-3-1, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-1-4-1 {
-  fill: var(--cds-charts-1-4-1, #007d79);
-}
-.cds--cc--chart-wrapper .fill-1-4-1.hovered {
-  fill: var(--cds-charts-1-4-1-hovered, #007d79);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-1-4-1 {
-  background-color: var(--cds-charts-1-4-1, #007d79);
-}
-.cds--cc--chart-wrapper .background-1-4-1.hovered {
-  background-color: var(--cds-charts-1-4-1-hovered, #007d79);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-1-4-1 {
-  stroke: var(--cds-charts-1-4-1, #007d79);
-}
-.cds--cc--chart-wrapper .stop-color-1-4-1 {
-  stop-color: var(--cds-charts-1-4-1, #007d79);
-}
-.cds--cc--chart-wrapper .fill-2-1-1 {
-  fill: var(--cds-charts-2-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-2-1-1.hovered {
-  fill: var(--cds-charts-2-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-1-1 {
-  background-color: var(--cds-charts-2-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .background-2-1-1.hovered {
-  background-color: var(--cds-charts-2-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-1-1 {
-  stroke: var(--cds-charts-2-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-2-1-1 {
-  stop-color: var(--cds-charts-2-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-2-1-2 {
-  fill: var(--cds-charts-2-1-2, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-2-1-2.hovered {
-  fill: var(--cds-charts-2-1-2-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-1-2 {
-  background-color: var(--cds-charts-2-1-2, #009d9a);
-}
-.cds--cc--chart-wrapper .background-2-1-2.hovered {
-  background-color: var(--cds-charts-2-1-2-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-1-2 {
-  stroke: var(--cds-charts-2-1-2, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-2-1-2 {
-  stop-color: var(--cds-charts-2-1-2, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-2-2-1 {
-  fill: var(--cds-charts-2-2-1, #8a3ffc);
-}
-.cds--cc--chart-wrapper .fill-2-2-1.hovered {
-  fill: var(--cds-charts-2-2-1-hovered, #8a3ffc);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-2-1 {
-  background-color: var(--cds-charts-2-2-1, #8a3ffc);
-}
-.cds--cc--chart-wrapper .background-2-2-1.hovered {
-  background-color: var(--cds-charts-2-2-1-hovered, #8a3ffc);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-2-1 {
-  stroke: var(--cds-charts-2-2-1, #8a3ffc);
-}
-.cds--cc--chart-wrapper .stop-color-2-2-1 {
-  stop-color: var(--cds-charts-2-2-1, #8a3ffc);
-}
-.cds--cc--chart-wrapper .fill-2-2-2 {
-  fill: var(--cds-charts-2-2-2, #520408);
-}
-.cds--cc--chart-wrapper .fill-2-2-2.hovered {
-  fill: var(--cds-charts-2-2-2-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-2-2 {
-  background-color: var(--cds-charts-2-2-2, #520408);
-}
-.cds--cc--chart-wrapper .background-2-2-2.hovered {
-  background-color: var(--cds-charts-2-2-2-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-2-2 {
-  stroke: var(--cds-charts-2-2-2, #520408);
-}
-.cds--cc--chart-wrapper .stop-color-2-2-2 {
-  stop-color: var(--cds-charts-2-2-2, #520408);
-}
-.cds--cc--chart-wrapper .fill-2-3-1 {
-  fill: var(--cds-charts-2-3-1, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-2-3-1.hovered {
-  fill: var(--cds-charts-2-3-1-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-3-1 {
-  background-color: var(--cds-charts-2-3-1, #9f1853);
-}
-.cds--cc--chart-wrapper .background-2-3-1.hovered {
-  background-color: var(--cds-charts-2-3-1-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-3-1 {
-  stroke: var(--cds-charts-2-3-1, #9f1853);
-}
-.cds--cc--chart-wrapper .stop-color-2-3-1 {
-  stop-color: var(--cds-charts-2-3-1, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-2-3-2 {
-  fill: var(--cds-charts-2-3-2, #520408);
-}
-.cds--cc--chart-wrapper .fill-2-3-2.hovered {
-  fill: var(--cds-charts-2-3-2-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-3-2 {
-  background-color: var(--cds-charts-2-3-2, #520408);
-}
-.cds--cc--chart-wrapper .background-2-3-2.hovered {
-  background-color: var(--cds-charts-2-3-2-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-3-2 {
-  stroke: var(--cds-charts-2-3-2, #520408);
-}
-.cds--cc--chart-wrapper .stop-color-2-3-2 {
-  stop-color: var(--cds-charts-2-3-2, #520408);
-}
-.cds--cc--chart-wrapper .fill-2-4-1 {
-  fill: var(--cds-charts-2-4-1, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-2-4-1.hovered {
-  fill: var(--cds-charts-2-4-1-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-4-1 {
-  background-color: var(--cds-charts-2-4-1, #1192e8);
-}
-.cds--cc--chart-wrapper .background-2-4-1.hovered {
-  background-color: var(--cds-charts-2-4-1-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-4-1 {
-  stroke: var(--cds-charts-2-4-1, #1192e8);
-}
-.cds--cc--chart-wrapper .stop-color-2-4-1 {
-  stop-color: var(--cds-charts-2-4-1, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-2-4-2 {
-  fill: var(--cds-charts-2-4-2, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-2-4-2.hovered {
-  fill: var(--cds-charts-2-4-2-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-4-2 {
-  background-color: var(--cds-charts-2-4-2, #005d5d);
-}
-.cds--cc--chart-wrapper .background-2-4-2.hovered {
-  background-color: var(--cds-charts-2-4-2-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-4-2 {
-  stroke: var(--cds-charts-2-4-2, #005d5d);
-}
-.cds--cc--chart-wrapper .stop-color-2-4-2 {
-  stop-color: var(--cds-charts-2-4-2, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-2-5-1 {
-  fill: var(--cds-charts-2-5-1, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-2-5-1.hovered {
-  fill: var(--cds-charts-2-5-1-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-5-1 {
-  background-color: var(--cds-charts-2-5-1, #009d9a);
-}
-.cds--cc--chart-wrapper .background-2-5-1.hovered {
-  background-color: var(--cds-charts-2-5-1-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-5-1 {
-  stroke: var(--cds-charts-2-5-1, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-2-5-1 {
-  stop-color: var(--cds-charts-2-5-1, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-2-5-2 {
-  fill: var(--cds-charts-2-5-2, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-2-5-2.hovered {
-  fill: var(--cds-charts-2-5-2-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-2-5-2 {
-  background-color: var(--cds-charts-2-5-2, #002d9c);
-}
-.cds--cc--chart-wrapper .background-2-5-2.hovered {
-  background-color: var(--cds-charts-2-5-2-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-2-5-2 {
-  stroke: var(--cds-charts-2-5-2, #002d9c);
-}
-.cds--cc--chart-wrapper .stop-color-2-5-2 {
-  stop-color: var(--cds-charts-2-5-2, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-3-1-1 {
-  fill: var(--cds-charts-3-1-1, #ee5396);
-}
-.cds--cc--chart-wrapper .fill-3-1-1.hovered {
-  fill: var(--cds-charts-3-1-1-hovered, #ee5396);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-1-1 {
-  background-color: var(--cds-charts-3-1-1, #ee5396);
-}
-.cds--cc--chart-wrapper .background-3-1-1.hovered {
-  background-color: var(--cds-charts-3-1-1-hovered, #ee5396);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-1-1 {
-  stroke: var(--cds-charts-3-1-1, #ee5396);
-}
-.cds--cc--chart-wrapper .stop-color-3-1-1 {
-  stop-color: var(--cds-charts-3-1-1, #ee5396);
-}
-.cds--cc--chart-wrapper .fill-3-1-2 {
-  fill: var(--cds-charts-3-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-3-1-2.hovered {
-  fill: var(--cds-charts-3-1-2-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-1-2 {
-  background-color: var(--cds-charts-3-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .background-3-1-2.hovered {
-  background-color: var(--cds-charts-3-1-2-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-1-2 {
-  stroke: var(--cds-charts-3-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .stop-color-3-1-2 {
-  stop-color: var(--cds-charts-3-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-3-1-3 {
-  fill: var(--cds-charts-3-1-3, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-3-1-3.hovered {
-  fill: var(--cds-charts-3-1-3-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-1-3 {
-  background-color: var(--cds-charts-3-1-3, #6929c4);
-}
-.cds--cc--chart-wrapper .background-3-1-3.hovered {
-  background-color: var(--cds-charts-3-1-3-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-1-3 {
-  stroke: var(--cds-charts-3-1-3, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-3-1-3 {
-  stop-color: var(--cds-charts-3-1-3, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-3-2-1 {
-  fill: var(--cds-charts-3-2-1, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-3-2-1.hovered {
-  fill: var(--cds-charts-3-2-1-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-2-1 {
-  background-color: var(--cds-charts-3-2-1, #9f1853);
-}
-.cds--cc--chart-wrapper .background-3-2-1.hovered {
-  background-color: var(--cds-charts-3-2-1-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-2-1 {
-  stroke: var(--cds-charts-3-2-1, #9f1853);
-}
-.cds--cc--chart-wrapper .stop-color-3-2-1 {
-  stop-color: var(--cds-charts-3-2-1, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-3-2-2 {
-  fill: var(--cds-charts-3-2-2, #fa4d56);
-}
-.cds--cc--chart-wrapper .fill-3-2-2.hovered {
-  fill: var(--cds-charts-3-2-2-hovered, #fa4d56);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-2-2 {
-  background-color: var(--cds-charts-3-2-2, #fa4d56);
-}
-.cds--cc--chart-wrapper .background-3-2-2.hovered {
-  background-color: var(--cds-charts-3-2-2-hovered, #fa4d56);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-2-2 {
-  stroke: var(--cds-charts-3-2-2, #fa4d56);
-}
-.cds--cc--chart-wrapper .stop-color-3-2-2 {
-  stop-color: var(--cds-charts-3-2-2, #fa4d56);
-}
-.cds--cc--chart-wrapper .fill-3-2-3 {
-  fill: var(--cds-charts-3-2-3, #520408);
-}
-.cds--cc--chart-wrapper .fill-3-2-3.hovered {
-  fill: var(--cds-charts-3-2-3-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-2-3 {
-  background-color: var(--cds-charts-3-2-3, #520408);
-}
-.cds--cc--chart-wrapper .background-3-2-3.hovered {
-  background-color: var(--cds-charts-3-2-3-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-2-3 {
-  stroke: var(--cds-charts-3-2-3, #520408);
-}
-.cds--cc--chart-wrapper .stop-color-3-2-3 {
-  stop-color: var(--cds-charts-3-2-3, #520408);
-}
-.cds--cc--chart-wrapper .fill-3-3-1 {
-  fill: var(--cds-charts-3-3-1, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-3-3-1.hovered {
-  fill: var(--cds-charts-3-3-1-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-3-1 {
-  background-color: var(--cds-charts-3-3-1, #a56eff);
-}
-.cds--cc--chart-wrapper .background-3-3-1.hovered {
-  background-color: var(--cds-charts-3-3-1-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-3-1 {
-  stroke: var(--cds-charts-3-3-1, #a56eff);
-}
-.cds--cc--chart-wrapper .stop-color-3-3-1 {
-  stop-color: var(--cds-charts-3-3-1, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-3-3-2 {
-  fill: var(--cds-charts-3-3-2, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-3-3-2.hovered {
-  fill: var(--cds-charts-3-3-2-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-3-2 {
-  background-color: var(--cds-charts-3-3-2, #005d5d);
-}
-.cds--cc--chart-wrapper .background-3-3-2.hovered {
-  background-color: var(--cds-charts-3-3-2-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-3-2 {
-  stroke: var(--cds-charts-3-3-2, #005d5d);
-}
-.cds--cc--chart-wrapper .stop-color-3-3-2 {
-  stop-color: var(--cds-charts-3-3-2, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-3-3-3 {
-  fill: var(--cds-charts-3-3-3, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-3-3-3.hovered {
-  fill: var(--cds-charts-3-3-3-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-3-3 {
-  background-color: var(--cds-charts-3-3-3, #002d9c);
-}
-.cds--cc--chart-wrapper .background-3-3-3.hovered {
-  background-color: var(--cds-charts-3-3-3-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-3-3 {
-  stroke: var(--cds-charts-3-3-3, #002d9c);
-}
-.cds--cc--chart-wrapper .stop-color-3-3-3 {
-  stop-color: var(--cds-charts-3-3-3, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-3-4-1 {
-  fill: var(--cds-charts-3-4-1, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-3-4-1.hovered {
-  fill: var(--cds-charts-3-4-1-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-4-1 {
-  background-color: var(--cds-charts-3-4-1, #a56eff);
-}
-.cds--cc--chart-wrapper .background-3-4-1.hovered {
-  background-color: var(--cds-charts-3-4-1-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-4-1 {
-  stroke: var(--cds-charts-3-4-1, #a56eff);
-}
-.cds--cc--chart-wrapper .stop-color-3-4-1 {
-  stop-color: var(--cds-charts-3-4-1, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-3-4-2 {
-  fill: var(--cds-charts-3-4-2, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-3-4-2.hovered {
-  fill: var(--cds-charts-3-4-2-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-4-2 {
-  background-color: var(--cds-charts-3-4-2, #005d5d);
-}
-.cds--cc--chart-wrapper .background-3-4-2.hovered {
-  background-color: var(--cds-charts-3-4-2-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-4-2 {
-  stroke: var(--cds-charts-3-4-2, #005d5d);
-}
-.cds--cc--chart-wrapper .stop-color-3-4-2 {
-  stop-color: var(--cds-charts-3-4-2, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-3-4-3 {
-  fill: var(--cds-charts-3-4-3, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-3-4-3.hovered {
-  fill: var(--cds-charts-3-4-3-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-4-3 {
-  background-color: var(--cds-charts-3-4-3, #9f1853);
-}
-.cds--cc--chart-wrapper .background-3-4-3.hovered {
-  background-color: var(--cds-charts-3-4-3-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-4-3 {
-  stroke: var(--cds-charts-3-4-3, #9f1853);
-}
-.cds--cc--chart-wrapper .stop-color-3-4-3 {
-  stop-color: var(--cds-charts-3-4-3, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-3-5-1 {
-  fill: var(--cds-charts-3-5-1, #012749);
-}
-.cds--cc--chart-wrapper .fill-3-5-1.hovered {
-  fill: var(--cds-charts-3-5-1-hovered, #012749);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-5-1 {
-  background-color: var(--cds-charts-3-5-1, #012749);
-}
-.cds--cc--chart-wrapper .background-3-5-1.hovered {
-  background-color: var(--cds-charts-3-5-1-hovered, #012749);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-5-1 {
-  stroke: var(--cds-charts-3-5-1, #012749);
-}
-.cds--cc--chart-wrapper .stop-color-3-5-1 {
-  stop-color: var(--cds-charts-3-5-1, #012749);
-}
-.cds--cc--chart-wrapper .fill-3-5-2 {
-  fill: var(--cds-charts-3-5-2, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-3-5-2.hovered {
-  fill: var(--cds-charts-3-5-2-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-5-2 {
-  background-color: var(--cds-charts-3-5-2, #6929c4);
-}
-.cds--cc--chart-wrapper .background-3-5-2.hovered {
-  background-color: var(--cds-charts-3-5-2-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-5-2 {
-  stroke: var(--cds-charts-3-5-2, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-3-5-2 {
-  stop-color: var(--cds-charts-3-5-2, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-3-5-3 {
-  fill: var(--cds-charts-3-5-3, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-3-5-3.hovered {
-  fill: var(--cds-charts-3-5-3-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-3-5-3 {
-  background-color: var(--cds-charts-3-5-3, #009d9a);
-}
-.cds--cc--chart-wrapper .background-3-5-3.hovered {
-  background-color: var(--cds-charts-3-5-3-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-3-5-3 {
-  stroke: var(--cds-charts-3-5-3, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-3-5-3 {
-  stop-color: var(--cds-charts-3-5-3, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-4-1-1 {
-  fill: var(--cds-charts-4-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-4-1-1.hovered {
-  fill: var(--cds-charts-4-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-1-1 {
-  background-color: var(--cds-charts-4-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .background-4-1-1.hovered {
-  background-color: var(--cds-charts-4-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-1-1 {
-  stroke: var(--cds-charts-4-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-4-1-1 {
-  stop-color: var(--cds-charts-4-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-4-1-2 {
-  fill: var(--cds-charts-4-1-2, #012749);
-}
-.cds--cc--chart-wrapper .fill-4-1-2.hovered {
-  fill: var(--cds-charts-4-1-2-hovered, #012749);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-1-2 {
-  background-color: var(--cds-charts-4-1-2, #012749);
-}
-.cds--cc--chart-wrapper .background-4-1-2.hovered {
-  background-color: var(--cds-charts-4-1-2-hovered, #012749);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-1-2 {
-  stroke: var(--cds-charts-4-1-2, #012749);
-}
-.cds--cc--chart-wrapper .stop-color-4-1-2 {
-  stop-color: var(--cds-charts-4-1-2, #012749);
-}
-.cds--cc--chart-wrapper .fill-4-1-3 {
-  fill: var(--cds-charts-4-1-3, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-4-1-3.hovered {
-  fill: var(--cds-charts-4-1-3-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-1-3 {
-  background-color: var(--cds-charts-4-1-3, #009d9a);
-}
-.cds--cc--chart-wrapper .background-4-1-3.hovered {
-  background-color: var(--cds-charts-4-1-3-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-1-3 {
-  stroke: var(--cds-charts-4-1-3, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-4-1-3 {
-  stop-color: var(--cds-charts-4-1-3, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-4-1-4 {
-  fill: var(--cds-charts-4-1-4, #ee5396);
-}
-.cds--cc--chart-wrapper .fill-4-1-4.hovered {
-  fill: var(--cds-charts-4-1-4-hovered, #ee5396);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-1-4 {
-  background-color: var(--cds-charts-4-1-4, #ee5396);
-}
-.cds--cc--chart-wrapper .background-4-1-4.hovered {
-  background-color: var(--cds-charts-4-1-4-hovered, #ee5396);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-1-4 {
-  stroke: var(--cds-charts-4-1-4, #ee5396);
-}
-.cds--cc--chart-wrapper .stop-color-4-1-4 {
-  stop-color: var(--cds-charts-4-1-4, #ee5396);
-}
-.cds--cc--chart-wrapper .fill-4-2-1 {
-  fill: var(--cds-charts-4-2-1, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-4-2-1.hovered {
-  fill: var(--cds-charts-4-2-1-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-2-1 {
-  background-color: var(--cds-charts-4-2-1, #9f1853);
-}
-.cds--cc--chart-wrapper .background-4-2-1.hovered {
-  background-color: var(--cds-charts-4-2-1-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-2-1 {
-  stroke: var(--cds-charts-4-2-1, #9f1853);
-}
-.cds--cc--chart-wrapper .stop-color-4-2-1 {
-  stop-color: var(--cds-charts-4-2-1, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-4-2-2 {
-  fill: var(--cds-charts-4-2-2, #fa4d56);
-}
-.cds--cc--chart-wrapper .fill-4-2-2.hovered {
-  fill: var(--cds-charts-4-2-2-hovered, #fa4d56);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-2-2 {
-  background-color: var(--cds-charts-4-2-2, #fa4d56);
-}
-.cds--cc--chart-wrapper .background-4-2-2.hovered {
-  background-color: var(--cds-charts-4-2-2-hovered, #fa4d56);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-2-2 {
-  stroke: var(--cds-charts-4-2-2, #fa4d56);
-}
-.cds--cc--chart-wrapper .stop-color-4-2-2 {
-  stop-color: var(--cds-charts-4-2-2, #fa4d56);
-}
-.cds--cc--chart-wrapper .fill-4-2-3 {
-  fill: var(--cds-charts-4-2-3, #520408);
-}
-.cds--cc--chart-wrapper .fill-4-2-3.hovered {
-  fill: var(--cds-charts-4-2-3-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-2-3 {
-  background-color: var(--cds-charts-4-2-3, #520408);
-}
-.cds--cc--chart-wrapper .background-4-2-3.hovered {
-  background-color: var(--cds-charts-4-2-3-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-2-3 {
-  stroke: var(--cds-charts-4-2-3, #520408);
-}
-.cds--cc--chart-wrapper .stop-color-4-2-3 {
-  stop-color: var(--cds-charts-4-2-3, #520408);
-}
-.cds--cc--chart-wrapper .fill-4-2-4 {
-  fill: var(--cds-charts-4-2-4, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-4-2-4.hovered {
-  fill: var(--cds-charts-4-2-4-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-2-4 {
-  background-color: var(--cds-charts-4-2-4, #a56eff);
-}
-.cds--cc--chart-wrapper .background-4-2-4.hovered {
-  background-color: var(--cds-charts-4-2-4-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-2-4 {
-  stroke: var(--cds-charts-4-2-4, #a56eff);
-}
-.cds--cc--chart-wrapper .stop-color-4-2-4 {
-  stop-color: var(--cds-charts-4-2-4, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-4-3-1 {
-  fill: var(--cds-charts-4-3-1, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-4-3-1.hovered {
-  fill: var(--cds-charts-4-3-1-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-3-1 {
-  background-color: var(--cds-charts-4-3-1, #009d9a);
-}
-.cds--cc--chart-wrapper .background-4-3-1.hovered {
-  background-color: var(--cds-charts-4-3-1-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-3-1 {
-  stroke: var(--cds-charts-4-3-1, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-4-3-1 {
-  stop-color: var(--cds-charts-4-3-1, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-4-3-2 {
-  fill: var(--cds-charts-4-3-2, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-4-3-2.hovered {
-  fill: var(--cds-charts-4-3-2-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-3-2 {
-  background-color: var(--cds-charts-4-3-2, #002d9c);
-}
-.cds--cc--chart-wrapper .background-4-3-2.hovered {
-  background-color: var(--cds-charts-4-3-2-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-3-2 {
-  stroke: var(--cds-charts-4-3-2, #002d9c);
-}
-.cds--cc--chart-wrapper .stop-color-4-3-2 {
-  stop-color: var(--cds-charts-4-3-2, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-4-3-3 {
-  fill: var(--cds-charts-4-3-3, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-4-3-3.hovered {
-  fill: var(--cds-charts-4-3-3-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-3-3 {
-  background-color: var(--cds-charts-4-3-3, #a56eff);
-}
-.cds--cc--chart-wrapper .background-4-3-3.hovered {
-  background-color: var(--cds-charts-4-3-3-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-3-3 {
-  stroke: var(--cds-charts-4-3-3, #a56eff);
-}
-.cds--cc--chart-wrapper .stop-color-4-3-3 {
-  stop-color: var(--cds-charts-4-3-3, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-4-3-4 {
-  fill: var(--cds-charts-4-3-4, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-4-3-4.hovered {
-  fill: var(--cds-charts-4-3-4-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-4-3-4 {
-  background-color: var(--cds-charts-4-3-4, #9f1853);
-}
-.cds--cc--chart-wrapper .background-4-3-4.hovered {
-  background-color: var(--cds-charts-4-3-4-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-4-3-4 {
-  stroke: var(--cds-charts-4-3-4, #9f1853);
-}
-.cds--cc--chart-wrapper .stop-color-4-3-4 {
-  stop-color: var(--cds-charts-4-3-4, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-5-1-1 {
-  fill: var(--cds-charts-5-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-5-1-1.hovered {
-  fill: var(--cds-charts-5-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-1-1 {
-  background-color: var(--cds-charts-5-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .background-5-1-1.hovered {
-  background-color: var(--cds-charts-5-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-1-1 {
-  stroke: var(--cds-charts-5-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-5-1-1 {
-  stop-color: var(--cds-charts-5-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-5-1-2 {
-  fill: var(--cds-charts-5-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-5-1-2.hovered {
-  fill: var(--cds-charts-5-1-2-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-1-2 {
-  background-color: var(--cds-charts-5-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .background-5-1-2.hovered {
-  background-color: var(--cds-charts-5-1-2-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-1-2 {
-  stroke: var(--cds-charts-5-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .stop-color-5-1-2 {
-  stop-color: var(--cds-charts-5-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-5-1-3 {
-  fill: var(--cds-charts-5-1-3, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-5-1-3.hovered {
-  fill: var(--cds-charts-5-1-3-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-1-3 {
-  background-color: var(--cds-charts-5-1-3, #005d5d);
-}
-.cds--cc--chart-wrapper .background-5-1-3.hovered {
-  background-color: var(--cds-charts-5-1-3-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-1-3 {
-  stroke: var(--cds-charts-5-1-3, #005d5d);
-}
-.cds--cc--chart-wrapper .stop-color-5-1-3 {
-  stop-color: var(--cds-charts-5-1-3, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-5-1-4 {
-  fill: var(--cds-charts-5-1-4, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-5-1-4.hovered {
-  fill: var(--cds-charts-5-1-4-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-1-4 {
-  background-color: var(--cds-charts-5-1-4, #9f1853);
-}
-.cds--cc--chart-wrapper .background-5-1-4.hovered {
-  background-color: var(--cds-charts-5-1-4-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-1-4 {
-  stroke: var(--cds-charts-5-1-4, #9f1853);
-}
-.cds--cc--chart-wrapper .stop-color-5-1-4 {
-  stop-color: var(--cds-charts-5-1-4, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-5-1-5 {
-  fill: var(--cds-charts-5-1-5, #520408);
-}
-.cds--cc--chart-wrapper .fill-5-1-5.hovered {
-  fill: var(--cds-charts-5-1-5-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-1-5 {
-  background-color: var(--cds-charts-5-1-5, #520408);
-}
-.cds--cc--chart-wrapper .background-5-1-5.hovered {
-  background-color: var(--cds-charts-5-1-5-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-1-5 {
-  stroke: var(--cds-charts-5-1-5, #520408);
-}
-.cds--cc--chart-wrapper .stop-color-5-1-5 {
-  stop-color: var(--cds-charts-5-1-5, #520408);
-}
-.cds--cc--chart-wrapper .fill-5-2-1 {
-  fill: var(--cds-charts-5-2-1, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-5-2-1.hovered {
-  fill: var(--cds-charts-5-2-1-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-2-1 {
-  background-color: var(--cds-charts-5-2-1, #002d9c);
-}
-.cds--cc--chart-wrapper .background-5-2-1.hovered {
-  background-color: var(--cds-charts-5-2-1-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-2-1 {
-  stroke: var(--cds-charts-5-2-1, #002d9c);
-}
-.cds--cc--chart-wrapper .stop-color-5-2-1 {
-  stop-color: var(--cds-charts-5-2-1, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-5-2-2 {
-  fill: var(--cds-charts-5-2-2, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-5-2-2.hovered {
-  fill: var(--cds-charts-5-2-2-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-2-2 {
-  background-color: var(--cds-charts-5-2-2, #009d9a);
-}
-.cds--cc--chart-wrapper .background-5-2-2.hovered {
-  background-color: var(--cds-charts-5-2-2-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-2-2 {
-  stroke: var(--cds-charts-5-2-2, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-5-2-2 {
-  stop-color: var(--cds-charts-5-2-2, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-5-2-3 {
-  fill: var(--cds-charts-5-2-3, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-5-2-3.hovered {
-  fill: var(--cds-charts-5-2-3-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-2-3 {
-  background-color: var(--cds-charts-5-2-3, #9f1853);
-}
-.cds--cc--chart-wrapper .background-5-2-3.hovered {
-  background-color: var(--cds-charts-5-2-3-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-2-3 {
-  stroke: var(--cds-charts-5-2-3, #9f1853);
-}
-.cds--cc--chart-wrapper .stop-color-5-2-3 {
-  stop-color: var(--cds-charts-5-2-3, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-5-2-4 {
-  fill: var(--cds-charts-5-2-4, #520408);
-}
-.cds--cc--chart-wrapper .fill-5-2-4.hovered {
-  fill: var(--cds-charts-5-2-4-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-2-4 {
-  background-color: var(--cds-charts-5-2-4, #520408);
-}
-.cds--cc--chart-wrapper .background-5-2-4.hovered {
-  background-color: var(--cds-charts-5-2-4-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-2-4 {
-  stroke: var(--cds-charts-5-2-4, #520408);
-}
-.cds--cc--chart-wrapper .stop-color-5-2-4 {
-  stop-color: var(--cds-charts-5-2-4, #520408);
-}
-.cds--cc--chart-wrapper .fill-5-2-5 {
-  fill: var(--cds-charts-5-2-5, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-5-2-5.hovered {
-  fill: var(--cds-charts-5-2-5-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-5-2-5 {
-  background-color: var(--cds-charts-5-2-5, #a56eff);
-}
-.cds--cc--chart-wrapper .background-5-2-5.hovered {
-  background-color: var(--cds-charts-5-2-5-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-5-2-5 {
-  stroke: var(--cds-charts-5-2-5, #a56eff);
-}
-.cds--cc--chart-wrapper .stop-color-5-2-5 {
-  stop-color: var(--cds-charts-5-2-5, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-14-1-1 {
-  fill: var(--cds-charts-14-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-14-1-1.hovered {
-  fill: var(--cds-charts-14-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-1 {
-  background-color: var(--cds-charts-14-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .background-14-1-1.hovered {
-  background-color: var(--cds-charts-14-1-1-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-1 {
-  stroke: var(--cds-charts-14-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-1 {
-  stop-color: var(--cds-charts-14-1-1, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-14-1-2 {
-  fill: var(--cds-charts-14-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-14-1-2.hovered {
-  fill: var(--cds-charts-14-1-2-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-2 {
-  background-color: var(--cds-charts-14-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .background-14-1-2.hovered {
-  background-color: var(--cds-charts-14-1-2-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-2 {
-  stroke: var(--cds-charts-14-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-2 {
-  stop-color: var(--cds-charts-14-1-2, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-14-1-3 {
-  fill: var(--cds-charts-14-1-3, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-14-1-3.hovered {
-  fill: var(--cds-charts-14-1-3-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-3 {
-  background-color: var(--cds-charts-14-1-3, #005d5d);
-}
-.cds--cc--chart-wrapper .background-14-1-3.hovered {
-  background-color: var(--cds-charts-14-1-3-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-3 {
-  stroke: var(--cds-charts-14-1-3, #005d5d);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-3 {
-  stop-color: var(--cds-charts-14-1-3, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-14-1-4 {
-  fill: var(--cds-charts-14-1-4, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-14-1-4.hovered {
-  fill: var(--cds-charts-14-1-4-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-4 {
-  background-color: var(--cds-charts-14-1-4, #9f1853);
-}
-.cds--cc--chart-wrapper .background-14-1-4.hovered {
-  background-color: var(--cds-charts-14-1-4-hovered, #9f1853);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-4 {
-  stroke: var(--cds-charts-14-1-4, #9f1853);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-4 {
-  stop-color: var(--cds-charts-14-1-4, #9f1853);
-}
-.cds--cc--chart-wrapper .fill-14-1-5 {
-  fill: var(--cds-charts-14-1-5, #fa4d56);
-}
-.cds--cc--chart-wrapper .fill-14-1-5.hovered {
-  fill: var(--cds-charts-14-1-5-hovered, #fa4d56);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-5 {
-  background-color: var(--cds-charts-14-1-5, #fa4d56);
-}
-.cds--cc--chart-wrapper .background-14-1-5.hovered {
-  background-color: var(--cds-charts-14-1-5-hovered, #fa4d56);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-5 {
-  stroke: var(--cds-charts-14-1-5, #fa4d56);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-5 {
-  stop-color: var(--cds-charts-14-1-5, #fa4d56);
-}
-.cds--cc--chart-wrapper .fill-14-1-6 {
-  fill: var(--cds-charts-14-1-6, #520408);
-}
-.cds--cc--chart-wrapper .fill-14-1-6.hovered {
-  fill: var(--cds-charts-14-1-6-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-6 {
-  background-color: var(--cds-charts-14-1-6, #520408);
-}
-.cds--cc--chart-wrapper .background-14-1-6.hovered {
-  background-color: var(--cds-charts-14-1-6-hovered, #520408);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-6 {
-  stroke: var(--cds-charts-14-1-6, #520408);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-6 {
-  stop-color: var(--cds-charts-14-1-6, #520408);
-}
-.cds--cc--chart-wrapper .fill-14-1-7 {
-  fill: var(--cds-charts-14-1-7, #198038);
-}
-.cds--cc--chart-wrapper .fill-14-1-7.hovered {
-  fill: var(--cds-charts-14-1-7-hovered, #198038);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-7 {
-  background-color: var(--cds-charts-14-1-7, #198038);
-}
-.cds--cc--chart-wrapper .background-14-1-7.hovered {
-  background-color: var(--cds-charts-14-1-7-hovered, #198038);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-7 {
-  stroke: var(--cds-charts-14-1-7, #198038);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-7 {
-  stop-color: var(--cds-charts-14-1-7, #198038);
-}
-.cds--cc--chart-wrapper .fill-14-1-8 {
-  fill: var(--cds-charts-14-1-8, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-14-1-8.hovered {
-  fill: var(--cds-charts-14-1-8-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-8 {
-  background-color: var(--cds-charts-14-1-8, #002d9c);
-}
-.cds--cc--chart-wrapper .background-14-1-8.hovered {
-  background-color: var(--cds-charts-14-1-8-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-8 {
-  stroke: var(--cds-charts-14-1-8, #002d9c);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-8 {
-  stop-color: var(--cds-charts-14-1-8, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-14-1-9 {
-  fill: var(--cds-charts-14-1-9, #ee5396);
-}
-.cds--cc--chart-wrapper .fill-14-1-9.hovered {
-  fill: var(--cds-charts-14-1-9-hovered, #ee5396);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-9 {
-  background-color: var(--cds-charts-14-1-9, #ee5396);
-}
-.cds--cc--chart-wrapper .background-14-1-9.hovered {
-  background-color: var(--cds-charts-14-1-9-hovered, #ee5396);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-9 {
-  stroke: var(--cds-charts-14-1-9, #ee5396);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-9 {
-  stop-color: var(--cds-charts-14-1-9, #ee5396);
-}
-.cds--cc--chart-wrapper .fill-14-1-10 {
-  fill: var(--cds-charts-14-1-10, #b28600);
-}
-.cds--cc--chart-wrapper .fill-14-1-10.hovered {
-  fill: var(--cds-charts-14-1-10-hovered, #b28600);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-10 {
-  background-color: var(--cds-charts-14-1-10, #b28600);
-}
-.cds--cc--chart-wrapper .background-14-1-10.hovered {
-  background-color: var(--cds-charts-14-1-10-hovered, #b28600);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-10 {
-  stroke: var(--cds-charts-14-1-10, #b28600);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-10 {
-  stop-color: var(--cds-charts-14-1-10, #b28600);
-}
-.cds--cc--chart-wrapper .fill-14-1-11 {
-  fill: var(--cds-charts-14-1-11, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-14-1-11.hovered {
-  fill: var(--cds-charts-14-1-11-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-11 {
-  background-color: var(--cds-charts-14-1-11, #009d9a);
-}
-.cds--cc--chart-wrapper .background-14-1-11.hovered {
-  background-color: var(--cds-charts-14-1-11-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-11 {
-  stroke: var(--cds-charts-14-1-11, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-11 {
-  stop-color: var(--cds-charts-14-1-11, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-14-1-12 {
-  fill: var(--cds-charts-14-1-12, #012749);
-}
-.cds--cc--chart-wrapper .fill-14-1-12.hovered {
-  fill: var(--cds-charts-14-1-12-hovered, #012749);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-12 {
-  background-color: var(--cds-charts-14-1-12, #012749);
-}
-.cds--cc--chart-wrapper .background-14-1-12.hovered {
-  background-color: var(--cds-charts-14-1-12-hovered, #012749);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-12 {
-  stroke: var(--cds-charts-14-1-12, #012749);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-12 {
-  stop-color: var(--cds-charts-14-1-12, #012749);
-}
-.cds--cc--chart-wrapper .fill-14-1-13 {
-  fill: var(--cds-charts-14-1-13, #8a3800);
-}
-.cds--cc--chart-wrapper .fill-14-1-13.hovered {
-  fill: var(--cds-charts-14-1-13-hovered, #8a3800);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-13 {
-  background-color: var(--cds-charts-14-1-13, #8a3800);
-}
-.cds--cc--chart-wrapper .background-14-1-13.hovered {
-  background-color: var(--cds-charts-14-1-13-hovered, #8a3800);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-13 {
-  stroke: var(--cds-charts-14-1-13, #8a3800);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-13 {
-  stop-color: var(--cds-charts-14-1-13, #8a3800);
-}
-.cds--cc--chart-wrapper .fill-14-1-14 {
-  fill: var(--cds-charts-14-1-14, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-14-1-14.hovered {
-  fill: var(--cds-charts-14-1-14-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-14-1-14 {
-  background-color: var(--cds-charts-14-1-14, #a56eff);
-}
-.cds--cc--chart-wrapper .background-14-1-14.hovered {
-  background-color: var(--cds-charts-14-1-14-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-14-1-14 {
-  stroke: var(--cds-charts-14-1-14, #a56eff);
-}
-.cds--cc--chart-wrapper .stop-color-14-1-14 {
-  stop-color: var(--cds-charts-14-1-14, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-1 {
-  fill: var(--cds-charts-mono-1-1, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-1.hovered {
-  fill: var(--cds-charts-mono-1-1-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-1 {
-  background-color: var(--cds-charts-mono-1-1, #ffffff);
-}
-.cds--cc--chart-wrapper .background-mono-1-1.hovered {
-  background-color: var(--cds-charts-mono-1-1-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-1 {
-  stroke: var(--cds-charts-mono-1-1, #ffffff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-1 {
-  stop-color: var(--cds-charts-mono-1-1, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-2 {
-  fill: var(--cds-charts-mono-1-2, #f6f2ff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-2.hovered {
-  fill: var(--cds-charts-mono-1-2-hovered, #f6f2ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-2 {
-  background-color: var(--cds-charts-mono-1-2, #f6f2ff);
-}
-.cds--cc--chart-wrapper .background-mono-1-2.hovered {
-  background-color: var(--cds-charts-mono-1-2-hovered, #f6f2ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-2 {
-  stroke: var(--cds-charts-mono-1-2, #f6f2ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-2 {
-  stop-color: var(--cds-charts-mono-1-2, #f6f2ff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-3 {
-  fill: var(--cds-charts-mono-1-3, #e8daff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-3.hovered {
-  fill: var(--cds-charts-mono-1-3-hovered, #e8daff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-3 {
-  background-color: var(--cds-charts-mono-1-3, #e8daff);
-}
-.cds--cc--chart-wrapper .background-mono-1-3.hovered {
-  background-color: var(--cds-charts-mono-1-3-hovered, #e8daff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-3 {
-  stroke: var(--cds-charts-mono-1-3, #e8daff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-3 {
-  stop-color: var(--cds-charts-mono-1-3, #e8daff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-4 {
-  fill: var(--cds-charts-mono-1-4, #d4bbff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-4.hovered {
-  fill: var(--cds-charts-mono-1-4-hovered, #d4bbff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-4 {
-  background-color: var(--cds-charts-mono-1-4, #d4bbff);
-}
-.cds--cc--chart-wrapper .background-mono-1-4.hovered {
-  background-color: var(--cds-charts-mono-1-4-hovered, #d4bbff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-4 {
-  stroke: var(--cds-charts-mono-1-4, #d4bbff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-4 {
-  stop-color: var(--cds-charts-mono-1-4, #d4bbff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-5 {
-  fill: var(--cds-charts-mono-1-5, #be95ff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-5.hovered {
-  fill: var(--cds-charts-mono-1-5-hovered, #be95ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-5 {
-  background-color: var(--cds-charts-mono-1-5, #be95ff);
-}
-.cds--cc--chart-wrapper .background-mono-1-5.hovered {
-  background-color: var(--cds-charts-mono-1-5-hovered, #be95ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-5 {
-  stroke: var(--cds-charts-mono-1-5, #be95ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-5 {
-  stop-color: var(--cds-charts-mono-1-5, #be95ff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-6 {
-  fill: var(--cds-charts-mono-1-6, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-6.hovered {
-  fill: var(--cds-charts-mono-1-6-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-6 {
-  background-color: var(--cds-charts-mono-1-6, #a56eff);
-}
-.cds--cc--chart-wrapper .background-mono-1-6.hovered {
-  background-color: var(--cds-charts-mono-1-6-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-6 {
-  stroke: var(--cds-charts-mono-1-6, #a56eff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-6 {
-  stop-color: var(--cds-charts-mono-1-6, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-mono-1-7 {
-  fill: var(--cds-charts-mono-1-7, #8a3ffc);
-}
-.cds--cc--chart-wrapper .fill-mono-1-7.hovered {
-  fill: var(--cds-charts-mono-1-7-hovered, #8a3ffc);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-7 {
-  background-color: var(--cds-charts-mono-1-7, #8a3ffc);
-}
-.cds--cc--chart-wrapper .background-mono-1-7.hovered {
-  background-color: var(--cds-charts-mono-1-7-hovered, #8a3ffc);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-7 {
-  stroke: var(--cds-charts-mono-1-7, #8a3ffc);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-7 {
-  stop-color: var(--cds-charts-mono-1-7, #8a3ffc);
-}
-.cds--cc--chart-wrapper .fill-mono-1-8 {
-  fill: var(--cds-charts-mono-1-8, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-mono-1-8.hovered {
-  fill: var(--cds-charts-mono-1-8-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-8 {
-  background-color: var(--cds-charts-mono-1-8, #6929c4);
-}
-.cds--cc--chart-wrapper .background-mono-1-8.hovered {
-  background-color: var(--cds-charts-mono-1-8-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-8 {
-  stroke: var(--cds-charts-mono-1-8, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-8 {
-  stop-color: var(--cds-charts-mono-1-8, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-mono-1-9 {
-  fill: var(--cds-charts-mono-1-9, #491d8b);
-}
-.cds--cc--chart-wrapper .fill-mono-1-9.hovered {
-  fill: var(--cds-charts-mono-1-9-hovered, #491d8b);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-9 {
-  background-color: var(--cds-charts-mono-1-9, #491d8b);
-}
-.cds--cc--chart-wrapper .background-mono-1-9.hovered {
-  background-color: var(--cds-charts-mono-1-9-hovered, #491d8b);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-9 {
-  stroke: var(--cds-charts-mono-1-9, #491d8b);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-9 {
-  stop-color: var(--cds-charts-mono-1-9, #491d8b);
-}
-.cds--cc--chart-wrapper .fill-mono-1-10 {
-  fill: var(--cds-charts-mono-1-10, #31135e);
-}
-.cds--cc--chart-wrapper .fill-mono-1-10.hovered {
-  fill: var(--cds-charts-mono-1-10-hovered, #31135e);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-10 {
-  background-color: var(--cds-charts-mono-1-10, #31135e);
-}
-.cds--cc--chart-wrapper .background-mono-1-10.hovered {
-  background-color: var(--cds-charts-mono-1-10-hovered, #31135e);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-10 {
-  stroke: var(--cds-charts-mono-1-10, #31135e);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-10 {
-  stop-color: var(--cds-charts-mono-1-10, #31135e);
-}
-.cds--cc--chart-wrapper .fill-mono-1-11 {
-  fill: var(--cds-charts-mono-1-11, #1c0f30);
-}
-.cds--cc--chart-wrapper .fill-mono-1-11.hovered {
-  fill: var(--cds-charts-mono-1-11-hovered, #1c0f30);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-1-11 {
-  background-color: var(--cds-charts-mono-1-11, #1c0f30);
-}
-.cds--cc--chart-wrapper .background-mono-1-11.hovered {
-  background-color: var(--cds-charts-mono-1-11-hovered, #1c0f30);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-1-11 {
-  stroke: var(--cds-charts-mono-1-11, #1c0f30);
-}
-.cds--cc--chart-wrapper .stop-color-mono-1-11 {
-  stop-color: var(--cds-charts-mono-1-11, #1c0f30);
-}
-.cds--cc--chart-wrapper .fill-mono-2-1 {
-  fill: var(--cds-charts-mono-2-1, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-1.hovered {
-  fill: var(--cds-charts-mono-2-1-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-1 {
-  background-color: var(--cds-charts-mono-2-1, #ffffff);
-}
-.cds--cc--chart-wrapper .background-mono-2-1.hovered {
-  background-color: var(--cds-charts-mono-2-1-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-1 {
-  stroke: var(--cds-charts-mono-2-1, #ffffff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-1 {
-  stop-color: var(--cds-charts-mono-2-1, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-2 {
-  fill: var(--cds-charts-mono-2-2, #edf5ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-2.hovered {
-  fill: var(--cds-charts-mono-2-2-hovered, #edf5ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-2 {
-  background-color: var(--cds-charts-mono-2-2, #edf5ff);
-}
-.cds--cc--chart-wrapper .background-mono-2-2.hovered {
-  background-color: var(--cds-charts-mono-2-2-hovered, #edf5ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-2 {
-  stroke: var(--cds-charts-mono-2-2, #edf5ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-2 {
-  stop-color: var(--cds-charts-mono-2-2, #edf5ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-3 {
-  fill: var(--cds-charts-mono-2-3, #d0e2ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-3.hovered {
-  fill: var(--cds-charts-mono-2-3-hovered, #d0e2ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-3 {
-  background-color: var(--cds-charts-mono-2-3, #d0e2ff);
-}
-.cds--cc--chart-wrapper .background-mono-2-3.hovered {
-  background-color: var(--cds-charts-mono-2-3-hovered, #d0e2ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-3 {
-  stroke: var(--cds-charts-mono-2-3, #d0e2ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-3 {
-  stop-color: var(--cds-charts-mono-2-3, #d0e2ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-4 {
-  fill: var(--cds-charts-mono-2-4, #a6c8ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-4.hovered {
-  fill: var(--cds-charts-mono-2-4-hovered, #a6c8ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-4 {
-  background-color: var(--cds-charts-mono-2-4, #a6c8ff);
-}
-.cds--cc--chart-wrapper .background-mono-2-4.hovered {
-  background-color: var(--cds-charts-mono-2-4-hovered, #a6c8ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-4 {
-  stroke: var(--cds-charts-mono-2-4, #a6c8ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-4 {
-  stop-color: var(--cds-charts-mono-2-4, #a6c8ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-5 {
-  fill: var(--cds-charts-mono-2-5, #78a9ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-5.hovered {
-  fill: var(--cds-charts-mono-2-5-hovered, #78a9ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-5 {
-  background-color: var(--cds-charts-mono-2-5, #78a9ff);
-}
-.cds--cc--chart-wrapper .background-mono-2-5.hovered {
-  background-color: var(--cds-charts-mono-2-5-hovered, #78a9ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-5 {
-  stroke: var(--cds-charts-mono-2-5, #78a9ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-5 {
-  stop-color: var(--cds-charts-mono-2-5, #78a9ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-6 {
-  fill: var(--cds-charts-mono-2-6, #4589ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-6.hovered {
-  fill: var(--cds-charts-mono-2-6-hovered, #4589ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-6 {
-  background-color: var(--cds-charts-mono-2-6, #4589ff);
-}
-.cds--cc--chart-wrapper .background-mono-2-6.hovered {
-  background-color: var(--cds-charts-mono-2-6-hovered, #4589ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-6 {
-  stroke: var(--cds-charts-mono-2-6, #4589ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-6 {
-  stop-color: var(--cds-charts-mono-2-6, #4589ff);
-}
-.cds--cc--chart-wrapper .fill-mono-2-7 {
-  fill: var(--cds-charts-mono-2-7, #0f62fe);
-}
-.cds--cc--chart-wrapper .fill-mono-2-7.hovered {
-  fill: var(--cds-charts-mono-2-7-hovered, #0f62fe);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-7 {
-  background-color: var(--cds-charts-mono-2-7, #0f62fe);
-}
-.cds--cc--chart-wrapper .background-mono-2-7.hovered {
-  background-color: var(--cds-charts-mono-2-7-hovered, #0f62fe);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-7 {
-  stroke: var(--cds-charts-mono-2-7, #0f62fe);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-7 {
-  stop-color: var(--cds-charts-mono-2-7, #0f62fe);
-}
-.cds--cc--chart-wrapper .fill-mono-2-8 {
-  fill: var(--cds-charts-mono-2-8, #0043ce);
-}
-.cds--cc--chart-wrapper .fill-mono-2-8.hovered {
-  fill: var(--cds-charts-mono-2-8-hovered, #0043ce);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-8 {
-  background-color: var(--cds-charts-mono-2-8, #0043ce);
-}
-.cds--cc--chart-wrapper .background-mono-2-8.hovered {
-  background-color: var(--cds-charts-mono-2-8-hovered, #0043ce);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-8 {
-  stroke: var(--cds-charts-mono-2-8, #0043ce);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-8 {
-  stop-color: var(--cds-charts-mono-2-8, #0043ce);
-}
-.cds--cc--chart-wrapper .fill-mono-2-9 {
-  fill: var(--cds-charts-mono-2-9, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-mono-2-9.hovered {
-  fill: var(--cds-charts-mono-2-9-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-9 {
-  background-color: var(--cds-charts-mono-2-9, #002d9c);
-}
-.cds--cc--chart-wrapper .background-mono-2-9.hovered {
-  background-color: var(--cds-charts-mono-2-9-hovered, #002d9c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-9 {
-  stroke: var(--cds-charts-mono-2-9, #002d9c);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-9 {
-  stop-color: var(--cds-charts-mono-2-9, #002d9c);
-}
-.cds--cc--chart-wrapper .fill-mono-2-10 {
-  fill: var(--cds-charts-mono-2-10, #001d6c);
-}
-.cds--cc--chart-wrapper .fill-mono-2-10.hovered {
-  fill: var(--cds-charts-mono-2-10-hovered, #001d6c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-10 {
-  background-color: var(--cds-charts-mono-2-10, #001d6c);
-}
-.cds--cc--chart-wrapper .background-mono-2-10.hovered {
-  background-color: var(--cds-charts-mono-2-10-hovered, #001d6c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-10 {
-  stroke: var(--cds-charts-mono-2-10, #001d6c);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-10 {
-  stop-color: var(--cds-charts-mono-2-10, #001d6c);
-}
-.cds--cc--chart-wrapper .fill-mono-2-11 {
-  fill: var(--cds-charts-mono-2-11, #001141);
-}
-.cds--cc--chart-wrapper .fill-mono-2-11.hovered {
-  fill: var(--cds-charts-mono-2-11-hovered, #001141);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-2-11 {
-  background-color: var(--cds-charts-mono-2-11, #001141);
-}
-.cds--cc--chart-wrapper .background-mono-2-11.hovered {
-  background-color: var(--cds-charts-mono-2-11-hovered, #001141);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-2-11 {
-  stroke: var(--cds-charts-mono-2-11, #001141);
-}
-.cds--cc--chart-wrapper .stop-color-mono-2-11 {
-  stop-color: var(--cds-charts-mono-2-11, #001141);
-}
-.cds--cc--chart-wrapper .fill-mono-3-1 {
-  fill: var(--cds-charts-mono-3-1, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-1.hovered {
-  fill: var(--cds-charts-mono-3-1-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-1 {
-  background-color: var(--cds-charts-mono-3-1, #ffffff);
-}
-.cds--cc--chart-wrapper .background-mono-3-1.hovered {
-  background-color: var(--cds-charts-mono-3-1-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-1 {
-  stroke: var(--cds-charts-mono-3-1, #ffffff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-1 {
-  stop-color: var(--cds-charts-mono-3-1, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-2 {
-  fill: var(--cds-charts-mono-3-2, #e5f6ff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-2.hovered {
-  fill: var(--cds-charts-mono-3-2-hovered, #e5f6ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-2 {
-  background-color: var(--cds-charts-mono-3-2, #e5f6ff);
-}
-.cds--cc--chart-wrapper .background-mono-3-2.hovered {
-  background-color: var(--cds-charts-mono-3-2-hovered, #e5f6ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-2 {
-  stroke: var(--cds-charts-mono-3-2, #e5f6ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-2 {
-  stop-color: var(--cds-charts-mono-3-2, #e5f6ff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-3 {
-  fill: var(--cds-charts-mono-3-3, #bae6ff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-3.hovered {
-  fill: var(--cds-charts-mono-3-3-hovered, #bae6ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-3 {
-  background-color: var(--cds-charts-mono-3-3, #bae6ff);
-}
-.cds--cc--chart-wrapper .background-mono-3-3.hovered {
-  background-color: var(--cds-charts-mono-3-3-hovered, #bae6ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-3 {
-  stroke: var(--cds-charts-mono-3-3, #bae6ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-3 {
-  stop-color: var(--cds-charts-mono-3-3, #bae6ff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-4 {
-  fill: var(--cds-charts-mono-3-4, #82cfff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-4.hovered {
-  fill: var(--cds-charts-mono-3-4-hovered, #82cfff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-4 {
-  background-color: var(--cds-charts-mono-3-4, #82cfff);
-}
-.cds--cc--chart-wrapper .background-mono-3-4.hovered {
-  background-color: var(--cds-charts-mono-3-4-hovered, #82cfff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-4 {
-  stroke: var(--cds-charts-mono-3-4, #82cfff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-4 {
-  stop-color: var(--cds-charts-mono-3-4, #82cfff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-5 {
-  fill: var(--cds-charts-mono-3-5, #33b1ff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-5.hovered {
-  fill: var(--cds-charts-mono-3-5-hovered, #33b1ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-5 {
-  background-color: var(--cds-charts-mono-3-5, #33b1ff);
-}
-.cds--cc--chart-wrapper .background-mono-3-5.hovered {
-  background-color: var(--cds-charts-mono-3-5-hovered, #33b1ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-5 {
-  stroke: var(--cds-charts-mono-3-5, #33b1ff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-5 {
-  stop-color: var(--cds-charts-mono-3-5, #33b1ff);
-}
-.cds--cc--chart-wrapper .fill-mono-3-6 {
-  fill: var(--cds-charts-mono-3-6, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-mono-3-6.hovered {
-  fill: var(--cds-charts-mono-3-6-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-6 {
-  background-color: var(--cds-charts-mono-3-6, #1192e8);
-}
-.cds--cc--chart-wrapper .background-mono-3-6.hovered {
-  background-color: var(--cds-charts-mono-3-6-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-6 {
-  stroke: var(--cds-charts-mono-3-6, #1192e8);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-6 {
-  stop-color: var(--cds-charts-mono-3-6, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-mono-3-7 {
-  fill: var(--cds-charts-mono-3-7, #0072c3);
-}
-.cds--cc--chart-wrapper .fill-mono-3-7.hovered {
-  fill: var(--cds-charts-mono-3-7-hovered, #0072c3);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-7 {
-  background-color: var(--cds-charts-mono-3-7, #0072c3);
-}
-.cds--cc--chart-wrapper .background-mono-3-7.hovered {
-  background-color: var(--cds-charts-mono-3-7-hovered, #0072c3);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-7 {
-  stroke: var(--cds-charts-mono-3-7, #0072c3);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-7 {
-  stop-color: var(--cds-charts-mono-3-7, #0072c3);
-}
-.cds--cc--chart-wrapper .fill-mono-3-8 {
-  fill: var(--cds-charts-mono-3-8, #00539a);
-}
-.cds--cc--chart-wrapper .fill-mono-3-8.hovered {
-  fill: var(--cds-charts-mono-3-8-hovered, #00539a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-8 {
-  background-color: var(--cds-charts-mono-3-8, #00539a);
-}
-.cds--cc--chart-wrapper .background-mono-3-8.hovered {
-  background-color: var(--cds-charts-mono-3-8-hovered, #00539a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-8 {
-  stroke: var(--cds-charts-mono-3-8, #00539a);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-8 {
-  stop-color: var(--cds-charts-mono-3-8, #00539a);
-}
-.cds--cc--chart-wrapper .fill-mono-3-9 {
-  fill: var(--cds-charts-mono-3-9, #003a6d);
-}
-.cds--cc--chart-wrapper .fill-mono-3-9.hovered {
-  fill: var(--cds-charts-mono-3-9-hovered, #003a6d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-9 {
-  background-color: var(--cds-charts-mono-3-9, #003a6d);
-}
-.cds--cc--chart-wrapper .background-mono-3-9.hovered {
-  background-color: var(--cds-charts-mono-3-9-hovered, #003a6d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-9 {
-  stroke: var(--cds-charts-mono-3-9, #003a6d);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-9 {
-  stop-color: var(--cds-charts-mono-3-9, #003a6d);
-}
-.cds--cc--chart-wrapper .fill-mono-3-10 {
-  fill: var(--cds-charts-mono-3-10, #012749);
-}
-.cds--cc--chart-wrapper .fill-mono-3-10.hovered {
-  fill: var(--cds-charts-mono-3-10-hovered, #012749);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-10 {
-  background-color: var(--cds-charts-mono-3-10, #012749);
-}
-.cds--cc--chart-wrapper .background-mono-3-10.hovered {
-  background-color: var(--cds-charts-mono-3-10-hovered, #012749);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-10 {
-  stroke: var(--cds-charts-mono-3-10, #012749);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-10 {
-  stop-color: var(--cds-charts-mono-3-10, #012749);
-}
-.cds--cc--chart-wrapper .fill-mono-3-11 {
-  fill: var(--cds-charts-mono-3-11, #061727);
-}
-.cds--cc--chart-wrapper .fill-mono-3-11.hovered {
-  fill: var(--cds-charts-mono-3-11-hovered, #061727);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-3-11 {
-  background-color: var(--cds-charts-mono-3-11, #061727);
-}
-.cds--cc--chart-wrapper .background-mono-3-11.hovered {
-  background-color: var(--cds-charts-mono-3-11-hovered, #061727);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-3-11 {
-  stroke: var(--cds-charts-mono-3-11, #061727);
-}
-.cds--cc--chart-wrapper .stop-color-mono-3-11 {
-  stop-color: var(--cds-charts-mono-3-11, #061727);
-}
-.cds--cc--chart-wrapper .fill-mono-4-1 {
-  fill: var(--cds-charts-mono-4-1, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-mono-4-1.hovered {
-  fill: var(--cds-charts-mono-4-1-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-1 {
-  background-color: var(--cds-charts-mono-4-1, #ffffff);
-}
-.cds--cc--chart-wrapper .background-mono-4-1.hovered {
-  background-color: var(--cds-charts-mono-4-1-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-1 {
-  stroke: var(--cds-charts-mono-4-1, #ffffff);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-1 {
-  stop-color: var(--cds-charts-mono-4-1, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-mono-4-2 {
-  fill: var(--cds-charts-mono-4-2, #d9fbfb);
-}
-.cds--cc--chart-wrapper .fill-mono-4-2.hovered {
-  fill: var(--cds-charts-mono-4-2-hovered, #d9fbfb);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-2 {
-  background-color: var(--cds-charts-mono-4-2, #d9fbfb);
-}
-.cds--cc--chart-wrapper .background-mono-4-2.hovered {
-  background-color: var(--cds-charts-mono-4-2-hovered, #d9fbfb);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-2 {
-  stroke: var(--cds-charts-mono-4-2, #d9fbfb);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-2 {
-  stop-color: var(--cds-charts-mono-4-2, #d9fbfb);
-}
-.cds--cc--chart-wrapper .fill-mono-4-3 {
-  fill: var(--cds-charts-mono-4-3, #9ef0f0);
-}
-.cds--cc--chart-wrapper .fill-mono-4-3.hovered {
-  fill: var(--cds-charts-mono-4-3-hovered, #9ef0f0);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-3 {
-  background-color: var(--cds-charts-mono-4-3, #9ef0f0);
-}
-.cds--cc--chart-wrapper .background-mono-4-3.hovered {
-  background-color: var(--cds-charts-mono-4-3-hovered, #9ef0f0);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-3 {
-  stroke: var(--cds-charts-mono-4-3, #9ef0f0);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-3 {
-  stop-color: var(--cds-charts-mono-4-3, #9ef0f0);
-}
-.cds--cc--chart-wrapper .fill-mono-4-4 {
-  fill: var(--cds-charts-mono-4-4, #3ddbd9);
-}
-.cds--cc--chart-wrapper .fill-mono-4-4.hovered {
-  fill: var(--cds-charts-mono-4-4-hovered, #3ddbd9);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-4 {
-  background-color: var(--cds-charts-mono-4-4, #3ddbd9);
-}
-.cds--cc--chart-wrapper .background-mono-4-4.hovered {
-  background-color: var(--cds-charts-mono-4-4-hovered, #3ddbd9);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-4 {
-  stroke: var(--cds-charts-mono-4-4, #3ddbd9);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-4 {
-  stop-color: var(--cds-charts-mono-4-4, #3ddbd9);
-}
-.cds--cc--chart-wrapper .fill-mono-4-5 {
-  fill: var(--cds-charts-mono-4-5, #08bdba);
-}
-.cds--cc--chart-wrapper .fill-mono-4-5.hovered {
-  fill: var(--cds-charts-mono-4-5-hovered, #08bdba);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-5 {
-  background-color: var(--cds-charts-mono-4-5, #08bdba);
-}
-.cds--cc--chart-wrapper .background-mono-4-5.hovered {
-  background-color: var(--cds-charts-mono-4-5-hovered, #08bdba);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-5 {
-  stroke: var(--cds-charts-mono-4-5, #08bdba);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-5 {
-  stop-color: var(--cds-charts-mono-4-5, #08bdba);
-}
-.cds--cc--chart-wrapper .fill-mono-4-6 {
-  fill: var(--cds-charts-mono-4-6, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-mono-4-6.hovered {
-  fill: var(--cds-charts-mono-4-6-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-6 {
-  background-color: var(--cds-charts-mono-4-6, #009d9a);
-}
-.cds--cc--chart-wrapper .background-mono-4-6.hovered {
-  background-color: var(--cds-charts-mono-4-6-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-6 {
-  stroke: var(--cds-charts-mono-4-6, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-6 {
-  stop-color: var(--cds-charts-mono-4-6, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-mono-4-7 {
-  fill: var(--cds-charts-mono-4-7, #007d79);
-}
-.cds--cc--chart-wrapper .fill-mono-4-7.hovered {
-  fill: var(--cds-charts-mono-4-7-hovered, #007d79);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-7 {
-  background-color: var(--cds-charts-mono-4-7, #007d79);
-}
-.cds--cc--chart-wrapper .background-mono-4-7.hovered {
-  background-color: var(--cds-charts-mono-4-7-hovered, #007d79);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-7 {
-  stroke: var(--cds-charts-mono-4-7, #007d79);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-7 {
-  stop-color: var(--cds-charts-mono-4-7, #007d79);
-}
-.cds--cc--chart-wrapper .fill-mono-4-8 {
-  fill: var(--cds-charts-mono-4-8, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-mono-4-8.hovered {
-  fill: var(--cds-charts-mono-4-8-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-8 {
-  background-color: var(--cds-charts-mono-4-8, #005d5d);
-}
-.cds--cc--chart-wrapper .background-mono-4-8.hovered {
-  background-color: var(--cds-charts-mono-4-8-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-8 {
-  stroke: var(--cds-charts-mono-4-8, #005d5d);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-8 {
-  stop-color: var(--cds-charts-mono-4-8, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-mono-4-9 {
-  fill: var(--cds-charts-mono-4-9, #004144);
-}
-.cds--cc--chart-wrapper .fill-mono-4-9.hovered {
-  fill: var(--cds-charts-mono-4-9-hovered, #004144);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-9 {
-  background-color: var(--cds-charts-mono-4-9, #004144);
-}
-.cds--cc--chart-wrapper .background-mono-4-9.hovered {
-  background-color: var(--cds-charts-mono-4-9-hovered, #004144);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-9 {
-  stroke: var(--cds-charts-mono-4-9, #004144);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-9 {
-  stop-color: var(--cds-charts-mono-4-9, #004144);
-}
-.cds--cc--chart-wrapper .fill-mono-4-10 {
-  fill: var(--cds-charts-mono-4-10, #022b30);
-}
-.cds--cc--chart-wrapper .fill-mono-4-10.hovered {
-  fill: var(--cds-charts-mono-4-10-hovered, #022b30);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-10 {
-  background-color: var(--cds-charts-mono-4-10, #022b30);
-}
-.cds--cc--chart-wrapper .background-mono-4-10.hovered {
-  background-color: var(--cds-charts-mono-4-10-hovered, #022b30);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-10 {
-  stroke: var(--cds-charts-mono-4-10, #022b30);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-10 {
-  stop-color: var(--cds-charts-mono-4-10, #022b30);
-}
-.cds--cc--chart-wrapper .fill-mono-4-11 {
-  fill: var(--cds-charts-mono-4-11, #081a1c);
-}
-.cds--cc--chart-wrapper .fill-mono-4-11.hovered {
-  fill: var(--cds-charts-mono-4-11-hovered, #081a1c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-mono-4-11 {
-  background-color: var(--cds-charts-mono-4-11, #081a1c);
-}
-.cds--cc--chart-wrapper .background-mono-4-11.hovered {
-  background-color: var(--cds-charts-mono-4-11-hovered, #081a1c);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-mono-4-11 {
-  stroke: var(--cds-charts-mono-4-11, #081a1c);
-}
-.cds--cc--chart-wrapper .stop-color-mono-4-11 {
-  stop-color: var(--cds-charts-mono-4-11, #081a1c);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-1 {
-  fill: var(--cds-charts-diverge-1-1, #750e13);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-1.hovered {
-  fill: var(--cds-charts-diverge-1-1-hovered, #750e13);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-1 {
-  background-color: var(--cds-charts-diverge-1-1, #750e13);
-}
-.cds--cc--chart-wrapper .background-diverge-1-1.hovered {
-  background-color: var(--cds-charts-diverge-1-1-hovered, #750e13);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-1 {
-  stroke: var(--cds-charts-diverge-1-1, #750e13);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-1 {
-  stop-color: var(--cds-charts-diverge-1-1, #750e13);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-2 {
-  fill: var(--cds-charts-diverge-1-2, #a2191f);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-2.hovered {
-  fill: var(--cds-charts-diverge-1-2-hovered, #a2191f);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-2 {
-  background-color: var(--cds-charts-diverge-1-2, #a2191f);
-}
-.cds--cc--chart-wrapper .background-diverge-1-2.hovered {
-  background-color: var(--cds-charts-diverge-1-2-hovered, #a2191f);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-2 {
-  stroke: var(--cds-charts-diverge-1-2, #a2191f);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-2 {
-  stop-color: var(--cds-charts-diverge-1-2, #a2191f);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-3 {
-  fill: var(--cds-charts-diverge-1-3, #da1e28);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-3.hovered {
-  fill: var(--cds-charts-diverge-1-3-hovered, #da1e28);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-3 {
-  background-color: var(--cds-charts-diverge-1-3, #da1e28);
-}
-.cds--cc--chart-wrapper .background-diverge-1-3.hovered {
-  background-color: var(--cds-charts-diverge-1-3-hovered, #da1e28);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-3 {
-  stroke: var(--cds-charts-diverge-1-3, #da1e28);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-3 {
-  stop-color: var(--cds-charts-diverge-1-3, #da1e28);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-4 {
-  fill: var(--cds-charts-diverge-1-4, #fa4d56);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-4.hovered {
-  fill: var(--cds-charts-diverge-1-4-hovered, #fa4d56);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-4 {
-  background-color: var(--cds-charts-diverge-1-4, #fa4d56);
-}
-.cds--cc--chart-wrapper .background-diverge-1-4.hovered {
-  background-color: var(--cds-charts-diverge-1-4-hovered, #fa4d56);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-4 {
-  stroke: var(--cds-charts-diverge-1-4, #fa4d56);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-4 {
-  stop-color: var(--cds-charts-diverge-1-4, #fa4d56);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-5 {
-  fill: var(--cds-charts-diverge-1-5, #ff8389);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-5.hovered {
-  fill: var(--cds-charts-diverge-1-5-hovered, #ff8389);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-5 {
-  background-color: var(--cds-charts-diverge-1-5, #ff8389);
-}
-.cds--cc--chart-wrapper .background-diverge-1-5.hovered {
-  background-color: var(--cds-charts-diverge-1-5-hovered, #ff8389);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-5 {
-  stroke: var(--cds-charts-diverge-1-5, #ff8389);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-5 {
-  stop-color: var(--cds-charts-diverge-1-5, #ff8389);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-6 {
-  fill: var(--cds-charts-diverge-1-6, #ffb3b8);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-6.hovered {
-  fill: var(--cds-charts-diverge-1-6-hovered, #ffb3b8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-6 {
-  background-color: var(--cds-charts-diverge-1-6, #ffb3b8);
-}
-.cds--cc--chart-wrapper .background-diverge-1-6.hovered {
-  background-color: var(--cds-charts-diverge-1-6-hovered, #ffb3b8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-6 {
-  stroke: var(--cds-charts-diverge-1-6, #ffb3b8);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-6 {
-  stop-color: var(--cds-charts-diverge-1-6, #ffb3b8);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-7 {
-  fill: var(--cds-charts-diverge-1-7, #ffd7d9);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-7.hovered {
-  fill: var(--cds-charts-diverge-1-7-hovered, #ffd7d9);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-7 {
-  background-color: var(--cds-charts-diverge-1-7, #ffd7d9);
-}
-.cds--cc--chart-wrapper .background-diverge-1-7.hovered {
-  background-color: var(--cds-charts-diverge-1-7-hovered, #ffd7d9);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-7 {
-  stroke: var(--cds-charts-diverge-1-7, #ffd7d9);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-7 {
-  stop-color: var(--cds-charts-diverge-1-7, #ffd7d9);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-8 {
-  fill: var(--cds-charts-diverge-1-8, #fff1f1);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-8.hovered {
-  fill: var(--cds-charts-diverge-1-8-hovered, #fff1f1);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-8 {
-  background-color: var(--cds-charts-diverge-1-8, #fff1f1);
-}
-.cds--cc--chart-wrapper .background-diverge-1-8.hovered {
-  background-color: var(--cds-charts-diverge-1-8-hovered, #fff1f1);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-8 {
-  stroke: var(--cds-charts-diverge-1-8, #fff1f1);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-8 {
-  stop-color: var(--cds-charts-diverge-1-8, #fff1f1);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-9 {
-  fill: var(--cds-charts-diverge-1-9, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-9.hovered {
-  fill: var(--cds-charts-diverge-1-9-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-9 {
-  background-color: var(--cds-charts-diverge-1-9, #ffffff);
-}
-.cds--cc--chart-wrapper .background-diverge-1-9.hovered {
-  background-color: var(--cds-charts-diverge-1-9-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-9 {
-  stroke: var(--cds-charts-diverge-1-9, #ffffff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-9 {
-  stop-color: var(--cds-charts-diverge-1-9, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-10 {
-  fill: var(--cds-charts-diverge-1-10, #e5f6ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-10.hovered {
-  fill: var(--cds-charts-diverge-1-10-hovered, #e5f6ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-10 {
-  background-color: var(--cds-charts-diverge-1-10, #e5f6ff);
-}
-.cds--cc--chart-wrapper .background-diverge-1-10.hovered {
-  background-color: var(--cds-charts-diverge-1-10-hovered, #e5f6ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-10 {
-  stroke: var(--cds-charts-diverge-1-10, #e5f6ff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-10 {
-  stop-color: var(--cds-charts-diverge-1-10, #e5f6ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-11 {
-  fill: var(--cds-charts-diverge-1-11, #bae6ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-11.hovered {
-  fill: var(--cds-charts-diverge-1-11-hovered, #bae6ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-11 {
-  background-color: var(--cds-charts-diverge-1-11, #bae6ff);
-}
-.cds--cc--chart-wrapper .background-diverge-1-11.hovered {
-  background-color: var(--cds-charts-diverge-1-11-hovered, #bae6ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-11 {
-  stroke: var(--cds-charts-diverge-1-11, #bae6ff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-11 {
-  stop-color: var(--cds-charts-diverge-1-11, #bae6ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-12 {
-  fill: var(--cds-charts-diverge-1-12, #82cfff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-12.hovered {
-  fill: var(--cds-charts-diverge-1-12-hovered, #82cfff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-12 {
-  background-color: var(--cds-charts-diverge-1-12, #82cfff);
-}
-.cds--cc--chart-wrapper .background-diverge-1-12.hovered {
-  background-color: var(--cds-charts-diverge-1-12-hovered, #82cfff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-12 {
-  stroke: var(--cds-charts-diverge-1-12, #82cfff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-12 {
-  stop-color: var(--cds-charts-diverge-1-12, #82cfff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-13 {
-  fill: var(--cds-charts-diverge-1-13, #33b1ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-13.hovered {
-  fill: var(--cds-charts-diverge-1-13-hovered, #33b1ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-13 {
-  background-color: var(--cds-charts-diverge-1-13, #33b1ff);
-}
-.cds--cc--chart-wrapper .background-diverge-1-13.hovered {
-  background-color: var(--cds-charts-diverge-1-13-hovered, #33b1ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-13 {
-  stroke: var(--cds-charts-diverge-1-13, #33b1ff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-13 {
-  stop-color: var(--cds-charts-diverge-1-13, #33b1ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-14 {
-  fill: var(--cds-charts-diverge-1-14, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-14.hovered {
-  fill: var(--cds-charts-diverge-1-14-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-14 {
-  background-color: var(--cds-charts-diverge-1-14, #1192e8);
-}
-.cds--cc--chart-wrapper .background-diverge-1-14.hovered {
-  background-color: var(--cds-charts-diverge-1-14-hovered, #1192e8);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-14 {
-  stroke: var(--cds-charts-diverge-1-14, #1192e8);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-14 {
-  stop-color: var(--cds-charts-diverge-1-14, #1192e8);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-15 {
-  fill: var(--cds-charts-diverge-1-15, #0072c3);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-15.hovered {
-  fill: var(--cds-charts-diverge-1-15-hovered, #0072c3);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-15 {
-  background-color: var(--cds-charts-diverge-1-15, #0072c3);
-}
-.cds--cc--chart-wrapper .background-diverge-1-15.hovered {
-  background-color: var(--cds-charts-diverge-1-15-hovered, #0072c3);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-15 {
-  stroke: var(--cds-charts-diverge-1-15, #0072c3);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-15 {
-  stop-color: var(--cds-charts-diverge-1-15, #0072c3);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-16 {
-  fill: var(--cds-charts-diverge-1-16, #00539a);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-16.hovered {
-  fill: var(--cds-charts-diverge-1-16-hovered, #00539a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-16 {
-  background-color: var(--cds-charts-diverge-1-16, #00539a);
-}
-.cds--cc--chart-wrapper .background-diverge-1-16.hovered {
-  background-color: var(--cds-charts-diverge-1-16-hovered, #00539a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-16 {
-  stroke: var(--cds-charts-diverge-1-16, #00539a);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-16 {
-  stop-color: var(--cds-charts-diverge-1-16, #00539a);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-17 {
-  fill: var(--cds-charts-diverge-1-17, #003a6d);
-}
-.cds--cc--chart-wrapper .fill-diverge-1-17.hovered {
-  fill: var(--cds-charts-diverge-1-17-hovered, #003a6d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-1-17 {
-  background-color: var(--cds-charts-diverge-1-17, #003a6d);
-}
-.cds--cc--chart-wrapper .background-diverge-1-17.hovered {
-  background-color: var(--cds-charts-diverge-1-17-hovered, #003a6d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-1-17 {
-  stroke: var(--cds-charts-diverge-1-17, #003a6d);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-1-17 {
-  stop-color: var(--cds-charts-diverge-1-17, #003a6d);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-1 {
-  fill: var(--cds-charts-diverge-2-1, #491d8b);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-1.hovered {
-  fill: var(--cds-charts-diverge-2-1-hovered, #491d8b);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-1 {
-  background-color: var(--cds-charts-diverge-2-1, #491d8b);
-}
-.cds--cc--chart-wrapper .background-diverge-2-1.hovered {
-  background-color: var(--cds-charts-diverge-2-1-hovered, #491d8b);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-1 {
-  stroke: var(--cds-charts-diverge-2-1, #491d8b);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-1 {
-  stop-color: var(--cds-charts-diverge-2-1, #491d8b);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-2 {
-  fill: var(--cds-charts-diverge-2-2, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-2.hovered {
-  fill: var(--cds-charts-diverge-2-2-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-2 {
-  background-color: var(--cds-charts-diverge-2-2, #6929c4);
-}
-.cds--cc--chart-wrapper .background-diverge-2-2.hovered {
-  background-color: var(--cds-charts-diverge-2-2-hovered, #6929c4);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-2 {
-  stroke: var(--cds-charts-diverge-2-2, #6929c4);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-2 {
-  stop-color: var(--cds-charts-diverge-2-2, #6929c4);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-3 {
-  fill: var(--cds-charts-diverge-2-3, #8a3ffc);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-3.hovered {
-  fill: var(--cds-charts-diverge-2-3-hovered, #8a3ffc);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-3 {
-  background-color: var(--cds-charts-diverge-2-3, #8a3ffc);
-}
-.cds--cc--chart-wrapper .background-diverge-2-3.hovered {
-  background-color: var(--cds-charts-diverge-2-3-hovered, #8a3ffc);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-3 {
-  stroke: var(--cds-charts-diverge-2-3, #8a3ffc);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-3 {
-  stop-color: var(--cds-charts-diverge-2-3, #8a3ffc);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-4 {
-  fill: var(--cds-charts-diverge-2-4, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-4.hovered {
-  fill: var(--cds-charts-diverge-2-4-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-4 {
-  background-color: var(--cds-charts-diverge-2-4, #a56eff);
-}
-.cds--cc--chart-wrapper .background-diverge-2-4.hovered {
-  background-color: var(--cds-charts-diverge-2-4-hovered, #a56eff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-4 {
-  stroke: var(--cds-charts-diverge-2-4, #a56eff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-4 {
-  stop-color: var(--cds-charts-diverge-2-4, #a56eff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-5 {
-  fill: var(--cds-charts-diverge-2-5, #be95ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-5.hovered {
-  fill: var(--cds-charts-diverge-2-5-hovered, #be95ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-5 {
-  background-color: var(--cds-charts-diverge-2-5, #be95ff);
-}
-.cds--cc--chart-wrapper .background-diverge-2-5.hovered {
-  background-color: var(--cds-charts-diverge-2-5-hovered, #be95ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-5 {
-  stroke: var(--cds-charts-diverge-2-5, #be95ff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-5 {
-  stop-color: var(--cds-charts-diverge-2-5, #be95ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-6 {
-  fill: var(--cds-charts-diverge-2-6, #d4bbff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-6.hovered {
-  fill: var(--cds-charts-diverge-2-6-hovered, #d4bbff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-6 {
-  background-color: var(--cds-charts-diverge-2-6, #d4bbff);
-}
-.cds--cc--chart-wrapper .background-diverge-2-6.hovered {
-  background-color: var(--cds-charts-diverge-2-6-hovered, #d4bbff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-6 {
-  stroke: var(--cds-charts-diverge-2-6, #d4bbff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-6 {
-  stop-color: var(--cds-charts-diverge-2-6, #d4bbff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-7 {
-  fill: var(--cds-charts-diverge-2-7, #e8daff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-7.hovered {
-  fill: var(--cds-charts-diverge-2-7-hovered, #e8daff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-7 {
-  background-color: var(--cds-charts-diverge-2-7, #e8daff);
-}
-.cds--cc--chart-wrapper .background-diverge-2-7.hovered {
-  background-color: var(--cds-charts-diverge-2-7-hovered, #e8daff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-7 {
-  stroke: var(--cds-charts-diverge-2-7, #e8daff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-7 {
-  stop-color: var(--cds-charts-diverge-2-7, #e8daff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-8 {
-  fill: var(--cds-charts-diverge-2-8, #f6f2ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-8.hovered {
-  fill: var(--cds-charts-diverge-2-8-hovered, #f6f2ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-8 {
-  background-color: var(--cds-charts-diverge-2-8, #f6f2ff);
-}
-.cds--cc--chart-wrapper .background-diverge-2-8.hovered {
-  background-color: var(--cds-charts-diverge-2-8-hovered, #f6f2ff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-8 {
-  stroke: var(--cds-charts-diverge-2-8, #f6f2ff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-8 {
-  stop-color: var(--cds-charts-diverge-2-8, #f6f2ff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-9 {
-  fill: var(--cds-charts-diverge-2-9, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-9.hovered {
-  fill: var(--cds-charts-diverge-2-9-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-9 {
-  background-color: var(--cds-charts-diverge-2-9, #ffffff);
-}
-.cds--cc--chart-wrapper .background-diverge-2-9.hovered {
-  background-color: var(--cds-charts-diverge-2-9-hovered, #ffffff);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-9 {
-  stroke: var(--cds-charts-diverge-2-9, #ffffff);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-9 {
-  stop-color: var(--cds-charts-diverge-2-9, #ffffff);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-10 {
-  fill: var(--cds-charts-diverge-2-10, #d9fbfb);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-10.hovered {
-  fill: var(--cds-charts-diverge-2-10-hovered, #d9fbfb);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-10 {
-  background-color: var(--cds-charts-diverge-2-10, #d9fbfb);
-}
-.cds--cc--chart-wrapper .background-diverge-2-10.hovered {
-  background-color: var(--cds-charts-diverge-2-10-hovered, #d9fbfb);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-10 {
-  stroke: var(--cds-charts-diverge-2-10, #d9fbfb);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-10 {
-  stop-color: var(--cds-charts-diverge-2-10, #d9fbfb);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-11 {
-  fill: var(--cds-charts-diverge-2-11, #9ef0f0);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-11.hovered {
-  fill: var(--cds-charts-diverge-2-11-hovered, #9ef0f0);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-11 {
-  background-color: var(--cds-charts-diverge-2-11, #9ef0f0);
-}
-.cds--cc--chart-wrapper .background-diverge-2-11.hovered {
-  background-color: var(--cds-charts-diverge-2-11-hovered, #9ef0f0);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-11 {
-  stroke: var(--cds-charts-diverge-2-11, #9ef0f0);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-11 {
-  stop-color: var(--cds-charts-diverge-2-11, #9ef0f0);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-12 {
-  fill: var(--cds-charts-diverge-2-12, #3ddbd9);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-12.hovered {
-  fill: var(--cds-charts-diverge-2-12-hovered, #3ddbd9);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-12 {
-  background-color: var(--cds-charts-diverge-2-12, #3ddbd9);
-}
-.cds--cc--chart-wrapper .background-diverge-2-12.hovered {
-  background-color: var(--cds-charts-diverge-2-12-hovered, #3ddbd9);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-12 {
-  stroke: var(--cds-charts-diverge-2-12, #3ddbd9);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-12 {
-  stop-color: var(--cds-charts-diverge-2-12, #3ddbd9);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-13 {
-  fill: var(--cds-charts-diverge-2-13, #08bdba);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-13.hovered {
-  fill: var(--cds-charts-diverge-2-13-hovered, #08bdba);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-13 {
-  background-color: var(--cds-charts-diverge-2-13, #08bdba);
-}
-.cds--cc--chart-wrapper .background-diverge-2-13.hovered {
-  background-color: var(--cds-charts-diverge-2-13-hovered, #08bdba);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-13 {
-  stroke: var(--cds-charts-diverge-2-13, #08bdba);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-13 {
-  stop-color: var(--cds-charts-diverge-2-13, #08bdba);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-14 {
-  fill: var(--cds-charts-diverge-2-14, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-14.hovered {
-  fill: var(--cds-charts-diverge-2-14-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-14 {
-  background-color: var(--cds-charts-diverge-2-14, #009d9a);
-}
-.cds--cc--chart-wrapper .background-diverge-2-14.hovered {
-  background-color: var(--cds-charts-diverge-2-14-hovered, #009d9a);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-14 {
-  stroke: var(--cds-charts-diverge-2-14, #009d9a);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-14 {
-  stop-color: var(--cds-charts-diverge-2-14, #009d9a);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-15 {
-  fill: var(--cds-charts-diverge-2-15, #007d79);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-15.hovered {
-  fill: var(--cds-charts-diverge-2-15-hovered, #007d79);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-15 {
-  background-color: var(--cds-charts-diverge-2-15, #007d79);
-}
-.cds--cc--chart-wrapper .background-diverge-2-15.hovered {
-  background-color: var(--cds-charts-diverge-2-15-hovered, #007d79);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-15 {
-  stroke: var(--cds-charts-diverge-2-15, #007d79);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-15 {
-  stop-color: var(--cds-charts-diverge-2-15, #007d79);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-16 {
-  fill: var(--cds-charts-diverge-2-16, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-16.hovered {
-  fill: var(--cds-charts-diverge-2-16-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-16 {
-  background-color: var(--cds-charts-diverge-2-16, #005d5d);
-}
-.cds--cc--chart-wrapper .background-diverge-2-16.hovered {
-  background-color: var(--cds-charts-diverge-2-16-hovered, #005d5d);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-16 {
-  stroke: var(--cds-charts-diverge-2-16, #005d5d);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-16 {
-  stop-color: var(--cds-charts-diverge-2-16, #005d5d);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-17 {
-  fill: var(--cds-charts-diverge-2-17, #004144);
-}
-.cds--cc--chart-wrapper .fill-diverge-2-17.hovered {
-  fill: var(--cds-charts-diverge-2-17-hovered, #004144);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .background-diverge-2-17 {
-  background-color: var(--cds-charts-diverge-2-17, #004144);
-}
-.cds--cc--chart-wrapper .background-diverge-2-17.hovered {
-  background-color: var(--cds-charts-diverge-2-17-hovered, #004144);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .stroke-diverge-2-17 {
-  stroke: var(--cds-charts-diverge-2-17, #004144);
-}
-.cds--cc--chart-wrapper .stop-color-diverge-2-17 {
-  stop-color: var(--cds-charts-diverge-2-17, #004144);
-}
-
-.cds--cc--tooltip .tooltip-1-1-1 {
-  background-color: var(--cds-charts-1-1-1, #6929c4);
-}
-.cds--cc--tooltip .tooltip-1-2-1 {
-  background-color: var(--cds-charts-1-2-1, #002d9c);
-}
-.cds--cc--tooltip .tooltip-1-3-1 {
-  background-color: var(--cds-charts-1-3-1, #1192e8);
-}
-.cds--cc--tooltip .tooltip-1-4-1 {
-  background-color: var(--cds-charts-1-4-1, #007d79);
-}
-.cds--cc--tooltip .tooltip-2-1-1 {
-  background-color: var(--cds-charts-2-1-1, #6929c4);
-}
-.cds--cc--tooltip .tooltip-2-1-2 {
-  background-color: var(--cds-charts-2-1-2, #009d9a);
-}
-.cds--cc--tooltip .tooltip-2-2-1 {
-  background-color: var(--cds-charts-2-2-1, #8a3ffc);
-}
-.cds--cc--tooltip .tooltip-2-2-2 {
-  background-color: var(--cds-charts-2-2-2, #520408);
-}
-.cds--cc--tooltip .tooltip-2-3-1 {
-  background-color: var(--cds-charts-2-3-1, #9f1853);
-}
-.cds--cc--tooltip .tooltip-2-3-2 {
-  background-color: var(--cds-charts-2-3-2, #520408);
-}
-.cds--cc--tooltip .tooltip-2-4-1 {
-  background-color: var(--cds-charts-2-4-1, #1192e8);
-}
-.cds--cc--tooltip .tooltip-2-4-2 {
-  background-color: var(--cds-charts-2-4-2, #005d5d);
-}
-.cds--cc--tooltip .tooltip-2-5-1 {
-  background-color: var(--cds-charts-2-5-1, #009d9a);
-}
-.cds--cc--tooltip .tooltip-2-5-2 {
-  background-color: var(--cds-charts-2-5-2, #002d9c);
-}
-.cds--cc--tooltip .tooltip-3-1-1 {
-  background-color: var(--cds-charts-3-1-1, #ee5396);
-}
-.cds--cc--tooltip .tooltip-3-1-2 {
-  background-color: var(--cds-charts-3-1-2, #1192e8);
-}
-.cds--cc--tooltip .tooltip-3-1-3 {
-  background-color: var(--cds-charts-3-1-3, #6929c4);
-}
-.cds--cc--tooltip .tooltip-3-2-1 {
-  background-color: var(--cds-charts-3-2-1, #9f1853);
-}
-.cds--cc--tooltip .tooltip-3-2-2 {
-  background-color: var(--cds-charts-3-2-2, #fa4d56);
-}
-.cds--cc--tooltip .tooltip-3-2-3 {
-  background-color: var(--cds-charts-3-2-3, #520408);
-}
-.cds--cc--tooltip .tooltip-3-3-1 {
-  background-color: var(--cds-charts-3-3-1, #a56eff);
-}
-.cds--cc--tooltip .tooltip-3-3-2 {
-  background-color: var(--cds-charts-3-3-2, #005d5d);
-}
-.cds--cc--tooltip .tooltip-3-3-3 {
-  background-color: var(--cds-charts-3-3-3, #002d9c);
-}
-.cds--cc--tooltip .tooltip-3-4-1 {
-  background-color: var(--cds-charts-3-4-1, #a56eff);
-}
-.cds--cc--tooltip .tooltip-3-4-2 {
-  background-color: var(--cds-charts-3-4-2, #005d5d);
-}
-.cds--cc--tooltip .tooltip-3-4-3 {
-  background-color: var(--cds-charts-3-4-3, #9f1853);
-}
-.cds--cc--tooltip .tooltip-3-5-1 {
-  background-color: var(--cds-charts-3-5-1, #012749);
-}
-.cds--cc--tooltip .tooltip-3-5-2 {
-  background-color: var(--cds-charts-3-5-2, #6929c4);
-}
-.cds--cc--tooltip .tooltip-3-5-3 {
-  background-color: var(--cds-charts-3-5-3, #009d9a);
-}
-.cds--cc--tooltip .tooltip-4-1-1 {
-  background-color: var(--cds-charts-4-1-1, #6929c4);
-}
-.cds--cc--tooltip .tooltip-4-1-2 {
-  background-color: var(--cds-charts-4-1-2, #012749);
-}
-.cds--cc--tooltip .tooltip-4-1-3 {
-  background-color: var(--cds-charts-4-1-3, #009d9a);
-}
-.cds--cc--tooltip .tooltip-4-1-4 {
-  background-color: var(--cds-charts-4-1-4, #ee5396);
-}
-.cds--cc--tooltip .tooltip-4-2-1 {
-  background-color: var(--cds-charts-4-2-1, #9f1853);
-}
-.cds--cc--tooltip .tooltip-4-2-2 {
-  background-color: var(--cds-charts-4-2-2, #fa4d56);
-}
-.cds--cc--tooltip .tooltip-4-2-3 {
-  background-color: var(--cds-charts-4-2-3, #520408);
-}
-.cds--cc--tooltip .tooltip-4-2-4 {
-  background-color: var(--cds-charts-4-2-4, #a56eff);
-}
-.cds--cc--tooltip .tooltip-4-3-1 {
-  background-color: var(--cds-charts-4-3-1, #009d9a);
-}
-.cds--cc--tooltip .tooltip-4-3-2 {
-  background-color: var(--cds-charts-4-3-2, #002d9c);
-}
-.cds--cc--tooltip .tooltip-4-3-3 {
-  background-color: var(--cds-charts-4-3-3, #a56eff);
-}
-.cds--cc--tooltip .tooltip-4-3-4 {
-  background-color: var(--cds-charts-4-3-4, #9f1853);
-}
-.cds--cc--tooltip .tooltip-5-1-1 {
-  background-color: var(--cds-charts-5-1-1, #6929c4);
-}
-.cds--cc--tooltip .tooltip-5-1-2 {
-  background-color: var(--cds-charts-5-1-2, #1192e8);
-}
-.cds--cc--tooltip .tooltip-5-1-3 {
-  background-color: var(--cds-charts-5-1-3, #005d5d);
-}
-.cds--cc--tooltip .tooltip-5-1-4 {
-  background-color: var(--cds-charts-5-1-4, #9f1853);
-}
-.cds--cc--tooltip .tooltip-5-1-5 {
-  background-color: var(--cds-charts-5-1-5, #520408);
-}
-.cds--cc--tooltip .tooltip-5-2-1 {
-  background-color: var(--cds-charts-5-2-1, #002d9c);
-}
-.cds--cc--tooltip .tooltip-5-2-2 {
-  background-color: var(--cds-charts-5-2-2, #009d9a);
-}
-.cds--cc--tooltip .tooltip-5-2-3 {
-  background-color: var(--cds-charts-5-2-3, #9f1853);
-}
-.cds--cc--tooltip .tooltip-5-2-4 {
-  background-color: var(--cds-charts-5-2-4, #520408);
-}
-.cds--cc--tooltip .tooltip-5-2-5 {
-  background-color: var(--cds-charts-5-2-5, #a56eff);
-}
-.cds--cc--tooltip .tooltip-14-1-1 {
-  background-color: var(--cds-charts-14-1-1, #6929c4);
-}
-.cds--cc--tooltip .tooltip-14-1-2 {
-  background-color: var(--cds-charts-14-1-2, #1192e8);
-}
-.cds--cc--tooltip .tooltip-14-1-3 {
-  background-color: var(--cds-charts-14-1-3, #005d5d);
-}
-.cds--cc--tooltip .tooltip-14-1-4 {
-  background-color: var(--cds-charts-14-1-4, #9f1853);
-}
-.cds--cc--tooltip .tooltip-14-1-5 {
-  background-color: var(--cds-charts-14-1-5, #fa4d56);
-}
-.cds--cc--tooltip .tooltip-14-1-6 {
-  background-color: var(--cds-charts-14-1-6, #520408);
-}
-.cds--cc--tooltip .tooltip-14-1-7 {
-  background-color: var(--cds-charts-14-1-7, #198038);
-}
-.cds--cc--tooltip .tooltip-14-1-8 {
-  background-color: var(--cds-charts-14-1-8, #002d9c);
-}
-.cds--cc--tooltip .tooltip-14-1-9 {
-  background-color: var(--cds-charts-14-1-9, #ee5396);
-}
-.cds--cc--tooltip .tooltip-14-1-10 {
-  background-color: var(--cds-charts-14-1-10, #b28600);
-}
-.cds--cc--tooltip .tooltip-14-1-11 {
-  background-color: var(--cds-charts-14-1-11, #009d9a);
-}
-.cds--cc--tooltip .tooltip-14-1-12 {
-  background-color: var(--cds-charts-14-1-12, #012749);
-}
-.cds--cc--tooltip .tooltip-14-1-13 {
-  background-color: var(--cds-charts-14-1-13, #8a3800);
-}
-.cds--cc--tooltip .tooltip-14-1-14 {
-  background-color: var(--cds-charts-14-1-14, #a56eff);
-}
-
-.cds--cc--legend .additional > .icon .area-1 {
-  fill: var(--cds-zone-fill-01, #f4f4f4);
-  stroke: var(--cds-zone-stroke-01, #8d8d8d);
-}
-.cds--cc--legend .additional > .icon .area-2 {
-  fill: var(--cds-zone-fill-02, #e0e0e0);
-  stroke: var(--cds-zone-stroke-02, #8d8d8d);
-}
-.cds--cc--legend .additional > .icon .area-3 {
-  fill: var(--cds-zone-fill-03, #c6c6c6);
-  stroke: var(--cds-zone-stroke-03, #8d8d8d);
-}
-.cds--cc--legend .additional > .icon .quartile-wrapper {
-  fill: var(--cds-zone-fill-02, #e0e0e0);
-  stroke: var(--cds-zone-stroke-01, #8d8d8d);
-}
-.cds--cc--legend .additional > .icon .quartile-line {
-  fill: var(--cds-layer-inverse-absolute, #000000);
-}
-
-.cds--cc--axes {
-  font-family: var(--cds-charts-font-family-condensed);
-  overflow: visible;
-}
-.cds--cc--axes g.axis g.ticks.invisible {
-  visibility: hidden;
-}
-.cds--cc--axes g.axis g.tick-hover rect.axis-holder {
-  fill: transparent;
-  stroke: transparent;
-  stroke-width: 2px;
-}
-.cds--cc--axes g.axis g.tick-hover:hover rect.axis-holder,
-.cds--cc--axes g.axis g.tick-hover:focus rect.axis-holder {
-  fill: var(--cds-layer-selected-inverse, #161616);
-  stroke: var(--cds-layer-selected-inverse, #161616);
-  stroke-width: 2px;
-}
-.cds--cc--axes g.axis g.tick-hover:hover text,
-.cds--cc--axes g.axis g.tick-hover:focus text {
-  fill: var(--cds-layer-selected);
-}
-.cds--cc--axes g.axis g.tick text {
-  fill: var(--cds-text-secondary, #525252);
-  font-family: var(--cds-charts-font-family-condensed);
-}
-.cds--cc--axes g.axis g.tick text.tick-label--primary {
-  font-weight: bold;
-}
-.cds--cc--axes g.axis g.tick text.tick-label {
-  font-weight: normal;
-}
-.cds--cc--axes g.axis g.tick line {
-  display: none;
-}
-.cds--cc--axes g.axis path.domain {
-  stroke: var(--cds-border-strong-01, #8d8d8d);
-}
-.cds--cc--axes g.axis .axis-title {
-  font-family: var(--cds-charts-font-family);
-  font-weight: 600;
-  fill: var(--cds-text-primary, #161616);
-}
-
-.cds--cc--chart-wrapper g.callouts {
-  stroke: var(--cds-text-secondary, #525252);
-}
-
-svg.cds--cc--color-legend {
-  display: flex;
-  user-select: none;
-}
-svg.cds--cc--color-legend g.legend-title text {
-  fill: var(--cds-layer-inverse-absolute, #000000);
-}
-
-.cds--cc--card-node {
-  display: flex;
-  position: relative;
-  background-color: var(--cds-layer-01, #f4f4f4);
-  z-index: 1;
-  box-sizing: border-box;
-  font-family: var(--cds-charts-font-family);
-  width: 100%;
-  height: 100%;
-  padding: 1rem 0.5rem;
-  border-left: 0.25rem solid var(--cds-border-inverse, #161616);
-}
-
-.cds--cc--card-node--a,
-.cds--cc--card-node--button {
-  border-top: none;
-  border-right: none;
-  border-bottom: none;
-  color: inherit;
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.cds--cc--card-node--button {
-  font-family: var(--cds-charts-font-family);
-  text-align: left;
-  width: 100%;
-}
-
-.cds--cc--card-node--a:focus,
-.cds--cc--card-node--a:hover,
-.cds--cc--card-node--button:focus,
-.cds--cc--card-node--button:hover {
-  background-color: var(--cds-network-diagrams-background-hover, #f1f1f1);
-}
-
-.cds--cc--card-node--a:focus,
-.cds--cc--card-node--button:focus {
-  outline: 2px solid var(--cds-focus, #0f62fe);
-  outline-offset: -2px;
-}
-@media screen and (prefers-contrast) {
-  .cds--cc--card-node--a:focus,
-  .cds--cc--card-node--button:focus {
-    outline-style: dotted;
-  }
-}
-
-.cds--cc--card-node--stacked::before {
-  content: '';
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  z-index: 0;
-  border-top: 0.125rem solid var(--cds-layer-accent-01, #e0e0e0);
-  border-right: 0.125rem solid var(--cds-layer-accent-01, #e0e0e0);
-  pointer-events: none;
-  left: 0.3125rem;
-  bottom: 0.3125rem;
-}
-.cds--cc--card-node--stacked::after {
-  content: '';
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  z-index: 0;
-  border-top: 0.125rem solid var(--cds-layer-accent-01, #e0e0e0);
-  border-right: 0.125rem solid var(--cds-layer-accent-01, #e0e0e0);
-  pointer-events: none;
-  left: 0.6875rem;
-  bottom: 0.6875rem;
-}
-
-.cds--cc--card-node__column {
-  padding: 0 0.5rem;
-}
-
-.cds--cc--card-node__column--farside {
-  margin-left: auto;
-}
-
-.cds--cc--card-node__title {
-  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
-  font-weight: var(--cds-productive-heading-01-font-weight, 600);
-  line-height: var(--cds-productive-heading-01-line-height, 1.28572);
-  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
-  margin: 0;
-}
-
-.cds--cc--card-node__subtitle {
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.28572);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  margin: 0;
-}
-
-.cds--cc--card-node__label {
-  display: block;
-  font-size: var(--cds-label-01-font-size, 0.75rem);
-  font-weight: var(--cds-label-01-font-weight, 400);
-  line-height: var(--cds-label-01-line-height, 1.33333);
-  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
-  color: var(--cds-text-secondary, #525252);
-  padding-top: 1.5rem;
-}
-
-.cds--cc--shape-node {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: var(--cds-layer-01, #f4f4f4);
-  box-sizing: border-box;
-  font-family: var(--cds-charts-font-family);
-  width: 100%;
-  height: 100%;
-  position: relative;
-}
-
-.cds--cc--shape-node--circle {
-  border-radius: 100%;
-}
-
-.cds--cc--shape-node--square {
-  border-radius: 0;
-}
-
-.cds--cc--shape-node--rounded-square {
-  border-radius: 0.5rem;
-}
-
-.cds--cc--shape-node--a,
-.cds--cc--shape-node--button {
-  border: none;
-  color: inherit;
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.cds--cc--shape-node--button {
-  font-family: var(--cds-charts-font-family);
-  text-align: left;
-  width: 100%;
-}
-
-.cds--cc--shape-node--a:focus,
-.cds--cc--shape-node--a:hover,
-.cds--cc--shape-node--button:focus,
-.cds--cc--shape-node--button:hover {
-  background-color: var(--cds-network-diagrams-background-hover, #f1f1f1);
-}
-.cds--cc--shape-node--a:focus .cds--cc--shape-node__title,
-.cds--cc--shape-node--a:focus .cds--cc--shape-node__subtitle,
-.cds--cc--shape-node--a:hover .cds--cc--shape-node__title,
-.cds--cc--shape-node--a:hover .cds--cc--shape-node__subtitle,
-.cds--cc--shape-node--button:focus .cds--cc--shape-node__title,
-.cds--cc--shape-node--button:focus .cds--cc--shape-node__subtitle,
-.cds--cc--shape-node--button:hover .cds--cc--shape-node__title,
-.cds--cc--shape-node--button:hover .cds--cc--shape-node__subtitle {
-  font-weight: 600;
-}
-
-.cds--cc--shape-node--a:focus:focus,
-.cds--cc--shape-node--button:focus:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--cds-focus, #0f62fe);
-}
-
-.cds--cc--shape-node__body {
-  position: absolute;
-  top: calc(100% + 0.125rem);
-  text-align: center;
-}
-
-.cds--cc--shape-node__subtitle {
-  padding-bottom: 0.125rem;
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.28572);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  color: var(--cds-text-primary, #161616);
-}
-
-.cds--cc--shape-node__icon {
-  display: flex;
-}
-
-.cds--cc--shape-node__title {
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.28572);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  color: var(--cds-text-primary, #161616);
-  padding-top: 0.125rem;
-  margin-bottom: 1px;
-}
-
-.cds--cc--edge {
-  fill: transparent;
-}
-
-.cds--cc--edge__container {
-  stroke-width: 1.5rem;
-  stroke: transparent;
-  stroke-dasharray: none;
-}
-
-.cds--cc--edge__inner {
-  stroke-width: 0.0625rem;
-  stroke: var(--cds-border-strong-01, #8d8d8d);
-}
-
-.cds--cc--edge__outer {
-  stroke-width: 0.15625rem;
-  stroke: transparent;
-}
-
-.cds--cc--edge:hover .cds--cc--edge__inner {
-  stroke-width: 0.15625rem;
-}
-
-.cds--cc--edge--dash-sm {
-  stroke-dasharray: 2 4;
-}
-
-.cds--cc--edge--dash-md {
-  stroke-dasharray: 4 4;
-}
-
-.cds--cc--edge--dash-lg {
-  stroke-dasharray: 8 4;
-}
-
-.cds--cc--edge--dash-xl {
-  stroke-dasharray: 16 4;
-}
-
-.cds--cc--edge--tunnel .cds--cc--edge__outer {
-  stroke: var(--cds-layer-accent-01, #e0e0e0);
-  stroke-width: 0.375rem;
-}
-
-.cds--cc--edge--double .cds--cc--edge__inner {
-  stroke: var(--cds-background, #ffffff);
-}
-.cds--cc--edge--double .cds--cc--edge__outer {
-  stroke: var(--cds-border-inverse, #161616);
-  stroke-width: 0.28125rem;
-}
-
-.cds--cc--marker {
-  fill: var(--cds-border-inverse, #161616);
-}
-
-.cds--cc--grid rect.chart-grid-backdrop {
-  fill: var(--cds-grid-bg, #ffffff);
-}
-.cds--cc--grid rect.chart-grid-backdrop.stroked {
-  stroke: var(--cds-layer-accent-01, #e0e0e0);
-}
-.cds--cc--grid rect.stroke {
-  stroke: var(--cds-layer-accent-01, #e0e0e0);
-}
-.cds--cc--grid g.x.grid g.tick line,
-.cds--cc--grid g.y.grid g.tick line {
-  pointer-events: none;
-  stroke-width: 1px;
-  stroke: var(--cds-layer-accent-01, #e0e0e0);
-}
-.cds--cc--grid g.x.grid g.tick.active line,
-.cds--cc--grid g.y.grid g.tick.active line {
-  stroke-dasharray: 2px;
-  stroke: var(--cds-focus, #0f62fe);
-}
-
-.cds--cc--grid-brush g.grid-brush rect.selection {
-  fill: none;
-  fill-opacity: 0;
-  stroke: none;
-}
-
-.cds--cc--grid-brush rect.frontSelection {
-  fill: var(--cds-layer-accent-01, #e0e0e0);
-  fill-opacity: 0.3;
-  stroke: var(--cds-button-tertiary, #0f62fe);
-}
-
-.cds--cc--highlight rect.highlight-bar {
-  pointer-events: none;
-  fill: #ee5396;
-  stroke: #ee5396;
-}
-
-.cds--cc--layout-row {
-  display: flex;
-  flex-direction: row;
-}
-.cds--cc--layout-column {
-  display: flex;
-  flex-direction: column;
-}
-.cds--cc--layout-row-reverse {
-  display: flex;
-  flex-direction: row-reverse;
-}
-.cds--cc--layout-column-reverse {
-  display: flex;
-  flex-direction: column-reverse;
-}
-.cds--cc--layout-alignitems-center {
-  align-items: center;
-}
-
-.cds--cc--chart-wrapper .layout-child {
-  overflow: visible;
-}
-
-.cds--cc--chart-wrapper svg.layout-svg-wrapper {
-  height: inherit;
-  width: inherit;
-  overflow: visible;
-}
-
-div.cds--cc--legend {
-  font-family: var(--cds-charts-font-family-condensed);
-  display: flex;
-  user-select: none;
-  -webkit-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-div.cds--cc--legend[data-name='legend-items'] {
-  width: 100%;
-  margin: -5px;
-}
-div.cds--cc--legend div.legend-item {
-  display: flex;
-  align-items: center;
-  margin: 5px;
-}
-div.cds--cc--legend div.legend-item div.checkbox {
-  width: 13px;
-  height: 13px;
-  margin-right: 4px;
-  border-radius: 2px;
-  border: solid 1px var(--cds-background, #ffffff);
-  box-shadow: 0 0 0 2px transparent;
-}
-@media (forced-colors: active) {
-  div.cds--cc--legend div.legend-item div.checkbox {
-    forced-color-adjust: none;
-  }
-}
-div.cds--cc--legend div.legend-item div.checkbox:not(.active) {
-  border-color: var(--cds-text-secondary, #525252);
-  background: var(--cds-background, #ffffff);
-}
-div.cds--cc--legend div.legend-item div.checkbox svg {
-  display: none;
-  vertical-align: text-top;
-  fill: var(--cds-background, #ffffff);
-  stroke: var(--cds-background, #ffffff);
-}
-div.cds--cc--legend div.legend-item.additional svg.icon {
-  margin-right: 4px;
-}
-div.cds--cc--legend div.legend-item p {
-  font-size: 12px;
-  fill: var(--cds-text-secondary, #525252);
-  line-height: 1rem;
-}
-div.cds--cc--legend.center-aligned {
-  justify-content: center;
-}
-div.cds--cc--legend.right-aligned {
-  justify-content: flex-end;
-}
-div.cds--cc--legend.has-deactivated-items div.legend-item div.checkbox svg {
-  display: block;
-}
-div.cds--cc--legend.vertical {
-  margin: -5px;
-  flex-direction: column;
-}
-div.cds--cc--legend.vertical div.legend-item {
-  margin-right: 0;
-  margin-bottom: 10px;
-}
-div.cds--cc--legend.clickable div.legend-item:not(.additional):hover {
-  cursor: pointer;
-}
-div.cds--cc--legend.clickable
-  div.legend-item:not(.additional):hover
-  div.checkbox {
-  border: solid 1px var(--cds-background, #ffffff);
-  box-shadow: 0 0 0 2px #0f62fe;
-}
-div.cds--cc--legend.clickable
-  div.legend-item:not(.additional):hover
-  div.checkbox:not(.active) {
-  border-color: var(--cds-text-secondary, #525252);
-}
-
-.cds--cc--meter-title {
-  overflow: visible;
-}
-.cds--cc--meter-title text.meter-title,
-.cds--cc--meter-title text.proportional-meter-title,
-.cds--cc--meter-title text.proportional-meter-total,
-.cds--cc--meter-title text.percent-value {
-  fill: var(--cds-text-primary, #161616);
-}
-.cds--cc--meter-title g.status-indicator.status--danger circle.status {
-  fill: var(--cds-support-error, #da1e28);
-}
-.cds--cc--meter-title g.status-indicator.status--warning circle.status {
-  fill: var(--cds-support-warning, #f1c21b);
-}
-.cds--cc--meter-title g.status-indicator.status--warning path.innerFill {
-  fill: #000000;
-}
-.cds--cc--meter-title g.status-indicator.status--success circle.status {
-  fill: var(--cds-support-success, #24a148);
-}
-.cds--cc--meter-title g.status-indicator path.innerFill {
-  fill: var(--cds-layer-01-absolute, #ffffff);
-}
-
-.cds--cc--ruler line.ruler-line,
-.cds--cc--ruler-binned line.ruler-line {
-  stroke: var(--cds-layer-inverse-absolute, #000000);
-  stroke-width: 1px;
-  stroke-dasharray: 2;
-  pointer-events: none;
-}
-
-.cds--cc--skeleton rect.chart-skeleton-backdrop {
-  fill: var(--cds-grid-bg, #ffffff);
-}
-.cds--cc--skeleton .shimmer-effect-lines {
-  stroke-width: 1px;
-}
-.cds--cc--skeleton .shimmer-effect-sparkline {
-  stroke-width: 0px;
-}
-.cds--cc--skeleton .empty-state-lines {
-  stroke-width: 1px;
-  stroke: var(--cds-layer-accent-01, #e0e0e0);
-}
-.cds--cc--skeleton .shimmer-lines .stop-bg-shimmer {
-  stop-color: var(--cds-layer-accent-01, #e0e0e0);
-}
-.cds--cc--skeleton .shimmer-lines .stop-shimmer {
-  stop-color: #ffffff;
-}
-.cds--cc--skeleton .empty-state-areas {
-  fill: rgba(127, 127, 127, 0.1);
-}
-.cds--cc--skeleton .shimmer-areas .stop-bg-shimmer {
-  stop-color: rgba(127, 127, 127, 0.1);
-}
-.cds--cc--skeleton .shimmer-areas .stop-shimmer {
-  stop-color: rgba(255, 255, 255, 0.15);
-}
-
-.cds--cc--skeleton-lines rect.chart-skeleton-backdrop {
-  fill: var(--cds-grid-bg, #ffffff);
-}
-.cds--cc--skeleton-lines .shimmer-effect-lines {
-  stroke-width: 1px;
-}
-.cds--cc--skeleton-lines .shimmer-effect-sparkline {
-  stroke-width: 0px;
-}
-.cds--cc--skeleton-lines .empty-state-lines {
-  stroke-width: 1px;
-  stroke: var(--cds-layer-accent-01, #e0e0e0);
-}
-.cds--cc--skeleton-lines .shimmer-lines .stop-bg-shimmer {
-  stop-color: var(--cds-layer-accent-01, #e0e0e0);
-}
-.cds--cc--skeleton-lines .shimmer-lines .stop-shimmer {
-  stop-color: #ffffff;
-}
-
-.cds--cc--threshold line.threshold-line {
-  stroke: #fa4d56;
-  stroke-width: 1;
-  stroke-dasharray: 4;
-  cursor: pointer;
-  pointer-events: none;
-}
-.cds--cc--threshold line.threshold-line.active {
-  stroke-width: 2;
-}
-.cds--cc--threshold rect.threshold-hoverable-area {
-  height: 20px;
-  transform: translate(0, -10px);
-  cursor: pointer;
-  fill: transparent;
-}
-.cds--cc--threshold rect.threshold-hoverable-area.rotate {
-  transform: rotate(90deg) translate(0, -10px);
-}
-
-.cds--cc--threshold--label {
-  background-color: #fa4d56;
-  pointer-events: none;
-  transition: opacity 0.1s;
-  transition-timing-function: cubic-bezier(0.4, 0.14, 0.3, 1);
-  display: inline;
-  box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.2);
-  position: absolute;
-  word-wrap: break-word;
-  z-index: 1059;
-  font-family: var(--cds-charts-font-family-condensed);
-  color: var(--cds-text-primary, #161616);
-  line-height: 16px;
-  font-size: 12px;
-  padding: 4px;
-  min-width: 20px;
-}
-.cds--cc--threshold--label.hidden {
-  opacity: 0;
-  transition: opacity 0.1s;
-  transition-timing-function: cubic-bezier(0.4, 0.14, 0.3, 1);
-}
-
-.cds--cc--title p.title {
-  color: var(--cds-text-primary, #161616);
-  font-size: 16px;
-  font-family: var(--cds-charts-font-family);
-  font-weight: 600;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  padding-right: 15px;
-}
-
-.cds--chart-holder .layout-child.title {
-  height: unset !important;
-  overflow: hidden;
-}
-
-.cds--chart-holder .cds--cc--toolbar {
-  display: flex;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu-options {
-  box-sizing: border-box;
-  padding: 0;
-  border: 0;
-  margin: 0;
-  font-family: inherit;
-  font-size: 100%;
-  vertical-align: baseline;
-  box-shadow: 0 2px 6px var(--cds-shadow, rgba(0, 0, 0, 0.3));
-  position: absolute;
-  z-index: 6000;
-  display: none;
-  background-color: var(--cds-layer);
-  width: 10rem;
-  flex-direction: column;
-  align-items: flex-start;
-  top: 32px;
-  inset-inline-start: 0;
-  list-style: none;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu-options *,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu-options ::before,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu-options ::after {
-  box-sizing: inherit;
-}
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu-options
-  .cds--overflow-menu-options__option {
-  box-sizing: border-box;
-  border: 0;
-  margin: 0;
-  font-family: inherit;
-  font-size: 100%;
-  vertical-align: baseline;
-  display: flex;
-  align-items: center;
-  padding: 0;
-  background-color: transparent;
-  block-size: 2.5rem;
-  inline-size: 100%;
-  transition: background-color 0.11s cubic-bezier(0, 0, 0.38, 0.9);
-}
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu-options
-  .cds--overflow-menu-options__option:hover {
-  background-color: var(--cds-layer-hover);
-}
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu-options
-  .cds--overflow-menu-options__option
-  .cds--overflow-menu-options__btn {
-  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-compact-01-font-weight, 400);
-  line-height: var(--cds-body-compact-01-line-height, 1.28572);
-  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-  display: inline-flex;
-  align-items: center;
-  padding: 0 1rem;
-  border: none;
-  background-color: transparent;
-  block-size: 100%;
-  color: var(--cds-text-secondary, #525252);
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 400;
-  inline-size: 100%;
-  max-inline-size: 11.25rem;
-  text-align: start;
-  transition:
-    outline 0.11s cubic-bezier(0, 0, 0.38, 0.9),
-    background-color 0.11s cubic-bezier(0, 0, 0.38, 0.9),
-    color 0.11s cubic-bezier(0, 0, 0.38, 0.9);
-}
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu-options
-  .cds--overflow-menu-options__option
-  .cds--overflow-menu-options__btn:focus {
-  outline: 2px solid var(--cds-focus, #0f62fe);
-  outline-offset: -2px;
-}
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu-options
-  .cds--overflow-menu-options__option
-  *,
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu-options
-  .cds--overflow-menu-options__option
-  ::before,
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu-options
-  .cds--overflow-menu-options__option
-  ::after {
-  box-sizing: inherit;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu--flip {
-  right: 0;
-  left: unset;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu--flip.is-open {
-  display: table;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu--flip ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu__trigger {
-  width: 2rem;
-  height: 2rem;
-  appearance: none;
-  background: none;
-  block-size: 2.5rem;
-  border: 0;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: flex;
-  font-family: inherit;
-  font-size: 100%;
-  inline-size: 2.5rem;
-  align-items: center;
-  justify-content: center;
-  margin: 0;
-  min-height: 2.5rem;
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-  padding: 0;
-  position: relative;
-  text-align: start;
-  transition:
-    outline 110ms cubic-bezier(0, 0, 0.38, 0.9),
-    background-color 110ms cubic-bezier(0, 0, 0.38, 0.9);
-  vertical-align: baseline;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu:hover,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu__trigger:hover {
-  background-color: var(--cds-layer-hover);
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu:focus,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu__trigger:focus {
-  outline: 2px solid var(--cds-focus, #0f62fe);
-  outline-offset: -2px;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu *,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu ::before,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu ::after,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu__trigger *,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu__trigger ::before,
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu__trigger ::after {
-  box-sizing: inherit;
-}
-.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu > :first-child,
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu__trigger
-  > :first-child {
-  margin-block-start: 0;
-}
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu
-  .cds--overflow-menu__icon,
-.cds--chart-holder
-  .cds--cc--toolbar
-  .cds--overflow-menu__trigger
-  .cds--overflow-menu__icon {
-  block-size: 1rem;
-  fill: var(--cds-icon-primary, #161616);
-  inline-size: 1rem;
-}
-
-.cds--chart-holder {
-  --cds-layout-size-height-min: 0px;
-  --cds-layout-size-height-lg: 3rem;
-  --cds-layout-size-height-max: 999999999px;
-  --cds-layout-density-padding-inline-min: 0px;
-  --cds-layout-density-padding-inline-normal: 1rem;
-  --cds-layout-density-padding-inline-max: 999999999px;
-  --cds-layout-size-height-lg: 3rem;
-}
-.cds--chart-holder .cds--modal {
-  position: fixed;
-  z-index: 9000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--cds-overlay, rgba(22, 22, 22, 0.5));
-  block-size: 100vh;
-  content: '';
-  inline-size: 100vw;
-  inset-block-start: 0;
-  inset-inline-start: 0;
-  opacity: 0;
-  transition:
-    opacity 0.24s cubic-bezier(0.4, 0.14, 1, 1),
-    visibility 0ms linear 0.24s;
-  visibility: hidden;
-}
-.cds--chart-holder .cds--modal.is-visible {
-  z-index: 99999;
-  opacity: 1;
-  transition:
-    opacity 0.24s cubic-bezier(0, 0, 0.3, 1),
-    visibility 0ms linear;
-  visibility: inherit;
-}
-.cds--chart-holder .cds--modal.is-visible .cds--modal-container {
-  transform: translateZ(0);
-  transition: transform 0.24s cubic-bezier(0, 0, 0.3, 1);
-}
-.cds--chart-holder .cds--modal .cds--modal-container {
-  position: fixed;
-  top: 0;
+.cds--css-grid,
+.cds--subgrid {
   display: grid;
-  overflow: hidden;
-  width: 100%;
-  height: 100%;
-  max-height: 100%;
-  background-color: var(--cds-layer);
-  grid-template-columns: 100%;
-  grid-template-rows: auto 1fr auto;
-  outline: 3px solid transparent;
-  outline-offset: -3px;
-  transform: translate3d(0, -24px, 0);
-  transform-origin: top center;
-  transition: transform 0.24s cubic-bezier(0.4, 0.14, 1, 1);
+  grid-template-columns: repeat(var(--cds-grid-columns), minmax(0, 1fr));
 }
-@media (max-width: 671px) {
-  .cds--chart-holder .cds--modal .cds--modal-container {
-    transform: none;
-  }
+.carbon-chart-wrapper ol,
+.carbon-chart-wrapper ul,
+.cds--accordion {
+  list-style: none;
 }
-@media (min-width: 42rem) {
-  .cds--chart-holder .cds--modal .cds--modal-container {
-    position: static;
-    width: 84%;
-    height: auto;
-    max-height: 90%;
-  }
-}
-@media (min-width: 66rem) {
-  .cds--chart-holder .cds--modal .cds--modal-container {
-    width: 60%;
-    max-height: 84%;
-  }
-}
-@media (min-width: 82rem) {
-  .cds--chart-holder .cds--modal .cds--modal-container {
-    width: 48%;
-  }
-}
-.cds--chart-holder .cds--modal .cds--modal-container .cds--modal-header {
-  padding-top: 1rem;
-  padding-right: 3rem;
-  padding-left: 1rem;
-  margin-bottom: 0.5rem;
-  grid-column: 1/-1;
-  grid-row: 1/1;
-}
-.cds--chart-holder .cds--modal .cds--modal-container .cds--modal-header__label {
-  margin-top: 0;
-  margin-bottom: 0;
-  box-sizing: border-box;
-  padding: 0;
-  border: 0;
-  margin: 0;
-  font-family: inherit;
-  vertical-align: baseline;
-  font-size: var(--cds-label-01-font-size, 0.75rem);
-  font-weight: var(--cds-label-01-font-weight, 400);
-  line-height: var(--cds-label-01-line-height, 1.33333);
-  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
-  color: var(--cds-text-secondary, #525252);
-  --docs-content-width: 75%;
-  width: var(--docs-content-width);
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-header__heading {
-  margin-top: 0.5rem !important;
-  margin-bottom: 1rem !important;
-  box-sizing: border-box;
-  padding: 0;
-  border: 0;
-  margin: 0;
-  font-family: inherit;
-  vertical-align: baseline;
-  font-size: var(--cds-heading-03-font-size, 1.25rem);
-  font-weight: var(--cds-heading-03-font-weight, 400);
-  line-height: var(--cds-heading-03-line-height, 1.4);
-  letter-spacing: var(--cds-heading-03-letter-spacing, 0);
-  padding-right: calc(20% - 3rem);
-  color: var(--cds-text-primary, #161616);
-  --docs-content-width: 75%;
-  width: var(--docs-content-width);
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-header
-  .cds--modal-close {
-  position: absolute;
-  z-index: 2;
-  top: 0;
-  right: 0;
-  overflow: hidden;
-  width: 3rem;
-  height: 3rem;
-  padding: 0.75rem;
-  border: 2px solid transparent;
+.cds--accordion.cds--skeleton .cds--accordion__heading:hover:before,
+.cds--accordion__heading[disabled]:hover:before {
   background-color: transparent;
-  cursor: pointer;
-  transition: background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
-  margin: 0;
-  border-radius: 0;
-  font-family: inherit;
 }
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-header
-  .cds--modal-close:hover {
-  background-color: var(--cds-layer-hover);
+.cds--breadcrumb-item [aria-current='page']:hover,
+.cds--breadcrumb-item.cds--breadcrumb-item--current .cds--link:hover,
+.cds--link {
+  text-decoration: none;
 }
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-header
-  .cds--modal-close:focus {
-  border-color: var(--cds-focus, #0f62fe);
-  outline: none;
+.cds--breadcrumb.cds--skeleton .cds--link:before,
+.cds--btn.cds--skeleton:before {
+  animation: skeleton 3s ease-in-out infinite;
+  will-change: transform-origin, transform, opacity;
 }
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-header
-  .cds--modal-close__icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  fill: var(--cds-icon-primary, #161616);
+.cds--btn-set .cds--btn:first-of-type:not(:focus),
+.cds--btn-set .cds--btn:focus + .cds--btn,
+.cds--btn-set--stacked .cds--btn:first-of-type:not(:focus) {
+  box-shadow: inherit;
 }
-.cds--chart-holder .cds--modal .cds--modal-container .cds--modal-content {
-  padding: 0 !important;
-  margin-bottom: 0;
-  color-scheme: var(--cds-color-scheme, light);
-  font-size: var(--cds-body-01-font-size, 0.875rem);
-  line-height: var(--cds-body-01-line-height, 1.42857);
-  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
-  position: relative;
-  color: var(--cds-text-primary, #161616);
-  font-weight: 400;
-  grid-column: 1/-1;
-  grid-row: 2/-2;
-  overflow-y: auto;
+.cds--breadcrumb .cds--link,
+.cds--checkbox {
+  white-space: nowrap;
 }
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table {
-  position: relative;
+.cds--dropdown__wrapper--inline .cds--form-requirement,
+.cds--list-box__wrapper--inline .cds--form-requirement {
+  grid-column: 2;
+}
+.carbon-chart-wrapper table,
+.cds--data-table,
+.cds--structured-list {
   border-collapse: collapse;
-  width: 100%;
   border-spacing: 0;
 }
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table
-  thead {
-  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
-  font-weight: var(--cds-heading-compact-01-font-weight, 600);
-  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
-  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
-  background-color: var(--cds-layer-accent);
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table
-  thead
-  tr {
-  width: 100%;
-  height: 3rem;
-  border: none;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table
-  thead
-  tr
-  th {
-  position: sticky;
-  top: 0;
-  padding-right: 1rem;
-  padding-left: 1rem;
-  background-color: var(--cds-layer-accent);
-  color: var(--cds-text-primary, #161616);
-  text-align: start;
-  vertical-align: middle;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table
-  thead
-  tr
-  th
-  .cds--table-header-label {
-  text-align: left;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table
-  tbody {
-  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-compact-01-font-weight, 400);
-  line-height: var(--cds-body-compact-01-line-height, 1.28572);
-  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
-  background-color: var(--cds-layer);
-  width: 100%;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table
-  tbody
-  tr {
-  transition: background-color 70ms cubic-bezier(0, 0, 0.38, 0.9);
-  width: 100;
-  height: 3rem;
-  border: none;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table
-  tbody
-  tr:hover {
-  background: var(--cds-layer-hover) !important;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-content
-  .cds--data-table
-  tbody
-  tr
-  td {
-  transition: background-color 70ms cubic-bezier(0, 0, 0.38, 0.9);
-  padding-right: 1rem;
-  padding-left: 1rem;
-  border-top: 1px solid var(--cds-layer);
-  border-bottom: 1px solid var(--cds-border-subtle);
-  color: var(--cds-text-secondary, #525252);
-  text-align: left;
-  vertical-align: middle;
-}
-.cds--chart-holder .cds--modal .cds--modal-container .cds--modal-footer {
-  background-color: transparent;
-  display: flex;
-  height: 4rem;
-  justify-content: flex-end;
-  margin-top: auto;
-  grid-column: 1/-1;
-  grid-row: -1/-1;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-footer
-  .cds--cc-modal-footer-spacer {
-  width: 50%;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-footer
-  .cds--btn {
-  max-width: none;
-  height: 4rem;
-  flex: 0 1 50%;
-  align-items: baseline;
-  padding-top: 0.875rem;
-  padding-bottom: 2rem;
-  margin: 0;
-  --cds-layout-size-height-local: clamp(
-    var(--cds-layout-size-height-min),
-    var(--cds-layout-size-height, var(--cds-layout-size-height-lg)),
-    var(--cds-layout-size-height-max)
-  );
-  --cds-layout-density-padding-inline-local: clamp(
-    var(--cds-layout-density-padding-inline-min),
-    var(
-      --cds-layout-density-padding-inline,
-      var(--cds-layout-density-padding-inline-normal)
-    ),
-    var(--cds-layout-density-padding-inline-max)
-  );
-  --temp-1lh: (var(--cds-body-compact-01-line-height, 1.28572) * 1em);
-  --temp-expressive-1lh: (var(--cds-body-compact-02-line-height, 1.375) * 1em);
-  --temp-padding-block-max: calc(
-    (var(--cds-layout-size-height-lg) - var(--temp-1lh)) / 2 - 0.0625rem
-  );
-  box-sizing: border-box;
-  padding: 0;
-  border: 0;
-  font-family: inherit;
-  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-compact-01-font-weight, 400);
-  line-height: var(--cds-body-compact-01-line-height, 1.28572);
-  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
-  position: relative;
-  display: inline-flex;
-  width: max-content;
-  max-width: 20rem;
-  min-height: var(--cds-layout-size-height-local);
-  justify-content: space-between;
-  border-radius: 0;
-  cursor: pointer;
-  outline: none;
-  padding-block: min(
-    (var(--cds-layout-size-height-local) - var(--temp-1lh)) / 2 - 0.0625rem,
-    var(--temp-padding-block-max)
-  );
-  padding-inline-end: calc(
-    var(--cds-layout-density-padding-inline-local) * 3 + 1rem - 0.0625rem
-  );
-  padding-inline-start: calc(
-    var(--cds-layout-density-padding-inline-local) - 0.0625rem
-  );
-  text-align: left;
-  text-decoration: none;
-  transition:
-    background 70ms cubic-bezier(0, 0, 0.38, 0.9),
-    box-shadow 70ms cubic-bezier(0, 0, 0.38, 0.9),
-    border-color 70ms cubic-bezier(0, 0, 0.38, 0.9),
-    outline 70ms cubic-bezier(0, 0, 0.38, 0.9);
-  vertical-align: top;
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-footer
-  .cds--btn--primary {
-  border-width: 1px;
-  border-style: solid;
-  border-color: transparent;
-  background-color: var(--cds-button-primary, #0f62fe);
-  color: var(--cds-text-on-color, #ffffff);
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-footer
-  .cds--btn--primary:hover {
-  color: var(--cds-text-on-color, #ffffff);
-  background-color: var(--cds-button-primary-hover, #0050e6);
-}
-.cds--chart-holder
-  .cds--modal
-  .cds--modal-container
-  .cds--modal-footer
-  .cds--btn--primary:focus {
-  border-color: var(--cds-button-focus-color, var(--cds-focus, #0f62fe));
-  box-shadow:
-    inset 0 0 0 1px var(--cds-button-focus-color, var(--cds-focus, #0f62fe)),
-    inset 0 0 0 2px var(--cds-background, #ffffff);
-}
-
-@supports (-moz-appearance: none) {
-  .cds--data-table td {
-    background-clip: padding-box;
-  }
-}
-.cds--cc--tooltip {
-  background-color: var(--cds-layer-02, #ffffff);
-  pointer-events: none;
-  transition-timing-function: cubic-bezier(0.4, 0.14, 0.3, 1);
-  display: inline;
-  visibility: visible;
-  box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.2);
-  position: absolute;
-  word-wrap: break-word;
-  z-index: 1059;
-  font-family: var(--cds-charts-font-family-condensed);
-  transition:
-    visibility 0s linear 0.1s,
-    opacity 0.1s;
-}
-.cds--cc--tooltip.hidden {
-  opacity: 0;
-  visibility: hidden;
-  transition:
-    visibility 0s linear 0s,
-    opacity 0.1s;
-  transition-timing-function: cubic-bezier(0.4, 0.14, 0.3, 1);
-}
-.cds--cc--tooltip .content-box {
-  color: var(--cds-text-primary, #161616);
-}
-.cds--cc--tooltip .content-box .title-tooltip.title-tooltip-nowrap {
-  width: max-content;
-}
-.cds--cc--tooltip .content-box .title-tooltip {
-  width: auto;
-  padding: 4px;
-  min-width: 20px;
-  max-width: 270px;
-}
-.cds--cc--tooltip .content-box .title-tooltip p {
-  margin: 2px;
-  font-size: 12px;
-  line-height: 1rem;
-}
-.cds--cc--tooltip .content-box .datapoint-tooltip {
-  display: flex;
-  padding: 4px;
-  flex-flow: row nowrap;
-  width: auto;
-  min-width: 20px;
-  justify-content: flex-start;
-  align-items: center;
-}
-.cds--cc--tooltip .content-box .datapoint-tooltip div.label {
-  display: flex;
-  flex: 1;
-}
-.cds--cc--tooltip .content-box .datapoint-tooltip div.label p {
-  flex: 1;
-  padding-right: 8px;
-}
-.cds--cc--tooltip
-  .content-box
-  .datapoint-tooltip
-  div.label
-  span.label-icon
-  svg {
-  height: 12px;
-  padding-top: 3px;
-  vertical-align: top;
-  padding-left: 4px;
-  width: auto;
-  fill: var(--cds-layer-inverse-absolute, #000000);
-}
-.cds--cc--tooltip .content-box .datapoint-tooltip.bold div.label p {
-  font-weight: 600;
-}
-.cds--cc--tooltip .content-box .datapoint-tooltip p {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 16px;
-  font-size: 12px;
-  display: inline-block;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-.cds--cc--tooltip .content-box .datapoint-tooltip p.value {
-  width: auto;
-  margin-left: 6px;
-}
-.cds--cc--tooltip .content-box ul.multi-tooltip {
-  margin: 0;
-  padding: 0;
-}
-.cds--cc--tooltip .content-box ul.multi-tooltip li {
-  list-style: none;
-  position: relative;
-}
-.cds--cc--tooltip .content-box ul.multi-tooltip li:not(:last-child) {
-  border-bottom: 1px solid var(--cds-tooltip-line-border, #e0e0e0);
-}
-.cds--cc--tooltip .content-box svg.arrow-right rect {
-  fill: none;
-}
-.cds--cc--tooltip .tooltip-color {
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 4px;
-  height: 100%;
-}
-@media (forced-colors: active) {
-  .cds--cc--tooltip .tooltip-color {
-    forced-color-adjust: none;
-  }
-}
-.cds--cc--tooltip .tooltip-color + div.label p {
-  margin-left: 4px;
-}
-
-.cds--cc--zero-line line.domain {
-  stroke: var(--cds-border-strong-01, #8d8d8d);
-}
-
-.cds--cc--zoom-bar rect.zoom-bg {
-  fill: var(--cds-background, #ffffff);
-  stroke: var(--cds-layer-01, #f4f4f4);
-}
-.cds--cc--zoom-bar rect.zoom-slider-bg {
-  fill: var(--cds-layer-01, #f4f4f4);
-}
-.cds--cc--zoom-bar rect.zoom-slider-selected-area {
-  fill: var(--cds-icon-secondary, #525252);
-}
+.cds--cc--axes g.axis path.domain,
+.cds--cc--zero-line line.domain,
 .cds--cc--zoom-bar path.zoom-bg-baseline {
   stroke: var(--cds-border-strong-01, #8d8d8d);
-  stroke-width: 2;
 }
-.cds--cc--zoom-bar path.zoom-graph-area {
-  fill: var(--cds-layer-accent-01, #e0e0e0);
-  stroke: var(--cds-border-strong-01, #8d8d8d);
-  stroke-width: 1;
+.cds--cc--axes g.axis g.tick text,
+div.cds--cc--legend div.legend-item p {
+  fill: var(--cds-text-secondary, #525252);
 }
-.cds--cc--zoom-bar path.zoom-graph-area-unselected {
-  fill: var(--cds-layer-01, #f4f4f4);
-  stroke: none;
-}
-.cds--cc--zoom-bar g.zoom-bar-brush rect.handle {
-  fill: var(--cds-icon-secondary, #525252);
-}
-.cds--cc--zoom-bar g.zoom-bar-brush rect.handle-bar {
-  fill: var(--cds-layer-02, #ffffff);
-}
-.cds--cc--zoom-bar g.zoom-bar-brush rect.selection {
-  fill: none;
-  stroke: none;
-}
-.cds--cc--zoom-bar rect[class^='highlight-'] {
-  fill: #ee5396;
-  stroke: #ee5396;
-}
-
-.cds--cc--alluvial rect.node,
-.cds--cc--alluvial rect.node-text-bg {
-  fill: var(--cds-layer-inverse-absolute, #000000);
-}
-.cds--cc--alluvial text.node-text {
-  fill: var(--cds-layer-01-absolute, #ffffff);
-}
-.cds--cc--alluvial polygon.arrow-down {
-  fill: var(--cds-layer-01, #f4f4f4);
-}
-
-.cds--cc--area path.area,
-.cds--cc--area-stacked path.area {
-  pointer-events: none;
-}
-
-.cds--cc--bubble circle.dot.hovered {
-  fill-opacity: 1;
-  transition: all 0.1s;
-  transition-timing-function: cubic-bezier(0.4, 0.14, 0.3, 1);
-}
-.cds--cc--bubble circle.dot.unfilled {
-  fill: var(--cds-layer-01, #f4f4f4);
-}
-.cds--cc--bubble g.lines path.line {
-  mix-blend-mode: multiply;
-}
-
-.cds--cc--bullet path.range-box {
-  pointer-events: none;
-}
-.cds--cc--bullet path.range-box.order-1 {
-  fill: var(--cds-zone-fill-01, #f4f4f4);
-  stroke: var(--cds-zone-stroke-01, #8d8d8d);
-}
-.cds--cc--bullet path.range-box.order-2 {
-  fill: var(--cds-zone-fill-02, #e0e0e0);
-  stroke: var(--cds-zone-stroke-02, #8d8d8d);
-}
-.cds--cc--bullet path.range-box.order-3 {
-  fill: var(--cds-zone-fill-03, #c6c6c6);
-  stroke: var(--cds-zone-stroke-03, #8d8d8d);
-}
-.cds--cc--bullet path.marker,
-.cds--cc--bullet path.quartile {
-  pointer-events: none;
-  stroke-width: 1.5px;
-  stroke: var(--cds-layer-inverse-absolute, #000000);
-}
-.cds--cc--bullet path.quartile.over-bar {
-  stroke: var(--cds-layer-01-absolute, #ffffff);
-}
-
-.cds--cc--choropleth path.border {
-  stroke: var(--cds-border-subtle-selected-01, #c6c6c6);
-}
-.cds--cc--choropleth g.missing-data path {
-  stroke: var(--cds-border-subtle-selected-01, #c6c6c6);
-  fill: var(--cds-background, #ffffff);
-}
-.cds--cc--choropleth pattern path.pattern-fill {
-  stroke: var(--cds-border-strong-01, #8d8d8d);
-  stroke-width: 0.5px;
-}
-
-.cds--cc--circle-pack circle.node {
-  stroke-width: 1.5px;
-}
-.cds--cc--circle-pack circle.node.hovered {
-  fill-opacity: 1;
-}
-.cds--cc--circle-pack circle.node.non-focal {
-  fill: var(--cds-icon-disabled, rgba(22, 22, 22, 0.25));
-  fill-opacity: 30%;
-  stroke: var(--cds-icon-disabled, rgba(22, 22, 22, 0.25));
-}
-.cds--cc--circle-pack circle.node.clickable {
-  cursor: zoom-in;
-}
-
-.cds--cc--chart-wrapper.zoomed-in {
-  cursor: zoom-out;
-}
-.cds--cc--chart-wrapper.zoomed-in
-  .cds--cc--circle-pack
-  circle.node.hovered-child {
-  stroke: 1.5px solid initial;
-}
-.cds--cc--chart-wrapper.zoomed-in .cds--cc--circle-pack circle.node.clickable {
-  cursor: zoom-out;
-}
-
-.cds--cc--donut {
-  overflow: visible;
-}
-
-.cds--cc--gauge {
-  overflow: visible;
-}
-.cds--cc--gauge path.arc-background {
-  fill: var(--cds-layer-01, #f4f4f4);
-}
-.cds--cc--gauge .gauge-delta-arrow.status--danger {
-  fill: var(--cds-support-error, #da1e28);
-}
-.cds--cc--gauge .gauge-delta-arrow.status--warning {
-  fill: var(--cds-support-warning, #f1c21b);
-}
-.cds--cc--gauge .gauge-delta-arrow.status--success {
-  fill: var(--cds-support-success, #24a148);
-}
-
-.cds--cc--heatmap g.highlighter-hidden {
-  visibility: hidden;
-}
-.cds--cc--heatmap g.cell-highlight line {
-  stroke: white;
-  stroke-width: 1px;
-}
-.cds--cc--heatmap g.cell-2 line {
-  stroke: white;
-  stroke-width: 2px !important;
-}
-.cds--cc--heatmap g.multi-cell line {
-  stroke: white;
-  stroke-width: 2px;
-}
-.cds--cc--heatmap rect.pattern-fill {
-  fill: var(--cds-border-strong-01, #8d8d8d);
-}
-.cds--cc--heatmap g.shadows line.top {
-  filter: drop-shadow(0px -3px 2px black);
-}
-.cds--cc--heatmap g.shadows line.down {
-  filter: drop-shadow(0px 3px 2px black);
-}
-.cds--cc--heatmap g.shadows line.left {
-  filter: drop-shadow(-3px 0px 2px black);
-}
-.cds--cc--heatmap g.shadows line.right {
-  filter: drop-shadow(3px 0px 2px black);
-}
-.cds--cc--heatmap rect.heat {
-  stroke-width: 0px;
-  stroke: var(--cds-background, #ffffff);
-}
-.cds--cc--heatmap rect.null-state {
-  fill: var(--cds-icon-inverse, #ffffff);
-}
-
-.cds--cc--line path.line {
-  pointer-events: none;
-  fill: none;
-  stroke-width: 1.5;
-}
-.cds--cc--line path.line.sparkline-loading {
-  animation: shimmer 2.5s infinite linear;
-}
-@keyframes shimmer {
-  0% {
-    stroke: var(--cds-layer-accent-01, #e0e0e0);
-  }
-  20% {
-    stroke: #ffffff;
-    opacity: 0.5;
-  }
-  100% {
-    stroke: var(--cds-layer-accent-01, #e0e0e0);
-  }
-}
-
-.cds--cc--lollipop line.line {
-  pointer-events: none;
-}
-.cds--cc--lollipop circle.dot {
-  stroke-width: 1.5;
-}
-
-.cds--cc--meter rect.container {
-  fill: var(--cds-layer-01, #f4f4f4);
-}
-.cds--cc--meter line.rangeIndicator {
-  stroke: var(--cds-meter-range-indicator, #a8a8a8);
-  stroke-width: 1px;
-}
-.cds--cc--meter rect.value.status--danger {
-  fill: var(--cds-support-error, #da1e28);
-}
-.cds--cc--meter rect.value.status--warning {
-  fill: var(--cds-support-warning, #f1c21b);
-  stroke-width: 1px;
-  stroke: var(--cds-alert-stroke, #b28600);
-}
-.cds--cc--meter rect.value.status--success {
-  fill: var(--cds-support-success, #24a148);
-}
-.cds--cc--meter line.peak {
-  stroke: var(--cds-border-inverse, #161616);
-  stroke-width: 2px;
-}
-
-.cds--cc--pie {
-  overflow: visible;
-}
-
-.cds--cc--radar .blobs path {
-  stroke-width: 1.5px;
-}
-.cds--cc--radar .y-axes path,
-.cds--cc--radar .x-axes line {
-  stroke-width: 1px;
-  stroke: var(--cds-layer-accent-01, #e0e0e0);
-}
-.cds--cc--radar .x-axes line.hovered {
-  stroke: var(--cds-layer-inverse-absolute, #000000);
-}
-
-.cds--cc--scatter circle.dot.hovered {
-  fill-opacity: 1;
-  transition: all 0.1s;
-  transition-timing-function: cubic-bezier(0.4, 0.14, 0.3, 1);
-}
-.cds--cc--scatter circle.dot.unfilled {
-  fill: var(--cds-layer-01, #f4f4f4);
-  stroke-width: 1.5;
-}
-.cds--cc--scatter circle.dot.threshold-anomaly {
-  stroke-width: 3;
-}
+.cds--cc--bubble g.lines path.line,
 .cds--cc--scatter g.lines path.line {
   mix-blend-mode: multiply;
 }
-
-.cds--cc--scatter-stacked circle.dot.unfilled {
-  fill: var(--cds-layer-01, #f4f4f4);
-  stroke-width: 1.5;
+.cds--chart-holder,
+.cds--chart-holder[data-carbon-theme='g100'],
+.cds--chart-holder[data-carbon-theme='g90'] {
+  --cds-charts-2-2-1: #8a3ffc;
+  --cds-charts-2-2-1-hovered: #751cfb;
+  --cds-charts-14-1-5: #fa4d56;
+  --cds-charts-14-1-5-hovered: #f92a35;
+  --cds-charts-mono-1-1: #fff;
+  --cds-charts-mono-1-1-hovered: #ededed;
+  --cds-charts-mono-1-2: #f6f2ff;
+  --cds-charts-mono-1-2-hovered: #ddceff;
+  --cds-charts-mono-1-3: #e8daff;
+  --cds-charts-mono-1-3-hovered: #d2b6ff;
+  --cds-charts-mono-1-4: #d4bbff;
+  --cds-charts-mono-1-4-hovered: #bd97ff;
+  --cds-charts-mono-1-5: #be95ff;
+  --cds-charts-mono-1-5-hovered: #a871ff;
+  --cds-charts-mono-1-6: #a56eff;
+  --cds-charts-mono-1-6-hovered: #8f4aff;
+  --cds-charts-mono-1-7: #8a3ffc;
+  --cds-charts-mono-1-7-hovered: #751cfb;
+  --cds-charts-mono-1-8: #6929c4;
+  --cds-charts-mono-1-8-hovered: #5923a6;
+  --cds-charts-mono-1-9: #491d8b;
+  --cds-charts-mono-1-9-hovered: #39176d;
+  --cds-charts-mono-1-10: #31135e;
+  --cds-charts-mono-1-10-hovered: #220d40;
+  --cds-charts-mono-1-11: #1c0f30;
+  --cds-charts-mono-1-11-hovered: #0c0715;
+  --cds-charts-mono-2-1: #fff;
+  --cds-charts-mono-2-1-hovered: #ededed;
+  --cds-charts-mono-2-2: #edf5ff;
+  --cds-charts-mono-2-2-hovered: #c9e1ff;
+  --cds-charts-mono-2-3: #d0e2ff;
+  --cds-charts-mono-2-3-hovered: #acccff;
+  --cds-charts-mono-2-4: #a6c8ff;
+  --cds-charts-mono-2-4-hovered: #82b2ff;
+  --cds-charts-mono-2-5: #78a9ff;
+  --cds-charts-mono-2-5-hovered: #5492ff;
+  --cds-charts-mono-2-6: #4589ff;
+  --cds-charts-mono-2-6-hovered: #2172ff;
+  --cds-charts-mono-2-7: #0f62fe;
+  --cds-charts-mono-2-7-hovered: #0151e8;
+  --cds-charts-mono-2-8: #0043ce;
+  --cds-charts-mono-2-8-hovered: #0037aa;
+  --cds-charts-mono-2-9: #002d9c;
+  --cds-charts-mono-2-9-hovered: #002378;
+  --cds-charts-mono-2-10: #001d6c;
+  --cds-charts-mono-2-10-hovered: #001348;
+  --cds-charts-mono-2-11: #001141;
+  --cds-charts-mono-2-11-hovered: #00081d;
+  --cds-charts-mono-3-1: #fff;
+  --cds-charts-mono-3-1-hovered: #ededed;
+  --cds-charts-mono-3-2: #e5f6ff;
+  --cds-charts-mono-3-2-hovered: #c1eaff;
+  --cds-charts-mono-3-3: #bae6ff;
+  --cds-charts-mono-3-3-hovered: #96d9ff;
+  --cds-charts-mono-3-4: #82cfff;
+  --cds-charts-mono-3-4-hovered: #5ec1ff;
+  --cds-charts-mono-3-5: #33b1ff;
+  --cds-charts-mono-3-5-hovered: #0fa3ff;
+  --cds-charts-mono-3-6: #1192e8;
+  --cds-charts-mono-3-6-hovered: #0f7dc7;
+  --cds-charts-mono-3-7: #0072c3;
+  --cds-charts-mono-3-7-hovered: #005d9f;
+  --cds-charts-mono-3-8: #00539a;
+  --cds-charts-mono-3-8-hovered: #004076;
+  --cds-charts-mono-3-9: #003a6d;
+  --cds-charts-mono-3-9-hovered: #002749;
+  --cds-charts-mono-3-10: #012749;
+  --cds-charts-mono-3-10-hovered: #011426;
+  --cds-charts-mono-3-11: #061727;
+  --cds-charts-mono-3-11-hovered: #010508;
+  --cds-charts-mono-4-1: #fff;
+  --cds-charts-mono-4-1-hovered: #ededed;
+  --cds-charts-mono-4-2: #d9fbfb;
+  --cds-charts-mono-4-2-hovered: #b9f8f8;
+  --cds-charts-mono-4-3: #9ef0f0;
+  --cds-charts-mono-4-3-hovered: #7febeb;
+  --cds-charts-mono-4-4: #3ddbd9;
+  --cds-charts-mono-4-4-hovered: #26cecc;
+  --cds-charts-mono-4-5: #08bdba;
+  --cds-charts-mono-4-5-hovered: #079b98;
+  --cds-charts-mono-4-6: #009d9a;
+  --cds-charts-mono-4-6-hovered: #007977;
+  --cds-charts-mono-4-7: #007d79;
+  --cds-charts-mono-4-7-hovered: #005956;
+  --cds-charts-mono-4-8: #005d5d;
+  --cds-charts-mono-4-8-hovered: #003939;
+  --cds-charts-mono-4-9: #004144;
+  --cds-charts-mono-4-9-hovered: #001f20;
+  --cds-charts-mono-4-10: #022b30;
+  --cds-charts-mono-4-10-hovered: #010c0e;
+  --cds-charts-mono-4-11: #081a1c;
+  --cds-charts-mono-4-11-hovered: #000;
+  --cds-charts-diverge-1-1: #750e13;
+  --cds-charts-diverge-1-1-hovered: #550a0e;
+  --cds-charts-diverge-1-2: #a2191f;
+  --cds-charts-diverge-1-2-hovered: #831419;
+  --cds-charts-diverge-1-3: #da1e28;
+  --cds-charts-diverge-1-3-hovered: #bb1a22;
+  --cds-charts-diverge-1-4: #fa4d56;
+  --cds-charts-diverge-1-4-hovered: #f92a35;
+  --cds-charts-diverge-1-5: #ff8389;
+  --cds-charts-diverge-1-5-hovered: #ff5f67;
+  --cds-charts-diverge-1-6: #ffb3b8;
+  --cds-charts-diverge-1-6-hovered: #ff8f97;
+  --cds-charts-diverge-1-7: #ffd7d9;
+  --cds-charts-diverge-1-7-hovered: #ffb3b7;
+  --cds-charts-diverge-1-8: #fff1f1;
+  --cds-charts-diverge-1-8-hovered: #ffcdcd;
+  --cds-charts-diverge-1-9: #fff;
+  --cds-charts-diverge-1-9-hovered: #ededed;
+  --cds-charts-diverge-1-10: #e5f6ff;
+  --cds-charts-diverge-1-10-hovered: #c1eaff;
+  --cds-charts-diverge-1-11: #bae6ff;
+  --cds-charts-diverge-1-11-hovered: #96d9ff;
+  --cds-charts-diverge-1-12: #82cfff;
+  --cds-charts-diverge-1-12-hovered: #5ec1ff;
+  --cds-charts-diverge-1-13: #33b1ff;
+  --cds-charts-diverge-1-13-hovered: #0fa3ff;
+  --cds-charts-diverge-1-14: #1192e8;
+  --cds-charts-diverge-1-14-hovered: #0f7dc7;
+  --cds-charts-diverge-1-15: #0072c3;
+  --cds-charts-diverge-1-15-hovered: #005d9f;
+  --cds-charts-diverge-1-16: #00539a;
+  --cds-charts-diverge-1-16-hovered: #004076;
+  --cds-charts-diverge-1-17: #003a6d;
+  --cds-charts-diverge-1-17-hovered: #002749;
+  --cds-charts-diverge-2-1: #491d8b;
+  --cds-charts-diverge-2-1-hovered: #39176d;
+  --cds-charts-diverge-2-2: #6929c4;
+  --cds-charts-diverge-2-2-hovered: #5923a6;
+  --cds-charts-diverge-2-3: #8a3ffc;
+  --cds-charts-diverge-2-3-hovered: #751cfb;
+  --cds-charts-diverge-2-4: #a56eff;
+  --cds-charts-diverge-2-4-hovered: #8f4aff;
+  --cds-charts-diverge-2-5: #be95ff;
+  --cds-charts-diverge-2-5-hovered: #a871ff;
+  --cds-charts-diverge-2-6: #d4bbff;
+  --cds-charts-diverge-2-6-hovered: #bd97ff;
+  --cds-charts-diverge-2-7: #e8daff;
+  --cds-charts-diverge-2-7-hovered: #d2b6ff;
+  --cds-charts-diverge-2-8: #f6f2ff;
+  --cds-charts-diverge-2-8-hovered: #ddceff;
+  --cds-charts-diverge-2-9: #fff;
+  --cds-charts-diverge-2-9-hovered: #ededed;
+  --cds-charts-diverge-2-10: #d9fbfb;
+  --cds-charts-diverge-2-10-hovered: #b9f8f8;
+  --cds-charts-diverge-2-11: #9ef0f0;
+  --cds-charts-diverge-2-11-hovered: #7febeb;
+  --cds-charts-diverge-2-12: #3ddbd9;
+  --cds-charts-diverge-2-12-hovered: #26cecc;
+  --cds-charts-diverge-2-13: #08bdba;
+  --cds-charts-diverge-2-13-hovered: #079b98;
+  --cds-charts-diverge-2-14: #009d9a;
+  --cds-charts-diverge-2-14-hovered: #007977;
+  --cds-charts-diverge-2-15: #007d79;
+  --cds-charts-diverge-2-15-hovered: #005956;
+  --cds-charts-diverge-2-16: #005d5d;
+  --cds-charts-diverge-2-16-hovered: #003939;
+  --cds-charts-diverge-2-17: #004144;
+  --cds-charts-diverge-2-17-hovered: #001f20;
 }
-.cds--cc--scatter-stacked circle.dot.threshold-anomaly {
-  stroke-width: 3;
+.cds--chart-holder,
+.cds--chart-holder[data-carbon-theme='g10'],
+html[data-carbon-theme='g10'] {
+  --cds-null-state: none;
+  --cds-spacing-01: 0.125rem;
+  --cds-spacing-02: 0.25rem;
+  --cds-spacing-03: 0.5rem;
+  --cds-spacing-04: 0.75rem;
+  --cds-spacing-05: 1rem;
+  --cds-spacing-06: 1.5rem;
+  --cds-spacing-07: 2rem;
+  --cds-spacing-08: 2.5rem;
+  --cds-spacing-09: 3rem;
+  --cds-spacing-10: 4rem;
+  --cds-spacing-11: 5rem;
+  --cds-spacing-12: 6rem;
+  --cds-spacing-13: 10rem;
+  --cds-fluid-spacing-01: 0;
+  --cds-fluid-spacing-02: 2vw;
+  --cds-fluid-spacing-03: 5vw;
+  --cds-fluid-spacing-04: 10vw;
+  --cds-label-01-font-size: 0.75rem;
+  --cds-label-01-font-weight: 400;
+  --cds-label-01-line-height: 1.33333;
+  --cds-label-01-letter-spacing: 0.32px;
+  --cds-label-02-font-size: 0.875rem;
+  --cds-label-02-font-weight: 400;
+  --cds-label-02-line-height: 1.28572;
+  --cds-label-02-letter-spacing: 0.16px;
+  --cds-helper-text-01-font-size: 0.75rem;
+  --cds-helper-text-01-line-height: 1.33333;
+  --cds-helper-text-01-letter-spacing: 0.32px;
+  --cds-helper-text-02-font-size: carbon--type-scale(2);
+  --cds-helper-text-02-font-weight: carbon--font-weight('regular');
+  --cds-helper-text-02-line-height: 1.28572;
+  --cds-helper-text-02-letter-spacing: 0.16px;
+  --cds-body-short-01-font-size: 0.875rem;
+  --cds-body-short-01-font-weight: 400;
+  --cds-body-short-01-line-height: 1.28572;
+  --cds-body-short-01-letter-spacing: 0.16px;
+  --cds-body-short-02-font-size: 1rem;
+  --cds-body-short-02-font-weight: 400;
+  --cds-body-short-02-line-height: 1.375;
+  --cds-body-short-02-letter-spacing: 0;
+  --cds-body-long-01-font-size: 0.875rem;
+  --cds-body-long-01-font-weight: 400;
+  --cds-body-long-01-line-height: 1.42857;
+  --cds-body-long-01-letter-spacing: 0.16px;
+  --cds-body-long-02-font-size: 1rem;
+  --cds-body-long-02-font-weight: 400;
+  --cds-body-long-02-line-height: 1.5;
+  --cds-body-long-02-letter-spacing: 0;
+  --cds-code-01-font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', monospace;
+  --cds-code-01-font-size: 0.75rem;
+  --cds-code-01-font-weight: 400;
+  --cds-code-01-line-height: 1.33333;
+  --cds-code-01-letter-spacing: 0.32px;
+  --cds-code-02-font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', monospace;
+  --cds-code-02-font-size: 0.875rem;
+  --cds-code-02-font-weight: 400;
+  --cds-code-02-line-height: 1.42857;
+  --cds-code-02-letter-spacing: 0.32px;
+  --cds-heading-01-font-size: 0.875rem;
+  --cds-heading-01-font-weight: 600;
+  --cds-heading-01-line-height: 1.42857;
+  --cds-heading-01-letter-spacing: 0.16px;
+  --cds-heading-02-font-size: 1rem;
+  --cds-heading-02-font-weight: 600;
+  --cds-heading-02-line-height: 1.5;
+  --cds-heading-02-letter-spacing: 0;
+  --cds-productive-heading-01-font-size: 0.875rem;
+  --cds-productive-heading-01-font-weight: 600;
+  --cds-productive-heading-01-line-height: 1.28572;
+  --cds-productive-heading-01-letter-spacing: 0.16px;
+  --cds-productive-heading-02-font-size: 1rem;
+  --cds-productive-heading-02-font-weight: 600;
+  --cds-productive-heading-02-line-height: 1.375;
+  --cds-productive-heading-02-letter-spacing: 0;
+  --cds-productive-heading-03-font-size: 1.25rem;
+  --cds-productive-heading-03-font-weight: 400;
+  --cds-productive-heading-03-line-height: 1.4;
+  --cds-productive-heading-03-letter-spacing: 0;
+  --cds-productive-heading-04-font-size: 1.75rem;
+  --cds-productive-heading-04-font-weight: 400;
+  --cds-productive-heading-04-line-height: 1.28572;
+  --cds-productive-heading-04-letter-spacing: 0;
+  --cds-productive-heading-05-font-size: 2rem;
+  --cds-productive-heading-05-font-weight: 400;
+  --cds-productive-heading-05-line-height: 1.25;
+  --cds-productive-heading-05-letter-spacing: 0;
+  --cds-productive-heading-06-font-size: 2.625rem;
+  --cds-productive-heading-06-font-weight: 300;
+  --cds-productive-heading-06-line-height: 1.199;
+  --cds-productive-heading-06-letter-spacing: 0;
+  --cds-productive-heading-07-font-size: 3.375rem;
+  --cds-productive-heading-07-font-weight: 300;
+  --cds-productive-heading-07-line-height: 1.19;
+  --cds-productive-heading-07-letter-spacing: 0;
+  --cds-expressive-paragraph-01-font-size: 1.5rem;
+  --cds-expressive-paragraph-01-font-weight: 300;
+  --cds-expressive-paragraph-01-line-height: 1.334;
+  --cds-expressive-paragraph-01-letter-spacing: 0;
+  --cds-expressive-heading-01-font-size: 0.875rem;
+  --cds-expressive-heading-01-font-weight: 600;
+  --cds-expressive-heading-01-line-height: 1.42857;
+  --cds-expressive-heading-01-letter-spacing: 0.16px;
+  --cds-expressive-heading-02-font-size: 1rem;
+  --cds-expressive-heading-02-font-weight: 600;
+  --cds-expressive-heading-02-line-height: 1.5;
+  --cds-expressive-heading-02-letter-spacing: 0;
+  --cds-expressive-heading-03-font-size: 1.25rem;
+  --cds-expressive-heading-03-font-weight: 400;
+  --cds-expressive-heading-03-line-height: 1.4;
+  --cds-expressive-heading-03-letter-spacing: 0;
+  --cds-expressive-heading-04-font-size: 1.75rem;
+  --cds-expressive-heading-04-font-weight: 400;
+  --cds-expressive-heading-04-line-height: 1.28572;
+  --cds-expressive-heading-04-letter-spacing: 0;
+  --cds-expressive-heading-05-font-size: 2rem;
+  --cds-expressive-heading-05-font-weight: 400;
+  --cds-expressive-heading-05-line-height: 1.25;
+  --cds-expressive-heading-05-letter-spacing: 0;
+  --cds-expressive-heading-06-font-size: 2rem;
+  --cds-expressive-heading-06-font-weight: 600;
+  --cds-expressive-heading-06-line-height: 1.25;
+  --cds-expressive-heading-06-letter-spacing: 0;
+  --cds-quotation-01-font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
+  --cds-quotation-01-font-size: 1.25rem;
+  --cds-quotation-01-font-weight: 400;
+  --cds-quotation-01-line-height: 1.3;
+  --cds-quotation-01-letter-spacing: 0;
+  --cds-quotation-02-font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
+  --cds-quotation-02-font-size: 2rem;
+  --cds-quotation-02-font-weight: 300;
+  --cds-quotation-02-line-height: 1.25;
+  --cds-quotation-02-letter-spacing: 0;
+  --cds-display-01-font-size: 2.625rem;
+  --cds-display-01-font-weight: 300;
+  --cds-display-01-line-height: 1.19;
+  --cds-display-01-letter-spacing: 0;
+  --cds-display-02-font-size: 2.625rem;
+  --cds-display-02-font-weight: 600;
+  --cds-display-02-line-height: 1.19;
+  --cds-display-02-letter-spacing: 0;
+  --cds-display-03-font-size: 2.625rem;
+  --cds-display-03-font-weight: 300;
+  --cds-display-03-line-height: 1.19;
+  --cds-display-03-letter-spacing: 0;
+  --cds-display-04-font-size: 2.625rem;
+  --cds-display-04-font-weight: 300;
+  --cds-display-04-line-height: 1.19;
+  --cds-display-04-letter-spacing: 0;
+  --cds-legal-01-font-size: 0.75rem;
+  --cds-legal-01-font-weight: 400;
+  --cds-legal-01-line-height: 1.33333;
+  --cds-legal-01-letter-spacing: 0.32px;
+  --cds-legal-02-font-size: 0.875rem;
+  --cds-legal-02-font-weight: 400;
+  --cds-legal-02-line-height: 1.28572;
+  --cds-legal-02-letter-spacing: 0.16px;
+  --cds-body-compact-01-font-size: 0.875rem;
+  --cds-body-compact-01-font-weight: 400;
+  --cds-body-compact-01-line-height: 1.28572;
+  --cds-body-compact-01-letter-spacing: 0.16px;
+  --cds-body-compact-02-font-size: 1rem;
+  --cds-body-compact-02-font-weight: 400;
+  --cds-body-compact-02-line-height: 1.375;
+  --cds-body-compact-02-letter-spacing: 0;
+  --cds-heading-compact-01-font-size: 0.875rem;
+  --cds-heading-compact-01-font-weight: 600;
+  --cds-heading-compact-01-line-height: 1.28572;
+  --cds-heading-compact-01-letter-spacing: 0.16px;
+  --cds-heading-compact-02-font-size: 1rem;
+  --cds-heading-compact-02-font-weight: 600;
+  --cds-heading-compact-02-line-height: 1.375;
+  --cds-heading-compact-02-letter-spacing: 0;
+  --cds-body-01-font-size: 0.875rem;
+  --cds-body-01-font-weight: 400;
+  --cds-body-01-line-height: 1.42857;
+  --cds-body-01-letter-spacing: 0.16px;
+  --cds-body-02-font-size: 1rem;
+  --cds-body-02-font-weight: 400;
+  --cds-body-02-line-height: 1.5;
+  --cds-body-02-letter-spacing: 0;
+  --cds-heading-03-font-size: 1.25rem;
+  --cds-heading-03-font-weight: 400;
+  --cds-heading-03-line-height: 1.4;
+  --cds-heading-03-letter-spacing: 0;
+  --cds-heading-04-font-size: 1.75rem;
+  --cds-heading-04-font-weight: 400;
+  --cds-heading-04-line-height: 1.28572;
+  --cds-heading-04-letter-spacing: 0;
+  --cds-heading-05-font-size: 2rem;
+  --cds-heading-05-font-weight: 400;
+  --cds-heading-05-line-height: 1.25;
+  --cds-heading-05-letter-spacing: 0;
+  --cds-heading-06-font-size: 2.625rem;
+  --cds-heading-06-font-weight: 300;
+  --cds-heading-06-line-height: 1.199;
+  --cds-heading-06-letter-spacing: 0;
+  --cds-heading-07-font-size: 3.375rem;
+  --cds-heading-07-font-weight: 300;
+  --cds-heading-07-line-height: 1.19;
+  --cds-heading-07-letter-spacing: 0;
+  --cds-fluid-heading-03-font-size: 1.25rem;
+  --cds-fluid-heading-03-font-weight: 400;
+  --cds-fluid-heading-03-line-height: 1.4;
+  --cds-fluid-heading-03-letter-spacing: 0;
+  --cds-fluid-heading-04-font-size: 1.75rem;
+  --cds-fluid-heading-04-font-weight: 400;
+  --cds-fluid-heading-04-line-height: 1.28572;
+  --cds-fluid-heading-04-letter-spacing: 0;
+  --cds-fluid-heading-05-font-size: 2rem;
+  --cds-fluid-heading-05-font-weight: 400;
+  --cds-fluid-heading-05-line-height: 1.25;
+  --cds-fluid-heading-05-letter-spacing: 0;
+  --cds-fluid-heading-06-font-size: 2rem;
+  --cds-fluid-heading-06-font-weight: 600;
+  --cds-fluid-heading-06-line-height: 1.25;
+  --cds-fluid-heading-06-letter-spacing: 0;
+  --cds-fluid-paragraph-01-font-size: 1.5rem;
+  --cds-fluid-paragraph-01-font-weight: 300;
+  --cds-fluid-paragraph-01-line-height: 1.334;
+  --cds-fluid-paragraph-01-letter-spacing: 0;
+  --cds-fluid-quotation-01-font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
+  --cds-fluid-quotation-01-font-size: 1.25rem;
+  --cds-fluid-quotation-01-font-weight: 400;
+  --cds-fluid-quotation-01-line-height: 1.3;
+  --cds-fluid-quotation-01-letter-spacing: 0;
+  --cds-fluid-quotation-02-font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
+  --cds-fluid-quotation-02-font-size: 2rem;
+  --cds-fluid-quotation-02-font-weight: 300;
+  --cds-fluid-quotation-02-line-height: 1.25;
+  --cds-fluid-quotation-02-letter-spacing: 0;
+  --cds-fluid-display-01-font-size: 2.625rem;
+  --cds-fluid-display-01-font-weight: 300;
+  --cds-fluid-display-01-line-height: 1.19;
+  --cds-fluid-display-01-letter-spacing: 0;
+  --cds-fluid-display-02-font-size: 2.625rem;
+  --cds-fluid-display-02-font-weight: 600;
+  --cds-fluid-display-02-line-height: 1.19;
+  --cds-fluid-display-02-letter-spacing: 0;
+  --cds-fluid-display-03-font-size: 2.625rem;
+  --cds-fluid-display-03-font-weight: 300;
+  --cds-fluid-display-03-line-height: 1.19;
+  --cds-fluid-display-03-letter-spacing: 0;
+  --cds-fluid-display-04-font-size: 2.625rem;
+  --cds-fluid-display-04-font-weight: 300;
+  --cds-fluid-display-04-line-height: 1.19;
+  --cds-fluid-display-04-letter-spacing: 0;
 }
-
-.cds--cc--chart-wrapper .cds--cc--tree g.links {
-  fill: none;
-  stroke: var(--cds-border-strong-01, #8d8d8d);
-  stroke-opacity: 0.4;
-  stroke-width: 1.5;
-}
-.cds--cc--chart-wrapper .cds--cc--tree g.clickable {
-  cursor: pointer;
-}
-.cds--cc--chart-wrapper .cds--cc--tree g.clickable:hover text {
-  font-weight: 600;
-}
-.cds--cc--chart-wrapper .cds--cc--tree g.clickable:hover circle {
-  fill: var(--cds-text-primary, #161616);
-  transition: all 0.1s ease-out;
-}
-.cds--cc--chart-wrapper .cds--cc--tree circle.parent {
-  fill: var(--cds-text-secondary, #525252);
-}
-.cds--cc--chart-wrapper .cds--cc--tree circle.child {
-  fill: var(--cds-border-strong-01, #8d8d8d);
-}
-.cds--cc--chart-wrapper .cds--cc--tree text {
-  fill: var(--cds-text-primary, #161616);
-}
-.cds--cc--chart-wrapper .cds--cc--tree text.text-stroke {
-  stroke: var(--cds-text-inverse, #ffffff);
-  stroke-width: 2px;
-}
-
-.cds--cc--treemap text {
-  pointer-events: none;
-}
-
-.cds--cc--wordcloud text.word.light {
-  font-weight: 300;
-}
-
-.cds--chart-holder {
-  --cds-charts-font-family:
-    'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', sans-serif;
-  --cds-charts-font-family-condensed:
-    'IBM Plex Sans Condensed', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', sans-serif;
-  font-family: var(--cds-charts-font-family);
-}
-
-.cds--cc--chart-wrapper p {
-  padding: 0;
+.carbon-chart-wrapper a,
+.carbon-chart-wrapper abbr,
+.carbon-chart-wrapper acronym,
+.carbon-chart-wrapper address,
+.carbon-chart-wrapper applet,
+.carbon-chart-wrapper article,
+.carbon-chart-wrapper aside,
+.carbon-chart-wrapper audio,
+.carbon-chart-wrapper b,
+.carbon-chart-wrapper big,
+.carbon-chart-wrapper blockquote,
+.carbon-chart-wrapper body,
+.carbon-chart-wrapper canvas,
+.carbon-chart-wrapper caption,
+.carbon-chart-wrapper center,
+.carbon-chart-wrapper cite,
+.carbon-chart-wrapper code,
+.carbon-chart-wrapper dd,
+.carbon-chart-wrapper del,
+.carbon-chart-wrapper details,
+.carbon-chart-wrapper dfn,
+.carbon-chart-wrapper div,
+.carbon-chart-wrapper dl,
+.carbon-chart-wrapper dt,
+.carbon-chart-wrapper em,
+.carbon-chart-wrapper embed,
+.carbon-chart-wrapper fieldset,
+.carbon-chart-wrapper figcaption,
+.carbon-chart-wrapper figure,
+.carbon-chart-wrapper footer,
+.carbon-chart-wrapper form,
+.carbon-chart-wrapper h1,
+.carbon-chart-wrapper h2,
+.carbon-chart-wrapper h3,
+.carbon-chart-wrapper h4,
+.carbon-chart-wrapper h5,
+.carbon-chart-wrapper h6,
+.carbon-chart-wrapper header,
+.carbon-chart-wrapper hgroup,
+.carbon-chart-wrapper html,
+.carbon-chart-wrapper i,
+.carbon-chart-wrapper iframe,
+.carbon-chart-wrapper img,
+.carbon-chart-wrapper ins,
+.carbon-chart-wrapper kbd,
+.carbon-chart-wrapper label,
+.carbon-chart-wrapper legend,
+.carbon-chart-wrapper li,
+.carbon-chart-wrapper mark,
+.carbon-chart-wrapper menu,
+.carbon-chart-wrapper nav,
+.carbon-chart-wrapper object,
+.carbon-chart-wrapper ol,
+.carbon-chart-wrapper output,
+.carbon-chart-wrapper p,
+.carbon-chart-wrapper pre,
+.carbon-chart-wrapper q,
+.carbon-chart-wrapper ruby,
+.carbon-chart-wrapper s,
+.carbon-chart-wrapper samp,
+.carbon-chart-wrapper section,
+.carbon-chart-wrapper small,
+.carbon-chart-wrapper span,
+.carbon-chart-wrapper strike,
+.carbon-chart-wrapper strong,
+.carbon-chart-wrapper sub,
+.carbon-chart-wrapper summary,
+.carbon-chart-wrapper sup,
+.carbon-chart-wrapper table,
+.carbon-chart-wrapper tbody,
+.carbon-chart-wrapper td,
+.carbon-chart-wrapper tfoot,
+.carbon-chart-wrapper th,
+.carbon-chart-wrapper thead,
+.carbon-chart-wrapper time,
+.carbon-chart-wrapper tr,
+.carbon-chart-wrapper tt,
+.carbon-chart-wrapper u,
+.carbon-chart-wrapper ul,
+.carbon-chart-wrapper var,
+.carbon-chart-wrapper video {
+  border: 0;
+  font: inherit;
+  font-size: 100%;
   margin: 0;
-  font-size: 12px;
+  padding: 0;
+  vertical-align: baseline;
+}
+.carbon-chart-wrapper body,
+.cds--actionable-notification body,
+.cds--breadcrumb body,
+.cds--checkbox-group body,
+.cds--checkbox-label body,
+.cds--content-switcher-btn body,
+.cds--copy-btn body,
+.cds--dropdown body,
+.cds--dropdown-list body,
+.cds--fieldset body,
+.cds--file--label body,
+.cds--form-requirement body,
+.cds--inline-notification body,
+.cds--label body,
+.cds--label-description body,
+.cds--list-box body,
+.cds--number body,
+.cds--number__controls body,
+.cds--overflow-menu body,
+.cds--overflow-menu-options body,
+.cds--overflow-menu-options__option body,
+.cds--overflow-menu__trigger body,
+.cds--pagination-nav body,
+.cds--snippet body,
+.cds--snippet--inline body,
+.cds--structured-list body,
+.cds--structured-list-td body,
+.cds--structured-list-th body,
+.cds--tabs body,
+.cds--text-input body,
+.cds--toast-notification body {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+.carbon-chart-wrapper article,
+.carbon-chart-wrapper aside,
+.carbon-chart-wrapper details,
+.carbon-chart-wrapper figcaption,
+.carbon-chart-wrapper figure,
+.carbon-chart-wrapper footer,
+.carbon-chart-wrapper header,
+.carbon-chart-wrapper hgroup,
+.carbon-chart-wrapper menu,
+.carbon-chart-wrapper nav,
+.carbon-chart-wrapper section {
+  display: block;
+}
+.carbon-chart-wrapper body {
+  background-color: var(--cds-background, #fff);
+  color: var(--cds-text-primary, #161616);
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
   font-weight: 400;
-  color: var(--cds-text-secondary, #525252);
+  line-height: 1;
 }
-.cds--cc--chart-wrapper text {
-  font-size: 12px;
-  font-weight: 400;
-  fill: var(--cds-text-secondary, #525252);
+.carbon-chart-wrapper blockquote,
+.carbon-chart-wrapper q {
+  quotes: none;
 }
-.cds--cc--chart-wrapper g.gauge-numbers text.gauge-value-number {
-  font-family: var(--cds-charts-font-family);
-  font-weight: 300;
+.carbon-chart-wrapper blockquote:after,
+.carbon-chart-wrapper blockquote:before,
+.carbon-chart-wrapper q:after,
+.carbon-chart-wrapper q:before {
+  content: '';
+  content: none;
 }
-.cds--cc--chart-wrapper text.meter-title,
-.cds--cc--chart-wrapper text.percent-value {
-  font-size: 16px;
-  font-family: var(--cds-charts-font-family);
+.carbon-chart-wrapper html {
+  box-sizing: border-box;
+  font-size: 100%;
 }
-.cds--cc--chart-wrapper text.meter-title {
+.carbon-chart-wrapper *,
+.carbon-chart-wrapper :after,
+.carbon-chart-wrapper :before {
+  box-sizing: inherit;
+}
+.carbon-chart-wrapper code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.carbon-chart-wrapper strong {
   font-weight: 600;
 }
-
-.cds--chart-holder {
-  position: relative;
-  display: block;
+.carbon-chart-wrapper h1 {
+  font-size: var(--cds-heading-06-font-size, 2.625rem);
+  font-weight: var(--cds-heading-06-font-weight, 300);
+  letter-spacing: var(--cds-heading-06-letter-spacing, 0);
+  line-height: var(--cds-heading-06-line-height, 1.199);
+}
+.carbon-chart-wrapper h2 {
+  font-size: var(--cds-heading-05-font-size, 2rem);
+  font-weight: var(--cds-heading-05-font-weight, 400);
+  letter-spacing: var(--cds-heading-05-letter-spacing, 0);
+  line-height: var(--cds-heading-05-line-height, 1.25);
+}
+.carbon-chart-wrapper h3 {
+  font-size: var(--cds-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-heading-04-font-weight, 400);
+  letter-spacing: var(--cds-heading-04-letter-spacing, 0);
+  line-height: var(--cds-heading-04-line-height, 1.28572);
+}
+.carbon-chart-wrapper h4 {
+  font-size: var(--cds-heading-03-font-size, 1.25rem);
+  font-weight: var(--cds-heading-03-font-weight, 400);
+  letter-spacing: var(--cds-heading-03-letter-spacing, 0);
+  line-height: var(--cds-heading-03-line-height, 1.4);
+}
+.carbon-chart-wrapper h5 {
+  font-size: var(--cds-heading-02-font-size, 1rem);
+  font-weight: var(--cds-heading-02-font-weight, 600);
+  letter-spacing: var(--cds-heading-02-letter-spacing, 0);
+  line-height: var(--cds-heading-02-line-height, 1.5);
+}
+.carbon-chart-wrapper h6 {
+  font-size: var(--cds-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-01-font-weight, 600);
+  letter-spacing: var(--cds-heading-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-01-line-height, 1.42857);
+}
+.carbon-chart-wrapper p {
+  font-size: var(--cds-body-02-font-size, 1rem);
+  font-weight: var(--cds-body-02-font-weight, 400);
+  letter-spacing: var(--cds-body-02-letter-spacing, 0);
+  line-height: var(--cds-body-02-line-height, 1.5);
+}
+.carbon-chart-wrapper a {
+  color: var(--cds-link-primary, #0062fe);
+}
+.carbon-chart-wrapper em,
+div.container.tutorial .hljs-emphasis {
+  font-style: italic;
+}
+.carbon-chart-wrapper :root {
+  --cds-grid-gutter: 2rem;
+  --cds-grid-columns: 4;
+  --cds-grid-margin: 0;
+}
+@media (min-width: 42rem) {
+  .carbon-chart-wrapper :root {
+    --cds-grid-columns: 8;
+    --cds-grid-margin: 1rem;
+  }
+}
+.cds--css-grid {
+  --cds-grid-gutter-start: calc(var(--cds-grid-gutter) / 2);
+  --cds-grid-gutter-end: calc(var(--cds-grid-gutter) / 2);
+  --cds-grid-column-hang: calc(var(--cds-grid-gutter) / 2);
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 99rem;
+  padding-left: var(--cds-grid-margin);
+  padding-right: var(--cds-grid-margin);
   width: 100%;
-  height: 100%;
 }
-.cds--chart-holder.filled,
-.cds--chart-holder.fullscreen {
-  background-color: var(--cds-background, #ffffff);
+.cds--css-grid--full-width {
+  max-width: 100%;
 }
-.cds--chart-holder.filled .cds--cc--chart-wrapper,
-.cds--chart-holder.fullscreen .cds--cc--chart-wrapper {
-  background-color: var(--cds-background, #ffffff);
+.cds--btn,
+.cds--btn-set .cds--btn.cds--btn--expressive {
+  max-width: 20rem;
 }
-.cds--chart-holder .DONT_STYLE_ME_css_styles_verifier {
-  overflow: hidden;
-  opacity: 0;
+.cds--css-grid-column {
+  --cds-grid-mode-start: var(--cds-grid-gutter-start);
+  --cds-grid-mode-end: var(--cds-grid-gutter-end);
+  margin-left: var(--cds-grid-gutter-start);
+  margin-right: var(--cds-grid-gutter-end);
 }
-
-.cds--chart-holder {
-  --cds-ai-aura-end: rgba(255, 255, 255, 0);
-  --cds-ai-aura-hover-background: #edf5ff;
-  --cds-ai-aura-hover-end: rgba(255, 255, 255, 0);
-  --cds-ai-aura-hover-start: rgba(69, 137, 255, 0.32);
-  --cds-ai-aura-start: rgba(69, 137, 255, 0.1);
-  --cds-ai-aura-start-sm: rgba(69, 137, 255, 0.16);
-  --cds-ai-border-end: #78a9ff;
-  --cds-ai-border-start: rgba(166, 200, 255, 0.64);
-  --cds-ai-border-strong: #4589ff;
-  --cds-ai-drop-shadow: rgba(15, 98, 254, 0.1);
-  --cds-ai-inner-shadow: rgba(69, 137, 255, 0.1);
-  --cds-ai-overlay: rgba(0, 17, 65, 0.5);
-  --cds-ai-popover-background: #ffffff;
-  --cds-ai-popover-caret-bottom: #78a9ff;
-  --cds-ai-popover-caret-bottom-background: #eaf1ff;
-  --cds-ai-popover-caret-bottom-background-actions: #e9effa;
-  --cds-ai-popover-caret-center: #a0c3ff;
-  --cds-ai-popover-shadow-outer-01: rgba(0, 67, 206, 0.06);
-  --cds-ai-popover-shadow-outer-02: rgba(0, 0, 0, 0.04);
-  --cds-ai-skeleton-background: #d0e2ff;
-  --cds-ai-skeleton-element-background: #4589ff;
-  --cds-background: #ffffff;
-  --cds-background-active: rgba(141, 141, 141, 0.5);
-  --cds-background-brand: #0f62fe;
-  --cds-background-hover: rgba(141, 141, 141, 0.12);
+[dir='rtl'] .cds--css-grid-column {
+  margin-left: var(--cds-grid-gutter-end);
+  margin-right: var(--cds-grid-gutter-start);
+}
+.cds--css-grid--narrow {
+  --cds-grid-gutter-start: 0;
+}
+.cds--css-grid--condensed {
+  --cds-grid-gutter: 0.0625rem;
+  --cds-grid-column-hang: 0.96875rem;
+}
+.cds--subgrid {
+  margin-left: calc(var(--cds-grid-mode-start) * -1);
+  margin-right: calc(var(--cds-grid-mode-end) * -1);
+}
+[dir='rtl'] .cds--subgrid {
+  margin-left: calc(var(--cds-grid-mode-end) * -1);
+  margin-right: calc(var(--cds-grid-mode-start) * -1);
+}
+.cds--subgrid--wide {
+  --cds-grid-gutter-start: 1rem;
+  --cds-grid-gutter-end: 1rem;
+  --cds-grid-column-hang: 0;
+}
+.cds--subgrid--narrow {
+  --cds-grid-gutter-start: 0;
+  --cds-grid-gutter-end: 1rem;
+  --cds-grid-column-hang: 1rem;
+}
+.cds--subgrid--condensed {
+  --cds-grid-gutter-start: 0.03125rem;
+  --cds-grid-gutter-end: 0.03125rem;
+  --cds-grid-column-hang: 0.96875rem;
+}
+.cds--grid-column-hang {
+  margin-left: var(--cds-grid-column-hang);
+}
+.cds--accordion,
+.cds--accordion__heading {
+  font-family: inherit;
+  font-size: 100%;
+  margin: 0;
+  vertical-align: baseline;
+  width: 100%;
+}
+[dir='rtl'] .cds--grid-column-hang {
+  margin-left: 0;
+  margin-right: var(--cds-grid-column-hang);
+}
+.cds--col-span-0 {
+  display: none;
+}
+.cds--col-span-1 {
+  --cds-grid-columns: 1;
+  display: block;
+  grid-column: span 1 / span 1;
+}
+.cds--col-span-2 {
+  --cds-grid-columns: 2;
+  display: block;
+  grid-column: span 2 / span 2;
+}
+.cds--col-span-3 {
+  --cds-grid-columns: 3;
+  display: block;
+  grid-column: span 3 / span 3;
+}
+.cds--col-span-4 {
+  --cds-grid-columns: 4;
+  display: block;
+  grid-column: span 4 / span 4;
+}
+.cds--col-span-5 {
+  --cds-grid-columns: 5;
+  display: block;
+  grid-column: span 5 / span 5;
+}
+.cds--col-span-6 {
+  --cds-grid-columns: 6;
+  display: block;
+  grid-column: span 6 / span 6;
+}
+.cds--col-span-7 {
+  --cds-grid-columns: 7;
+  display: block;
+  grid-column: span 7 / span 7;
+}
+.cds--col-span-8 {
+  --cds-grid-columns: 8;
+  display: block;
+  grid-column: span 8 / span 8;
+}
+.cds--col-span-9 {
+  --cds-grid-columns: 9;
+  display: block;
+  grid-column: span 9 / span 9;
+}
+.cds--col-span-10 {
+  --cds-grid-columns: 10;
+  display: block;
+  grid-column: span 10 / span 10;
+}
+.cds--col-span-11 {
+  --cds-grid-columns: 11;
+  display: block;
+  grid-column: span 11 / span 11;
+}
+.cds--col-span-12 {
+  --cds-grid-columns: 12;
+  display: block;
+  grid-column: span 12 / span 12;
+}
+.cds--col-span-13 {
+  --cds-grid-columns: 13;
+  display: block;
+  grid-column: span 13 / span 13;
+}
+.cds--col-span-14 {
+  --cds-grid-columns: 14;
+  display: block;
+  grid-column: span 14 / span 14;
+}
+.cds--col-span-15 {
+  --cds-grid-columns: 15;
+  display: block;
+  grid-column: span 15 / span 15;
+}
+.cds--col-span-16 {
+  --cds-grid-columns: 16;
+  display: block;
+  grid-column: span 16 / span 16;
+}
+.cds--sm\:col-span-0 {
+  display: none;
+}
+.cds--sm\:col-span-1 {
+  --cds-grid-columns: 1;
+  display: block;
+  grid-column: span 1 / span 1;
+}
+.cds--sm\:col-span-2 {
+  --cds-grid-columns: 2;
+  display: block;
+  grid-column: span 2 / span 2;
+}
+.cds--sm\:col-span-3 {
+  --cds-grid-columns: 3;
+  display: block;
+  grid-column: span 3 / span 3;
+}
+.cds--sm\:col-span-4 {
+  --cds-grid-columns: 4;
+  display: block;
+  grid-column: span 4 / span 4;
+}
+.cds--sm\:col-span-auto {
+  grid-column: auto;
+}
+.cds--sm\:col-span-100 {
+  grid-column: 1/-1;
+}
+.cds--sm\:col-span-75 {
+  --cds-grid-columns: 3;
+  grid-column: span 3 / span 3;
+}
+.cds--sm\:col-span-50 {
+  --cds-grid-columns: 2;
+  grid-column: span 2 / span 2;
+}
+.cds--sm\:col-span-25 {
+  --cds-grid-columns: 1;
+  grid-column: span 1 / span 1;
+}
+@media (min-width: 42rem) {
+  .cds--md\:col-span-0 {
+    display: none;
+  }
+  .cds--md\:col-span-1 {
+    --cds-grid-columns: 1;
+    display: block;
+    grid-column: span 1 / span 1;
+  }
+  .cds--md\:col-span-2 {
+    --cds-grid-columns: 2;
+    display: block;
+    grid-column: span 2 / span 2;
+  }
+  .cds--md\:col-span-3 {
+    --cds-grid-columns: 3;
+    display: block;
+    grid-column: span 3 / span 3;
+  }
+  .cds--md\:col-span-4 {
+    --cds-grid-columns: 4;
+    display: block;
+    grid-column: span 4 / span 4;
+  }
+  .cds--md\:col-span-5 {
+    --cds-grid-columns: 5;
+    display: block;
+    grid-column: span 5 / span 5;
+  }
+  .cds--md\:col-span-6 {
+    --cds-grid-columns: 6;
+    display: block;
+    grid-column: span 6 / span 6;
+  }
+  .cds--md\:col-span-7 {
+    --cds-grid-columns: 7;
+    display: block;
+    grid-column: span 7 / span 7;
+  }
+  .cds--md\:col-span-8 {
+    --cds-grid-columns: 8;
+    display: block;
+    grid-column: span 8 / span 8;
+  }
+  .cds--md\:col-span-auto {
+    grid-column: auto;
+  }
+  .cds--md\:col-span-100 {
+    grid-column: 1/-1;
+  }
+  .cds--md\:col-span-75 {
+    --cds-grid-columns: 6;
+    grid-column: span 6 / span 6;
+  }
+  .cds--md\:col-span-50 {
+    --cds-grid-columns: 4;
+    grid-column: span 4 / span 4;
+  }
+  .cds--md\:col-span-25 {
+    --cds-grid-columns: 2;
+    grid-column: span 2 / span 2;
+  }
+}
+@media (min-width: 66rem) {
+  .carbon-chart-wrapper :root {
+    --cds-grid-columns: 16;
+  }
+  .cds--lg\:col-span-0 {
+    display: none;
+  }
+  .cds--lg\:col-span-1 {
+    --cds-grid-columns: 1;
+    display: block;
+    grid-column: span 1 / span 1;
+  }
+  .cds--lg\:col-span-2 {
+    --cds-grid-columns: 2;
+    display: block;
+    grid-column: span 2 / span 2;
+  }
+  .cds--lg\:col-span-3 {
+    --cds-grid-columns: 3;
+    display: block;
+    grid-column: span 3 / span 3;
+  }
+  .cds--lg\:col-span-4 {
+    --cds-grid-columns: 4;
+    display: block;
+    grid-column: span 4 / span 4;
+  }
+  .cds--lg\:col-span-5 {
+    --cds-grid-columns: 5;
+    display: block;
+    grid-column: span 5 / span 5;
+  }
+  .cds--lg\:col-span-6 {
+    --cds-grid-columns: 6;
+    display: block;
+    grid-column: span 6 / span 6;
+  }
+  .cds--lg\:col-span-7 {
+    --cds-grid-columns: 7;
+    display: block;
+    grid-column: span 7 / span 7;
+  }
+  .cds--lg\:col-span-8 {
+    --cds-grid-columns: 8;
+    display: block;
+    grid-column: span 8 / span 8;
+  }
+  .cds--lg\:col-span-9 {
+    --cds-grid-columns: 9;
+    display: block;
+    grid-column: span 9 / span 9;
+  }
+  .cds--lg\:col-span-10 {
+    --cds-grid-columns: 10;
+    display: block;
+    grid-column: span 10 / span 10;
+  }
+  .cds--lg\:col-span-11 {
+    --cds-grid-columns: 11;
+    display: block;
+    grid-column: span 11 / span 11;
+  }
+  .cds--lg\:col-span-12 {
+    --cds-grid-columns: 12;
+    display: block;
+    grid-column: span 12 / span 12;
+  }
+  .cds--lg\:col-span-13 {
+    --cds-grid-columns: 13;
+    display: block;
+    grid-column: span 13 / span 13;
+  }
+  .cds--lg\:col-span-14 {
+    --cds-grid-columns: 14;
+    display: block;
+    grid-column: span 14 / span 14;
+  }
+  .cds--lg\:col-span-15 {
+    --cds-grid-columns: 15;
+    display: block;
+    grid-column: span 15 / span 15;
+  }
+  .cds--lg\:col-span-16 {
+    --cds-grid-columns: 16;
+    display: block;
+    grid-column: span 16 / span 16;
+  }
+  .cds--lg\:col-span-auto {
+    grid-column: auto;
+  }
+  .cds--lg\:col-span-100 {
+    grid-column: 1/-1;
+  }
+  .cds--lg\:col-span-75 {
+    --cds-grid-columns: 12;
+    grid-column: span 12 / span 12;
+  }
+  .cds--lg\:col-span-50 {
+    --cds-grid-columns: 8;
+    grid-column: span 8 / span 8;
+  }
+  .cds--lg\:col-span-25 {
+    --cds-grid-columns: 4;
+    grid-column: span 4 / span 4;
+  }
+}
+@media (min-width: 82rem) {
+  .cds--xlg\:col-span-0 {
+    display: none;
+  }
+  .cds--xlg\:col-span-1 {
+    --cds-grid-columns: 1;
+    display: block;
+    grid-column: span 1 / span 1;
+  }
+  .cds--xlg\:col-span-2 {
+    --cds-grid-columns: 2;
+    display: block;
+    grid-column: span 2 / span 2;
+  }
+  .cds--xlg\:col-span-3 {
+    --cds-grid-columns: 3;
+    display: block;
+    grid-column: span 3 / span 3;
+  }
+  .cds--xlg\:col-span-4 {
+    --cds-grid-columns: 4;
+    display: block;
+    grid-column: span 4 / span 4;
+  }
+  .cds--xlg\:col-span-5 {
+    --cds-grid-columns: 5;
+    display: block;
+    grid-column: span 5 / span 5;
+  }
+  .cds--xlg\:col-span-6 {
+    --cds-grid-columns: 6;
+    display: block;
+    grid-column: span 6 / span 6;
+  }
+  .cds--xlg\:col-span-7 {
+    --cds-grid-columns: 7;
+    display: block;
+    grid-column: span 7 / span 7;
+  }
+  .cds--xlg\:col-span-8 {
+    --cds-grid-columns: 8;
+    display: block;
+    grid-column: span 8 / span 8;
+  }
+  .cds--xlg\:col-span-9 {
+    --cds-grid-columns: 9;
+    display: block;
+    grid-column: span 9 / span 9;
+  }
+  .cds--xlg\:col-span-10 {
+    --cds-grid-columns: 10;
+    display: block;
+    grid-column: span 10 / span 10;
+  }
+  .cds--xlg\:col-span-11 {
+    --cds-grid-columns: 11;
+    display: block;
+    grid-column: span 11 / span 11;
+  }
+  .cds--xlg\:col-span-12 {
+    --cds-grid-columns: 12;
+    display: block;
+    grid-column: span 12 / span 12;
+  }
+  .cds--xlg\:col-span-13 {
+    --cds-grid-columns: 13;
+    display: block;
+    grid-column: span 13 / span 13;
+  }
+  .cds--xlg\:col-span-14 {
+    --cds-grid-columns: 14;
+    display: block;
+    grid-column: span 14 / span 14;
+  }
+  .cds--xlg\:col-span-15 {
+    --cds-grid-columns: 15;
+    display: block;
+    grid-column: span 15 / span 15;
+  }
+  .cds--xlg\:col-span-16 {
+    --cds-grid-columns: 16;
+    display: block;
+    grid-column: span 16 / span 16;
+  }
+  .cds--xlg\:col-span-auto {
+    grid-column: auto;
+  }
+  .cds--xlg\:col-span-100 {
+    grid-column: 1/-1;
+  }
+  .cds--xlg\:col-span-75 {
+    --cds-grid-columns: 12;
+    grid-column: span 12 / span 12;
+  }
+  .cds--xlg\:col-span-50 {
+    --cds-grid-columns: 8;
+    grid-column: span 8 / span 8;
+  }
+  .cds--xlg\:col-span-25 {
+    --cds-grid-columns: 4;
+    grid-column: span 4 / span 4;
+  }
+}
+@media (min-width: 99rem) {
+  .carbon-chart-wrapper :root {
+    --cds-grid-margin: 1.5rem;
+  }
+  .cds--max\:col-span-0 {
+    display: none;
+  }
+  .cds--max\:col-span-1 {
+    --cds-grid-columns: 1;
+    display: block;
+    grid-column: span 1 / span 1;
+  }
+  .cds--max\:col-span-2 {
+    --cds-grid-columns: 2;
+    display: block;
+    grid-column: span 2 / span 2;
+  }
+  .cds--max\:col-span-3 {
+    --cds-grid-columns: 3;
+    display: block;
+    grid-column: span 3 / span 3;
+  }
+  .cds--max\:col-span-4 {
+    --cds-grid-columns: 4;
+    display: block;
+    grid-column: span 4 / span 4;
+  }
+  .cds--max\:col-span-5 {
+    --cds-grid-columns: 5;
+    display: block;
+    grid-column: span 5 / span 5;
+  }
+  .cds--max\:col-span-6 {
+    --cds-grid-columns: 6;
+    display: block;
+    grid-column: span 6 / span 6;
+  }
+  .cds--max\:col-span-7 {
+    --cds-grid-columns: 7;
+    display: block;
+    grid-column: span 7 / span 7;
+  }
+  .cds--max\:col-span-8 {
+    --cds-grid-columns: 8;
+    display: block;
+    grid-column: span 8 / span 8;
+  }
+  .cds--max\:col-span-9 {
+    --cds-grid-columns: 9;
+    display: block;
+    grid-column: span 9 / span 9;
+  }
+  .cds--max\:col-span-10 {
+    --cds-grid-columns: 10;
+    display: block;
+    grid-column: span 10 / span 10;
+  }
+  .cds--max\:col-span-11 {
+    --cds-grid-columns: 11;
+    display: block;
+    grid-column: span 11 / span 11;
+  }
+  .cds--max\:col-span-12 {
+    --cds-grid-columns: 12;
+    display: block;
+    grid-column: span 12 / span 12;
+  }
+  .cds--max\:col-span-13 {
+    --cds-grid-columns: 13;
+    display: block;
+    grid-column: span 13 / span 13;
+  }
+  .cds--max\:col-span-14 {
+    --cds-grid-columns: 14;
+    display: block;
+    grid-column: span 14 / span 14;
+  }
+  .cds--max\:col-span-15 {
+    --cds-grid-columns: 15;
+    display: block;
+    grid-column: span 15 / span 15;
+  }
+  .cds--max\:col-span-16 {
+    --cds-grid-columns: 16;
+    display: block;
+    grid-column: span 16 / span 16;
+  }
+  .cds--max\:col-span-auto {
+    grid-column: auto;
+  }
+  .cds--max\:col-span-100 {
+    grid-column: 1/-1;
+  }
+  .cds--max\:col-span-75 {
+    --cds-grid-columns: 12;
+    grid-column: span 12 / span 12;
+  }
+  .cds--max\:col-span-50 {
+    --cds-grid-columns: 8;
+    grid-column: span 8 / span 8;
+  }
+  .cds--max\:col-span-25 {
+    --cds-grid-columns: 4;
+    grid-column: span 4 / span 4;
+  }
+}
+.cds--col-span-auto {
+  grid-column: auto;
+}
+.cds--col-span-100 {
+  grid-column: 1/-1;
+}
+.cds--col-span-75 {
+  --cds-grid-columns: 3;
+  grid-column: span 3 / span 3;
+}
+@media (min-width: 42rem) {
+  .cds--col-span-75 {
+    --cds-grid-columns: 6;
+    grid-column: span 6 / span 6;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--col-span-75 {
+    --cds-grid-columns: 12;
+    grid-column: span 12 / span 12;
+  }
+}
+.cds--col-span-50 {
+  --cds-grid-columns: 2;
+  grid-column: span 2 / span 2;
+}
+@media (min-width: 42rem) {
+  .cds--col-span-50 {
+    --cds-grid-columns: 4;
+    grid-column: span 4 / span 4;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--col-span-50 {
+    --cds-grid-columns: 8;
+    grid-column: span 8 / span 8;
+  }
+}
+.cds--col-span-25 {
+  --cds-grid-columns: 1;
+  grid-column: span 1 / span 1;
+}
+.cds--col-start-1 {
+  grid-column-start: 1;
+}
+.cds--col-start-2 {
+  grid-column-start: 2;
+}
+.cds--col-start-3 {
+  grid-column-start: 3;
+}
+.cds--col-start-4 {
+  grid-column-start: 4;
+}
+.cds--col-start-5 {
+  grid-column-start: 5;
+}
+.cds--col-start-6 {
+  grid-column-start: 6;
+}
+.cds--col-start-7 {
+  grid-column-start: 7;
+}
+.cds--col-start-8 {
+  grid-column-start: 8;
+}
+.cds--col-start-9 {
+  grid-column-start: 9;
+}
+.cds--col-start-10 {
+  grid-column-start: 10;
+}
+.cds--col-start-11 {
+  grid-column-start: 11;
+}
+.cds--col-start-12 {
+  grid-column-start: 12;
+}
+.cds--col-start-13 {
+  grid-column-start: 13;
+}
+.cds--col-start-14 {
+  grid-column-start: 14;
+}
+.cds--col-start-15 {
+  grid-column-start: 15;
+}
+.cds--col-start-16 {
+  grid-column-start: 16;
+}
+.cds--col-end-2 {
+  grid-column-end: 2;
+}
+.cds--col-end-3 {
+  grid-column-end: 3;
+}
+.cds--col-end-4 {
+  grid-column-end: 4;
+}
+.cds--col-end-5 {
+  grid-column-end: 5;
+}
+.cds--col-end-6 {
+  grid-column-end: 6;
+}
+.cds--col-end-7 {
+  grid-column-end: 7;
+}
+.cds--col-end-8 {
+  grid-column-end: 8;
+}
+.cds--col-end-9 {
+  grid-column-end: 9;
+}
+.cds--col-end-10 {
+  grid-column-end: 10;
+}
+.cds--col-end-11 {
+  grid-column-end: 11;
+}
+.cds--col-end-12 {
+  grid-column-end: 12;
+}
+.cds--col-end-13 {
+  grid-column-end: 13;
+}
+.cds--col-end-14 {
+  grid-column-end: 14;
+}
+.cds--col-end-15 {
+  grid-column-end: 15;
+}
+.cds--col-end-16 {
+  grid-column-end: 16;
+}
+.cds--col-end-17 {
+  grid-column-end: 17;
+}
+.cds--col-start-auto {
+  grid-column-start: auto;
+}
+.cds--col-end-auto {
+  grid-column-end: auto;
+}
+.cds--sm\:col-start-1 {
+  grid-column-start: 1;
+}
+.cds--sm\:col-start-2 {
+  grid-column-start: 2;
+}
+.cds--sm\:col-start-3 {
+  grid-column-start: 3;
+}
+.cds--sm\:col-start-4 {
+  grid-column-start: 4;
+}
+.cds--sm\:col-start-5 {
+  grid-column-start: 5;
+}
+.cds--sm\:col-start-6 {
+  grid-column-start: 6;
+}
+.cds--sm\:col-start-7 {
+  grid-column-start: 7;
+}
+.cds--sm\:col-start-8 {
+  grid-column-start: 8;
+}
+.cds--sm\:col-start-9 {
+  grid-column-start: 9;
+}
+.cds--sm\:col-start-10 {
+  grid-column-start: 10;
+}
+.cds--sm\:col-start-11 {
+  grid-column-start: 11;
+}
+.cds--sm\:col-start-12 {
+  grid-column-start: 12;
+}
+.cds--sm\:col-start-13 {
+  grid-column-start: 13;
+}
+.cds--sm\:col-start-14 {
+  grid-column-start: 14;
+}
+.cds--sm\:col-start-15 {
+  grid-column-start: 15;
+}
+.cds--sm\:col-start-16 {
+  grid-column-start: 16;
+}
+.cds--sm\:col-end-2 {
+  grid-column-end: 2;
+}
+.cds--sm\:col-end-3 {
+  grid-column-end: 3;
+}
+.cds--sm\:col-end-4 {
+  grid-column-end: 4;
+}
+.cds--sm\:col-end-5 {
+  grid-column-end: 5;
+}
+.cds--sm\:col-end-6 {
+  grid-column-end: 6;
+}
+.cds--sm\:col-end-7 {
+  grid-column-end: 7;
+}
+.cds--sm\:col-end-8 {
+  grid-column-end: 8;
+}
+.cds--sm\:col-end-9 {
+  grid-column-end: 9;
+}
+.cds--sm\:col-end-10 {
+  grid-column-end: 10;
+}
+.cds--sm\:col-end-11 {
+  grid-column-end: 11;
+}
+.cds--sm\:col-end-12 {
+  grid-column-end: 12;
+}
+.cds--sm\:col-end-13 {
+  grid-column-end: 13;
+}
+.cds--sm\:col-end-14 {
+  grid-column-end: 14;
+}
+.cds--sm\:col-end-15 {
+  grid-column-end: 15;
+}
+.cds--sm\:col-end-16 {
+  grid-column-end: 16;
+}
+.cds--sm\:col-end-17 {
+  grid-column-end: 17;
+}
+.cds--sm\:col-start-auto {
+  grid-column-start: auto;
+}
+.cds--sm\:col-end-auto {
+  grid-column-end: auto;
+}
+@media (min-width: 42rem) {
+  .cds--col-span-25 {
+    --cds-grid-columns: 2;
+    grid-column: span 2 / span 2;
+  }
+  .cds--md\:col-start-1 {
+    grid-column-start: 1;
+  }
+  .cds--md\:col-start-2 {
+    grid-column-start: 2;
+  }
+  .cds--md\:col-start-3 {
+    grid-column-start: 3;
+  }
+  .cds--md\:col-start-4 {
+    grid-column-start: 4;
+  }
+  .cds--md\:col-start-5 {
+    grid-column-start: 5;
+  }
+  .cds--md\:col-start-6 {
+    grid-column-start: 6;
+  }
+  .cds--md\:col-start-7 {
+    grid-column-start: 7;
+  }
+  .cds--md\:col-start-8 {
+    grid-column-start: 8;
+  }
+  .cds--md\:col-start-9 {
+    grid-column-start: 9;
+  }
+  .cds--md\:col-start-10 {
+    grid-column-start: 10;
+  }
+  .cds--md\:col-start-11 {
+    grid-column-start: 11;
+  }
+  .cds--md\:col-start-12 {
+    grid-column-start: 12;
+  }
+  .cds--md\:col-start-13 {
+    grid-column-start: 13;
+  }
+  .cds--md\:col-start-14 {
+    grid-column-start: 14;
+  }
+  .cds--md\:col-start-15 {
+    grid-column-start: 15;
+  }
+  .cds--md\:col-start-16 {
+    grid-column-start: 16;
+  }
+  .cds--md\:col-end-2 {
+    grid-column-end: 2;
+  }
+  .cds--md\:col-end-3 {
+    grid-column-end: 3;
+  }
+  .cds--md\:col-end-4 {
+    grid-column-end: 4;
+  }
+  .cds--md\:col-end-5 {
+    grid-column-end: 5;
+  }
+  .cds--md\:col-end-6 {
+    grid-column-end: 6;
+  }
+  .cds--md\:col-end-7 {
+    grid-column-end: 7;
+  }
+  .cds--md\:col-end-8 {
+    grid-column-end: 8;
+  }
+  .cds--md\:col-end-9 {
+    grid-column-end: 9;
+  }
+  .cds--md\:col-end-10 {
+    grid-column-end: 10;
+  }
+  .cds--md\:col-end-11 {
+    grid-column-end: 11;
+  }
+  .cds--md\:col-end-12 {
+    grid-column-end: 12;
+  }
+  .cds--md\:col-end-13 {
+    grid-column-end: 13;
+  }
+  .cds--md\:col-end-14 {
+    grid-column-end: 14;
+  }
+  .cds--md\:col-end-15 {
+    grid-column-end: 15;
+  }
+  .cds--md\:col-end-16 {
+    grid-column-end: 16;
+  }
+  .cds--md\:col-end-17 {
+    grid-column-end: 17;
+  }
+  .cds--md\:col-start-auto {
+    grid-column-start: auto;
+  }
+  .cds--md\:col-end-auto {
+    grid-column-end: auto;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--col-span-25 {
+    --cds-grid-columns: 4;
+    grid-column: span 4 / span 4;
+  }
+  .cds--lg\:col-start-1 {
+    grid-column-start: 1;
+  }
+  .cds--lg\:col-start-2 {
+    grid-column-start: 2;
+  }
+  .cds--lg\:col-start-3 {
+    grid-column-start: 3;
+  }
+  .cds--lg\:col-start-4 {
+    grid-column-start: 4;
+  }
+  .cds--lg\:col-start-5 {
+    grid-column-start: 5;
+  }
+  .cds--lg\:col-start-6 {
+    grid-column-start: 6;
+  }
+  .cds--lg\:col-start-7 {
+    grid-column-start: 7;
+  }
+  .cds--lg\:col-start-8 {
+    grid-column-start: 8;
+  }
+  .cds--lg\:col-start-9 {
+    grid-column-start: 9;
+  }
+  .cds--lg\:col-start-10 {
+    grid-column-start: 10;
+  }
+  .cds--lg\:col-start-11 {
+    grid-column-start: 11;
+  }
+  .cds--lg\:col-start-12 {
+    grid-column-start: 12;
+  }
+  .cds--lg\:col-start-13 {
+    grid-column-start: 13;
+  }
+  .cds--lg\:col-start-14 {
+    grid-column-start: 14;
+  }
+  .cds--lg\:col-start-15 {
+    grid-column-start: 15;
+  }
+  .cds--lg\:col-start-16 {
+    grid-column-start: 16;
+  }
+  .cds--lg\:col-end-2 {
+    grid-column-end: 2;
+  }
+  .cds--lg\:col-end-3 {
+    grid-column-end: 3;
+  }
+  .cds--lg\:col-end-4 {
+    grid-column-end: 4;
+  }
+  .cds--lg\:col-end-5 {
+    grid-column-end: 5;
+  }
+  .cds--lg\:col-end-6 {
+    grid-column-end: 6;
+  }
+  .cds--lg\:col-end-7 {
+    grid-column-end: 7;
+  }
+  .cds--lg\:col-end-8 {
+    grid-column-end: 8;
+  }
+  .cds--lg\:col-end-9 {
+    grid-column-end: 9;
+  }
+  .cds--lg\:col-end-10 {
+    grid-column-end: 10;
+  }
+  .cds--lg\:col-end-11 {
+    grid-column-end: 11;
+  }
+  .cds--lg\:col-end-12 {
+    grid-column-end: 12;
+  }
+  .cds--lg\:col-end-13 {
+    grid-column-end: 13;
+  }
+  .cds--lg\:col-end-14 {
+    grid-column-end: 14;
+  }
+  .cds--lg\:col-end-15 {
+    grid-column-end: 15;
+  }
+  .cds--lg\:col-end-16 {
+    grid-column-end: 16;
+  }
+  .cds--lg\:col-end-17 {
+    grid-column-end: 17;
+  }
+  .cds--lg\:col-start-auto {
+    grid-column-start: auto;
+  }
+  .cds--lg\:col-end-auto {
+    grid-column-end: auto;
+  }
+}
+.cds--layer-one,
+:root {
+  --cds-layer: var(--cds-layer-01, #f4f4f4);
+  --cds-layer-active: var(--cds-layer-active-01, #c6c6c6);
+  --cds-layer-hover: var(--cds-layer-hover-01, #e8e8e8);
+  --cds-layer-selected: var(--cds-layer-selected-01, #e0e0e0);
+  --cds-layer-selected-hover: var(--cds-layer-selected-hover-01, #d1d1d1);
+  --cds-layer-accent: var(--cds-layer-accent-01, #e0e0e0);
+  --cds-layer-accent-hover: var(--cds-layer-accent-hover-01, #d1d1d1);
+  --cds-layer-accent-active: var(--cds-layer-accent-active-01, #a8a8a8);
+  --cds-field: var(--cds-field-01, #f4f4f4);
+  --cds-field-hover: var(--cds-field-hover-01, #e8e8e8);
+  --cds-border-subtle: var(--cds-border-subtle-00, #e0e0e0);
+  --cds-border-subtle-selected: var(--cds-border-subtle-selected-01, #c6c6c6);
+  --cds-border-strong: var(--cds-border-strong-01, #8d8d8d);
+  --cds-border-tile: var(--cds-border-tile-01, #c6c6c6);
+}
+.cds--layer-two {
+  --cds-layer: var(--cds-layer-02, #fff);
+  --cds-layer-active: var(--cds-layer-active-02, #c6c6c6);
+  --cds-layer-hover: var(--cds-layer-hover-02, #e8e8e8);
+  --cds-layer-selected: var(--cds-layer-selected-02, #e0e0e0);
+  --cds-layer-selected-hover: var(--cds-layer-selected-hover-02, #d1d1d1);
+  --cds-layer-accent: var(--cds-layer-accent-02, #e0e0e0);
+  --cds-layer-accent-hover: var(--cds-layer-accent-hover-02, #d1d1d1);
+  --cds-layer-accent-active: var(--cds-layer-accent-active-02, #a8a8a8);
+  --cds-field: var(--cds-field-02, #fff);
+  --cds-field-hover: var(--cds-field-hover-02, #e8e8e8);
+  --cds-border-subtle: var(--cds-border-subtle-01, #c6c6c6);
+  --cds-border-subtle-selected: var(--cds-border-subtle-selected-02, #c6c6c6);
+  --cds-border-strong: var(--cds-border-strong-02, #8d8d8d);
+  --cds-border-tile: var(--cds-border-tile-02, #a8a8a8);
+}
+.cds--layer-three {
+  --cds-layer: var(--cds-layer-03, #f4f4f4);
+  --cds-layer-active: var(--cds-layer-active-03, #c6c6c6);
+  --cds-layer-hover: var(--cds-layer-hover-03, #e8e8e8);
+  --cds-layer-selected: var(--cds-layer-selected-03, #e0e0e0);
+  --cds-layer-selected-hover: var(--cds-layer-selected-hover-03, #d1d1d1);
+  --cds-layer-accent: var(--cds-layer-accent-03, #e0e0e0);
+  --cds-layer-accent-hover: var(--cds-layer-accent-hover-03, #d1d1d1);
+  --cds-layer-accent-active: var(--cds-layer-accent-active-03, #a8a8a8);
+  --cds-field: var(--cds-field-03, #f4f4f4);
+  --cds-field-hover: var(--cds-field-hover-03, #e8e8e8);
+  --cds-border-subtle: var(--cds-border-subtle-02, #e0e0e0);
+  --cds-border-subtle-selected: var(--cds-border-subtle-selected-03, #c6c6c6);
+  --cds-border-strong: var(--cds-border-strong-03, #8d8d8d);
+  --cds-border-tile: var(--cds-border-tile-03, #c6c6c6);
+}
+.cds--g10,
+.cds--white {
+  --cds-background-active: hsla(0, 0%, 55%, 0.5);
+  --cds-background-hover: hsla(0, 0%, 55%, 0.12);
   --cds-background-inverse: #393939;
   --cds-background-inverse-hover: #474747;
-  --cds-background-selected: rgba(141, 141, 141, 0.2);
-  --cds-background-selected-hover: rgba(141, 141, 141, 0.32);
+  --cds-background-selected: hsla(0, 0%, 55%, 0.2);
   --cds-border-disabled: #c6c6c6;
   --cds-border-interactive: #0f62fe;
   --cds-border-inverse: #161616;
-  --cds-border-strong-01: #8d8d8d;
   --cds-border-strong-02: #8d8d8d;
   --cds-border-strong-03: #8d8d8d;
+  --cds-border-subtle-selected-01: #c6c6c6;
+  --cds-border-subtle-selected-02: #c6c6c6;
+  --cds-border-subtle-selected-03: #c6c6c6;
+  --cds-field-hover-01: #e8e8e8;
+  --cds-field-hover-02: #e8e8e8;
+  --cds-field-hover-03: #e8e8e8;
+  --cds-focus: #0f62fe;
+  --cds-focus-inset: #fff;
+  --cds-focus-inverse: #fff;
+  --cds-highlight: #d0e2ff;
+  --cds-icon-disabled: hsla(0, 0%, 9%, 0.25);
+  --cds-icon-interactive: #0f62fe;
+  --cds-icon-inverse: #fff;
+  --cds-icon-on-color: #fff;
+  --cds-icon-on-color-disabled: #8d8d8d;
+  --cds-icon-primary: #161616;
+  --cds-icon-secondary: #525252;
+  --cds-interactive: #0f62fe;
+  --cds-layer-accent-01: #e0e0e0;
+  --cds-layer-accent-02: #e0e0e0;
+  --cds-layer-accent-03: #e0e0e0;
+  --cds-layer-accent-active-01: #a8a8a8;
+  --cds-layer-accent-active-02: #a8a8a8;
+  --cds-layer-accent-active-03: #a8a8a8;
+  --cds-layer-accent-hover-01: #d1d1d1;
+  --cds-layer-accent-hover-02: #d1d1d1;
+  --cds-layer-accent-hover-03: #d1d1d1;
+  --cds-layer-active-01: #c6c6c6;
+  --cds-layer-active-02: #c6c6c6;
+  --cds-layer-active-03: #c6c6c6;
+  --cds-layer-hover-01: #e8e8e8;
+  --cds-layer-hover-02: #e8e8e8;
+  --cds-layer-hover-03: #e8e8e8;
+  --cds-layer-selected-01: #e0e0e0;
+  --cds-layer-selected-02: #e0e0e0;
+  --cds-layer-selected-03: #e0e0e0;
+  --cds-layer-selected-disabled: #8d8d8d;
+  --cds-layer-selected-hover-01: #d1d1d1;
+  --cds-layer-selected-hover-02: #d1d1d1;
+  --cds-layer-selected-hover-03: #d1d1d1;
+  --cds-layer-selected-inverse: #161616;
+  --cds-link-inverse: #78a9ff;
+  --cds-link-inverse-active: #f4f4f4;
+  --cds-link-inverse-hover: #a6c8ff;
+  --cds-link-primary: #0f62fe;
+  --cds-link-primary-hover: #0043ce;
+  --cds-link-secondary: #0043ce;
+  --cds-link-visited: #8a3ffc;
+  --cds-overlay: hsla(0, 0%, 9%, 0.5);
+  --cds-shadow: rgba(0, 0, 0, 0.3);
+  --cds-skeleton-background: #e8e8e8;
+  --cds-skeleton-element: #c6c6c6;
+  --cds-support-caution-major: #ff832b;
+  --cds-support-caution-minor: #f1c21b;
+  --cds-support-caution-undefined: #8a3ffc;
+  --cds-support-error: #da1e28;
+  --cds-support-error-inverse: #fa4d56;
+  --cds-support-info: #0043ce;
+  --cds-support-info-inverse: #4589ff;
+  --cds-support-success: #24a148;
+  --cds-support-success-inverse: #42be65;
+  --cds-support-warning: #f1c21b;
+  --cds-support-warning-inverse: #f1c21b;
+  --cds-text-disabled: hsla(0, 0%, 9%, 0.25);
+  --cds-text-error: #da1e28;
+  --cds-text-helper: #6f6f6f;
+  --cds-text-inverse: #fff;
+  --cds-text-on-color: #fff;
+  --cds-text-on-color-disabled: #8d8d8d;
+  --cds-text-placeholder: hsla(0, 0%, 9%, 0.4);
+  --cds-text-primary: #161616;
+  --cds-text-secondary: #525252;
+  --cds-layer: var(--cds-layer-01, #f4f4f4);
+  --cds-layer-active: var(--cds-layer-active-01, #c6c6c6);
+  --cds-layer-hover: var(--cds-layer-hover-01, #e8e8e8);
+  --cds-layer-selected: var(--cds-layer-selected-01, #e0e0e0);
+  --cds-layer-selected-hover: var(--cds-layer-selected-hover-01, #d1d1d1);
+  --cds-layer-accent: var(--cds-layer-accent-01, #e0e0e0);
+  --cds-layer-accent-hover: var(--cds-layer-accent-hover-01, #d1d1d1);
+  --cds-layer-accent-active: var(--cds-layer-accent-active-01, #a8a8a8);
+  --cds-field: var(--cds-field-01, #f4f4f4);
+  --cds-field-hover: var(--cds-field-hover-01, #e8e8e8);
+  --cds-border-subtle: var(--cds-border-subtle-00, #e0e0e0);
+  --cds-border-subtle-selected: var(--cds-border-subtle-selected-01, #c6c6c6);
+  --cds-border-strong: var(--cds-border-strong-01, #8d8d8d);
+  --cds-border-tile: var(--cds-border-tile-01, #c6c6c6);
+  --cds-button-separator: #e0e0e0;
+  --cds-button-primary: #0f62fe;
+  --cds-button-secondary: #393939;
+  --cds-button-tertiary: #0f62fe;
+  --cds-button-danger-primary: #da1e28;
+  --cds-button-danger-secondary: #da1e28;
+  --cds-button-danger-active: #750e13;
+  --cds-button-primary-active: #002d9c;
+  --cds-button-secondary-active: #6f6f6f;
+  --cds-button-tertiary-active: #002d9c;
+  --cds-button-danger-hover: #b81921;
+  --cds-button-primary-hover: #0050e6;
+  --cds-button-secondary-hover: #474747;
+  --cds-button-tertiary-hover: #0050e6;
+  --cds-button-disabled: #c6c6c6;
+  --cds-notification-background-error: #fff1f1;
+  --cds-notification-background-success: #defbe6;
+  --cds-notification-background-info: #edf5ff;
+  --cds-notification-background-warning: #fdf6dd;
+  --cds-notification-action-hover: #edf5ff;
+  --cds-notification-action-tertiary-inverse: #fff;
+  --cds-notification-action-tertiary-inverse-active: #c6c6c6;
+  --cds-notification-action-tertiary-inverse-hover: #f4f4f4;
+  --cds-notification-action-tertiary-inverse-text: #161616;
+  --cds-notification-action-tertiary-inverse-text-on-color-disabled: hsla(
+    0,
+    0%,
+    100%,
+    0.2
+  );
+  --cds-tag-background-red: #ffd7d9;
+  --cds-tag-color-red: #750e13;
+  --cds-tag-hover-red: #ffb3b8;
+  --cds-tag-background-magenta: #ffd6e8;
+  --cds-tag-color-magenta: #740937;
+  --cds-tag-hover-magenta: #ffafd2;
+  --cds-tag-background-purple: #e8daff;
+  --cds-tag-color-purple: #491d8b;
+  --cds-tag-hover-purple: #d4bbff;
+  --cds-tag-background-blue: #d0e2ff;
+  --cds-tag-color-blue: #002d9c;
+  --cds-tag-hover-blue: #a6c8ff;
+  --cds-tag-background-cyan: #bae6ff;
+  --cds-tag-color-cyan: #003a6d;
+  --cds-tag-hover-cyan: #82cfff;
+  --cds-tag-background-teal: #9ef0f0;
+  --cds-tag-color-teal: #004144;
+  --cds-tag-hover-teal: #3ddbd9;
+  --cds-tag-background-green: #a7f0ba;
+  --cds-tag-color-green: #044317;
+  --cds-tag-hover-green: #6fdc8c;
+  --cds-tag-background-gray: #e0e0e0;
+  --cds-tag-color-gray: #393939;
+  --cds-tag-hover-gray: #c6c6c6;
+  --cds-tag-background-cool-gray: #dde1e6;
+  --cds-tag-color-cool-gray: #343a3f;
+  --cds-tag-hover-cool-gray: #c1c7cd;
+  --cds-tag-background-warm-gray: #e5e0df;
+  --cds-tag-color-warm-gray: #3c3838;
+  --cds-tag-hover-warm-gray: #cac5c4;
+  --cds-background-brand: #0f62fe;
+  --cds-background-selected-hover: hsla(0, 0%, 55%, 0.32);
+  --cds-border-strong-01: #8d8d8d;
+  --cds-toggle-off: #8d8d8d;
+  background: var(--cds-background);
+  color: var(--cds-text-primary);
+}
+.cds--white {
+  --cds-background: #fff;
   --cds-border-subtle-00: #e0e0e0;
   --cds-border-subtle-01: #c6c6c6;
   --cds-border-subtle-02: #e0e0e0;
   --cds-border-subtle-03: #c6c6c6;
-  --cds-border-subtle-selected-01: #c6c6c6;
-  --cds-border-subtle-selected-02: #c6c6c6;
-  --cds-border-subtle-selected-03: #c6c6c6;
   --cds-border-tile-01: #c6c6c6;
   --cds-border-tile-02: #a8a8a8;
   --cds-border-tile-03: #c6c6c6;
-  --cds-chat-avatar-agent: #393939;
-  --cds-chat-avatar-bot: #6f6f6f;
-  --cds-chat-avatar-user: #0f62fe;
-  --cds-chat-bubble-agent: #ffffff;
-  --cds-chat-bubble-border: #e0e0e0;
-  --cds-chat-bubble-user: #e0e0e0;
-  --cds-chat-button: #0f62fe;
-  --cds-chat-button-active: rgba(141, 141, 141, 0.5);
-  --cds-chat-button-hover: rgba(141, 141, 141, 0.12);
-  --cds-chat-button-selected: rgba(141, 141, 141, 0.2);
-  --cds-chat-button-text-hover: #0043ce;
-  --cds-chat-button-text-selected: #525252;
-  --cds-chat-header-background: #ffffff;
-  --cds-chat-prompt-background: #ffffff;
-  --cds-chat-prompt-border-end: rgba(244, 244, 244, 0);
-  --cds-chat-prompt-border-start: #f4f4f4;
-  --cds-chat-shell-background: #ffffff;
   --cds-field-01: #f4f4f4;
-  --cds-field-02: #ffffff;
+  --cds-field-02: #fff;
   --cds-field-03: #f4f4f4;
-  --cds-field-hover-01: #e8e8e8;
-  --cds-field-hover-02: #e8e8e8;
-  --cds-field-hover-03: #e8e8e8;
-  --cds-focus: #0f62fe;
-  --cds-focus-inset: #ffffff;
-  --cds-focus-inverse: #ffffff;
-  --cds-highlight: #d0e2ff;
-  --cds-icon-disabled: rgba(22, 22, 22, 0.25);
-  --cds-icon-interactive: #0f62fe;
-  --cds-icon-inverse: #ffffff;
-  --cds-icon-on-color: #ffffff;
-  --cds-icon-on-color-disabled: #8d8d8d;
-  --cds-icon-primary: #161616;
-  --cds-icon-secondary: #525252;
-  --cds-interactive: #0f62fe;
   --cds-layer-01: #f4f4f4;
-  --cds-layer-02: #ffffff;
+  --cds-layer-02: #fff;
   --cds-layer-03: #f4f4f4;
-  --cds-layer-accent-01: #e0e0e0;
-  --cds-layer-accent-02: #e0e0e0;
-  --cds-layer-accent-03: #e0e0e0;
-  --cds-layer-accent-active-01: #a8a8a8;
-  --cds-layer-accent-active-02: #a8a8a8;
-  --cds-layer-accent-active-03: #a8a8a8;
-  --cds-layer-accent-hover-01: #d1d1d1;
-  --cds-layer-accent-hover-02: #d1d1d1;
-  --cds-layer-accent-hover-03: #d1d1d1;
-  --cds-layer-active-01: #c6c6c6;
-  --cds-layer-active-02: #c6c6c6;
-  --cds-layer-active-03: #c6c6c6;
-  --cds-layer-hover-01: #e8e8e8;
-  --cds-layer-hover-02: #e8e8e8;
-  --cds-layer-hover-03: #e8e8e8;
-  --cds-layer-selected-01: #e0e0e0;
-  --cds-layer-selected-02: #e0e0e0;
-  --cds-layer-selected-03: #e0e0e0;
-  --cds-layer-selected-disabled: #8d8d8d;
-  --cds-layer-selected-hover-01: #d1d1d1;
-  --cds-layer-selected-hover-02: #d1d1d1;
-  --cds-layer-selected-hover-03: #d1d1d1;
-  --cds-layer-selected-inverse: #161616;
-  --cds-link-inverse: #78a9ff;
-  --cds-link-inverse-active: #f4f4f4;
-  --cds-link-inverse-hover: #a6c8ff;
-  --cds-link-inverse-visited: #be95ff;
-  --cds-link-primary: #0f62fe;
-  --cds-link-primary-hover: #0043ce;
-  --cds-link-secondary: #0043ce;
-  --cds-link-visited: #8a3ffc;
-  --cds-overlay: rgba(22, 22, 22, 0.5);
-  --cds-shadow: rgba(0, 0, 0, 0.3);
-  --cds-skeleton-background: #e8e8e8;
-  --cds-skeleton-element: #c6c6c6;
-  --cds-support-caution-major: #ff832b;
-  --cds-support-caution-minor: #f1c21b;
-  --cds-support-caution-undefined: #8a3ffc;
-  --cds-support-error: #da1e28;
-  --cds-support-error-inverse: #fa4d56;
-  --cds-support-info: #0043ce;
-  --cds-support-info-inverse: #4589ff;
-  --cds-support-success: #24a148;
-  --cds-support-success-inverse: #42be65;
-  --cds-support-warning: #f1c21b;
-  --cds-support-warning-inverse: #f1c21b;
-  --cds-text-disabled: rgba(22, 22, 22, 0.25);
-  --cds-text-error: #da1e28;
-  --cds-text-helper: #6f6f6f;
-  --cds-text-inverse: #ffffff;
-  --cds-text-on-color: #ffffff;
-  --cds-text-on-color-disabled: #8d8d8d;
-  --cds-text-placeholder: rgba(22, 22, 22, 0.4);
-  --cds-text-primary: #161616;
-  --cds-text-secondary: #525252;
-  --cds-toggle-off: #8d8d8d;
-  --cds-spacing-01: 0.125rem;
-  --cds-spacing-02: 0.25rem;
-  --cds-spacing-03: 0.5rem;
-  --cds-spacing-04: 0.75rem;
-  --cds-spacing-05: 1rem;
-  --cds-spacing-06: 1.5rem;
-  --cds-spacing-07: 2rem;
-  --cds-spacing-08: 2.5rem;
-  --cds-spacing-09: 3rem;
-  --cds-spacing-10: 4rem;
-  --cds-spacing-11: 5rem;
-  --cds-spacing-12: 6rem;
-  --cds-spacing-13: 10rem;
-  --cds-fluid-spacing-01: 0;
-  --cds-fluid-spacing-02: 2vw;
-  --cds-fluid-spacing-03: 5vw;
-  --cds-fluid-spacing-04: 10vw;
-  --cds-caption-01-font-size: 0.75rem;
-  --cds-caption-01-font-weight: 400;
-  --cds-caption-01-line-height: 1.33333;
-  --cds-caption-01-letter-spacing: 0.32px;
-  --cds-caption-02-font-size: 0.875rem;
-  --cds-caption-02-font-weight: 400;
-  --cds-caption-02-line-height: 1.28572;
-  --cds-caption-02-letter-spacing: 0.32px;
-  --cds-label-01-font-size: 0.75rem;
-  --cds-label-01-font-weight: 400;
-  --cds-label-01-line-height: 1.33333;
-  --cds-label-01-letter-spacing: 0.32px;
-  --cds-label-02-font-size: 0.875rem;
-  --cds-label-02-font-weight: 400;
-  --cds-label-02-line-height: 1.28572;
-  --cds-label-02-letter-spacing: 0.16px;
-  --cds-helper-text-01-font-size: 0.75rem;
-  --cds-helper-text-01-line-height: 1.33333;
-  --cds-helper-text-01-letter-spacing: 0.32px;
-  --cds-helper-text-02-font-size: 0.875rem;
-  --cds-helper-text-02-font-weight: 400;
-  --cds-helper-text-02-line-height: 1.28572;
-  --cds-helper-text-02-letter-spacing: 0.16px;
-  --cds-body-short-01-font-size: 0.875rem;
-  --cds-body-short-01-font-weight: 400;
-  --cds-body-short-01-line-height: 1.28572;
-  --cds-body-short-01-letter-spacing: 0.16px;
-  --cds-body-short-02-font-size: 1rem;
-  --cds-body-short-02-font-weight: 400;
-  --cds-body-short-02-line-height: 1.375;
-  --cds-body-short-02-letter-spacing: 0;
-  --cds-body-long-01-font-size: 0.875rem;
-  --cds-body-long-01-font-weight: 400;
-  --cds-body-long-01-line-height: 1.42857;
-  --cds-body-long-01-letter-spacing: 0.16px;
-  --cds-body-long-02-font-size: 1rem;
-  --cds-body-long-02-font-weight: 400;
-  --cds-body-long-02-line-height: 1.5;
-  --cds-body-long-02-letter-spacing: 0;
-  --cds-code-01-font-family:
-    'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', monospace;
-  --cds-code-01-font-size: 0.75rem;
-  --cds-code-01-font-weight: 400;
-  --cds-code-01-line-height: 1.33333;
-  --cds-code-01-letter-spacing: 0.32px;
-  --cds-code-02-font-family:
-    'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', monospace;
-  --cds-code-02-font-size: 0.875rem;
-  --cds-code-02-font-weight: 400;
-  --cds-code-02-line-height: 1.42857;
-  --cds-code-02-letter-spacing: 0.32px;
-  --cds-heading-01-font-size: 0.875rem;
-  --cds-heading-01-font-weight: 600;
-  --cds-heading-01-line-height: 1.42857;
-  --cds-heading-01-letter-spacing: 0.16px;
-  --cds-heading-02-font-size: 1rem;
-  --cds-heading-02-font-weight: 600;
-  --cds-heading-02-line-height: 1.5;
-  --cds-heading-02-letter-spacing: 0;
-  --cds-productive-heading-01-font-size: 0.875rem;
-  --cds-productive-heading-01-font-weight: 600;
-  --cds-productive-heading-01-line-height: 1.28572;
-  --cds-productive-heading-01-letter-spacing: 0.16px;
-  --cds-productive-heading-02-font-size: 1rem;
-  --cds-productive-heading-02-font-weight: 600;
-  --cds-productive-heading-02-line-height: 1.375;
-  --cds-productive-heading-02-letter-spacing: 0;
-  --cds-productive-heading-03-font-size: 1.25rem;
-  --cds-productive-heading-03-font-weight: 400;
-  --cds-productive-heading-03-line-height: 1.4;
-  --cds-productive-heading-03-letter-spacing: 0;
-  --cds-productive-heading-04-font-size: 1.75rem;
-  --cds-productive-heading-04-font-weight: 400;
-  --cds-productive-heading-04-line-height: 1.28572;
-  --cds-productive-heading-04-letter-spacing: 0;
-  --cds-productive-heading-05-font-size: 2rem;
-  --cds-productive-heading-05-font-weight: 400;
-  --cds-productive-heading-05-line-height: 1.25;
-  --cds-productive-heading-05-letter-spacing: 0;
-  --cds-productive-heading-06-font-size: 2.625rem;
-  --cds-productive-heading-06-font-weight: 300;
-  --cds-productive-heading-06-line-height: 1.199;
-  --cds-productive-heading-06-letter-spacing: 0;
-  --cds-productive-heading-07-font-size: 3.375rem;
-  --cds-productive-heading-07-font-weight: 300;
-  --cds-productive-heading-07-line-height: 1.19;
-  --cds-productive-heading-07-letter-spacing: 0;
-  --cds-expressive-paragraph-01-font-size: 1.5rem;
-  --cds-expressive-paragraph-01-font-weight: 300;
-  --cds-expressive-paragraph-01-line-height: 1.334;
-  --cds-expressive-paragraph-01-letter-spacing: 0;
-  --cds-expressive-heading-01-font-size: 0.875rem;
-  --cds-expressive-heading-01-font-weight: 600;
-  --cds-expressive-heading-01-line-height: 1.42857;
-  --cds-expressive-heading-01-letter-spacing: 0.16px;
-  --cds-expressive-heading-02-font-size: 1rem;
-  --cds-expressive-heading-02-font-weight: 600;
-  --cds-expressive-heading-02-line-height: 1.5;
-  --cds-expressive-heading-02-letter-spacing: 0;
-  --cds-expressive-heading-03-font-size: 1.25rem;
-  --cds-expressive-heading-03-font-weight: 400;
-  --cds-expressive-heading-03-line-height: 1.4;
-  --cds-expressive-heading-03-letter-spacing: 0;
-  --cds-expressive-heading-04-font-size: 1.75rem;
-  --cds-expressive-heading-04-font-weight: 400;
-  --cds-expressive-heading-04-line-height: 1.28572;
-  --cds-expressive-heading-04-letter-spacing: 0;
-  --cds-expressive-heading-05-font-size: 2rem;
-  --cds-expressive-heading-05-font-weight: 400;
-  --cds-expressive-heading-05-line-height: 1.25;
-  --cds-expressive-heading-05-letter-spacing: 0;
-  --cds-expressive-heading-06-font-size: 2rem;
-  --cds-expressive-heading-06-font-weight: 600;
-  --cds-expressive-heading-06-line-height: 1.25;
-  --cds-expressive-heading-06-letter-spacing: 0;
-  --cds-quotation-01-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
-  --cds-quotation-01-font-size: 1.25rem;
-  --cds-quotation-01-font-weight: 400;
-  --cds-quotation-01-line-height: 1.3;
-  --cds-quotation-01-letter-spacing: 0;
-  --cds-quotation-02-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
-  --cds-quotation-02-font-size: 2rem;
-  --cds-quotation-02-font-weight: 300;
-  --cds-quotation-02-line-height: 1.25;
-  --cds-quotation-02-letter-spacing: 0;
-  --cds-display-01-font-size: 2.625rem;
-  --cds-display-01-font-weight: 300;
-  --cds-display-01-line-height: 1.19;
-  --cds-display-01-letter-spacing: 0;
-  --cds-display-02-font-size: 2.625rem;
-  --cds-display-02-font-weight: 600;
-  --cds-display-02-line-height: 1.19;
-  --cds-display-02-letter-spacing: 0;
-  --cds-display-03-font-size: 2.625rem;
-  --cds-display-03-font-weight: 300;
-  --cds-display-03-line-height: 1.19;
-  --cds-display-03-letter-spacing: 0;
-  --cds-display-04-font-size: 2.625rem;
-  --cds-display-04-font-weight: 300;
-  --cds-display-04-line-height: 1.19;
-  --cds-display-04-letter-spacing: 0;
-  --cds-legal-01-font-size: 0.75rem;
-  --cds-legal-01-font-weight: 400;
-  --cds-legal-01-line-height: 1.33333;
-  --cds-legal-01-letter-spacing: 0.32px;
-  --cds-legal-02-font-size: 0.875rem;
-  --cds-legal-02-font-weight: 400;
-  --cds-legal-02-line-height: 1.28572;
-  --cds-legal-02-letter-spacing: 0.16px;
-  --cds-body-compact-01-font-size: 0.875rem;
-  --cds-body-compact-01-font-weight: 400;
-  --cds-body-compact-01-line-height: 1.28572;
-  --cds-body-compact-01-letter-spacing: 0.16px;
-  --cds-body-compact-02-font-size: 1rem;
-  --cds-body-compact-02-font-weight: 400;
-  --cds-body-compact-02-line-height: 1.375;
-  --cds-body-compact-02-letter-spacing: 0;
-  --cds-heading-compact-01-font-size: 0.875rem;
-  --cds-heading-compact-01-font-weight: 600;
-  --cds-heading-compact-01-line-height: 1.28572;
-  --cds-heading-compact-01-letter-spacing: 0.16px;
-  --cds-heading-compact-02-font-size: 1rem;
-  --cds-heading-compact-02-font-weight: 600;
-  --cds-heading-compact-02-line-height: 1.375;
-  --cds-heading-compact-02-letter-spacing: 0;
-  --cds-body-01-font-size: 0.875rem;
-  --cds-body-01-font-weight: 400;
-  --cds-body-01-line-height: 1.42857;
-  --cds-body-01-letter-spacing: 0.16px;
-  --cds-body-02-font-size: 1rem;
-  --cds-body-02-font-weight: 400;
-  --cds-body-02-line-height: 1.5;
-  --cds-body-02-letter-spacing: 0;
-  --cds-heading-03-font-size: 1.25rem;
-  --cds-heading-03-font-weight: 400;
-  --cds-heading-03-line-height: 1.4;
-  --cds-heading-03-letter-spacing: 0;
-  --cds-heading-04-font-size: 1.75rem;
-  --cds-heading-04-font-weight: 400;
-  --cds-heading-04-line-height: 1.28572;
-  --cds-heading-04-letter-spacing: 0;
-  --cds-heading-05-font-size: 2rem;
-  --cds-heading-05-font-weight: 400;
-  --cds-heading-05-line-height: 1.25;
-  --cds-heading-05-letter-spacing: 0;
-  --cds-heading-06-font-size: 2.625rem;
-  --cds-heading-06-font-weight: 300;
-  --cds-heading-06-line-height: 1.199;
-  --cds-heading-06-letter-spacing: 0;
-  --cds-heading-07-font-size: 3.375rem;
-  --cds-heading-07-font-weight: 300;
-  --cds-heading-07-line-height: 1.19;
-  --cds-heading-07-letter-spacing: 0;
-  --cds-fluid-heading-03-font-size: 1.25rem;
-  --cds-fluid-heading-03-font-weight: 400;
-  --cds-fluid-heading-03-line-height: 1.4;
-  --cds-fluid-heading-03-letter-spacing: 0;
-  --cds-fluid-heading-04-font-size: 1.75rem;
-  --cds-fluid-heading-04-font-weight: 400;
-  --cds-fluid-heading-04-line-height: 1.28572;
-  --cds-fluid-heading-04-letter-spacing: 0;
-  --cds-fluid-heading-05-font-size: 2rem;
-  --cds-fluid-heading-05-font-weight: 400;
-  --cds-fluid-heading-05-line-height: 1.25;
-  --cds-fluid-heading-05-letter-spacing: 0;
-  --cds-fluid-heading-06-font-size: 2rem;
-  --cds-fluid-heading-06-font-weight: 600;
-  --cds-fluid-heading-06-line-height: 1.25;
-  --cds-fluid-heading-06-letter-spacing: 0;
-  --cds-fluid-paragraph-01-font-size: 1.5rem;
-  --cds-fluid-paragraph-01-font-weight: 300;
-  --cds-fluid-paragraph-01-line-height: 1.334;
-  --cds-fluid-paragraph-01-letter-spacing: 0;
-  --cds-fluid-quotation-01-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
-  --cds-fluid-quotation-01-font-size: 1.25rem;
-  --cds-fluid-quotation-01-font-weight: 400;
-  --cds-fluid-quotation-01-line-height: 1.3;
-  --cds-fluid-quotation-01-letter-spacing: 0;
-  --cds-fluid-quotation-02-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
-  --cds-fluid-quotation-02-font-size: 2rem;
-  --cds-fluid-quotation-02-font-weight: 300;
-  --cds-fluid-quotation-02-line-height: 1.25;
-  --cds-fluid-quotation-02-letter-spacing: 0;
-  --cds-fluid-display-01-font-size: 2.625rem;
-  --cds-fluid-display-01-font-weight: 300;
-  --cds-fluid-display-01-line-height: 1.19;
-  --cds-fluid-display-01-letter-spacing: 0;
-  --cds-fluid-display-02-font-size: 2.625rem;
-  --cds-fluid-display-02-font-weight: 600;
-  --cds-fluid-display-02-line-height: 1.19;
-  --cds-fluid-display-02-letter-spacing: 0;
-  --cds-fluid-display-03-font-size: 2.625rem;
-  --cds-fluid-display-03-font-weight: 300;
-  --cds-fluid-display-03-line-height: 1.19;
-  --cds-fluid-display-03-letter-spacing: 0;
-  --cds-fluid-display-04-font-size: 2.625rem;
-  --cds-fluid-display-04-font-weight: 300;
-  --cds-fluid-display-04-line-height: 1.19;
-  --cds-fluid-display-04-letter-spacing: 0;
-  --cds-color-scheme: light;
-  --cds-alert-stroke: #b28600;
-  --cds-layer-01-absolute: #ffffff;
-  --cds-layer-inverse-absolute: #000000;
-  --cds-null-state: none;
-  --cds-grid-bg: #ffffff;
-  --cds-meter-range-indicator: #a8a8a8;
-  --cds-network-diagrams-background-hover: #f1f1f1;
-  --cds-tooltip-line-border: #e0e0e0;
-  --cds-zone-fill-01: #f4f4f4;
-  --cds-zone-stroke-01: #8d8d8d;
-  --cds-zone-fill-02: #e0e0e0;
-  --cds-zone-stroke-02: #8d8d8d;
-  --cds-zone-fill-03: #c6c6c6;
-  --cds-zone-stroke-03: #8d8d8d;
-  --cds-layer: var(--cds-layer-01, #f4f4f4);
-  --cds-layer-active: var(--cds-layer-active-01, #c6c6c6);
-  --cds-layer-hover: var(--cds-layer-hover-01, #e8e8e8);
-  --cds-layer-selected: var(--cds-layer-selected-01, #e0e0e0);
-  --cds-layer-selected-hover: var(--cds-layer-selected-hover-01, #d1d1d1);
-  --cds-layer-accent: var(--cds-layer-accent-01, #e0e0e0);
-  --cds-layer-accent-hover: var(--cds-layer-accent-hover-01, #d1d1d1);
-  --cds-layer-accent-active: var(--cds-layer-accent-active-01, #a8a8a8);
-  --cds-field: var(--cds-field-01, #f4f4f4);
-  --cds-field-hover: var(--cds-field-hover-01, #e8e8e8);
-  --cds-border-subtle: var(--cds-border-subtle-00, #e0e0e0);
-  --cds-border-subtle-selected: var(--cds-border-subtle-selected-01, #c6c6c6);
-  --cds-border-strong: var(--cds-border-strong-01, #8d8d8d);
-  --cds-border-tile: var(--cds-border-tile-01, #c6c6c6);
 }
-
-.cds--chart-holder[data-carbon-theme='g10'] {
-  --cds-ai-aura-end: rgba(255, 255, 255, 0);
-  --cds-ai-aura-hover-background: #edf5ff;
-  --cds-ai-aura-hover-end: rgba(255, 255, 255, 0);
-  --cds-ai-aura-hover-start: rgba(69, 137, 255, 0.32);
-  --cds-ai-aura-start: rgba(69, 137, 255, 0.1);
-  --cds-ai-aura-start-sm: rgba(69, 137, 255, 0.16);
-  --cds-ai-border-end: #78a9ff;
-  --cds-ai-border-start: rgba(166, 200, 255, 0.64);
-  --cds-ai-border-strong: #4589ff;
-  --cds-ai-drop-shadow: rgba(15, 98, 254, 0.1);
-  --cds-ai-inner-shadow: rgba(69, 137, 255, 0.1);
-  --cds-ai-overlay: rgba(0, 17, 65, 0.5);
-  --cds-ai-popover-background: #ffffff;
-  --cds-ai-popover-caret-bottom: #78a9ff;
-  --cds-ai-popover-caret-bottom-background: #eaf1ff;
-  --cds-ai-popover-caret-bottom-background-actions: #e9effa;
-  --cds-ai-popover-caret-center: #a0c3ff;
-  --cds-ai-popover-shadow-outer-01: rgba(0, 67, 206, 0.06);
-  --cds-ai-popover-shadow-outer-02: rgba(0, 0, 0, 0.04);
-  --cds-ai-skeleton-background: #d0e2ff;
-  --cds-ai-skeleton-element-background: #4589ff;
+.cds--chart-holder[data-carbon-theme='g10'],
+.cds--g10,
+html[data-carbon-theme='g10'] {
   --cds-background: #f4f4f4;
-  --cds-background-active: rgba(141, 141, 141, 0.5);
-  --cds-background-brand: #0f62fe;
-  --cds-background-hover: rgba(141, 141, 141, 0.12);
-  --cds-background-inverse: #393939;
-  --cds-background-inverse-hover: #474747;
-  --cds-background-selected: rgba(141, 141, 141, 0.2);
-  --cds-background-selected-hover: rgba(141, 141, 141, 0.32);
-  --cds-border-disabled: #c6c6c6;
-  --cds-border-interactive: #0f62fe;
-  --cds-border-inverse: #161616;
-  --cds-border-strong-01: #8d8d8d;
-  --cds-border-strong-02: #8d8d8d;
-  --cds-border-strong-03: #8d8d8d;
   --cds-border-subtle-00: #c6c6c6;
   --cds-border-subtle-01: #e0e0e0;
   --cds-border-subtle-02: #c6c6c6;
   --cds-border-subtle-03: #e0e0e0;
-  --cds-border-subtle-selected-01: #c6c6c6;
-  --cds-border-subtle-selected-02: #c6c6c6;
-  --cds-border-subtle-selected-03: #c6c6c6;
   --cds-border-tile-01: #a8a8a8;
   --cds-border-tile-02: #c6c6c6;
-  --cds-border-tile-03: #a8a8a8;
-  --cds-chat-avatar-agent: #393939;
-  --cds-chat-avatar-bot: #6f6f6f;
-  --cds-chat-avatar-user: #0f62fe;
-  --cds-chat-bubble-agent: #ffffff;
-  --cds-chat-bubble-border: #e0e0e0;
-  --cds-chat-bubble-user: #e0e0e0;
-  --cds-chat-button: #0f62fe;
-  --cds-chat-button-active: rgba(141, 141, 141, 0.5);
-  --cds-chat-button-hover: rgba(141, 141, 141, 0.12);
-  --cds-chat-button-selected: rgba(141, 141, 141, 0.2);
-  --cds-chat-button-text-hover: #0043ce;
-  --cds-chat-button-text-selected: #525252;
-  --cds-chat-header-background: #ffffff;
-  --cds-chat-prompt-background: #ffffff;
-  --cds-chat-prompt-border-end: rgba(244, 244, 244, 0);
-  --cds-chat-prompt-border-start: #f4f4f4;
-  --cds-chat-shell-background: #ffffff;
-  --cds-field-01: #ffffff;
+  --cds-field-01: #fff;
   --cds-field-02: #f4f4f4;
-  --cds-field-03: #ffffff;
-  --cds-field-hover-01: #e8e8e8;
-  --cds-field-hover-02: #e8e8e8;
-  --cds-field-hover-03: #e8e8e8;
-  --cds-focus: #0f62fe;
-  --cds-focus-inset: #ffffff;
-  --cds-focus-inverse: #ffffff;
-  --cds-highlight: #d0e2ff;
-  --cds-icon-disabled: rgba(22, 22, 22, 0.25);
-  --cds-icon-interactive: #0f62fe;
-  --cds-icon-inverse: #ffffff;
-  --cds-icon-on-color: #ffffff;
-  --cds-icon-on-color-disabled: #8d8d8d;
-  --cds-icon-primary: #161616;
-  --cds-icon-secondary: #525252;
-  --cds-interactive: #0f62fe;
-  --cds-layer-01: #ffffff;
+  --cds-field-03: #fff;
+  --cds-layer-01: #fff;
   --cds-layer-02: #f4f4f4;
-  --cds-layer-03: #ffffff;
-  --cds-layer-accent-01: #e0e0e0;
-  --cds-layer-accent-02: #e0e0e0;
-  --cds-layer-accent-03: #e0e0e0;
-  --cds-layer-accent-active-01: #a8a8a8;
-  --cds-layer-accent-active-02: #a8a8a8;
-  --cds-layer-accent-active-03: #a8a8a8;
-  --cds-layer-accent-hover-01: #d1d1d1;
-  --cds-layer-accent-hover-02: #d1d1d1;
-  --cds-layer-accent-hover-03: #d1d1d1;
-  --cds-layer-active-01: #c6c6c6;
-  --cds-layer-active-02: #c6c6c6;
-  --cds-layer-active-03: #c6c6c6;
-  --cds-layer-hover-01: #e8e8e8;
-  --cds-layer-hover-02: #e8e8e8;
-  --cds-layer-hover-03: #e8e8e8;
-  --cds-layer-selected-01: #e0e0e0;
-  --cds-layer-selected-02: #e0e0e0;
-  --cds-layer-selected-03: #e0e0e0;
-  --cds-layer-selected-disabled: #8d8d8d;
-  --cds-layer-selected-hover-01: #d1d1d1;
-  --cds-layer-selected-hover-02: #d1d1d1;
-  --cds-layer-selected-hover-03: #d1d1d1;
-  --cds-layer-selected-inverse: #161616;
-  --cds-link-inverse: #78a9ff;
-  --cds-link-inverse-active: #f4f4f4;
-  --cds-link-inverse-hover: #a6c8ff;
-  --cds-link-inverse-visited: #be95ff;
-  --cds-link-primary: #0f62fe;
-  --cds-link-primary-hover: #0043ce;
-  --cds-link-secondary: #0043ce;
-  --cds-link-visited: #8a3ffc;
-  --cds-overlay: rgba(22, 22, 22, 0.5);
-  --cds-shadow: rgba(0, 0, 0, 0.3);
-  --cds-skeleton-background: #e8e8e8;
-  --cds-skeleton-element: #c6c6c6;
-  --cds-support-caution-major: #ff832b;
-  --cds-support-caution-minor: #f1c21b;
-  --cds-support-caution-undefined: #8a3ffc;
-  --cds-support-error: #da1e28;
-  --cds-support-error-inverse: #fa4d56;
-  --cds-support-info: #0043ce;
-  --cds-support-info-inverse: #4589ff;
-  --cds-support-success: #24a148;
-  --cds-support-success-inverse: #42be65;
-  --cds-support-warning: #f1c21b;
-  --cds-support-warning-inverse: #f1c21b;
-  --cds-text-disabled: rgba(22, 22, 22, 0.25);
-  --cds-text-error: #da1e28;
-  --cds-text-helper: #6f6f6f;
-  --cds-text-inverse: #ffffff;
-  --cds-text-on-color: #ffffff;
-  --cds-text-on-color-disabled: #8d8d8d;
-  --cds-text-placeholder: rgba(22, 22, 22, 0.4);
-  --cds-text-primary: #161616;
-  --cds-text-secondary: #525252;
-  --cds-toggle-off: #8d8d8d;
-  --cds-spacing-01: 0.125rem;
-  --cds-spacing-02: 0.25rem;
-  --cds-spacing-03: 0.5rem;
-  --cds-spacing-04: 0.75rem;
-  --cds-spacing-05: 1rem;
-  --cds-spacing-06: 1.5rem;
-  --cds-spacing-07: 2rem;
-  --cds-spacing-08: 2.5rem;
-  --cds-spacing-09: 3rem;
-  --cds-spacing-10: 4rem;
-  --cds-spacing-11: 5rem;
-  --cds-spacing-12: 6rem;
-  --cds-spacing-13: 10rem;
-  --cds-fluid-spacing-01: 0;
-  --cds-fluid-spacing-02: 2vw;
-  --cds-fluid-spacing-03: 5vw;
-  --cds-fluid-spacing-04: 10vw;
-  --cds-caption-01-font-size: 0.75rem;
-  --cds-caption-01-font-weight: 400;
-  --cds-caption-01-line-height: 1.33333;
-  --cds-caption-01-letter-spacing: 0.32px;
-  --cds-caption-02-font-size: 0.875rem;
-  --cds-caption-02-font-weight: 400;
-  --cds-caption-02-line-height: 1.28572;
-  --cds-caption-02-letter-spacing: 0.32px;
-  --cds-label-01-font-size: 0.75rem;
-  --cds-label-01-font-weight: 400;
-  --cds-label-01-line-height: 1.33333;
-  --cds-label-01-letter-spacing: 0.32px;
-  --cds-label-02-font-size: 0.875rem;
-  --cds-label-02-font-weight: 400;
-  --cds-label-02-line-height: 1.28572;
-  --cds-label-02-letter-spacing: 0.16px;
-  --cds-helper-text-01-font-size: 0.75rem;
-  --cds-helper-text-01-line-height: 1.33333;
-  --cds-helper-text-01-letter-spacing: 0.32px;
-  --cds-helper-text-02-font-size: 0.875rem;
-  --cds-helper-text-02-font-weight: 400;
-  --cds-helper-text-02-line-height: 1.28572;
-  --cds-helper-text-02-letter-spacing: 0.16px;
-  --cds-body-short-01-font-size: 0.875rem;
-  --cds-body-short-01-font-weight: 400;
-  --cds-body-short-01-line-height: 1.28572;
-  --cds-body-short-01-letter-spacing: 0.16px;
-  --cds-body-short-02-font-size: 1rem;
-  --cds-body-short-02-font-weight: 400;
-  --cds-body-short-02-line-height: 1.375;
-  --cds-body-short-02-letter-spacing: 0;
-  --cds-body-long-01-font-size: 0.875rem;
-  --cds-body-long-01-font-weight: 400;
-  --cds-body-long-01-line-height: 1.42857;
-  --cds-body-long-01-letter-spacing: 0.16px;
-  --cds-body-long-02-font-size: 1rem;
-  --cds-body-long-02-font-weight: 400;
-  --cds-body-long-02-line-height: 1.5;
-  --cds-body-long-02-letter-spacing: 0;
-  --cds-code-01-font-family:
-    'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', monospace;
-  --cds-code-01-font-size: 0.75rem;
-  --cds-code-01-font-weight: 400;
-  --cds-code-01-line-height: 1.33333;
-  --cds-code-01-letter-spacing: 0.32px;
-  --cds-code-02-font-family:
-    'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', monospace;
-  --cds-code-02-font-size: 0.875rem;
-  --cds-code-02-font-weight: 400;
-  --cds-code-02-line-height: 1.42857;
-  --cds-code-02-letter-spacing: 0.32px;
-  --cds-heading-01-font-size: 0.875rem;
-  --cds-heading-01-font-weight: 600;
-  --cds-heading-01-line-height: 1.42857;
-  --cds-heading-01-letter-spacing: 0.16px;
-  --cds-heading-02-font-size: 1rem;
-  --cds-heading-02-font-weight: 600;
-  --cds-heading-02-line-height: 1.5;
-  --cds-heading-02-letter-spacing: 0;
-  --cds-productive-heading-01-font-size: 0.875rem;
-  --cds-productive-heading-01-font-weight: 600;
-  --cds-productive-heading-01-line-height: 1.28572;
-  --cds-productive-heading-01-letter-spacing: 0.16px;
-  --cds-productive-heading-02-font-size: 1rem;
-  --cds-productive-heading-02-font-weight: 600;
-  --cds-productive-heading-02-line-height: 1.375;
-  --cds-productive-heading-02-letter-spacing: 0;
-  --cds-productive-heading-03-font-size: 1.25rem;
-  --cds-productive-heading-03-font-weight: 400;
-  --cds-productive-heading-03-line-height: 1.4;
-  --cds-productive-heading-03-letter-spacing: 0;
-  --cds-productive-heading-04-font-size: 1.75rem;
-  --cds-productive-heading-04-font-weight: 400;
-  --cds-productive-heading-04-line-height: 1.28572;
-  --cds-productive-heading-04-letter-spacing: 0;
-  --cds-productive-heading-05-font-size: 2rem;
-  --cds-productive-heading-05-font-weight: 400;
-  --cds-productive-heading-05-line-height: 1.25;
-  --cds-productive-heading-05-letter-spacing: 0;
-  --cds-productive-heading-06-font-size: 2.625rem;
-  --cds-productive-heading-06-font-weight: 300;
-  --cds-productive-heading-06-line-height: 1.199;
-  --cds-productive-heading-06-letter-spacing: 0;
-  --cds-productive-heading-07-font-size: 3.375rem;
-  --cds-productive-heading-07-font-weight: 300;
-  --cds-productive-heading-07-line-height: 1.19;
-  --cds-productive-heading-07-letter-spacing: 0;
-  --cds-expressive-paragraph-01-font-size: 1.5rem;
-  --cds-expressive-paragraph-01-font-weight: 300;
-  --cds-expressive-paragraph-01-line-height: 1.334;
-  --cds-expressive-paragraph-01-letter-spacing: 0;
-  --cds-expressive-heading-01-font-size: 0.875rem;
-  --cds-expressive-heading-01-font-weight: 600;
-  --cds-expressive-heading-01-line-height: 1.42857;
-  --cds-expressive-heading-01-letter-spacing: 0.16px;
-  --cds-expressive-heading-02-font-size: 1rem;
-  --cds-expressive-heading-02-font-weight: 600;
-  --cds-expressive-heading-02-line-height: 1.5;
-  --cds-expressive-heading-02-letter-spacing: 0;
-  --cds-expressive-heading-03-font-size: 1.25rem;
-  --cds-expressive-heading-03-font-weight: 400;
-  --cds-expressive-heading-03-line-height: 1.4;
-  --cds-expressive-heading-03-letter-spacing: 0;
-  --cds-expressive-heading-04-font-size: 1.75rem;
-  --cds-expressive-heading-04-font-weight: 400;
-  --cds-expressive-heading-04-line-height: 1.28572;
-  --cds-expressive-heading-04-letter-spacing: 0;
-  --cds-expressive-heading-05-font-size: 2rem;
-  --cds-expressive-heading-05-font-weight: 400;
-  --cds-expressive-heading-05-line-height: 1.25;
-  --cds-expressive-heading-05-letter-spacing: 0;
-  --cds-expressive-heading-06-font-size: 2rem;
-  --cds-expressive-heading-06-font-weight: 600;
-  --cds-expressive-heading-06-line-height: 1.25;
-  --cds-expressive-heading-06-letter-spacing: 0;
-  --cds-quotation-01-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
-  --cds-quotation-01-font-size: 1.25rem;
-  --cds-quotation-01-font-weight: 400;
-  --cds-quotation-01-line-height: 1.3;
-  --cds-quotation-01-letter-spacing: 0;
-  --cds-quotation-02-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
-  --cds-quotation-02-font-size: 2rem;
-  --cds-quotation-02-font-weight: 300;
-  --cds-quotation-02-line-height: 1.25;
-  --cds-quotation-02-letter-spacing: 0;
-  --cds-display-01-font-size: 2.625rem;
-  --cds-display-01-font-weight: 300;
-  --cds-display-01-line-height: 1.19;
-  --cds-display-01-letter-spacing: 0;
-  --cds-display-02-font-size: 2.625rem;
-  --cds-display-02-font-weight: 600;
-  --cds-display-02-line-height: 1.19;
-  --cds-display-02-letter-spacing: 0;
-  --cds-display-03-font-size: 2.625rem;
-  --cds-display-03-font-weight: 300;
-  --cds-display-03-line-height: 1.19;
-  --cds-display-03-letter-spacing: 0;
-  --cds-display-04-font-size: 2.625rem;
-  --cds-display-04-font-weight: 300;
-  --cds-display-04-line-height: 1.19;
-  --cds-display-04-letter-spacing: 0;
-  --cds-legal-01-font-size: 0.75rem;
-  --cds-legal-01-font-weight: 400;
-  --cds-legal-01-line-height: 1.33333;
-  --cds-legal-01-letter-spacing: 0.32px;
-  --cds-legal-02-font-size: 0.875rem;
-  --cds-legal-02-font-weight: 400;
-  --cds-legal-02-line-height: 1.28572;
-  --cds-legal-02-letter-spacing: 0.16px;
-  --cds-body-compact-01-font-size: 0.875rem;
-  --cds-body-compact-01-font-weight: 400;
-  --cds-body-compact-01-line-height: 1.28572;
-  --cds-body-compact-01-letter-spacing: 0.16px;
-  --cds-body-compact-02-font-size: 1rem;
-  --cds-body-compact-02-font-weight: 400;
-  --cds-body-compact-02-line-height: 1.375;
-  --cds-body-compact-02-letter-spacing: 0;
-  --cds-heading-compact-01-font-size: 0.875rem;
-  --cds-heading-compact-01-font-weight: 600;
-  --cds-heading-compact-01-line-height: 1.28572;
-  --cds-heading-compact-01-letter-spacing: 0.16px;
-  --cds-heading-compact-02-font-size: 1rem;
-  --cds-heading-compact-02-font-weight: 600;
-  --cds-heading-compact-02-line-height: 1.375;
-  --cds-heading-compact-02-letter-spacing: 0;
-  --cds-body-01-font-size: 0.875rem;
-  --cds-body-01-font-weight: 400;
-  --cds-body-01-line-height: 1.42857;
-  --cds-body-01-letter-spacing: 0.16px;
-  --cds-body-02-font-size: 1rem;
-  --cds-body-02-font-weight: 400;
-  --cds-body-02-line-height: 1.5;
-  --cds-body-02-letter-spacing: 0;
-  --cds-heading-03-font-size: 1.25rem;
-  --cds-heading-03-font-weight: 400;
-  --cds-heading-03-line-height: 1.4;
-  --cds-heading-03-letter-spacing: 0;
-  --cds-heading-04-font-size: 1.75rem;
-  --cds-heading-04-font-weight: 400;
-  --cds-heading-04-line-height: 1.28572;
-  --cds-heading-04-letter-spacing: 0;
-  --cds-heading-05-font-size: 2rem;
-  --cds-heading-05-font-weight: 400;
-  --cds-heading-05-line-height: 1.25;
-  --cds-heading-05-letter-spacing: 0;
-  --cds-heading-06-font-size: 2.625rem;
-  --cds-heading-06-font-weight: 300;
-  --cds-heading-06-line-height: 1.199;
-  --cds-heading-06-letter-spacing: 0;
-  --cds-heading-07-font-size: 3.375rem;
-  --cds-heading-07-font-weight: 300;
-  --cds-heading-07-line-height: 1.19;
-  --cds-heading-07-letter-spacing: 0;
-  --cds-fluid-heading-03-font-size: 1.25rem;
-  --cds-fluid-heading-03-font-weight: 400;
-  --cds-fluid-heading-03-line-height: 1.4;
-  --cds-fluid-heading-03-letter-spacing: 0;
-  --cds-fluid-heading-04-font-size: 1.75rem;
-  --cds-fluid-heading-04-font-weight: 400;
-  --cds-fluid-heading-04-line-height: 1.28572;
-  --cds-fluid-heading-04-letter-spacing: 0;
-  --cds-fluid-heading-05-font-size: 2rem;
-  --cds-fluid-heading-05-font-weight: 400;
-  --cds-fluid-heading-05-line-height: 1.25;
-  --cds-fluid-heading-05-letter-spacing: 0;
-  --cds-fluid-heading-06-font-size: 2rem;
-  --cds-fluid-heading-06-font-weight: 600;
-  --cds-fluid-heading-06-line-height: 1.25;
-  --cds-fluid-heading-06-letter-spacing: 0;
-  --cds-fluid-paragraph-01-font-size: 1.5rem;
-  --cds-fluid-paragraph-01-font-weight: 300;
-  --cds-fluid-paragraph-01-line-height: 1.334;
-  --cds-fluid-paragraph-01-letter-spacing: 0;
-  --cds-fluid-quotation-01-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
-  --cds-fluid-quotation-01-font-size: 1.25rem;
-  --cds-fluid-quotation-01-font-weight: 400;
-  --cds-fluid-quotation-01-line-height: 1.3;
-  --cds-fluid-quotation-01-letter-spacing: 0;
-  --cds-fluid-quotation-02-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
-  --cds-fluid-quotation-02-font-size: 2rem;
-  --cds-fluid-quotation-02-font-weight: 300;
-  --cds-fluid-quotation-02-line-height: 1.25;
-  --cds-fluid-quotation-02-letter-spacing: 0;
-  --cds-fluid-display-01-font-size: 2.625rem;
-  --cds-fluid-display-01-font-weight: 300;
-  --cds-fluid-display-01-line-height: 1.19;
-  --cds-fluid-display-01-letter-spacing: 0;
-  --cds-fluid-display-02-font-size: 2.625rem;
-  --cds-fluid-display-02-font-weight: 600;
-  --cds-fluid-display-02-line-height: 1.19;
-  --cds-fluid-display-02-letter-spacing: 0;
-  --cds-fluid-display-03-font-size: 2.625rem;
-  --cds-fluid-display-03-font-weight: 300;
-  --cds-fluid-display-03-line-height: 1.19;
-  --cds-fluid-display-03-letter-spacing: 0;
-  --cds-fluid-display-04-font-size: 2.625rem;
-  --cds-fluid-display-04-font-weight: 300;
-  --cds-fluid-display-04-line-height: 1.19;
-  --cds-fluid-display-04-letter-spacing: 0;
-  --cds-color-scheme: light;
-  --cds-alert-stroke: #b28600;
-  --cds-layer-01-absolute: #ffffff;
-  --cds-layer-inverse-absolute: #000000;
-  --cds-null-state: none;
-  --cds-grid-bg: #ffffff;
-  --cds-meter-range-indicator: #a8a8a8;
-  --cds-network-diagrams-background-hover: #f1f1f1;
-  --cds-tooltip-line-border: #e0e0e0;
-  --cds-zone-fill-01: #f4f4f4;
-  --cds-zone-stroke-01: #8d8d8d;
-  --cds-zone-fill-02: #e0e0e0;
-  --cds-zone-stroke-02: #8d8d8d;
-  --cds-zone-fill-03: #c6c6c6;
-  --cds-zone-stroke-03: #8d8d8d;
-  --cds-layer: var(--cds-layer-01, #f4f4f4);
-  --cds-layer-active: var(--cds-layer-active-01, #c6c6c6);
-  --cds-layer-hover: var(--cds-layer-hover-01, #e8e8e8);
-  --cds-layer-selected: var(--cds-layer-selected-01, #e0e0e0);
-  --cds-layer-selected-hover: var(--cds-layer-selected-hover-01, #d1d1d1);
-  --cds-layer-accent: var(--cds-layer-accent-01, #e0e0e0);
-  --cds-layer-accent-hover: var(--cds-layer-accent-hover-01, #d1d1d1);
-  --cds-layer-accent-active: var(--cds-layer-accent-active-01, #a8a8a8);
-  --cds-field: var(--cds-field-01, #f4f4f4);
-  --cds-field-hover: var(--cds-field-hover-01, #e8e8e8);
-  --cds-border-subtle: var(--cds-border-subtle-00, #e0e0e0);
-  --cds-border-subtle-selected: var(--cds-border-subtle-selected-01, #c6c6c6);
-  --cds-border-strong: var(--cds-border-strong-01, #8d8d8d);
-  --cds-border-tile: var(--cds-border-tile-01, #c6c6c6);
+  --cds-layer-03: #fff;
+  --cds-border-tile-03: #a8a8a8;
 }
-
-.cds--chart-holder[data-carbon-theme='g90'] {
-  --cds-ai-aura-end: rgba(0, 0, 0, 0);
-  --cds-ai-aura-hover-background: #474747;
-  --cds-ai-aura-hover-end: rgba(0, 0, 0, 0);
-  --cds-ai-aura-hover-start: rgba(69, 137, 255, 0.4);
-  --cds-ai-aura-start: rgba(69, 137, 255, 0.1);
-  --cds-ai-aura-start-sm: rgba(69, 137, 255, 0.16);
-  --cds-ai-border-end: #4589ff;
-  --cds-ai-border-start: rgba(166, 200, 255, 0.36);
-  --cds-ai-border-strong: #78a9ff;
-  --cds-ai-drop-shadow: rgba(0, 0, 0, 0.28);
-  --cds-ai-inner-shadow: rgba(69, 137, 255, 0.16);
-  --cds-ai-overlay: rgba(0, 0, 0, 0.5);
-  --cds-ai-popover-background: #161616;
-  --cds-ai-popover-caret-bottom: #4589ff;
-  --cds-ai-popover-caret-bottom-background: #202d45;
-  --cds-ai-popover-caret-bottom-background-actions: #1e283a;
-  --cds-ai-popover-caret-center: #4870b5;
-  --cds-ai-popover-shadow-outer-01: rgba(0, 0, 0, 0.12);
-  --cds-ai-popover-shadow-outer-02: rgba(0, 0, 0, 0.08);
-  --cds-ai-skeleton-background: rgba(120, 169, 255, 0.5);
-  --cds-ai-skeleton-element-background: rgba(120, 169, 255, 0.3);
-  --cds-background: #262626;
-  --cds-background-active: rgba(141, 141, 141, 0.4);
-  --cds-background-brand: #0f62fe;
-  --cds-background-hover: rgba(141, 141, 141, 0.16);
+.cds--g100,
+.cds--g90 {
+  --cds-background-active: hsla(0, 0%, 55%, 0.4);
+  --cds-background-hover: hsla(0, 0%, 55%, 0.16);
   --cds-background-inverse: #f4f4f4;
   --cds-background-inverse-hover: #e8e8e8;
-  --cds-background-selected: rgba(141, 141, 141, 0.24);
-  --cds-background-selected-hover: rgba(141, 141, 141, 0.32);
-  --cds-border-disabled: rgba(141, 141, 141, 0.5);
+  --cds-background-selected: hsla(0, 0%, 55%, 0.24);
+  --cds-border-disabled: hsla(0, 0%, 55%, 0.5);
   --cds-border-interactive: #4589ff;
   --cds-border-inverse: #f4f4f4;
+  --cds-focus: #fff;
+  --cds-focus-inset: #161616;
+  --cds-focus-inverse: #0f62fe;
+  --cds-icon-disabled: hsla(0, 0%, 96%, 0.25);
+  --cds-icon-interactive: #fff;
+  --cds-icon-inverse: #161616;
+  --cds-icon-on-color-disabled: hsla(0, 0%, 100%, 0.25);
+  --cds-icon-primary: #f4f4f4;
+  --cds-icon-secondary: #c6c6c6;
+  --cds-interactive: #4589ff;
+  --cds-layer-selected-disabled: #a8a8a8;
+  --cds-layer-selected-inverse: #f4f4f4;
+  --cds-link-inverse: #0f62fe;
+  --cds-link-inverse-active: #161616;
+  --cds-link-inverse-hover: #0043ce;
+  --cds-link-primary: #78a9ff;
+  --cds-link-primary-hover: #a6c8ff;
+  --cds-link-secondary: #a6c8ff;
+  --cds-link-visited: #be95ff;
+  --cds-overlay: rgba(0, 0, 0, 0.65);
+  --cds-shadow: rgba(0, 0, 0, 0.8);
+  --cds-support-caution-undefined: #a56eff;
+  --cds-support-error-inverse: #da1e28;
+  --cds-support-info: #4589ff;
+  --cds-support-info-inverse: #0043ce;
+  --cds-support-success: #42be65;
+  --cds-support-success-inverse: #24a148;
+  --cds-text-disabled: hsla(0, 0%, 96%, 0.25);
+  --cds-text-inverse: #161616;
+  --cds-text-on-color-disabled: hsla(0, 0%, 100%, 0.25);
+  --cds-text-placeholder: hsla(0, 0%, 96%, 0.4);
+  --cds-text-primary: #f4f4f4;
+  --cds-text-secondary: #c6c6c6;
+  --cds-button-separator: #161616;
+  --cds-button-secondary: #6f6f6f;
+  --cds-button-tertiary: #fff;
+  --cds-button-secondary-active: #393939;
+  --cds-button-tertiary-active: #c6c6c6;
+  --cds-button-secondary-hover: #5e5e5e;
+  --cds-button-tertiary-hover: #f4f4f4;
+  --cds-button-disabled: hsla(0, 0%, 55%, 0.3);
+  --cds-notification-action-tertiary-inverse: #0f62fe;
+  --cds-notification-action-tertiary-inverse-active: #002d9c;
+  --cds-notification-action-tertiary-inverse-hover: #0050e6;
+  --cds-notification-action-tertiary-inverse-text: #fff;
+  --cds-notification-action-tertiary-inverse-text-on-color-disabled: #8d8d8d;
+  --cds-tag-background-red: #a2191f;
+  --cds-tag-color-red: #ffd7d9;
+  --cds-tag-hover-red: #c21e25;
+  --cds-tag-background-magenta: #9f1853;
+  --cds-tag-color-magenta: #ffd6e8;
+  --cds-tag-hover-magenta: #bf1d63;
+  --cds-tag-background-purple: #6929c4;
+  --cds-tag-color-purple: #e8daff;
+  --cds-tag-hover-purple: #7c3dd6;
+  --cds-tag-background-blue: #0043ce;
+  --cds-tag-color-blue: #d0e2ff;
+  --cds-tag-hover-blue: #0053ff;
+  --cds-tag-background-cyan: #00539a;
+  --cds-tag-color-cyan: #bae6ff;
+  --cds-tag-hover-cyan: #0066bd;
+  --cds-tag-background-teal: #005d5d;
+  --cds-tag-color-teal: #9ef0f0;
+  --cds-tag-hover-teal: #007070;
+  --cds-tag-background-green: #0e6027;
+  --cds-tag-color-green: #a7f0ba;
+  --cds-tag-hover-green: #11742f;
+  --cds-tag-background-gray: #525252;
+  --cds-tag-color-gray: #e0e0e0;
+  --cds-tag-hover-gray: #636363;
+  --cds-tag-background-cool-gray: #4d5358;
+  --cds-tag-color-cool-gray: #dde1e6;
+  --cds-tag-hover-cool-gray: #5d646a;
+  --cds-tag-background-warm-gray: #565151;
+  --cds-tag-color-warm-gray: #e5e0df;
+  --cds-tag-hover-warm-gray: #696363;
+  background: var(--cds-background);
+  color: var(--cds-text-primary);
+}
+.cds--g90 {
+  --cds-background: #262626;
+  --cds-background-brand: #0f62fe;
+  --cds-background-selected-hover: hsla(0, 0%, 55%, 0.32);
   --cds-border-strong-01: #8d8d8d;
   --cds-border-strong-02: #a8a8a8;
   --cds-border-strong-03: #c6c6c6;
   --cds-border-subtle-00: #525252;
-  --cds-border-subtle-01: #6f6f6f;
-  --cds-border-subtle-02: #8d8d8d;
+  --cds-border-subtle-01: #525252;
+  --cds-border-subtle-02: #6f6f6f;
   --cds-border-subtle-03: #8d8d8d;
-  --cds-border-subtle-selected-01: #8d8d8d;
-  --cds-border-subtle-selected-02: #a8a8a8;
+  --cds-border-subtle-selected-01: #6f6f6f;
+  --cds-border-subtle-selected-02: #8d8d8d;
   --cds-border-subtle-selected-03: #a8a8a8;
   --cds-border-tile-01: #6f6f6f;
   --cds-border-tile-02: #8d8d8d;
   --cds-border-tile-03: #a8a8a8;
-  --cds-chat-avatar-agent: #c6c6c6;
-  --cds-chat-avatar-bot: #8d8d8d;
-  --cds-chat-avatar-user: #4589ff;
-  --cds-chat-bubble-agent: #262626;
-  --cds-chat-bubble-border: #525252;
-  --cds-chat-bubble-user: #393939;
-  --cds-chat-button: #78a9ff;
-  --cds-chat-button-active: rgba(141, 141, 141, 0.4);
-  --cds-chat-button-hover: rgba(141, 141, 141, 0.16);
-  --cds-chat-button-selected: rgba(141, 141, 141, 0.24);
-  --cds-chat-button-text-hover: #a6c8ff;
-  --cds-chat-button-text-selected: #c6c6c6;
-  --cds-chat-header-background: #262626;
-  --cds-chat-prompt-background: #161616;
-  --cds-chat-prompt-border-end: rgba(38, 38, 38, 0);
-  --cds-chat-prompt-border-start: #262626;
-  --cds-chat-shell-background: #262626;
   --cds-field-01: #393939;
   --cds-field-02: #525252;
   --cds-field-03: #6f6f6f;
   --cds-field-hover-01: #474747;
   --cds-field-hover-02: #636363;
   --cds-field-hover-03: #5e5e5e;
-  --cds-focus: #ffffff;
-  --cds-focus-inset: #161616;
-  --cds-focus-inverse: #0f62fe;
-  --cds-highlight: #002d9c;
-  --cds-icon-disabled: rgba(244, 244, 244, 0.25);
-  --cds-icon-interactive: #ffffff;
-  --cds-icon-inverse: #161616;
-  --cds-icon-on-color: #ffffff;
-  --cds-icon-on-color-disabled: rgba(255, 255, 255, 0.25);
-  --cds-icon-primary: #f4f4f4;
-  --cds-icon-secondary: #c6c6c6;
-  --cds-interactive: #4589ff;
+  --cds-highlight: #0043ce;
+  --cds-icon-on-color: #fff;
   --cds-layer-01: #393939;
   --cds-layer-02: #525252;
   --cds-layer-03: #6f6f6f;
@@ -6515,43 +2134,21755 @@ div.cds--cc--legend.clickable
   --cds-layer-selected-01: #525252;
   --cds-layer-selected-02: #6f6f6f;
   --cds-layer-selected-03: #525252;
-  --cds-layer-selected-disabled: #a8a8a8;
   --cds-layer-selected-hover-01: #636363;
   --cds-layer-selected-hover-02: #5e5e5e;
   --cds-layer-selected-hover-03: #636363;
+  --cds-skeleton-background: #333;
+  --cds-skeleton-element: #525252;
+  --cds-support-caution-major: #ff832b;
+  --cds-support-caution-minor: #f1c21b;
+  --cds-support-error: #ff8389;
+  --cds-support-warning: #f1c21b;
+  --cds-support-warning-inverse: #f1c21b;
+  --cds-text-error: #ffb3b8;
+  --cds-text-helper: #c6c6c6;
+  --cds-text-on-color: #fff;
+  --cds-toggle-off: #8d8d8d;
+  --cds-layer: var(--cds-layer-01, #f4f4f4);
+  --cds-layer-active: var(--cds-layer-active-01, #c6c6c6);
+  --cds-layer-hover: var(--cds-layer-hover-01, #e8e8e8);
+  --cds-layer-selected: var(--cds-layer-selected-01, #e0e0e0);
+  --cds-layer-selected-hover: var(--cds-layer-selected-hover-01, #d1d1d1);
+  --cds-layer-accent: var(--cds-layer-accent-01, #e0e0e0);
+  --cds-layer-accent-hover: var(--cds-layer-accent-hover-01, #d1d1d1);
+  --cds-layer-accent-active: var(--cds-layer-accent-active-01, #a8a8a8);
+  --cds-field: var(--cds-field-01, #f4f4f4);
+  --cds-field-hover: var(--cds-field-hover-01, #e8e8e8);
+  --cds-border-subtle: var(--cds-border-subtle-00, #e0e0e0);
+  --cds-border-subtle-selected: var(--cds-border-subtle-selected-01, #c6c6c6);
+  --cds-border-strong: var(--cds-border-strong-01, #8d8d8d);
+  --cds-border-tile: var(--cds-border-tile-01, #c6c6c6);
+  --cds-button-primary: #0f62fe;
+  --cds-button-danger-primary: #da1e28;
+  --cds-button-danger-secondary: #ff8389;
+  --cds-button-danger-active: #750e13;
+  --cds-button-primary-active: #002d9c;
+  --cds-button-danger-hover: #b81921;
+  --cds-button-primary-hover: #0050e6;
+  --cds-notification-background-error: #393939;
+  --cds-notification-background-success: #393939;
+  --cds-notification-background-info: #393939;
+  --cds-notification-background-warning: #393939;
+}
+.cds--chart-holder,
+.cds--chart-holder[data-carbon-theme='g10'],
+.cds--g100,
+html[data-carbon-theme='g10'] {
+  --cds-border-strong-02: #8d8d8d;
+  --cds-layer: var(--cds-layer-01, #f4f4f4);
+  --cds-layer-active: var(--cds-layer-active-01, #c6c6c6);
+  --cds-layer-hover: var(--cds-layer-hover-01, #e8e8e8);
+  --cds-layer-selected: var(--cds-layer-selected-01, #e0e0e0);
+  --cds-layer-selected-hover: var(--cds-layer-selected-hover-01, #d1d1d1);
+  --cds-layer-accent: var(--cds-layer-accent-01, #e0e0e0);
+  --cds-layer-accent-hover: var(--cds-layer-accent-hover-01, #d1d1d1);
+  --cds-layer-accent-active: var(--cds-layer-accent-active-01, #a8a8a8);
+  --cds-field: var(--cds-field-01, #f4f4f4);
+  --cds-field-hover: var(--cds-field-hover-01, #e8e8e8);
+  --cds-border-subtle: var(--cds-border-subtle-00, #e0e0e0);
+  --cds-border-subtle-selected: var(--cds-border-subtle-selected-01, #c6c6c6);
+  --cds-border-strong: var(--cds-border-strong-01, #8d8d8d);
+  --cds-border-tile: var(--cds-border-tile-01, #c6c6c6);
+  --cds-background-brand: #0f62fe;
+  --cds-background-selected-hover: hsla(0, 0%, 55%, 0.32);
+  --cds-icon-on-color: #fff;
+  --cds-support-caution-major: #ff832b;
+  --cds-support-caution-minor: #f1c21b;
+  --cds-support-warning: #f1c21b;
+  --cds-support-warning-inverse: #f1c21b;
+  --cds-text-on-color: #fff;
+  --cds-button-primary: #0f62fe;
+  --cds-button-danger-primary: #da1e28;
+  --cds-button-danger-active: #750e13;
+  --cds-button-primary-active: #002d9c;
+  --cds-button-danger-hover: #b81921;
+  --cds-button-primary-hover: #0050e6;
+}
+.cds--g100 {
+  --cds-background: #161616;
+  --cds-border-strong-01: #6f6f6f;
+  --cds-border-strong-03: #a8a8a8;
+  --cds-border-subtle-00: #393939;
+  --cds-border-subtle-01: #393939;
+  --cds-border-subtle-02: #525252;
+  --cds-border-subtle-03: #6f6f6f;
+  --cds-border-subtle-selected-01: #525252;
+  --cds-border-subtle-selected-02: #6f6f6f;
+  --cds-border-subtle-selected-03: #8d8d8d;
+  --cds-border-tile-01: #525252;
+  --cds-border-tile-02: #6f6f6f;
+  --cds-border-tile-03: #8d8d8d;
+  --cds-field-01: #262626;
+  --cds-field-02: #393939;
+  --cds-field-03: #525252;
+  --cds-field-hover-01: #333;
+  --cds-field-hover-02: #474747;
+  --cds-field-hover-03: #636363;
+  --cds-highlight: #002d9c;
+  --cds-layer-01: #262626;
+  --cds-layer-02: #393939;
+  --cds-layer-03: #525252;
+  --cds-layer-accent-01: #393939;
+  --cds-layer-accent-02: #525252;
+  --cds-layer-accent-03: #6f6f6f;
+  --cds-layer-accent-active-01: #6f6f6f;
+  --cds-layer-accent-active-02: #8d8d8d;
+  --cds-layer-accent-active-03: #393939;
+  --cds-layer-accent-hover-01: #474747;
+  --cds-layer-accent-hover-02: #636363;
+  --cds-layer-accent-hover-03: #5e5e5e;
+  --cds-layer-active-01: #525252;
+  --cds-layer-active-02: #6f6f6f;
+  --cds-layer-active-03: #8d8d8d;
+  --cds-layer-hover-01: #333;
+  --cds-layer-hover-02: #474747;
+  --cds-layer-hover-03: #636363;
+  --cds-layer-selected-01: #393939;
+  --cds-layer-selected-02: #525252;
+  --cds-layer-selected-03: #6f6f6f;
+  --cds-layer-selected-hover-01: #474747;
+  --cds-layer-selected-hover-02: #636363;
+  --cds-layer-selected-hover-03: #5e5e5e;
+  --cds-skeleton-background: #292929;
+  --cds-skeleton-element: #393939;
+  --cds-support-error: #fa4d56;
+  --cds-text-error: #ff8389;
+  --cds-text-helper: #a8a8a8;
+  --cds-toggle-off: #6f6f6f;
+  --cds-button-danger-secondary: #fa4d56;
+  --cds-notification-background-error: #262626;
+  --cds-notification-background-success: #262626;
+  --cds-notification-background-info: #262626;
+  --cds-notification-background-warning: #262626;
+}
+.cds--chart-holder,
+html {
+  --cds-background: #fff;
+  --cds-border-subtle-00: #e0e0e0;
+  --cds-border-subtle-01: #c6c6c6;
+  --cds-border-subtle-02: #e0e0e0;
+  --cds-border-subtle-03: #c6c6c6;
+  --cds-border-tile-01: #c6c6c6;
+  --cds-border-tile-02: #a8a8a8;
+  --cds-border-tile-03: #c6c6c6;
+  --cds-field-01: #f4f4f4;
+  --cds-field-02: #fff;
+  --cds-field-03: #f4f4f4;
+  --cds-layer-01: #f4f4f4;
+  --cds-layer-02: #fff;
+  --cds-layer-03: #f4f4f4;
+}
+.cds--chart-holder,
+.cds--chart-holder[data-carbon-theme='g10'],
+html,
+html[data-carbon-theme='g10'] {
+  --cds-background-active: hsla(0, 0%, 55%, 0.5);
+  --cds-background-hover: hsla(0, 0%, 55%, 0.12);
+  --cds-background-inverse: #393939;
+  --cds-background-inverse-hover: #474747;
+  --cds-background-selected: hsla(0, 0%, 55%, 0.2);
+  --cds-border-disabled: #c6c6c6;
+  --cds-border-interactive: #0f62fe;
+  --cds-border-inverse: #161616;
+  --cds-border-strong-01: #8d8d8d;
+  --cds-border-strong-03: #8d8d8d;
+  --cds-border-subtle-selected-01: #c6c6c6;
+  --cds-border-subtle-selected-02: #c6c6c6;
+  --cds-border-subtle-selected-03: #c6c6c6;
+  --cds-field-hover-01: #e8e8e8;
+  --cds-field-hover-02: #e8e8e8;
+  --cds-field-hover-03: #e8e8e8;
+  --cds-focus: #0f62fe;
+  --cds-focus-inset: #fff;
+  --cds-focus-inverse: #fff;
+  --cds-highlight: #d0e2ff;
+  --cds-icon-disabled: hsla(0, 0%, 9%, 0.25);
+  --cds-icon-interactive: #0f62fe;
+  --cds-icon-inverse: #fff;
+  --cds-icon-on-color-disabled: #8d8d8d;
+  --cds-icon-primary: #161616;
+  --cds-icon-secondary: #525252;
+  --cds-interactive: #0f62fe;
+  --cds-layer-accent-01: #e0e0e0;
+  --cds-layer-accent-02: #e0e0e0;
+  --cds-layer-accent-03: #e0e0e0;
+  --cds-layer-accent-active-01: #a8a8a8;
+  --cds-layer-accent-active-02: #a8a8a8;
+  --cds-layer-accent-active-03: #a8a8a8;
+  --cds-layer-accent-hover-01: #d1d1d1;
+  --cds-layer-accent-hover-02: #d1d1d1;
+  --cds-layer-accent-hover-03: #d1d1d1;
+  --cds-layer-active-01: #c6c6c6;
+  --cds-layer-active-02: #c6c6c6;
+  --cds-layer-active-03: #c6c6c6;
+  --cds-layer-hover-01: #e8e8e8;
+  --cds-layer-hover-02: #e8e8e8;
+  --cds-layer-hover-03: #e8e8e8;
+  --cds-layer-selected-01: #e0e0e0;
+  --cds-layer-selected-02: #e0e0e0;
+  --cds-layer-selected-03: #e0e0e0;
+  --cds-layer-selected-disabled: #8d8d8d;
+  --cds-layer-selected-hover-01: #d1d1d1;
+  --cds-layer-selected-hover-02: #d1d1d1;
+  --cds-layer-selected-hover-03: #d1d1d1;
+  --cds-layer-selected-inverse: #161616;
+  --cds-link-inverse: #78a9ff;
+  --cds-link-inverse-active: #f4f4f4;
+  --cds-link-inverse-hover: #a6c8ff;
+  --cds-link-primary: #0f62fe;
+  --cds-link-primary-hover: #0043ce;
+  --cds-link-secondary: #0043ce;
+  --cds-link-visited: #8a3ffc;
+  --cds-overlay: hsla(0, 0%, 9%, 0.5);
+  --cds-shadow: rgba(0, 0, 0, 0.3);
+  --cds-skeleton-background: #e8e8e8;
+  --cds-skeleton-element: #c6c6c6;
+  --cds-support-caution-undefined: #8a3ffc;
+  --cds-support-error: #da1e28;
+  --cds-support-error-inverse: #fa4d56;
+  --cds-support-info: #0043ce;
+  --cds-support-info-inverse: #4589ff;
+  --cds-support-success: #24a148;
+  --cds-support-success-inverse: #42be65;
+  --cds-text-disabled: hsla(0, 0%, 9%, 0.25);
+  --cds-text-error: #da1e28;
+  --cds-text-helper: #6f6f6f;
+  --cds-text-inverse: #fff;
+  --cds-text-on-color-disabled: #8d8d8d;
+  --cds-text-placeholder: hsla(0, 0%, 9%, 0.4);
+  --cds-text-primary: #161616;
+  --cds-text-secondary: #525252;
+  --cds-toggle-off: #8d8d8d;
+  --cds-button-separator: #e0e0e0;
+  --cds-button-secondary: #393939;
+  --cds-button-tertiary: #0f62fe;
+  --cds-button-danger-secondary: #da1e28;
+  --cds-button-secondary-active: #6f6f6f;
+  --cds-button-tertiary-active: #002d9c;
+  --cds-button-secondary-hover: #474747;
+  --cds-button-tertiary-hover: #0050e6;
+  --cds-button-disabled: #c6c6c6;
+  --cds-tag-background-red: #ffd7d9;
+  --cds-tag-color-red: #750e13;
+  --cds-tag-hover-red: #ffb3b8;
+  --cds-tag-background-magenta: #ffd6e8;
+  --cds-tag-color-magenta: #740937;
+  --cds-tag-hover-magenta: #ffafd2;
+  --cds-tag-background-purple: #e8daff;
+  --cds-tag-color-purple: #491d8b;
+  --cds-tag-hover-purple: #d4bbff;
+  --cds-tag-background-blue: #d0e2ff;
+  --cds-tag-color-blue: #002d9c;
+  --cds-tag-hover-blue: #a6c8ff;
+  --cds-tag-background-cyan: #bae6ff;
+  --cds-tag-color-cyan: #003a6d;
+  --cds-tag-hover-cyan: #82cfff;
+  --cds-tag-background-teal: #9ef0f0;
+  --cds-tag-color-teal: #004144;
+  --cds-tag-hover-teal: #3ddbd9;
+  --cds-tag-background-green: #a7f0ba;
+  --cds-tag-color-green: #044317;
+  --cds-tag-hover-green: #6fdc8c;
+  --cds-tag-background-gray: #e0e0e0;
+  --cds-tag-color-gray: #393939;
+  --cds-tag-hover-gray: #c6c6c6;
+  --cds-tag-background-cool-gray: #dde1e6;
+  --cds-tag-color-cool-gray: #343a3f;
+  --cds-tag-hover-cool-gray: #c1c7cd;
+  --cds-tag-background-warm-gray: #e5e0df;
+  --cds-tag-color-warm-gray: #3c3838;
+  --cds-tag-hover-warm-gray: #cac5c4;
+  --cds-notification-background-error: #fff1f1;
+  --cds-notification-background-success: #defbe6;
+  --cds-notification-background-info: #edf5ff;
+  --cds-notification-background-warning: #fdf6dd;
+  --cds-notification-action-hover: #edf5ff;
+  --cds-notification-action-tertiary-inverse: #fff;
+  --cds-notification-action-tertiary-inverse-active: #c6c6c6;
+  --cds-notification-action-tertiary-inverse-hover: #f4f4f4;
+  --cds-notification-action-tertiary-inverse-text: #161616;
+  --cds-notification-action-tertiary-inverse-text-on-color-disabled: hsla(
+    0,
+    0%,
+    100%,
+    0.2
+  );
+  --cds-color-scheme: light;
+  --cds-alert-stroke: #b28600;
+  --cds-layer-01-absolute: #fff;
+  --cds-layer-inverse-absolute: #000;
+  --cds-grid-bg: #fff;
+  --cds-meter-range-indicator: #a8a8a8;
+  --cds-network-diagrams-background-hover: #f1f1f1;
+  --cds-tooltip-line-border: #e0e0e0;
+  --cds-zone-fill-01: #f4f4f4;
+  --cds-zone-stroke-01: #8d8d8d;
+  --cds-zone-fill-02: #e0e0e0;
+  --cds-zone-stroke-02: #8d8d8d;
+  --cds-zone-fill-03: #c6c6c6;
+  --cds-zone-stroke-03: #8d8d8d;
+}
+.cds--accordion--flush .cds--accordion__title {
+  margin-left: 0;
+}
+.cds--accordion--flush .cds--accordion__arrow {
+  margin-right: 0;
+}
+.cds--accordion--flush .cds--accordion__content {
+  padding-left: 0;
+}
+.cds--accordion--flush:not(.cds--skeleton)
+  .cds--accordion__heading:focus:before,
+.cds--accordion--flush:not(.cds--skeleton)
+  .cds--accordion__heading:hover:before {
+  left: -1rem;
+  width: calc(100% + 32px);
+}
+.cds--accordion {
+  border: 0;
+  box-sizing: border-box;
+  padding: 0;
+}
+.cds--accordion *,
+.cds--accordion :after,
+.cds--accordion :before {
+  box-sizing: inherit;
+}
+.cds--accordion__item {
+  border-top: 1px solid var(--cds-border-subtle);
+  display: list-item;
+  overflow: visible;
+  transition: 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--accordion__item:last-child {
+  border-bottom: 1px solid var(--cds-border-subtle);
+}
+.cds--accordion__heading {
+  align-items: flex-start;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  color: var(--cds-text-primary, #161616);
+  cursor: pointer;
+  display: inline-block;
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+  min-height: 2.5rem;
+  padding: 0.625rem 0;
+  position: relative;
+  text-align: start;
+  transition: background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--accordion__content > p,
+.cds--accordion__title {
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+}
+.cds--accordion__heading *,
+.cds--accordion__heading :after,
+.cds--accordion__heading :before {
+  box-sizing: inherit;
+}
+.cds--accordion__heading::-moz-focus-inner {
+  border: 0;
+}
+.cds--accordion__heading:focus:before,
+.cds--accordion__heading:hover:before {
+  content: '';
+  height: calc(100% + 2px);
+  left: 0;
+  position: absolute;
+  top: -1px;
+  width: 100%;
+}
+.cds--accordion__heading:hover:before {
+  background-color: var(--cds-layer-hover);
+}
+.cds--accordion__heading:focus {
+  outline: 0;
+}
+.cds--accordion__heading:focus:before {
+  border: 2px solid var(--cds-focus, #0f62fe);
+  box-sizing: border-box;
+}
+@media screen and (prefers-contrast) {
+  .cds--accordion__heading:focus:before {
+    border-style: dotted;
+  }
+}
+.cds--accordion--lg .cds--accordion__heading {
+  align-items: center;
+  min-height: 3rem;
+}
+.cds--accordion--sm .cds--accordion__heading {
+  min-height: 2rem;
+  padding: 0.3125rem 0;
+}
+.cds--accordion__heading[disabled] {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--accordion__heading[disabled] .cds--accordion__arrow {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--accordion.cds--skeleton .cds--accordion__arrow,
+.cds--accordion__arrow,
+.cds--btn--ghost.cds--btn--icon-only .cds--btn__icon,
+.cds--btn--ghost.cds--btn--icon-only
+  .cds--btn__icon
+  path:not([data-icon-path]):not([fill='none']),
+.cds--btn--ghost:not([disabled]) svg {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--accordion__item--disabled,
+.cds--accordion__item--disabled + .cds--accordion__item {
+  border-top: 1px solid var(--cds-border-subtle);
+}
+li.cds--accordion__item--disabled:last-of-type {
+  border-bottom: 1px solid var(--cds-border-subtle);
+}
+.cds--accordion__arrow {
+  flex: 0 0 1rem;
+  height: 1rem;
+  margin: 2px 1rem 0 0;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  transform: rotate(-270deg);
+  transition: 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 1rem;
+}
+.cds--accordion__title {
+  margin: 0 0 0 1rem;
+  padding-right: 1rem;
+  text-align: left;
+  width: 100%;
+  z-index: 1;
+}
+.cds--accordion__content {
+  display: none;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  transition: padding 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+@media (min-width: 480px) {
+  .cds--accordion__content {
+    padding-right: 3rem;
+  }
+}
+@media (min-width: 640px) {
+  .cds--accordion__content {
+    padding-right: 25%;
+  }
+}
+.cds--breadcrumb html,
+.cds--link {
+  font-size: 100%;
+}
+.cds--accordion--start .cds--accordion__heading {
+  flex-direction: row;
+}
+.cds--accordion--start .cds--accordion__arrow {
+  margin: 2px 0 0 1rem;
+}
+.cds--accordion--start .cds--accordion__title {
+  margin-right: 1rem;
+}
+.cds--accordion--start .cds--accordion__content {
+  margin-left: 2rem;
+}
+.cds--accordion__item--collapsing .cds--accordion__content,
+.cds--accordion__item--expanding .cds--accordion__content {
+  display: block;
+}
+@keyframes collapse-accordion {
+  0% {
+    height: 100%;
+    opacity: 1;
+    visibility: inherit;
+  }
+  to {
+    height: 0;
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+@keyframes expand-accordion {
+  0% {
+    height: 0;
+    opacity: 0;
+    visibility: hidden;
+  }
+  to {
+    height: 100%;
+    opacity: 1;
+    visibility: inherit;
+  }
+}
+.cds--accordion__item--collapsing .cds--accordion__content {
+  animation: collapse-accordion 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--accordion__item--expanding .cds--accordion__content {
+  animation: expand-accordion 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--accordion__item--active {
+  overflow: visible;
+}
+.cds--accordion__item--active .cds--accordion__content {
+  display: block;
+  padding-bottom: 1.5rem;
+  padding-top: 0.5rem;
+  transition:
+    padding-top 0.11s cubic-bezier(0, 0, 0.38, 0.9),
+    padding-bottom 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+}
+.cds--accordion__item--active .cds--accordion__arrow {
+  fill: var(--cds-icon-primary, #161616);
+  transform: rotate(-90deg);
+}
+.cds--accordion.cds--skeleton .cds--accordion__button,
+.cds--accordion.cds--skeleton .cds--accordion__heading {
+  cursor: default;
+}
+.cds--accordion.cds--skeleton .cds--accordion__arrow {
+  cursor: default;
+  pointer-events: none;
+}
+.cds--accordion.cds--skeleton .cds--accordion__arrow:active,
+.cds--accordion.cds--skeleton .cds--accordion__arrow:focus,
+.cds--accordion.cds--skeleton .cds--accordion__arrow:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--accordion--end.cds--skeleton .cds--accordion__arrow {
+  margin-left: 1rem;
+}
+.cds--skeleton .cds--accordion__heading:focus .cds--accordion__arrow {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--accordion__title.cds--skeleton__text {
+  margin-bottom: 0;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--accordion__arrow,
+  .cds--accordion__item--active .cds--accordion__arrow {
+    fill: ButtonText;
+  }
+}
+.cds--aspect-ratio {
+  position: relative;
+}
+.cds--aspect-ratio:before {
+  content: '';
+  float: left;
+  height: 0;
+  margin-left: -1px;
+  width: 1px;
+}
+.cds--aspect-ratio:after {
+  clear: both;
+  content: '';
+  display: table;
+}
+.cds--aspect-ratio--16x9:before {
+  padding-top: 56.25%;
+}
+.cds--aspect-ratio--9x16:before {
+  padding-top: 177.7777777778%;
+}
+.cds--aspect-ratio--2x1:before {
+  padding-top: 50%;
+}
+.cds--aspect-ratio--1x2:before {
+  padding-top: 200%;
+}
+.cds--aspect-ratio--4x3:before {
+  padding-top: 75%;
+}
+.cds--aspect-ratio--3x4:before {
+  padding-top: 133.3333333333%;
+}
+.cds--aspect-ratio--3x2:before {
+  padding-top: 66.6666666667%;
+}
+.cds--aspect-ratio--2x3:before {
+  padding-top: 150%;
+}
+.cds--aspect-ratio--1x1:before {
+  padding-top: 100%;
+}
+@keyframes hide-feedback {
+  0% {
+    opacity: 1;
+    visibility: inherit;
+  }
+  to {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+@keyframes show-feedback {
+  0% {
+    opacity: 0;
+    visibility: hidden;
+  }
+  to {
+    opacity: 1;
+    visibility: inherit;
+  }
+}
+@keyframes skeleton {
+  0%,
+  to {
+    opacity: 0.3;
+    transform: scaleX(0);
+    transform-origin: left;
+  }
+  20% {
+    opacity: 1;
+    transform: scaleX(1);
+    transform-origin: left;
+  }
+  28%,
+  82% {
+    transform: scaleX(1);
+    transform-origin: right;
+  }
+  51%,
+  58% {
+    transform: scaleX(0);
+    transform-origin: right;
+  }
+  83% {
+    transform: scaleX(1);
+    transform-origin: left;
+  }
+  96% {
+    transform: scaleX(0);
+    transform-origin: left;
+  }
+}
+.cds--breadcrumb {
+  display: inline;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--breadcrumb body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--breadcrumb code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--breadcrumb strong {
+  font-weight: 600;
+}
+@media (min-width: 42rem) {
+  .cds--breadcrumb {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}
+.cds--breadcrumb-item {
+  align-items: center;
+  display: flex;
+  margin-right: 0.5rem;
+  position: relative;
+}
+.cds--btn,
+.cds--link,
+.cds--link__icon {
+  display: inline-flex;
+}
+.cds--breadcrumb-item .cds--link:visited {
+  color: var(--cds-link-primary, #0f62fe);
+}
+.cds--breadcrumb-item .cds--link:visited:hover {
+  color: var(--cds-link-primary-hover, #0043ce);
+}
+.cds--breadcrumb-item:after {
+  color: var(--cds-text-primary, #161616);
+  content: '/';
+  margin-left: 0.5rem;
+}
+.cds--link,
+.cds--link--disabled,
+.cds--link--disabled:hover {
+  border: 0;
+  font-family: inherit;
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  margin: 0;
+  padding: 0;
+  vertical-align: baseline;
+}
+.cds--breadcrumb--no-trailing-slash .cds--breadcrumb-item:last-child:after {
+  content: '';
+}
+.cds--breadcrumb-item:last-child,
+.cds--breadcrumb-item:last-child:after {
+  margin-right: 0;
+}
+.cds--breadcrumb-item [aria-current='page'],
+.cds--breadcrumb-item.cds--breadcrumb-item--current .cds--link {
+  color: var(--cds-text-primary, #161616);
+  cursor: auto;
+}
+.cds--breadcrumb-item .cds--overflow-menu {
+  height: 1.125rem;
+  position: relative;
+  width: 1.25rem;
+}
+.cds--breadcrumb-item .cds--overflow-menu:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+.cds--breadcrumb-item .cds--overflow-menu:hover {
+  background: 0 0;
+}
+.cds--breadcrumb-item .cds--overflow-menu:after {
+  background: var(--cds-link-primary-hover, #0043ce);
+  bottom: 2px;
+  content: '';
+  height: 1px;
+  opacity: 0;
+  position: absolute;
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 0.75rem;
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--breadcrumb-item .cds--overflow-menu:after {
+    transition: none;
+  }
+}
+.cds--breadcrumb-item .cds--overflow-menu:hover:after {
+  opacity: 1;
+}
+.cds--breadcrumb-item .cds--overflow-menu.cds--overflow-menu--open {
+  background: 0 0;
+  box-shadow: none;
+}
+.cds--breadcrumb-item .cds--overflow-menu__icon {
+  fill: var(--cds-link-primary, #0f62fe);
+  position: relative;
+  transform: translateY(4px);
+}
+.cds--btn--danger .cds--btn__icon,
+.cds--btn--danger .cds--btn__icon path:not([data-icon-path]):not([fill='none']),
+.cds--btn--danger--ghost .cds--btn__icon,
+.cds--btn--danger--ghost
+  .cds--btn__icon
+  path:not([data-icon-path]):not([fill='none']),
+.cds--btn--danger--tertiary .cds--btn__icon,
+.cds--btn--danger--tertiary
+  .cds--btn__icon
+  path:not([data-icon-path]):not([fill='none']),
+.cds--btn--ghost .cds--btn__icon,
+.cds--btn--ghost .cds--btn__icon path:not([data-icon-path]):not([fill='none']),
+.cds--btn--primary .cds--btn__icon,
+.cds--btn--primary
+  .cds--btn__icon
+  path:not([data-icon-path]):not([fill='none']),
+.cds--btn--secondary .cds--btn__icon,
+.cds--btn--secondary
+  .cds--btn__icon
+  path:not([data-icon-path]):not([fill='none']),
+.cds--btn--tertiary .cds--btn__icon,
+.cds--btn--tertiary
+  .cds--btn__icon
+  path:not([data-icon-path]):not([fill='none']),
+.cds--tag__close-icon svg,
+.cds--tag__custom-icon svg {
+  fill: currentColor;
+}
+.cds--breadcrumb-item .cds--overflow-menu:hover .cds--overflow-menu__icon {
+  fill: var(--cds-link-primary-hover, #0043ce);
+}
+.cds--breadcrumb-menu-options:focus {
+  outline: 0;
+}
+.cds--breadcrumb-menu-options.cds--overflow-menu-options:after {
+  background: 0 0;
+  border-bottom: 0.4375rem solid var(--cds-field);
+  border-left: 0.4375rem solid transparent;
+  border-right: 0.4375rem solid transparent;
+  height: 0;
+  left: 0.875rem;
+  margin: 0 auto;
+  top: -0.4375rem;
+  width: 0;
+}
+.cds--breadcrumb.cds--skeleton .cds--link {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  height: 1rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 6.25rem;
+}
+.cds--breadcrumb.cds--skeleton .cds--link:active,
+.cds--breadcrumb.cds--skeleton .cds--link:focus,
+.cds--breadcrumb.cds--skeleton .cds--link:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--label + .cds--tooltip .cds--tooltip__trigger:focus,
+.cds--link:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+.cds--breadcrumb.cds--skeleton .cds--link:before {
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+.cds--breadcrumb .cds--overflow-menu.cds--btn--icon-only {
+  min-height: 1.125rem;
+  padding-left: 0;
+  padding-right: 0;
+}
+.cds--link {
+  box-sizing: border-box;
+  color: var(--cds-link-text-color, var(--cds-link-primary, #0f62fe));
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  outline: 0;
+  transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--link *,
+.cds--link :after,
+.cds--link :before {
+  box-sizing: inherit;
+}
+.cds--link:hover {
+  color: var(
+    --cds-link-hover-text-color,
+    var(--cds-link-primary-hover, #0043ce)
+  );
+  text-decoration: underline;
+}
+.cds--link:active,
+.cds--link:active:visited,
+.cds--link:active:visited:hover {
+  color: var(--cds-text-primary, #161616);
+  text-decoration: underline;
+}
+.cds--link.cds--link--visited:visited:hover,
+.cds--link:visited:hover {
+  color: var(--cds-link-primary-hover, #0043ce);
+}
+.cds--link:focus {
+  outline-color: var(--cds-link-focus-text-color, var(--cds-focus, #0f62fe));
+}
+@media screen and (prefers-contrast) {
+  .cds--link:focus {
+    outline-style: dotted;
+  }
+}
+.cds--link:visited {
+  color: var(--cds-link-primary, #0f62fe);
+}
+.cds--link--disabled,
+.cds--link--disabled:hover {
+  box-sizing: border-box;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+  font-size: 100%;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: 400;
+  text-decoration: none;
+}
+.cds--btn--danger--ghost .cds--btn__icon,
+.cds--btn--ghost .cds--btn__icon {
+  margin-left: 0.5rem;
+  position: static;
+}
+.cds--link--disabled *,
+.cds--link--disabled :after,
+.cds--link--disabled :before,
+.cds--link--disabled:hover *,
+.cds--link--disabled:hover :after,
+.cds--link--disabled:hover :before {
+  box-sizing: inherit;
+}
+.cds--link.cds--link--visited:visited {
+  color: var(--cds-link-visited, #8a3ffc);
+}
+.cds--link.cds--link--inline {
+  display: inline;
+  text-decoration: underline;
+}
+.cds--link.cds--link--inline:focus,
+.cds--link.cds--link--inline:visited {
+  text-decoration: none;
+}
+.cds--link--disabled.cds--link--inline {
+  text-decoration: underline;
+}
+.cds--link--sm,
+.cds--link--sm.cds--link--disabled:hover {
+  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
+  letter-spacing: var(--cds-helper-text-01-letter-spacing, 0.32px);
+  line-height: var(--cds-helper-text-01-line-height, 1.33333);
+}
+.cds--link--lg,
+.cds--link--lg.cds--link--disabled:hover {
+  font-size: var(--cds-body-compact-02-font-size, 1rem);
+  font-weight: var(--cds-body-compact-02-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-02-letter-spacing, 0);
+  line-height: var(--cds-body-compact-02-line-height, 1.375);
+}
+.cds--btn,
+.cds--checkbox-group html,
+.cds--checkbox-label html,
+.cds--fieldset html,
+.cds--form-requirement html,
+.cds--label html,
+.cds--snippet html {
+  font-size: 100%;
+}
+.cds--link__icon {
+  align-self: center;
+  margin-left: 0.5rem;
+}
+.cds--assistive-text,
+.cds--visually-hidden {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  width: 1px;
+}
+.cds--btn {
+  align-items: center;
+  border: 0;
+  border-radius: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  justify-content: space-between;
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  margin: 0;
+  min-height: 3rem;
+  outline: 0;
+  padding: calc(0.875rem - 3px) calc(4rem - 1px) calc(0.875rem - 3px)
+    calc(1rem - 1px);
+  position: relative;
+  text-align: left;
+  text-decoration: none;
+  transition:
+    background 70ms cubic-bezier(0, 0, 0.38, 0.9),
+    box-shadow 70ms cubic-bezier(0, 0, 0.38, 0.9),
+    border-color 70ms cubic-bezier(0, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0, 0, 0.38, 0.9);
+  vertical-align: top;
+  width: -moz-max-content;
+  width: max-content;
+}
+.cds--btn *,
+.cds--btn :after,
+.cds--btn :before {
+  box-sizing: inherit;
+}
+.cds--checkbox-label:after,
+.cds--checkbox-label:before,
+.cds--list-box__field {
+  box-sizing: border-box;
+}
+.cds--btn.cds--btn--disabled,
+.cds--btn.cds--btn--disabled:focus,
+.cds--btn.cds--btn--disabled:hover,
+.cds--btn:disabled,
+.cds--btn:focus:disabled,
+.cds--btn:hover:disabled {
+  background: var(--cds-button-disabled, #c6c6c6);
+  border-color: var(--cds-button-disabled, #c6c6c6);
+  box-shadow: none;
+  color: var(--cds-text-on-color-disabled, #8d8d8d);
+  cursor: not-allowed;
+}
+.cds--btn--primary,
+.cds--btn--primary:hover,
+.cds--btn--secondary,
+.cds--btn--secondary:focus,
+.cds--btn--secondary:hover {
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--btn .cds--btn__icon {
+  flex-shrink: 0;
+  height: 1rem;
+  position: absolute;
+  right: 1rem;
+  width: 1rem;
+}
+.cds--btn::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+.cds--btn--primary:focus,
+.cds--btn--secondary:focus,
+.cds--btn--tertiary:focus {
+  border-color: var(--cds-button-focus-color, var(--cds-focus, #0f62fe));
+  box-shadow:
+    inset 0 0 0 1px var(--cds-button-focus-color, var(--cds-focus, #0f62fe)),
+    inset 0 0 0 2px var(--cds-background, #fff);
+}
+.cds--btn--primary {
+  background-color: var(--cds-button-primary, #0f62fe);
+  border: 1px solid transparent;
+}
+.cds--btn--primary:hover {
+  background-color: var(--cds-button-primary-hover, #0050e6);
+}
+.cds--btn--primary:active {
+  background-color: var(--cds-button-primary-active, #002d9c);
+}
+.cds--btn--secondary {
+  background-color: var(--cds-button-secondary, #393939);
+  border: 1px solid transparent;
+}
+.cds--btn--secondary:hover {
+  background-color: var(--cds-button-secondary-hover, #474747);
+}
+.cds--btn--secondary:active {
+  background-color: var(--cds-button-secondary-active, #6f6f6f);
+}
+.cds--btn--tertiary {
+  background-color: transparent;
+  border-color: var(--cds-button-tertiary, #0f62fe);
+  border-style: solid;
+  border-width: 1px;
+  color: var(--cds-button-tertiary, #0f62fe);
+}
+.cds--btn--tertiary:hover {
+  background-color: var(--cds-button-tertiary-hover, #0050e6);
+  color: var(--cds-text-inverse, #fff);
+}
+.cds--btn--tertiary:focus {
+  background-color: var(--cds-button-tertiary, #0f62fe);
+  color: var(--cds-text-inverse, #fff);
+}
+.cds--btn--tertiary:active {
+  background-color: var(--cds-button-tertiary-active, #002d9c);
+  border-color: transparent;
+  color: var(--cds-text-inverse, #fff);
+}
+.cds--btn--tertiary.cds--btn--disabled,
+.cds--btn--tertiary.cds--btn--disabled:focus,
+.cds--btn--tertiary.cds--btn--disabled:hover,
+.cds--btn--tertiary:disabled,
+.cds--btn--tertiary:focus:disabled,
+.cds--btn--tertiary:hover:disabled {
+  background: 0 0;
+  color: var(--cds-text-on-color-disabled, #8d8d8d);
+  outline: 0;
+}
+.cds--btn--ghost {
+  background-color: transparent;
+  border: 1px solid transparent;
+  color: var(--cds-link-primary, #0f62fe);
+  padding: calc(0.875rem - 3px) 1rem;
+}
+.cds--btn--ghost:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--btn--ghost:focus {
+  border-color: var(--cds-button-focus-color, var(--cds-focus, #0f62fe));
+  box-shadow:
+    inset 0 0 0 1px var(--cds-button-focus-color, var(--cds-focus, #0f62fe)),
+    inset 0 0 0 2px var(--cds-background, #fff);
+}
+.cds--btn--ghost:active {
+  background-color: var(--cds-layer-active);
+  background-color: var(--cds-background-active, hsla(0, 0%, 55%, 0.5));
+}
+.cds--btn--ghost:active,
+.cds--btn--ghost:hover {
+  color: var(--cds-link-primary-hover, #0043ce);
+}
+.cds--btn--ghost.cds--btn--disabled,
+.cds--btn--ghost.cds--btn--disabled:focus,
+.cds--btn--ghost.cds--btn--disabled:hover,
+.cds--btn--ghost:disabled,
+.cds--btn--ghost:focus:disabled,
+.cds--btn--ghost:hover:disabled {
+  background: 0 0;
+  border-color: transparent;
+  color: var(--cds-text-on-color-disabled, #8d8d8d);
+  outline: 0;
+}
+.cds--btn--danger--tertiary:focus,
+.cds--btn--danger:focus {
+  border-color: var(--cds-button-focus-color, var(--cds-focus, #0f62fe));
+  box-shadow:
+    inset 0 0 0 1px var(--cds-button-focus-color, var(--cds-focus, #0f62fe)),
+    inset 0 0 0 2px var(--cds-background, #fff);
+}
+.cds--btn--ghost.cds--btn--sm {
+  padding: calc(0.375rem - 3px) 1rem;
+}
+.cds--btn--ghost.cds--btn--field,
+.cds--btn--ghost.cds--btn--md {
+  padding: calc(0.675rem - 3px) 1rem;
+}
+.cds--btn--icon-only {
+  padding-left: 0.9375rem;
+  padding-right: 0.9375rem;
+}
+.cds--btn--icon-only .cds--btn__icon {
+  position: static;
+}
+.cds--btn--icon-only.cds--btn--danger--ghost .cds--btn__icon,
+.cds--btn--icon-only.cds--btn--ghost .cds--btn__icon {
+  margin: 0;
+}
+.cds--btn--icon-only.cds--btn--selected {
+  background: var(--cds-background-selected, hsla(0, 0%, 55%, 0.2));
+}
+.cds--btn path[data-icon-path='inner-path'] {
+  fill: none;
+}
+.cds--btn--ghost.cds--btn--icon-only[disabled] .cds--btn__icon,
+.cds--btn--ghost.cds--btn--icon-only[disabled]
+  .cds--btn__icon
+  path:not([data-icon-path]):not([fill='none']),
+.cds--btn.cds--btn--icon-only.cds--btn--ghost[disabled]:hover .cds--btn__icon {
+  fill: var(--cds-icon-on-color-disabled, #8d8d8d);
+}
+.cds--btn--ghost.cds--btn--icon-only[disabled] {
+  cursor: not-allowed;
+}
+.cds--btn--field.cds--btn--icon-only,
+.cds--btn--md.cds--btn--icon-only {
+  padding-left: 0.6875rem;
+  padding-right: 0.6875rem;
+}
+.cds--btn--sm.cds--btn--icon-only {
+  padding-left: 0.4375rem;
+  padding-right: 0.4375rem;
+}
+.cds--btn--danger {
+  background-color: var(--cds-button-danger-primary, #da1e28);
+  border: 1px solid transparent;
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--btn--danger--ghost,
+.cds--btn--danger--tertiary {
+  background-color: transparent;
+  color: var(--cds-button-danger-secondary, #da1e28);
+}
+.cds--btn--danger:hover {
+  background-color: var(--cds-button-danger-hover, #b81921);
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--btn--danger:active {
+  background-color: var(--cds-button-danger-active, #750e13);
+}
+.cds--btn--danger--tertiary {
+  border-color: var(--cds-button-danger-secondary, #da1e28);
+  border-style: solid;
+  border-width: 1px;
+}
+.cds--btn--danger--tertiary:hover {
+  background-color: var(--cds-button-danger-hover, #b81921);
+  border-color: var(--cds-button-danger-hover, #b81921);
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--btn--danger--tertiary:focus {
+  background-color: var(--cds-button-danger-primary, #da1e28);
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--btn--danger--tertiary:active {
+  background-color: var(--cds-button-danger-active, #750e13);
+  border-color: var(--cds-button-danger-active, #750e13);
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--btn--danger--tertiary.cds--btn--disabled,
+.cds--btn--danger--tertiary.cds--btn--disabled:focus,
+.cds--btn--danger--tertiary.cds--btn--disabled:hover,
+.cds--btn--danger--tertiary:disabled,
+.cds--btn--danger--tertiary:focus:disabled,
+.cds--btn--danger--tertiary:hover:disabled {
+  background: 0 0;
+  color: var(--cds-text-on-color-disabled, #8d8d8d);
+  outline: 0;
+}
+.cds--btn--danger--ghost {
+  border: 1px solid transparent;
+  padding: calc(0.875rem - 3px) 1rem;
+}
+.cds--form__helper-text,
+.cds--label {
+  color: var(--cds-text-secondary, #525252);
+}
+.cds--btn--danger--ghost:hover {
+  background-color: var(--cds-button-danger-hover, #b81921);
+}
+.cds--btn--danger--ghost:focus {
+  border-color: var(--cds-button-focus-color, var(--cds-focus, #0f62fe));
+  box-shadow:
+    inset 0 0 0 1px var(--cds-button-focus-color, var(--cds-focus, #0f62fe)),
+    inset 0 0 0 2px var(--cds-background, #fff);
+}
+.cds--btn--danger--ghost:active {
+  background-color: var(--cds-button-danger-active, #750e13);
+}
+.cds--btn--danger--ghost:active,
+.cds--btn--danger--ghost:hover {
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--btn--danger--ghost.cds--btn--disabled,
+.cds--btn--danger--ghost.cds--btn--disabled:focus,
+.cds--btn--danger--ghost.cds--btn--disabled:hover,
+.cds--btn--danger--ghost:disabled,
+.cds--btn--danger--ghost:focus:disabled,
+.cds--btn--danger--ghost:hover:disabled {
+  background: 0 0;
+  border-color: transparent;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  outline: 0;
+}
+.cds--btn.cds--skeleton,
+.cds--label.cds--skeleton {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  pointer-events: none;
+  position: relative;
+}
+.cds--btn--danger--ghost.cds--btn--sm {
+  padding: calc(0.375rem - 3px) 1rem;
+}
+.cds--btn--danger--ghost.cds--btn--field,
+.cds--btn--danger--ghost.cds--btn--md {
+  padding: calc(0.675rem - 3px) 1rem;
+}
+.cds--btn--sm {
+  min-height: 2rem;
+  padding: calc(0.375rem - 3px) calc(4rem - 4px) calc(0.375rem - 3px)
+    calc(1rem - 4px);
+}
+.cds--btn--2xl:not(.cds--btn--icon-only) {
+  align-items: baseline;
+  min-height: 5rem;
+  padding-left: 1rem;
+  padding-right: 4rem;
+  padding-top: 1rem;
+}
+.cds--btn--xl:not(.cds--btn--icon-only) {
+  align-items: baseline;
+  min-height: 4rem;
+  padding-left: 1rem;
+  padding-right: 4rem;
+  padding-top: 1rem;
+}
+.cds--btn--field,
+.cds--btn--md {
+  min-height: 2.5rem;
+  padding: calc(0.675rem - 3px) calc(4rem - 4px) calc(0.675rem - 3px)
+    calc(1rem - 4px);
+}
+.cds--btn--expressive {
+  font-size: var(--cds-body-compact-02-font-size, 1rem);
+  font-weight: var(--cds-body-compact-02-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-02-letter-spacing, 0);
+  line-height: var(--cds-body-compact-02-line-height, 1.375);
+  min-height: 3rem;
+}
+.cds--btn--icon-only.cds--btn--expressive {
+  padding: 12px 13px;
+}
+.cds--btn.cds--btn--expressive .cds--btn__icon {
+  height: 1.25rem;
+  width: 1.25rem;
+}
+.cds--btn.cds--skeleton {
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  width: 9.375rem;
+}
+.cds--btn.cds--skeleton:active,
+.cds--btn.cds--skeleton:focus,
+.cds--btn.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--btn.cds--skeleton:before {
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--breadcrumb.cds--skeleton .cds--link:before,
+  .cds--btn.cds--skeleton:before {
+    animation: none;
+  }
+}
+.cds--btn-set {
+  display: flex;
+}
+.cds--btn-set--stacked {
+  flex-direction: column;
+}
+.cds--btn-set .cds--btn {
+  max-width: 12.25rem;
+  width: 100%;
+}
+.cds--btn-set .cds--btn:not(:focus) {
+  box-shadow: -0.0625rem 0 0 0 var(--cds-button-separator, #e0e0e0);
+}
+.cds--btn-set--stacked .cds--btn:not(:focus) {
+  box-shadow: 0 -0.0625rem 0 0 var(--cds-button-separator, #e0e0e0);
+}
+.cds--btn-set .cds--btn.cds--btn--disabled:first-of-type,
+.cds--btn-set--stacked .cds--btn.cds--btn--disabled:first-of-type {
+  box-shadow: none;
+}
+.cds--btn-set .cds--btn.cds--btn--disabled {
+  box-shadow: -0.0625rem 0 0 0 var(--cds-icon-on-color-disabled, #8d8d8d);
+}
+.cds--btn-set--stacked .cds--btn.cds--btn--disabled {
+  box-shadow: 0 -0.0625rem 0 0 var(--cds-layer-selected-disabled, #8d8d8d);
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--btn:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--btn--ghost.cds--btn--icon-only .cds--btn__icon,
+  .cds--btn--ghost.cds--btn--icon-only
+    .cds--btn__icon
+    path:not([data-icon-path]):not([fill='none']) {
+    fill: ButtonText;
+  }
+}
+input:-webkit-autofill,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:hover,
+textarea:-webkit-autofill,
+textarea:-webkit-autofill:focus,
+textarea:-webkit-autofill:hover {
+  -webkit-text-fill-color: var(--cds-text-primary, #161616);
+  box-shadow: 0 0 0 1000px var(--cds-field) inset;
+}
+.cds--fieldset body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--fieldset code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--fieldset strong {
+  font-weight: 600;
+}
+.cds--form-item {
+  align-items: flex-start;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--form-requirement,
+.cds--label,
+.cds--label .cds--toggletip-label {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+}
+.cds--label {
+  display: inline-block;
+  font-weight: var(--cds-label-01-font-weight, 400);
+  font-weight: 400;
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+  line-height: 1rem;
+  margin-bottom: 0.5rem;
+  vertical-align: baseline;
+}
+.cds--form-requirement,
+.cds--label .cds--toggletip-label,
+.cds--label + .cds--tooltip .cds--tooltip__trigger {
+  font-weight: var(--cds-label-01-font-weight, 400);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+}
+.cds--label body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--label code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--form-requirement body,
+input[type='number'] {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+}
+.cds--label strong {
+  font-weight: 600;
+}
+.cds--label--no-margin {
+  margin-bottom: 0;
+}
+.cds--label + .cds--tooltip {
+  left: 0.5rem;
+  position: relative;
+  top: 0.2rem;
+}
+.cds--label + .cds--tooltip .cds--tooltip__trigger {
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  display: flex;
+  font-family: inherit;
+  font-size: 100%;
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  text-align: start;
+  vertical-align: baseline;
+  width: 100%;
+}
+.cds--label + .cds--tooltip .cds--tooltip__trigger *,
+.cds--label + .cds--tooltip .cds--tooltip__trigger :after,
+.cds--label + .cds--tooltip .cds--tooltip__trigger :before {
+  box-sizing: inherit;
+}
+.cds--label + .cds--tooltip .cds--tooltip__trigger::-moz-focus-inner {
+  border: 0;
+}
+.cds--label + .cds--tooltip .cds--tooltip__trigger svg {
+  fill: var(--cds-icon-secondary, #525252);
+}
+.cds--label + .cds--tooltip .cds--tooltip__trigger svg :hover {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--label + .cds--toggletip {
+  left: 0.5rem;
+  top: 0.2rem;
+}
+.cds--label.cds--skeleton {
+  border: none;
+  box-shadow: none;
+  height: 0.875rem;
+  padding: 0;
+  width: 4.6875rem;
+}
+.cds--label.cds--skeleton:active,
+.cds--label.cds--skeleton:focus,
+.cds--label.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--label.cds--skeleton:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--label.cds--skeleton:before {
+    animation: none;
+  }
+}
+.cds--combo-box[data-invalid]:not(.cds--multi-select--selected)
+  .cds--text-input:not(:focus),
+.cds--list-box[data-invalid]:not(.cds--multi-select--invalid--focused),
+.cds--number[data-invalid] input[type='number']:not(:focus),
+.cds--select-input__wrapper[data-invalid] .cds--select-input:not(:focus),
+.cds--text-area__wrapper[data-invalid] > .cds--text-area--invalid:not(:focus),
+.cds--text-input__field-wrapper[data-invalid]
+  > .cds--text-input--invalid:not(:focus),
+input[data-invalid]:not(:focus) {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--combo-box[data-invalid]:not(.cds--multi-select--selected)
+    .cds--text-input:not(:focus),
+  .cds--list-box[data-invalid]:not(.cds--multi-select--invalid--focused),
+  .cds--number[data-invalid] input[type='number']:not(:focus),
+  .cds--select-input__wrapper[data-invalid] .cds--select-input:not(:focus),
+  .cds--text-area__wrapper[data-invalid] > .cds--text-area--invalid:not(:focus),
+  .cds--text-input__field-wrapper[data-invalid]
+    > .cds--text-input--invalid:not(:focus),
+  input[data-invalid]:not(:focus) {
+    outline-style: dotted;
+  }
+}
+.cds--date-picker-input__wrapper--invalid ~ .cds--form-requirement,
+.cds--date-picker-input__wrapper--warn ~ .cds--form-requirement,
+.cds--date-picker-input__wrapper ~ .cds--form-requirement,
+.cds--list-box--warning ~ .cds--form-requirement,
+.cds--list-box[data-invalid] ~ .cds--form-requirement,
+.cds--number[data-invalid] .cds--number__input-wrapper ~ .cds--form-requirement,
+.cds--number__input-wrapper--warning ~ .cds--form-requirement,
+.cds--select--warning .cds--select-input__wrapper ~ .cds--form-requirement,
+.cds--select-input__wrapper[data-invalid] ~ .cds--form-requirement,
+.cds--text-area__wrapper--warn ~ .cds--form-requirement,
+.cds--text-area__wrapper[data-invalid] ~ .cds--form-requirement,
+.cds--text-input__field-wrapper--warning
+  > .cds--text-input
+  ~ .cds--form-requirement,
+.cds--text-input__field-wrapper--warning ~ .cds--form-requirement,
+.cds--text-input__field-wrapper[data-invalid] ~ .cds--form-requirement,
+.cds--time-picker--invalid ~ .cds--form-requirement,
+.cds--time-picker[data-invalid] ~ .cds--form-requirement,
+input[data-invalid] ~ .cds--form-requirement {
+  display: block;
+  font-weight: 400;
+  max-height: 12.5rem;
+  overflow: visible;
+}
+.cds--date-picker-input__wrapper--invalid ~ .cds--form-requirement,
+.cds--date-picker-input__wrapper ~ .cds--form-requirement,
+.cds--list-box[data-invalid] ~ .cds--form-requirement,
+.cds--number[data-invalid] .cds--number__input-wrapper ~ .cds--form-requirement,
+.cds--select-input__wrapper[data-invalid] ~ .cds--form-requirement,
+.cds--text-area__wrapper[data-invalid] ~ .cds--form-requirement,
+.cds--text-input__field-wrapper[data-invalid] ~ .cds--form-requirement,
+.cds--time-picker--invalid ~ .cds--form-requirement,
+.cds--time-picker[data-invalid] ~ .cds--form-requirement,
+input[data-invalid] ~ .cds--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+}
+.cds--form--fluid .cds--text-input__field-wrapper--warning,
+.cds--form--fluid .cds--text-input__field-wrapper[data-invalid] {
+  display: block;
+}
+.cds--form--fluid input[data-invalid] {
+  outline: 0;
+}
+.cds--form--fluid .cds--form-requirement {
+  margin: 0;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+}
+input:not(output):not([data-invalid]):-moz-ui-invalid {
+  box-shadow: none;
+}
+.cds--form-requirement {
+  display: none;
+  margin: 0.25rem 0 0;
+  max-height: 0;
+  overflow: hidden;
+}
+.cds--form-requirement body {
+  font-weight: 400;
+}
+.cds--form-requirement code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--form-requirement strong {
+  font-weight: 600;
+}
+.cds--select--inline .cds--form__helper-text {
+  margin-top: 0;
+}
+.cds--form__helper-text {
+  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
+  letter-spacing: var(--cds-helper-text-01-letter-spacing, 0.32px);
+  line-height: var(--cds-helper-text-01-line-height, 1.33333);
+  margin-top: 0.25rem;
+  opacity: 1;
+  width: 100%;
+  z-index: 0;
+}
+.cds--form__helper-text--disabled,
+.cds--label--disabled,
+fieldset[disabled] .cds--form__helper-text,
+fieldset[disabled] .cds--label {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--checkbox-group body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--checkbox-group code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--checkbox-group strong {
+  font-weight: 600;
+}
+.cds--form-item.cds--checkbox-wrapper {
+  margin-bottom: 0.25rem;
+  position: relative;
+}
+.cds--form-item.cds--checkbox-wrapper:first-of-type {
+  margin-top: 0.1875rem;
+}
+.cds--label + .cds--form-item.cds--checkbox-wrapper {
+  margin-top: -0.125rem;
+}
+.cds--form-item.cds--checkbox-wrapper:last-of-type {
+  margin-bottom: 0.1875rem;
+}
+.cds--checkbox {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  left: 0.7rem;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  top: 1.25rem;
+  visibility: inherit;
+  width: 1px;
+}
+.cds--checkbox-label {
+  cursor: pointer;
+  display: flex;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  min-height: 1.5rem;
+  padding-left: 1.25rem;
+  padding-top: 0.1875rem;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.cds--checkbox-label body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--checkbox-label code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--checkbox-label strong {
+  font-weight: 600;
+}
+.cds--checkbox-label-text {
+  padding-left: 0.375rem;
+}
+.cds--checkbox-label:before {
+  background-color: transparent;
+  border: 1px solid var(--cds-icon-primary, #161616);
+  border-radius: 2px;
+  content: '';
+  height: 1rem;
+  left: 0;
+  margin: 0.125rem 0.125rem 0.125rem 0.1875rem;
+  position: absolute;
+  top: 0.125rem;
+  width: 1rem;
+}
+.cds--checkbox-label:after {
+  background: 0 0;
+  border-bottom: 1.5px solid var(--cds-icon-inverse, #fff);
+  border-left: 1.5px solid var(--cds-icon-inverse, #fff);
+  content: '';
+  height: 0.3125rem;
+  left: 0.4375rem;
+  margin-top: -0.1875rem;
+  position: absolute;
+  top: 0.46875rem;
+  transform: scale(0) rotate(-45deg);
+  transform-origin: bottom right;
+  width: 0.5625rem;
+}
+.cds--checkbox-label-text.cds--skeleton,
+.cds--snippet.cds--skeleton span {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  box-shadow: none;
+  pointer-events: none;
+}
+.cds--checkbox-label[data-contained-checkbox-state='true']:before,
+.cds--checkbox:checked + .cds--checkbox-label:before,
+.cds--checkbox:indeterminate + .cds--checkbox-label:before {
+  background-color: var(--cds-icon-primary, #161616);
+  border: 1px;
+}
+.cds--checkbox-label-text.cds--skeleton:before,
+.cds--snippet.cds--skeleton span:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+.cds--checkbox-label[data-contained-checkbox-state='true']:after,
+.cds--checkbox:checked + .cds--checkbox-label:after {
+  transform: scale(1) rotate(-45deg);
+}
+.cds--checkbox:indeterminate + .cds--checkbox-label:after {
+  border-bottom: 2px solid var(--cds-icon-inverse, #fff);
+  border-left: 0 solid var(--cds-icon-inverse, #fff);
+  top: 0.6875rem;
+  transform: scale(1) rotate(0);
+  width: 0.5rem;
+}
+.cds--checkbox-label[data-contained-checkbox-state='true'].cds--checkbox-label__focus:before,
+.cds--checkbox-label__focus:before,
+.cds--checkbox:checked:focus + .cds--checkbox-label:before,
+.cds--checkbox:focus + .cds--checkbox-label:before,
+.cds--checkbox:indeterminate:focus + .cds--checkbox-label:before {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: 1px;
+}
+.cds--checkbox-label[data-contained-checkbox-disabled='true'],
+.cds--checkbox:disabled + .cds--checkbox-label {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--checkbox-label[data-contained-checkbox-disabled='true']:before,
+.cds--checkbox:disabled + .cds--checkbox-label:before {
+  border-color: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--checkbox-label[data-contained-checkbox-state='true'][data-contained-checkbox-disabled='true']:before,
+.cds--checkbox:checked:disabled + .cds--checkbox-label:before,
+.cds--checkbox:indeterminate:disabled + .cds--checkbox-label:before {
+  background-color: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--checkbox-group[data-invalid] .cds--checkbox-label:before,
+.cds--checkbox-wrapper--invalid .cds--checkbox-label:before,
+.cds--checkbox-wrapper--invalid
+  .cds--checkbox:checked
+  + .cds--checkbox-label:before {
+  border: 1px solid var(--cds-support-error, #da1e28);
+}
+.cds--checkbox-group
+  .cds--checkbox-wrapper--invalid
+  > .cds--checkbox__validation-msg,
+.cds--checkbox-group
+  .cds--checkbox-wrapper--warning
+  > .cds--checkbox__validation-msg,
+.cds--checkbox-group .cds--checkbox-wrapper > .cds--form__helper-text {
+  display: none;
+}
+.cds--checkbox-group:not(.cds--checkbox-group[data-invalid])
+  .cds--checkbox-wrapper--invalid
+  .cds--checkbox-label:before,
+.cds--checkbox-group:not(.cds--checkbox-group[data-invalid])
+  .cds--checkbox-wrapper--invalid
+  .cds--checkbox:checked
+  + .cds--checkbox-label:before {
+  border: 1px solid var(--cds-icon-primary, #161616);
+}
+.cds--checkbox-group__validation-msg,
+.cds--checkbox__validation-msg {
+  align-items: flex-end;
+  display: none;
+  margin-top: 0.25rem;
+}
+.cds--checkbox__invalid-icon {
+  fill: var(--cds-support-error, #da1e28);
+  margin: 0 0.0625rem 0 0.1875rem;
+}
+.cds--checkbox__invalid-icon--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--checkbox__invalid-icon--warning path:first-of-type {
+  fill: #000;
+}
+.cds--checkbox-group--invalid .cds--checkbox-group__validation-msg,
+.cds--checkbox-group--warning .cds--checkbox-group__validation-msg,
+.cds--checkbox-wrapper--invalid > .cds--checkbox__validation-msg,
+.cds--checkbox-wrapper--warning > .cds--checkbox__validation-msg {
+  display: flex;
+}
+.cds--checkbox-group--invalid
+  .cds--checkbox-group__validation-msg
+  .cds--form-requirement,
+.cds--checkbox-group--warning
+  .cds--checkbox-group__validation-msg
+  .cds--form-requirement,
+.cds--checkbox-wrapper--invalid
+  .cds--checkbox__validation-msg
+  .cds--form-requirement,
+.cds--checkbox-wrapper--warning
+  .cds--checkbox__validation-msg
+  .cds--form-requirement {
+  display: block;
+  margin-left: 0.5rem;
+  margin-top: 0;
+  max-height: 100%;
+  overflow: visible;
+}
+.cds--checkbox-group--invalid
+  .cds--checkbox-group__validation-msg
+  .cds--form-requirement,
+.cds--checkbox-wrapper--invalid
+  .cds--checkbox__validation-msg
+  .cds--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+}
+.cds--checkbox-group--readonly .cds--checkbox-label,
+.cds--checkbox-wrapper--readonly .cds--checkbox-label {
+  cursor: default;
+}
+.cds--checkbox-group--readonly .cds--checkbox-label-text,
+.cds--checkbox-wrapper--readonly .cds--checkbox-label-text {
+  cursor: text;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  user-select: text;
+}
+.cds--checkbox-group--readonly .cds--checkbox + .cds--checkbox-label:before,
+.cds--checkbox-wrapper--readonly .cds--checkbox + .cds--checkbox-label:before {
+  border-color: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--checkbox-group--readonly
+  .cds--checkbox:checked
+  + .cds--checkbox-label:before,
+.cds--checkbox-wrapper--readonly
+  .cds--checkbox:checked
+  + .cds--checkbox-label:before {
+  background: 0 0;
+  border: 1px solid var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--checkbox-group--readonly
+  .cds--checkbox:checked
+  + .cds--checkbox-label:after,
+.cds--checkbox-wrapper--readonly
+  .cds--checkbox:checked
+  + .cds--checkbox-label:after {
+  border-color: var(--cds-text-primary, #161616);
+}
+.cds--checkbox-skeleton .cds--checkbox-label {
+  cursor: default;
+}
+.cds--checkbox-label-text.cds--skeleton {
+  border: none;
+  height: 1rem;
+  margin: 0.0625rem 0 0 0.375rem;
+  padding: 0;
+  position: relative;
+  width: 6.25rem;
+}
+.cds--copy-btn .cds--copy-btn__feedback,
+.cds--snippet--inline .cds--copy-btn__feedback {
+  clip: auto;
+  box-shadow: 0 2px 6px var(--cds-shadow, rgba(0, 0, 0, 0.3));
+  box-sizing: content-box;
+  display: none;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  max-width: 13rem;
+  min-width: 1.5rem;
+  overflow: visible;
+  padding: 0.1875rem 1rem;
+  text-align: left;
+  transform: translateX(-50%);
+  z-index: 6000;
+}
+.cds--checkbox-label-text.cds--skeleton:active,
+.cds--checkbox-label-text.cds--skeleton:focus,
+.cds--checkbox-label-text.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--checkbox-label-text.cds--skeleton:before {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+.cds--checkbox--inline,
+.cds--copy-btn {
+  position: relative;
+}
+.cds--copy-btn:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--copy-btn:active {
+  background-color: var(--cds-layer-active);
+}
+.cds--copy-btn:before {
+  border-style: solid;
+  content: '';
+  display: none;
+  height: 0;
+  position: absolute;
+  width: 0;
+  z-index: 6000;
+}
+.cds--copy-btn .cds--copy-btn__feedback {
+  background-color: var(--cds-background-inverse, #393939);
+  border-radius: 0.125rem;
+  color: var(--cds-text-inverse, #fff);
+  font-weight: 400;
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  height: auto;
+  margin: auto;
+  width: -moz-max-content;
+  width: max-content;
+}
+@media (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .cds--copy-btn .cds--copy-btn__feedback {
+    width: auto;
+  }
+}
+@supports (-ms-accelerator: true) {
+  .cds--copy-btn .cds--copy-btn__feedback {
+    width: auto;
+  }
+}
+@supports (-ms-ime-align: auto) {
+  .cds--copy-btn .cds--copy-btn__feedback {
+    width: auto;
+  }
+}
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .cds--copy-btn .cds--copy-btn__feedback {
+    border: 1px solid transparent;
+  }
+}
+.cds--copy-btn.cds--copy-btn--animating .cds--copy-btn__feedback,
+.cds--copy-btn.cds--copy-btn--animating:before {
+  display: block;
+}
+.cds--copy-btn.cds--copy-btn--animating:before,
+.flatpickr-day.today.no-border {
+  border: none;
+}
+.cds--copy-btn.cds--copy-btn--animating.cds--copy-btn--fade-out
+  .cds--copy-btn__feedback,
+.cds--copy-btn.cds--copy-btn--animating.cds--copy-btn--fade-out:before {
+  animation: hide-feedback 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--copy-btn.cds--copy-btn--animating.cds--copy-btn--fade-in
+  .cds--copy-btn__feedback,
+.cds--copy-btn.cds--copy-btn--animating.cds--copy-btn--fade-in:before {
+  animation: show-feedback 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--copy {
+  font-size: 0;
+}
+.cds--snippet body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--snippet strong {
+  font-weight: 600;
+}
+.cds--snippet--disabled,
+.cds--snippet--disabled .cds--btn.cds--snippet-btn--expand {
+  background-color: var(--cds-layer);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--snippet--disabled .cds--copy-btn,
+.cds--snippet--disabled .cds--copy-btn:hover,
+.cds--snippet--disabled .cds--snippet-btn--expand:hover {
+  background-color: var(--cds-layer);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--snippet--disabled .cds--snippet-btn--expand .cds--icon-chevron--down,
+.cds--snippet--disabled .cds--snippet__icon {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger:focus
+  svg,
+.cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger:hover
+  svg,
+.cds--snippet__icon {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--snippet code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+  font-family: var(
+    --cds-code-01-font-family,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    '.SFNSText-Regular',
+    monospace
+  );
+  font-size: var(--cds-code-01-font-size, 0.75rem);
+  font-weight: var(--cds-code-01-font-weight, 400);
+  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
+  line-height: var(--cds-code-01-line-height, 1.33333);
+}
+.cds--snippet--inline {
+  background-color: var(--cds-layer);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--cds-text-primary, #161616);
+  cursor: pointer;
+  display: inline;
+  padding: 0;
+  position: relative;
+}
+.cds--snippet--inline html {
+  font-size: 100%;
+}
+.cds--snippet--inline body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--snippet--inline code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+  padding: 0 0.5rem;
+}
+.cds--snippet--inline strong {
+  font-weight: 600;
+}
+.cds--snippet--multi,
+.cds--snippet--single,
+.cds--snippet--single pre {
+  font-family: var(
+    --cds-code-01-font-family,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    '.SFNSText-Regular',
+    monospace
+  );
+  font-size: var(--cds-code-01-font-size, 0.75rem);
+  font-weight: var(--cds-code-01-font-weight, 400);
+  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
+  line-height: var(--cds-code-01-line-height, 1.33333);
+}
+.cds--snippet--inline:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--snippet--inline:active {
+  background-color: var(--cds-layer-active);
+}
+.cds--snippet--inline:focus {
+  border: 1px solid var(--cds-focus, #0f62fe);
+  outline: 0;
+}
+.cds--snippet--inline:before {
+  border: none;
+  content: '';
+  display: none;
+  height: 0;
+  position: absolute;
+  width: 0;
+  z-index: 6000;
+}
+.cds--snippet--inline .cds--copy-btn__feedback {
+  background-color: var(--cds-background-inverse, #393939);
+  border-radius: 0.125rem;
+  color: var(--cds-text-inverse, #fff);
+  font-weight: 400;
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  height: auto;
+  margin: auto;
+  width: -moz-max-content;
+  width: max-content;
+}
+.cds--data-table tbody tr:hover,
+.cds--snippet-btn--expand:hover {
+  background: var(--cds-layer-hover);
+}
+@media (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .cds--snippet--inline .cds--copy-btn__feedback {
+    width: auto;
+  }
+}
+@supports (-ms-accelerator: true) {
+  .cds--snippet--inline .cds--copy-btn__feedback {
+    width: auto;
+  }
+}
+@supports (-ms-ime-align: auto) {
+  .cds--snippet--inline .cds--copy-btn__feedback {
+    width: auto;
+  }
+}
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .cds--snippet--inline .cds--copy-btn__feedback {
+    border: 1px solid transparent;
+  }
+}
+.cds--snippet--inline.cds--copy-btn--animating .cds--copy-btn__feedback,
+.cds--snippet--inline.cds--copy-btn--animating:before {
+  display: block;
+}
+.cds--snippet--inline.cds--copy-btn--animating.cds--copy-btn--fade-out
+  .cds--copy-btn__feedback,
+.cds--snippet--inline.cds--copy-btn--animating.cds--copy-btn--fade-out:before {
+  animation: hide-feedback 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--snippet--inline.cds--copy-btn--animating.cds--copy-btn--fade-in
+  .cds--copy-btn__feedback,
+.cds--snippet--inline.cds--copy-btn--animating.cds--copy-btn--fade-in:before {
+  animation: show-feedback 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--snippet--inline.cds--snippet--no-copy {
+  display: inline-block;
+}
+.cds--snippet--inline.cds--snippet--no-copy:hover {
+  background-color: var(--cds-layer);
+  cursor: auto;
+}
+.cds--snippet--light.cds--snippet--inline.cds--snippet--no-copy:hover {
+  background-color: var(--cds-layer-hover);
+  cursor: auto;
+}
+.cds--snippet--single {
+  align-items: center;
+  background-color: var(--cds-layer);
+  display: flex;
+  height: 2.5rem;
+  max-width: 48rem;
+  padding-right: 2.5rem;
+  position: relative;
+  width: 100%;
+}
+.cds--snippet--single.cds--snippet--no-copy {
+  padding: 0;
+}
+.cds--list-box--disabled.cds--list-box[data-invalid].cds--list-box--inline
+  .cds--list-box__field,
+.cds--text-input--sm.cds--password-input {
+  padding-right: 2rem;
+}
+.cds--snippet--single.cds--snippet--no-copy:after {
+  right: 1rem;
+}
+.cds--snippet--single .cds--snippet-container {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  overflow-x: auto;
+  padding-left: 1rem;
+  position: relative;
+}
+.cds--snippet--single .cds--snippet-container:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--snippet--single .cds--snippet-container:focus {
+    outline-style: dotted;
+  }
+}
+.cds--snippet--single pre {
+  padding-right: 0.5rem;
+}
+.cds--copy-btn html,
+.cds--text-input html {
+  font-size: 100%;
+}
+.cds--snippet--inline code,
+.cds--snippet--single pre {
+  white-space: pre;
+}
+.cds--snippet--multi {
+  background-color: var(--cds-layer);
+  display: flex;
+  max-width: 48rem;
+  padding: 1rem;
+  position: relative;
+  width: 100%;
+}
+.cds--snippet-btn--expand,
+.cds--text-input {
+  color: var(--cds-text-primary, #161616);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+}
+.cds--snippet-btn--expand,
+.cds--text-input,
+.cds--text-input--password__visibility .cds--assistive-text,
+.cds--text-input--password__visibility + .cds--assistive-text,
+.cds--text-input--password__visibility:after {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--snippet--multi .cds--snippet-container {
+  max-height: 100%;
+  min-height: 100%;
+  order: 1;
+  overflow-y: auto;
+  position: relative;
+  transition: max-height 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--snippet--multi .cds--snippet-container:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  outline-offset: 0;
+}
+.cds--snippet--multi.cds--snippet--expand .cds--snippet-container {
+  padding-bottom: 1rem;
+  transition: max-height 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--snippet--multi.cds--snippet--wraptext pre {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+.cds--snippet--multi .cds--snippet-container pre {
+  overflow-x: auto;
+  padding-bottom: 1.5rem;
+  padding-right: 2.5rem;
+}
+.cds--snippet--multi.cds--snippet--no-copy .cds--snippet-container pre {
+  padding-right: 0;
+}
+.cds--snippet--multi.cds--snippet--expand .cds--snippet-container pre {
+  overflow-x: auto;
+}
+.cds--snippet--multi.cds--snippet--has-right-overflow
+  .cds--snippet-container
+  pre:after {
+  background-image: linear-gradient(to right, transparent, var(--cds-layer));
+  content: '';
+  height: 100%;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 1rem;
+}
+.cds--snippet--multi .cds--snippet-container pre code {
+  overflow: hidden;
+}
+.cds--snippet__icon {
+  height: 1rem;
+  transition: 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 1rem;
+}
+.cds--copy-btn {
+  align-items: center;
+  background-color: var(--cds-layer);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  height: 2.5rem;
+  justify-content: center;
+  outline: 0;
+  overflow: visible;
+  padding: 0;
+  width: 2.5rem;
+}
+.cds--copy-btn body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--copy-btn code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--snippet .cds--popover-container,
+.cds--snippet-btn--expand,
+.cds--text-input body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+}
+.cds--copy-btn strong {
+  font-weight: 600;
+}
+.cds--copy-btn:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-color: var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--copy-btn:focus,
+  .cds--snippet--multi .cds--snippet-container:focus {
+    outline-style: dotted;
+  }
+}
+.cds--snippet .cds--popover-container {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.cds--snippet--inline.cds--btn--md.cds--btn--icon-only {
+  padding-left: 0;
+  padding-right: 0;
+}
+.cds--snippet--inline.cds--btn--md {
+  min-height: 1.25rem;
+}
+.cds--snippet--inline.cds--btn--primary:hover {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--snippet.cds--snippet--multi .cds--popover-container {
+  right: 0.5rem;
+  top: 0.5rem;
+}
+.cds--snippet--multi .cds--copy-btn.cds--btn--md {
+  height: 2rem;
+  min-height: 2rem;
+  padding: 0;
+  width: 2rem;
+  z-index: 10;
+}
+.cds--snippet-btn--expand {
+  align-items: center;
+  background-color: var(--cds-layer);
+  border: 0;
+  bottom: 0;
+  display: inline-flex;
+  padding: 0.5rem 1rem;
+  position: absolute;
+  right: 0;
+  z-index: 10;
+}
+.cds--snippet-btn--expand .cds--snippet-btn--text {
+  position: relative;
+  top: -0.0625rem;
+}
+.cds--snippet-btn--expand--hide.cds--snippet-btn--expand {
+  display: none;
+}
+.cds--snippet-btn--expand .cds--icon-chevron--down {
+  fill: var(--cds-icon-primary, #161616);
+  margin-left: 0.5rem;
+  transform: rotate(0);
+  transition: 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--snippet-btn--expand:hover {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--snippet--light .cds--snippet__overflow-indicator--left,
+.cds--snippet__overflow-indicator--left {
+  background-image: linear-gradient(to left, transparent, var(--cds-layer));
+}
+.cds--snippet-btn--expand:active {
+  background-color: var(--cds-layer-active);
+}
+.cds--snippet-btn--expand:focus {
+  border-color: transparent;
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--snippet-btn--expand:focus {
+    outline-style: dotted;
+  }
+}
+.cds--snippet--expand .cds--snippet-btn--expand .cds--icon-chevron--down {
+  transform: rotate(180deg);
+  transition: transform 0.3s;
+}
+.cds--snippet--light,
+.cds--snippet--light .cds--btn.cds--snippet-btn--expand,
+.cds--snippet--light .cds--copy-btn,
+.cds--snippet--light .cds--snippet-button {
+  background-color: var(--cds-layer);
+}
+.cds--snippet--light .cds--btn.cds--snippet-btn--expand:hover,
+.cds--snippet--light .cds--copy-btn:hover,
+.cds--snippet--light .cds--snippet-button:hover,
+.cds--snippet--light.cds--snippet--inline:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--snippet--light .cds--btn.cds--snippet-btn--expand:active,
+.cds--snippet--light .cds--copy-btn:active,
+.cds--snippet--light .cds--snippet-button:active,
+.cds--snippet--light.cds--snippet--inline:active {
+  background-color: var(--cds-layer-active);
+}
+.cds--snippet--light.cds--snippet--multi .cds--snippet-container pre:after,
+.cds--snippet--light.cds--snippet--single:after {
+  background-image: linear-gradient(
+    to right,
+    rgba(var(--cds-layer), 0),
+    var(--cds-layer)
+  );
+}
+.cds--snippet.cds--skeleton .cds--snippet-container {
+  height: 100%;
+  width: 100%;
+}
+.cds--snippet-button .cds--btn--copy__feedback {
+  left: 50%;
+  right: auto;
+  top: 3.175rem;
+}
+.cds--snippet-button .cds--btn--copy__feedback:before {
+  top: 0;
+}
+.cds--snippet-button .cds--btn--copy__feedback:after {
+  top: -0.25rem;
+}
+.cds--snippet--multi .cds--snippet-button .cds--btn--copy__feedback {
+  top: 2.675rem;
+}
+.cds--snippet--inline .cds--btn--copy__feedback {
+  left: 50%;
+  right: auto;
+  top: calc(100% - 0.25rem);
+}
+.cds--snippet__overflow-indicator--left,
+.cds--snippet__overflow-indicator--right {
+  flex: 1 0 auto;
+  width: 1rem;
+  z-index: 1;
+}
+.cds--snippet__overflow-indicator--left {
+  margin-right: -1rem;
+  order: 0;
+}
+.cds--snippet__overflow-indicator--right {
+  background-image: linear-gradient(to right, transparent, var(--cds-layer));
+  margin-left: -1rem;
+  order: 2;
+}
+.cds--date-picker ~ .cds--label,
+.cds--number__control-btn.down-icon {
+  order: 1;
+}
+.cds--snippet--single .cds--snippet__overflow-indicator--left,
+.cds--snippet--single .cds--snippet__overflow-indicator--right {
+  height: calc(100% - 0.25rem);
+  position: absolute;
+  width: 2rem;
+}
+.cds--snippet--single .cds--snippet__overflow-indicator--right {
+  right: 2.5rem;
+}
+.cds--snippet--single.cds--snippet--no-copy
+  .cds--snippet__overflow-indicator--right {
+  right: 0;
+}
+.cds--snippet--single
+  .cds--snippet-container:focus
+  ~ .cds--snippet__overflow-indicator--right {
+  right: 2.625rem;
+}
+.cds--snippet--single
+  .cds--snippet-container:focus
+  + .cds--snippet__overflow-indicator--left {
+  left: 0.125rem;
+}
+.cds--snippet--light .cds--snippet__overflow-indicator--right {
+  background-image: linear-gradient(to right, transparent, var(--cds-layer));
+}
+.cds--snippet--multi.cds--skeleton {
+  height: 6.125rem;
+}
+.cds--snippet--single.cds--skeleton {
+  height: 3.5rem;
+}
+.cds--snippet.cds--skeleton span {
+  border: none;
+  display: block;
+  height: 1rem;
+  margin-top: 0.5rem;
+  padding: 0;
+  position: relative;
+  width: 100%;
+}
+.cds--snippet.cds--skeleton span:active,
+.cds--snippet.cds--skeleton span:focus,
+.cds--snippet.cds--skeleton span:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--snippet.cds--skeleton span:before {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--checkbox-label-text.cds--skeleton:before,
+  .cds--snippet.cds--skeleton span:before {
+    animation: none;
+  }
+}
+.cds--snippet.cds--skeleton span:first-child {
+  margin: 0;
+}
+.cds--snippet.cds--skeleton span:nth-child(2) {
+  width: 85%;
+}
+.cds--snippet.cds--skeleton span:nth-child(3) {
+  width: 95%;
+}
+.cds--snippet--single.cds--skeleton .cds--snippet-container {
+  padding-bottom: 0;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--snippet__icon {
+    fill: ButtonText;
+  }
+  .cds--snippet--inline:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--snippet--multi,
+  .cds--snippet--single {
+    outline: 1px solid transparent;
+  }
+}
+.cds--text-input {
+  background-color: var(--cds-field);
+  border: none;
+  border-bottom: 1px solid var(--cds-border-strong);
+  font-family: inherit;
+  height: 2.5rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0 1rem;
+  transition:
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--password-input,
+.cds--text-input--invalid,
+.cds--text-input--warning {
+  padding-right: 2.5rem;
+}
+.cds--data-table tbody tr,
+.cds--data-table tbody tr td,
+.cds--data-table tbody tr th,
+.cds--data-table th.cds--table-column-checkbox,
+.cds--tag--interactive {
+  transition: background-color 70ms cubic-bezier(0, 0, 0.38, 0.9);
+}
+.cds--text-input body {
+  font-weight: 400;
+}
+.cds--text-input code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--text-input strong {
+  font-weight: 600;
+}
+.cds--text-input:active,
+.cds--text-input:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--text-input:active,
+  .cds--text-input:focus {
+    outline-style: dotted;
+  }
+}
+.cds--text-input--password__visibility:focus,
+.cds--text-input--password__visibility:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+.cds--text-input-wrapper svg[hidden] {
+  display: none;
+}
+.cds--text-input--lg {
+  height: 3rem;
+}
+.cds--text-input--sm {
+  height: 2rem;
+}
+.cds--text-input--lg.cds--password-input {
+  padding-right: 3rem;
+}
+.cds--text-input::-moz-placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  opacity: 1;
+}
+.cds--text-input::placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  opacity: 1;
+}
+.cds--text-input--light {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--text-input__field-wrapper {
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+.cds--text-input__invalid-icon {
+  fill: var(--cds-support-error, #da1e28);
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.cds--text-input__invalid-icon--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--text-input__invalid-icon--warning path:first-of-type {
+  fill: #000;
+  opacity: 1;
+}
+.cds--text-input--password__visibility {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  overflow: visible;
+  position: relative;
+}
+@media screen and (prefers-contrast) {
+  .cds--text-input--password__visibility:focus,
+  .cds--text-input--password__visibility:focus svg {
+    outline-style: dotted;
+  }
+}
+.cds--text-input--password__visibility:focus {
+  outline: 1px solid transparent;
+}
+.cds--text-input--password__visibility .cds--assistive-text,
+.cds--text-input--password__visibility + .cds--assistive-text,
+.cds--text-input--password__visibility:after,
+.cds--text-input--password__visibility:before {
+  align-items: center;
+  bottom: 0;
+  display: flex;
+  left: 50%;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 6000;
+}
+.cds--text-input--password__visibility:after,
+.cds--text-input--password__visibility:before {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--text-input--password__visibility:after,
+  .cds--text-input--password__visibility:before {
+    transition: none;
+  }
+}
+.cds--text-input--password__visibility.cds--tooltip--a11y:after,
+.cds--text-input--password__visibility.cds--tooltip--a11y:before {
+  transition: none;
+}
+.cds--text-input--password__visibility:before {
+  border-style: solid;
+  content: '';
+  height: 0;
+  width: 0;
+}
+.cds--text-input--password__visibility .cds--assistive-text,
+.cds--text-input--password__visibility + .cds--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  opacity: 1;
+  white-space: normal;
+  word-break: break-word;
+}
+.cds--text-input--password__visibility .cds--assistive-text,
+.cds--text-input--password__visibility + .cds--assistive-text,
+.cds--text-input--password__visibility:after {
+  background-color: var(--cds-background-inverse, #393939);
+  border-radius: 0.125rem;
+  box-shadow: 0 2px 6px var(--cds-shadow, rgba(0, 0, 0, 0.3));
+  color: var(--cds-text-inverse, #fff);
+  font-weight: 400;
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  height: auto;
+  max-width: 13rem;
+  min-width: 1.5rem;
+  padding: 0.1875rem 1rem;
+  text-align: left;
+  transform: translateX(-50%);
+  width: -moz-max-content;
+  width: max-content;
+  z-index: 6000;
+}
+@media (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .cds--text-input--password__visibility .cds--assistive-text,
+  .cds--text-input--password__visibility + .cds--assistive-text,
+  .cds--text-input--password__visibility:after,
+  .cds--text-input--password__visibility:before {
+    display: inline-block;
+  }
+  .cds--text-input--password__visibility .cds--assistive-text,
+  .cds--text-input--password__visibility + .cds--assistive-text,
+  .cds--text-input--password__visibility:after {
+    width: auto;
+  }
+}
+@supports (-ms-accelerator: true) {
+  .cds--text-input--password__visibility .cds--assistive-text,
+  .cds--text-input--password__visibility + .cds--assistive-text,
+  .cds--text-input--password__visibility:after {
+    width: auto;
+  }
+}
+@supports (-ms-ime-align: auto) {
+  .cds--text-input--password__visibility .cds--assistive-text,
+  .cds--text-input--password__visibility + .cds--assistive-text,
+  .cds--text-input--password__visibility:after {
+    width: auto;
+  }
+}
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .cds--text-input--password__visibility .cds--assistive-text,
+  .cds--text-input--password__visibility + .cds--assistive-text,
+  .cds--text-input--password__visibility:after {
+    border: 1px solid transparent;
+  }
+}
+.cds--text-input--password__visibility:after {
+  content: attr(aria-label);
+}
+.cds--text-input--password__visibility.cds--tooltip--a11y:after {
+  content: none;
+}
+.cds--text-input--password__visibility.cds--tooltip--visible:after,
+.cds--text-input--password__visibility.cds--tooltip--visible:before,
+.cds--text-input--password__visibility:focus:after,
+.cds--text-input--password__visibility:focus:before,
+.cds--text-input--password__visibility:hover:after,
+.cds--text-input--password__visibility:hover:before {
+  opacity: 1;
+}
+@keyframes tooltip-fade {
+  0% {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.cds--text-input--password__visibility.cds--tooltip--visible
+  .cds--assistive-text,
+.cds--text-input--password__visibility.cds--tooltip--visible
+  + .cds--assistive-text,
+.cds--text-input--password__visibility:focus .cds--assistive-text,
+.cds--text-input--password__visibility:focus + .cds--assistive-text,
+.cds--text-input--password__visibility:hover .cds--assistive-text,
+.cds--text-input--password__visibility:hover + .cds--assistive-text {
+  clip: auto;
+  margin: auto;
+  overflow: visible;
+}
+.cds--text-input--password__visibility.cds--tooltip--hidden
+  .cds--assistive-text,
+.cds--text-input--password__visibility.cds--tooltip--hidden
+  + .cds--assistive-text,
+.cds--text-input__counter-alert {
+  clip: rect(0, 0, 0, 0);
+  margin: -1px;
+  overflow: hidden;
+}
+.cds--text-input--password__visibility.cds--tooltip--visible
+  .cds--assistive-text,
+.cds--text-input--password__visibility.cds--tooltip--visible
+  + .cds--assistive-text,
+.cds--text-input--password__visibility.cds--tooltip--visible.cds--tooltip--a11y:before,
+.cds--text-input--password__visibility:focus .cds--assistive-text,
+.cds--text-input--password__visibility:focus + .cds--assistive-text,
+.cds--text-input--password__visibility:focus.cds--tooltip--a11y:before,
+.cds--text-input--password__visibility:hover .cds--assistive-text,
+.cds--text-input--password__visibility:hover + .cds--assistive-text,
+.cds--text-input--password__visibility:hover.cds--tooltip--a11y:before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--text-input--password__visibility.cds--tooltip--hidden.cds--tooltip--a11y:before {
+  animation: none;
+  opacity: 0;
+}
+.cds--text-input--password__visibility .cds--assistive-text:after {
+  content: '';
+  display: block;
+  height: 0.75rem;
+  left: 0;
+  position: absolute;
+  top: -0.75rem;
+  width: 100%;
+}
+.cds--text-input--password__visibility:before {
+  border-color: transparent transparent var(--cds-background-inverse, #393939)
+    transparent;
+  border-width: 0 0.25rem 0.3125rem;
+  bottom: -0.5rem;
+  transform: translate(-50%, 100%);
+}
+.cds--text-input--password__visibility .cds--assistive-text,
+.cds--text-input--password__visibility + .cds--assistive-text,
+.cds--text-input--password__visibility:after {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+.cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger {
+  align-items: center;
+  background: 0 0;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  min-height: auto;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  transition: outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 2.5rem;
+}
+.cds--text-input--sm
+  + .cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger {
+  width: 2rem;
+}
+.cds--text-input--lg
+  + .cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger {
+  width: 3rem;
+}
+.cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger
+  svg {
+  fill: var(--cds-icon-secondary, #525252);
+  transition: fill 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger
+    svg {
+    fill: ButtonText;
+  }
+}
+.cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--tag--filter.cds--tag--disabled svg,
+.cds--text-input:disabled
+  ~ .cds--text-input--password__visibility__toggle.cds--tooltip__trigger
+  svg,
+.cds--text-input:disabled
+  ~ .cds--text-input--password__visibility__toggle.cds--tooltip__trigger
+  svg:hover {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--text-input--invalid.cds--password-input {
+  padding-right: 4rem;
+}
+.cds--text-input--invalid + .cds--text-input--password__visibility__toggle {
+  right: 1rem;
+}
+.cds--password-input-wrapper .cds--text-input__invalid-icon,
+.cds--text-input--invalid .cds--text-input--password__visibility__toggle {
+  right: 2.5rem;
+}
+.cds--text-input:disabled
+  ~ .cds--text-input--password__visibility__toggle.cds--tooltip__trigger {
+  cursor: not-allowed;
+}
+.cds--text-input__counter-alert {
+  border: 0;
+  height: 1px;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+.cds--text-input:disabled {
+  -webkit-text-fill-color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  background-color: var(--cds-field);
+  border-bottom: 1px solid transparent;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+.cds--text-input--light:disabled {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--text-input:disabled::-moz-placeholder {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  opacity: 1;
+}
+.cds--text-input:disabled::placeholder {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  opacity: 1;
+}
+.cds--text-input--invalid {
+  box-shadow: none;
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger:focus,
+  .cds--text-input--invalid {
+    outline-style: dotted;
+  }
+}
+.cds--list-box--inline .cds--list-box__menu-item__selected-icon,
+.cds--list-box.cds--list-box--inline .cds--list-box__menu-icon {
+  right: 0.5rem;
+}
+.cds--skeleton.cds--text-input {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+}
+.cds--skeleton.cds--text-input:active,
+.cds--skeleton.cds--text-input:focus,
+.cds--skeleton.cds--text-input:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--skeleton.cds--text-input:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+.cds--form--fluid .cds--text-input-wrapper {
+  background: var(--cds-field);
+  position: relative;
+  transition:
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--form--fluid .cds--label {
+  align-items: center;
+  display: flex;
+  height: 1rem;
+  left: 1rem;
+  margin: 0;
+  position: absolute;
+  top: 0.8125rem;
+  z-index: 1;
+}
+.cds--form--fluid .cds--form__helper-text,
+.cds--form--fluid .cds--text-input__divider,
+.cds--text-input__divider {
+  display: none;
+}
+.cds--form--fluid .cds--text-input {
+  min-height: 4rem;
+  padding: 2rem 1rem 0.8125rem;
+}
+.cds--form--fluid .cds--text-input--invalid,
+.cds--form--fluid .cds--text-input--warning {
+  border-bottom: none;
+}
+.cds--form--fluid .cds--text-input--invalid + .cds--text-input__divider,
+.cds--form--fluid .cds--text-input--warning + .cds--text-input__divider {
+  border-color: var(--cds-border-subtle);
+  border-style: solid;
+  border-bottom: none;
+  display: block;
+  margin: 0 1rem;
+}
+.cds--form--fluid .cds--text-input__invalid-icon {
+  top: 5rem;
+}
+.cds--form--fluid
+  .cds--text-input__field-wrapper--warning
+  > .cds--text-input--warning,
+.cds--form--fluid
+  .cds--text-input__field-wrapper[data-invalid]
+  > .cds--text-input--invalid {
+  outline: 0;
+}
+.cds--form--fluid .cds--text-input__field-wrapper--warning {
+  border-bottom: 1px solid var(--cds-border-strong);
+}
+.cds--form--fluid .cds--text-input__field-wrapper[data-invalid]:not(:focus) {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--form--fluid .cds--text-input__field-wrapper[data-invalid]:not(:focus) {
+    outline-style: dotted;
+  }
+}
+.cds--form--fluid .cds--text-input__field-wrapper--warning:focus-within,
+.cds--form--fluid .cds--text-input__field-wrapper[data-invalid]:focus-within {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--form--fluid .cds--text-input__field-wrapper--warning:focus-within,
+  .cds--form--fluid .cds--text-input__field-wrapper[data-invalid]:focus-within {
+    outline-style: dotted;
+  }
+}
+.cds--form--fluid
+  .cds--text-input__field-wrapper--warning
+  > .cds--text-input--warning:focus,
+.cds--form--fluid
+  .cds--text-input__field-wrapper[data-invalid]
+  > .cds--text-input--invalid:focus {
+  outline: 0;
+}
+.cds--text-input-wrapper.cds--text-input-wrapper--inline {
+  flex-flow: row wrap;
+}
+.cds--text-input-wrapper .cds--label--inline {
+  flex: 1;
+  margin: 0.8125rem 0 0;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+.cds--text-input-wrapper .cds--label--inline--sm {
+  margin-top: 0.5625rem;
+}
+.cds--text-input-wrapper .cds--label--inline--lg {
+  margin-top: 1.0625rem;
+}
+.cds--text-input__label-helper-wrapper {
+  flex: 2;
+  flex-direction: column;
+  margin-right: 1.5rem;
+  max-width: 8rem;
+  overflow-wrap: break-word;
+}
+.cds--text-input-wrapper .cds--form__helper-text--inline {
+  margin-top: 0.125rem;
+}
+.cds--text-input__field-outer-wrapper {
+  align-items: flex-start;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  width: 100%;
+}
+.cds--text-input__field-outer-wrapper--inline {
+  flex: 8;
+  flex-direction: column;
+}
+.cds--text-input-wrapper--inline .cds--form-requirement {
+  display: block;
+  font-weight: 400;
+  max-height: 12.5rem;
+  overflow: visible;
+}
+.cds--text-input-wrapper--inline--invalid .cds--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+}
+.cds--form--fluid .cds--text-input-wrapper--readonly,
+.cds--text-input-wrapper--readonly .cds--text-input {
+  background: 0 0;
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--text-input__label-wrapper,
+.flatpickr-months {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+.cds--text-input__label-wrapper .cds--text-input__label-counter {
+  align-self: end;
+}
+.cds--tag {
+  align-items: center;
+  background-color: var(--cds-tag-background-gray, #e0e0e0);
+  border-radius: 0.9375rem;
+  color: var(--cds-tag-color-gray, #393939);
+  cursor: default;
+  display: inline-flex;
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  justify-content: center;
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+  margin: 0.25rem;
+  max-width: 100%;
+  min-height: 1.5rem;
+  min-width: 2rem;
+  padding: 0.25rem 0.5rem;
+  vertical-align: middle;
+  word-break: break-word;
+}
+.cds--list-box__label,
+.cds--list-box__wrapper--inline .cds--label {
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--tag .cds--tag__close-icon:hover,
+.cds--tag.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-gray, #c6c6c6);
+}
+.cds--tag:not(:first-child) {
+  margin-left: 0;
+}
+.cds--tag--red {
+  background-color: var(--cds-tag-background-red, #ffd7d9);
+  color: var(--cds-tag-color-red, #750e13);
+}
+.cds--tag--red .cds--tag__close-icon:hover,
+.cds--tag--red.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-red, #ffb3b8);
+}
+.cds--tag--magenta {
+  background-color: var(--cds-tag-background-magenta, #ffd6e8);
+  color: var(--cds-tag-color-magenta, #740937);
+}
+.cds--tag--magenta .cds--tag__close-icon:hover,
+.cds--tag--magenta.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-magenta, #ffafd2);
+}
+.cds--tag--purple {
+  background-color: var(--cds-tag-background-purple, #e8daff);
+  color: var(--cds-tag-color-purple, #491d8b);
+}
+.cds--tag--purple .cds--tag__close-icon:hover,
+.cds--tag--purple.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-purple, #d4bbff);
+}
+.cds--tag--blue {
+  background-color: var(--cds-tag-background-blue, #d0e2ff);
+  color: var(--cds-tag-color-blue, #002d9c);
+}
+.cds--tag--blue .cds--tag__close-icon:hover,
+.cds--tag--blue.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-blue, #a6c8ff);
+}
+.cds--tag--cyan {
+  background-color: var(--cds-tag-background-cyan, #bae6ff);
+  color: var(--cds-tag-color-cyan, #003a6d);
+}
+.cds--tag--cyan .cds--tag__close-icon:hover,
+.cds--tag--cyan.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-cyan, #82cfff);
+}
+.cds--tag--teal {
+  background-color: var(--cds-tag-background-teal, #9ef0f0);
+  color: var(--cds-tag-color-teal, #004144);
+}
+.cds--tag--teal .cds--tag__close-icon:hover,
+.cds--tag--teal.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-teal, #3ddbd9);
+}
+.cds--tag--green {
+  background-color: var(--cds-tag-background-green, #a7f0ba);
+  color: var(--cds-tag-color-green, #044317);
+}
+.cds--tag--green .cds--tag__close-icon:hover,
+.cds--tag--green.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-green, #6fdc8c);
+}
+.cds--tag--gray {
+  background-color: var(--cds-tag-background-gray, #e0e0e0);
+  color: var(--cds-tag-color-gray, #393939);
+}
+.cds--tag--gray .cds--tag__close-icon:hover,
+.cds--tag--gray.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-gray, #c6c6c6);
+}
+.cds--tag--cool-gray {
+  background-color: var(--cds-tag-background-cool-gray, #dde1e6);
+  color: var(--cds-tag-color-cool-gray, #343a3f);
+}
+.cds--tag--cool-gray .cds--tag__close-icon:hover,
+.cds--tag--cool-gray.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-cool-gray, #c1c7cd);
+}
+.cds--tag--warm-gray {
+  background-color: var(--cds-tag-background-warm-gray, #e5e0df);
+  color: var(--cds-tag-color-warm-gray, #3c3838);
+}
+.cds--tag--warm-gray .cds--tag__close-icon:hover,
+.cds--tag--warm-gray.cds--tag--interactive:hover {
+  background-color: var(--cds-tag-hover-warm-gray, #cac5c4);
+}
+.cds--tag--high-contrast {
+  background-color: var(--cds-background-inverse, #393939);
+  color: var(--cds-text-inverse, #fff);
+}
+.cds--tag--high-contrast .cds--tag__close-icon:hover,
+.cds--tag--high-contrast.cds--tag--interactive:hover {
+  background-color: var(--cds-background-inverse-hover, #474747);
+}
+.cds--tag--outline {
+  background-color: var(--cds-background, #fff);
+  box-shadow: 0 0 0 1px var(--cds-background-inverse, #393939);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--tag--outline .cds--tag__close-icon:hover,
+.cds--tag--outline.cds--tag--interactive:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--tag--disabled,
+.cds--tag--filter.cds--tag--disabled,
+.cds--tag--interactive.cds--tag--disabled {
+  background-color: var(--cds-layer);
+  box-shadow: none;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--tag--interactive:focus,
+.cds--tag__close-icon:focus {
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe);
+  outline: 0;
+}
+.cds--tag--disabled .cds--tag__close-icon:hover,
+.cds--tag--disabled.cds--tag--interactive:hover,
+.cds--tag--filter.cds--tag--disabled .cds--tag__close-icon:hover,
+.cds--tag--filter.cds--tag--disabled.cds--tag--interactive:hover,
+.cds--tag--interactive.cds--tag--disabled .cds--tag__close-icon:hover,
+.cds--tag--interactive.cds--tag--disabled.cds--tag--interactive:hover {
+  background-color: var(--cds-layer);
+}
+.cds--tag--filter.cds--tag--disabled .cds--tag__close-icon:hover,
+.cds--tag__close-icon,
+.cds--tag__custom-icon {
+  background-color: transparent;
+}
+.cds--tag--disabled:hover,
+.cds--tag--filter.cds--tag--disabled:hover,
+.cds--tag--interactive.cds--tag--disabled:hover {
+  cursor: not-allowed;
+}
+.cds--tag__label {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--tag--interactive:hover,
+.flatpickr-input[readonly] {
+  cursor: pointer;
+}
+.cds--tag--filter {
+  cursor: pointer;
+  padding-bottom: 0;
+  padding-right: 0;
+  padding-top: 0;
+}
+.cds--tag--filter:hover {
+  outline: 0;
+}
+.cds--tag__close-icon {
+  align-items: center;
+  border: 0;
+  border-radius: 50%;
+  color: currentColor;
+  cursor: pointer;
+  display: flex;
+  flex-shrink: 0;
+  height: 1.5rem;
+  justify-content: center;
+  margin: 0 0 0 0.125rem;
+  padding: 0;
+  transition:
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    box-shadow 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 1.5rem;
+}
+.cds--tag__custom-icon {
+  border: 0;
+  color: currentColor;
+  flex-shrink: 0;
+  height: 1rem;
+  margin-right: 0.25rem;
+  outline: 0;
+  padding: 0;
+  width: 1rem;
+}
+.cds--tag--disabled .cds--tag__close-icon {
+  cursor: not-allowed;
+}
+.cds--tag__close-icon:focus {
+  border-radius: 50%;
+}
+.cds--tag--high-contrast .cds--tag__close-icon:focus {
+  box-shadow: inset 0 0 0 1px var(--cds-focus-inverse, #fff);
+}
+.cds--tag.cds--skeleton,
+.cds--tag.cds--skeleton .cds--tag__close-icon:hover,
+.cds--tag.cds--skeleton.cds--tag--interactive:hover {
+  background-color: var(--cds-skeleton-background, #e8e8e8);
+}
+.cds--tag--sm {
+  min-height: 1.125rem;
+  padding: 0 0.5rem;
+}
+.cds--tag--sm.cds--tag--filter {
+  padding-right: 0;
+}
+.cds--tag--sm .cds--tag__close-icon {
+  height: 1.125rem;
+  margin-left: 0.3125rem;
+  width: 1.125rem;
+}
+.cds--tag.cds--skeleton {
+  color: var(--cds-text-primary, #161616);
+  overflow: hidden;
+  width: 3.75rem;
+}
+@media not all and (-webkit-min-device-pixel-ratio: 0),
+  not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .cds--snippet__overflow-indicator--left {
+      background-image: linear-gradient(
+        to left,
+        rgba(var(--cds-layer), 0),
+        var(--cds-layer)
+      );
+    }
+    .cds--snippet__overflow-indicator--right {
+      background-image: linear-gradient(
+        to right,
+        rgba(var(--cds-layer), 0),
+        var(--cds-layer)
+      );
+    }
+    .cds--tag.cds--skeleton {
+      transform: translateZ(0);
+    }
+    circle.cds--loading__background {
+      stroke-dasharray: 265;
+      stroke-dashoffset: 0;
+    }
+  }
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--btn.cds--btn--icon-only.cds--text-input--password__visibility__toggle.cds--tooltip__trigger
+    svg,
+  .cds--btn.cds--btn--icon-only.cds--text-input--password__visibility__toggle.cds--tooltip__trigger:hover
+    svg {
+    fill: ButtonText;
+  }
+  .cds--tag {
+    outline: 1px solid transparent;
+  }
+  .cds--tag__close-icon svg,
+  .cds--tag__custom-icon svg {
+    fill: ButtonText;
+  }
+  .cds--tag__close-icon:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+}
+.cds--list-box__wrapper--inline {
+  grid-gap: 0.25rem;
+  align-items: center;
+  display: inline-grid;
+  grid-template: auto auto/auto auto;
+}
+.cds--list-box__wrapper--inline .cds--label {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+}
+.cds--contained-list--on-page .cds--contained-list__header,
+.cds--data-table thead {
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+}
+.cds--list-box__wrapper--inline .cds--form-requirement,
+.cds--list-box__wrapper--inline .cds--form__helper-text,
+.cds--list-box__wrapper--inline .cds--label {
+  margin: 0;
+}
+.cds--list-box__wrapper--inline .cds--form__helper-text {
+  max-width: none;
+}
+.cds--list-box {
+  background-color: var(--cds-field);
+  border: none;
+  border-bottom: 1px solid var(--cds-border-strong);
+  color: var(--cds-text-primary, #161616);
+  cursor: pointer;
+  height: 2.5rem;
+  max-height: 2.5rem;
+  position: relative;
+  transition: 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--list-box--disabled,
+.cds--list-box--disabled .cds--list-box__field,
+.cds--list-box--disabled .cds--list-box__menu-icon,
+.cds--list-box--disabled .cds--list-box__selection:hover {
+  cursor: not-allowed;
+}
+.cds--list-box html {
+  font-size: 100%;
+}
+.cds--list-box body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--list-box code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--list-box strong {
+  font-weight: 600;
+}
+.cds--list-box:hover {
+  background-color: var(--cds-field-hover);
+}
+.cds--list-box--lg {
+  height: 3rem;
+  max-height: 3rem;
+}
+.cds--list-box--sm {
+  height: 2rem;
+  max-height: 2rem;
+}
+.cds--list-box--expanded {
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--list-box--expanded:hover {
+  background-color: var(--cds-field);
+}
+.cds--list-box--expanded:hover.cds--list-box--light:hover {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--list-box .cds--text-input {
+  height: 100%;
+  min-width: 0;
+}
+.cds--list-box__invalid-icon {
+  fill: var(--cds-support-error, #da1e28);
+  position: absolute;
+  right: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.cds--list-box__invalid-icon--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--list-box__menu-icon > svg,
+.cds--list-box__selection > svg {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--list-box__invalid-icon--warning path[fill] {
+  fill: #000;
+  opacity: 1;
+}
+.cds--combo-box--readonly .cds--list-box__menu-icon svg,
+.cds--combo-box--readonly .cds--list-box__selection svg,
+.cds--list-box--disabled .cds--list-box__menu-icon > svg,
+.cds--list-box--disabled .cds--list-box__selection--multi > svg,
+.cds--list-box--disabled .cds--list-box__selection > svg {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--list-box.cds--list-box--warning .cds--list-box__field,
+.cds--list-box[data-invalid] .cds--list-box__field {
+  border-bottom: 0;
+  padding-right: 4rem;
+}
+.cds--list-box.cds--list-box--warning.cds--list-box--inline
+  .cds--list-box__field,
+.cds--list-box[data-invalid].cds--list-box--inline .cds--list-box__field {
+  padding-right: 3.5rem;
+}
+.cds--list-box--light {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--list-box--light:hover {
+  background-color: var(--cds-field-hover);
+}
+.cds--list-box--light .cds--list-box__menu {
+  background: var(--cds-layer);
+}
+.cds--list-box--light .cds--list-box__menu-item__option {
+  border-top-color: var(--cds-border-subtle);
+}
+.cds--list-box--light.cds--list-box--expanded {
+  border-bottom-color: transparent;
+}
+.cds--list-box--disabled:hover {
+  background-color: var(--cds-field);
+}
+.cds--list-box--light.cds--list-box--disabled {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--list-box--disabled,
+.cds--list-box--disabled .cds--list-box__field,
+.cds--list-box--disabled .cds--list-box__field:focus {
+  border-bottom-color: transparent;
+  outline: 0;
+}
+.cds--list-box--disabled .cds--list-box__label,
+.cds--list-box--disabled.cds--list-box--inline .cds--list-box__label {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--list-box--disabled .cds--list-box__menu-item,
+.cds--list-box--disabled .cds--list-box__menu-item--highlighted,
+.cds--list-box--disabled .cds--list-box__menu-item:hover {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  text-decoration: none;
+}
+.cds--list-box--inline .cds--list-box__label,
+.cds--list-box__label {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--actionable-notification a:hover,
+.cds--file-browse-btn:active,
+.cds--file-browse-btn:active:visited,
+.cds--file-browse-btn:focus,
+.cds--file-browse-btn:hover,
+.cds--inline-notification a:hover,
+.cds--toast-notification a:hover,
+div.container.tutorial .hljs-class .hljs-title,
+div.container.tutorial .hljs-doctag,
+div.container.tutorial .hljs-title.class_ {
+  text-decoration: underline;
+}
+.cds--list-box--disabled.cds--list-box[data-invalid] .cds--list-box__field {
+  padding-right: 3rem;
+}
+.cds--list-box.cds--list-box--inline {
+  background-color: transparent;
+  border-width: 0;
+}
+.cds--list-box.cds--list-box--inline:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--list-box.cds--list-box--inline.cds--list-box--expanded {
+  border-bottom-width: 0;
+}
+.cds--list-box.cds--list-box--inline.cds--list-box--expanded
+  .cds--list-box__field[aria-expanded='true'] {
+  border-width: 0;
+}
+.cds--list-box.cds--list-box--inline.cds--list-box--disabled:hover,
+.cds--list-box.cds--list-box--inline.cds--list-box--expanded:hover {
+  background-color: transparent;
+}
+.cds--list-box--disabled .cds--list-box__selection--multi,
+.cds--list-box--disabled
+  .cds--list-box__selection--multi
+  .cds--tag__close-icon:hover,
+.cds--list-box--disabled
+  .cds--list-box__selection--multi.cds--tag--interactive:hover {
+  background-color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--list-box.cds--list-box--inline .cds--list-box__field {
+  padding: 0 2rem 0 0.5rem;
+}
+.cds--list-box.cds--list-box--inline .cds--list-box__invalid-icon {
+  right: 2rem;
+}
+.cds--list-box--inline .cds--list-box__field {
+  height: 100%;
+}
+.cds--dropdown--inline .cds--list-box__field {
+  max-width: 30rem;
+}
+.cds--dropdown--inline .cds--list-box__menu {
+  max-width: 30rem;
+  min-width: 18rem;
+}
+.cds--list-box__field {
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  cursor: pointer;
+  display: inline-block;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: 100%;
+  height: calc(100% + 1px);
+  margin: 0;
+  outline: 0;
+  overflow: hidden;
+  padding: 0 3rem 0 1rem;
+  position: relative;
+  text-align: start;
+  text-overflow: ellipsis;
+  vertical-align: top;
+  white-space: nowrap;
+  width: 100%;
+}
+.cds--list-box__field *,
+.cds--list-box__field :after,
+.cds--list-box__field :before {
+  box-sizing: inherit;
+}
+.cds--list-box__field::-moz-focus-inner {
+  border: 0;
+}
+.cds--list-box__field:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--list-box__field:focus {
+    outline-style: dotted;
+  }
+}
+.cds--list-box__field[disabled] {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  outline: 0;
+}
+.cds--list-box__field .cds--text-input {
+  padding-right: 4.5rem;
+}
+.cds--list-box--warning .cds--list-box__field .cds--text-input,
+.cds--list-box[data-invalid] .cds--list-box__field .cds--text-input {
+  padding-right: 6.125rem;
+}
+.cds--list-box--warning
+  .cds--list-box__field
+  .cds--text-input
+  + .cds--list-box__invalid-icon,
+.cds--list-box[data-invalid]
+  .cds--list-box__field
+  .cds--text-input
+  + .cds--list-box__invalid-icon {
+  right: 4.125rem;
+}
+.cds--list-box__field .cds--text-input--empty {
+  padding-right: 3rem;
+}
+.cds--list-box--warning .cds--list-box__field .cds--text-input--empty,
+.cds--list-box[data-invalid] .cds--list-box__field .cds--text-input--empty {
+  padding-right: carbon--mini-units(9);
+}
+.cds--list-box--warning
+  .cds--list-box__field
+  .cds--text-input--empty
+  + .cds--list-box__invalid-icon,
+.cds--list-box[data-invalid]
+  .cds--list-box__field
+  .cds--text-input--empty
+  + .cds--list-box__invalid-icon {
+  right: 2.5rem;
+}
+.cds--list-box__label {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  white-space: nowrap;
+}
+.cds--list-box__menu-icon,
+.cds--list-box__selection {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 100%;
+  height: 1.5rem;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  text-align: start;
+  vertical-align: baseline;
+  width: 1.5rem;
+}
+.cds--list-box__menu-icon {
+  align-items: center;
+  box-sizing: border-box;
+  display: inline-block;
+  display: flex;
+  justify-content: center;
+  outline: 0;
+  right: 1rem;
+  transition: transform 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--list-box__menu-icon *,
+.cds--list-box__menu-icon :after,
+.cds--list-box__menu-icon :before {
+  box-sizing: inherit;
+}
+.cds--list-box__menu-icon::-moz-focus-inner {
+  border: 0;
+}
+.cds--list-box__menu-icon--open {
+  justify-content: center;
+  transform: rotate(180deg);
+  width: 1.5rem;
+}
+.cds--list-box__selection {
+  align-items: center;
+  box-sizing: border-box;
+  display: inline-block;
+  display: flex;
+  justify-content: center;
+  right: 2.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.cds--content-switcher-btn,
+.cds--content-switcher-btn body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+}
+.cds--list-box__selection *,
+.cds--list-box__selection :after,
+.cds--list-box__selection :before {
+  box-sizing: inherit;
+}
+.cds--list-box__selection::-moz-focus-inner {
+  border: 0;
+}
+.cds--list-box--disabled
+  .cds--list-box__menu-item:hover
+  + .cds--list-box__menu-item
+  .cds--list-box__menu-item__option,
+.cds--list-box--disabled .cds--list-box__menu-item__option:hover {
+  border-top-color: var(--cds-border-subtle);
+}
+.cds--list-box__selection:focus,
+.cds--list-box__selection:focus:hover {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--list-box__selection:focus,
+  .cds--list-box__selection:focus:hover {
+    outline-style: dotted;
+  }
+}
+.cds--list-box--disabled .cds--list-box__selection:focus,
+.cds--list-box__selection--multi:hover {
+  outline: 0;
+}
+.cds--list-box__selection--multi {
+  align-items: center;
+  background-color: var(--cds-background-inverse, #393939);
+  border-radius: 0.75rem;
+  color: var(--cds-text-inverse, #fff);
+  display: flex;
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  height: 1.5rem;
+  justify-content: space-between;
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+  line-height: 0;
+  margin-right: 0.625rem;
+  padding: 0.5rem 0.125rem 0.5rem 0.5rem;
+  position: static;
+  top: auto;
+  transform: none;
+  width: auto;
+}
+.cds--list-box__selection--multi > svg {
+  fill: var(--cds-icon-inverse, #fff);
+  height: 1.25rem;
+  margin-left: 0.25rem;
+  padding: 0.125rem;
+  width: 1.25rem;
+}
+.cds--list-box__selection--multi > svg:hover {
+  background-color: var(--cds-button-secondary-hover, #474747);
+  border-radius: 50%;
+}
+.cds--list-box--disabled .cds--list-box__selection--multi {
+  color: var(--cds-layer);
+}
+.cds--list-box--light .cds--list-box__menu-item:hover,
+.cds--list-box__menu-item:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--list-box--disabled .cds--list-box__selection--multi > svg:hover {
+  background-color: initial;
+}
+.cds--list-box__menu {
+  background-color: var(--cds-layer);
+  box-shadow: 0 2px 6px var(--cds-shadow, rgba(0, 0, 0, 0.3));
+  left: 0;
+  overflow-y: auto;
+  position: absolute;
+  right: 0;
+  transition: max-height 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+  z-index: 9100;
+}
+.cds--list-box__menu:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+@media screen and (prefers-contrast) {
+  .cds--list-box__menu:focus {
+    outline-style: dotted;
+  }
+}
+.cds--list-box
+  .cds--list-box__field[aria-expanded='false']
+  + .cds--list-box__menu {
+  display: none;
+  max-height: 0;
+}
+.cds--list-box--expanded .cds--list-box__menu {
+  display: block;
+  max-height: 13.75rem;
+}
+.cds--list-box--expanded.cds--list-box--lg .cds--list-box__menu {
+  max-height: 16.5rem;
+}
+.cds--dropdown--open.cds--dropdown--sm .cds--dropdown-list,
+.cds--list-box--expanded.cds--list-box--sm .cds--list-box__menu {
+  max-height: 11rem;
+}
+.cds--list-box__menu-item {
+  color: var(--cds-text-secondary, #525252);
+  cursor: pointer;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  height: 2.5rem;
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  position: relative;
+  transition: background 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.cds--list-box__menu-item:active {
+  background-color: var(--cds-layer-selected);
+}
+.cds--list-box--sm .cds--list-box__menu-item {
+  height: 2rem;
+}
+.cds--list-box--lg .cds--list-box__menu-item {
+  height: 3rem;
+}
+.cds--list-box--disabled .cds--list-box__menu-item:hover {
+  background-color: transparent;
+}
+.cds--list-box--light .cds--list-box__menu-item:active {
+  background-color: var(--cds-layer-selected);
+}
+.cds--list-box__menu-item:first-of-type .cds--list-box__menu-item__option,
+.cds--list-box__menu-item:hover
+  + .cds--list-box__menu-item
+  .cds--list-box__menu-item__option {
+  border-top-color: transparent;
+}
+.cds--list-box__menu-item:hover .cds--list-box__menu-item__option {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--list-box__menu-item__option {
+  border-bottom: 1px solid transparent;
+  border-top: 1px solid transparent;
+  border-top-color: var(--cds-border-subtle);
+  color: var(--cds-text-secondary, #525252);
+  display: block;
+  font-weight: 400;
+  height: 2.5rem;
+  line-height: 1rem;
+  margin: 0 1rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  overflow: hidden;
+  padding: 0.6875rem 1.5rem 0.6875rem 0;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  transition:
+    border-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  white-space: nowrap;
+}
+.cds--action-list .cds--btn--primary:after,
+.cds--action-list .cds--btn--primary:before,
+.cds--action-list .cds--btn--primary:focus:after,
+.cds--action-list .cds--btn--primary:focus:before,
+.cds--content-switcher--icon-only
+  .cds--content-switcher-popover__wrapper:first-of-type
+  .cds--content-switcher-btn:before,
+.cds--content-switcher-btn:disabled:after,
+.cds--content-switcher:not(.cds--content-switcher--icon-only)
+  .cds--content-switcher-btn:first-of-type:before,
+.cds--toolbar-search-container-persistent .cds--search-close:before {
+  display: none;
+}
+.cds--list-box__menu-item__option:focus {
+  border-color: transparent;
+  margin: 0;
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  padding: 0.6875rem 1rem;
+}
+@media screen and (prefers-contrast) {
+  .cds--list-box__menu-item__option:focus {
+    outline-style: dotted;
+  }
+}
+.cds--list-box__menu-item__option:hover {
+  border-color: transparent;
+  color: var(--cds-text-primary, #161616);
+}
+.cds--list-box--sm .cds--list-box__menu-item__option {
+  height: 2rem;
+  padding-bottom: 0.4375rem;
+  padding-top: 0.4375rem;
+}
+.cds--list-box--lg .cds--list-box__menu-item__option {
+  height: 3rem;
+  padding-bottom: 0.9375rem;
+  padding-top: 0.9375rem;
+}
+.cds--list-box--disabled
+  .cds--list-box__menu-item:hover
+  .cds--list-box__menu-item__option,
+.cds--list-box--disabled .cds--list-box__menu-item__option {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--list-box__menu-item[disabled],
+.cds--list-box__menu-item[disabled] *,
+.cds--list-box__menu-item[disabled] .cds--list-box__menu-item__option,
+.cds--list-box__menu-item[disabled]:hover {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+  outline: 0;
+}
+.cds--list-box__menu-item--active,
+.cds--list-box__menu-item--active .cds--list-box__menu-item__option,
+.cds--list-box__menu-item--highlighted .cds--list-box__menu-item__option {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--list-box__menu-item[disabled]:hover {
+  background-color: revert;
+}
+.cds--list-box__menu-item[disabled] .cds--checkbox-label:before {
+  border-color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--list-box__menu-item[disabled] .cds--list-box__menu-item__option,
+.cds--list-box__menu-item[disabled]:hover
+  + .cds--list-box__menu-item
+  .cds--list-box__menu-item__option {
+  border-top-color: var(--cds-border-subtle);
+}
+.cds--list-box__menu-item--active
+  + .cds--list-box__menu-item
+  > .cds--list-box__menu-item__option,
+.cds--list-box__menu-item--highlighted .cds--list-box__menu-item__option,
+.cds--list-box__menu-item--highlighted
+  + .cds--list-box__menu-item
+  .cds--list-box__menu-item__option {
+  border-top-color: transparent;
+}
+.cds--list-box.cds--list-box--inline .cds--list-box__menu-item__option {
+  margin: 0 0.5rem;
+}
+.cds--list-box.cds--list-box--inline .cds--list-box__menu-item__option:focus {
+  margin: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+.cds--list-box__menu-item--highlighted {
+  background-color: var(--cds-layer-selected);
+  border-color: transparent;
+  color: var(--cds-text-primary, #161616);
+}
+.cds--list-box--light .cds--list-box__menu-item--active,
+.cds--list-box__menu-item--active {
+  background-color: var(--cds-layer-selected);
+  border-bottom-color: var(--cds-layer-selected);
+}
+.cds--list-box__menu-item--active:hover {
+  background-color: var(--cds-layer-selected-hover);
+  border-bottom-color: var(--cds-layer-selected-hover);
+}
+.cds--combo-box--readonly .cds--text-input,
+.cds--combo-box.cds--list-box--expanded .cds--text-input {
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--list-box__menu-item__selected-icon {
+  fill: var(--cds-icon-primary, #161616);
+  display: none;
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.cds--list-box__menu-item--active .cds--list-box__menu-item__selected-icon {
+  display: block;
+}
+.cds--list-box__menu-item .cds--checkbox-label {
+  width: 100%;
+}
+.cds--list-box__menu-item .cds--checkbox-label-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--list-box--up .cds--list-box__menu {
+  bottom: 2.5rem;
+}
+.cds--list-box--up .cds--list-box--sm .cds--list-box__menu,
+.cds--list-box--up.cds--dropdown--sm .cds--list-box__menu,
+.cds--list-box--up.cds--list-box--sm .cds--list-box__menu {
+  bottom: 2rem;
+}
+.cds--list-box--up .cds--list-box--lg .cds--list-box__menu,
+.cds--list-box--up.cds--dropdown--lg .cds--list-box__menu,
+.cds--list-box--up.cds--list-box--lg .cds--list-box__menu {
+  bottom: 3rem;
+}
+.cds--list-box input[role='combobox'],
+.cds--list-box input[type='text'] {
+  background-color: inherit;
+  min-width: 0;
+  text-overflow: ellipsis;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--list-box__field,
+  .cds--list-box__menu,
+  .cds--multi-select .cds--tag--filter {
+    outline: 1px solid transparent;
+  }
+  .cds--list-box__field:focus,
+  .cds--list-box__menu-item--highlighted .cds--list-box__menu-item__option,
+  .cds--multi-select .cds--tag__close-icon:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--list-box__menu-icon > svg,
+  .cds--list-box__selection--multi > svg,
+  .cds--list-box__selection > svg {
+    fill: ButtonText;
+  }
+}
+.cds--combo-box:hover {
+  background-color: var(--cds-field);
+}
+.cds--combo-box--readonly,
+.cds--combo-box--readonly:hover,
+.cds--content-switcher-btn {
+  background-color: transparent;
+}
+.cds--combo-box.cds--list-box--light:hover {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--combo-box .cds--text-input::-ms-clear {
+  display: none;
+}
+.cds--combo-box--input--focus.cds--text-input {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--combo-box .cds--list-box__field,
+.cds--combo-box.cds--list-box--disabled.cds--list-box--warning
+  .cds--list-box__field,
+.cds--combo-box.cds--list-box--disabled.cds--list-box[data-invalid]
+  .cds--list-box__field,
+.cds--combo-box.cds--list-box--warning .cds--list-box__field,
+.cds--combo-box.cds--list-box[data-invalid] .cds--list-box__field {
+  padding: 0;
+}
+.cds--combo-box--readonly .cds--list-box__menu-icon,
+.cds--combo-box--readonly .cds--list-box__selection {
+  cursor: default;
+}
+.cds--combo-button__container {
+  -moz-column-gap: 0.0625rem;
+  column-gap: 0.0625rem;
+  display: inline-flex;
+}
+.cds--combo-button__container--sm .cds--combo-button__primary-action {
+  min-width: 7.9375rem;
+}
+.cds--combo-button__container--md .cds--combo-button__primary-action {
+  min-width: 7.4375rem;
+}
+.cds--combo-button__container--lg .cds--combo-button__primary-action {
+  min-width: 6.9375rem;
+}
+.cds--combo-button__primary-action .cds--btn {
+  width: 100%;
+}
+.cds--combo-button__trigger svg {
+  transition: transform 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--combo-button__container--open .cds--combo-button__trigger svg {
+  transform: rotate(180deg);
+}
+.cds--contained-list__header {
+  align-items: center;
+  display: flex;
+  padding-inline: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+.cds--contained-list__label {
+  width: 100%;
+}
+.cds--contained-list--on-page.cds--contained-list--sm
+  .cds--contained-list__header {
+  height: 2rem;
+}
+.cds--contained-list--sm
+  .cds--contained-list-item--clickable
+  .cds--contained-list-item__content,
+.cds--contained-list--sm .cds--contained-list-item__content {
+  min-height: 2rem;
+  padding: 0.375rem 1rem;
+}
+.cds--contained-list--on-page.cds--contained-list--md
+  .cds--contained-list__header {
+  height: 2.5rem;
+}
+.cds--contained-list--md
+  .cds--contained-list-item--clickable
+  .cds--contained-list-item__content,
+.cds--contained-list--md .cds--contained-list-item__content {
+  min-height: 2.5rem;
+  padding: 0.625rem 1rem;
+}
+.cds--contained-list--on-page.cds--contained-list--lg
+  .cds--contained-list__header {
+  height: 3rem;
+}
+.cds--contained-list--lg
+  .cds--contained-list-item--clickable
+  .cds--contained-list-item__content,
+.cds--contained-list--lg .cds--contained-list-item__content {
+  min-height: 3rem;
+  padding: 0.875rem 1rem;
+}
+.cds--contained-list--on-page.cds--contained-list--xl
+  .cds--contained-list__header {
+  height: 4rem;
+}
+.cds--contained-list--xl
+  .cds--contained-list-item--clickable
+  .cds--contained-list-item__content,
+.cds--contained-list--xl .cds--contained-list-item__content {
+  min-height: 4rem;
+  padding: 1.375rem 1rem;
+}
+.cds--contained-list--on-page + .cds--contained-list--on-page {
+  margin-block-start: 1rem;
+}
+.cds--contained-list--on-page .cds--contained-list__header {
+  background-color: var(--cds-background, #fff);
+  border-bottom: 1px solid var(--cds-border-subtle);
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+}
+.cds--layer-two .cds--contained-list--on-page .cds--contained-list__header {
+  background-color: var(--cds-layer-01, #f4f4f4);
+}
+.cds--layer-three .cds--contained-list--on-page .cds--contained-list__header {
+  background-color: var(--cds-layer-02, #fff);
+}
+.cds--contained-list--disclosed .cds--contained-list__header {
+  background-color: var(--cds-layer);
+  color: var(--cds-text-secondary, #525252);
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  height: 2rem;
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+}
+.cds--contained-list-item {
+  position: relative;
+}
+.cds--contained-list-item:not(:first-of-type) {
+  margin-top: -1px;
+}
+.cds--contained-list-item--clickable .cds--contained-list-item__content {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  font-family: inherit;
+  font-size: 100%;
+  margin: 0;
+  padding: 0;
+  text-align: start;
+  transition: background-color 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+  vertical-align: baseline;
+  width: 100%;
+}
+.cds--contained-list-item--clickable .cds--contained-list-item__content *,
+.cds--contained-list-item--clickable .cds--contained-list-item__content :after,
+.cds--contained-list-item--clickable
+  .cds--contained-list-item__content
+  :before {
+  box-sizing: inherit;
+}
+.cds--contained-list-item--clickable
+  .cds--contained-list-item__content::-moz-focus-inner {
+  border: 0;
+}
+.cds--contained-list-item--clickable .cds--contained-list-item__content,
+.cds--contained-list-item__content {
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+}
+.cds--contained-list-item:not(:last-of-type):before {
+  background-color: var(--cds-border-subtle);
+  bottom: 0;
+  content: '';
+  height: 1px;
+  left: 0;
+  position: absolute;
+  right: 0;
+}
+.cds--contained-list--inset-rulers
+  .cds--contained-list-item:not(:last-of-type):before {
+  left: 1rem;
+  right: 1rem;
+}
+.cds--contained-list-item--clickable
+  .cds--contained-list-item__content:not(:disabled):hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--contained-list-item--clickable
+  .cds--contained-list-item__content:not(:disabled):active {
+  background-color: var(--cds-layer-active);
+}
+.cds--contained-list-item--clickable
+  .cds--contained-list-item__content:disabled,
+.flatpickr-day.flatpickr-disabled {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--contained-list-item--clickable .cds--contained-list-item__content:focus {
+  outline: 0;
+}
+.cds--contained-list-item--clickable
+  .cds--contained-list-item__content:focus:after {
+  bottom: 0;
+  content: '';
+  left: 0;
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.cds--dropdown--inline.cds--dropdown--invalid .cds--dropdown__invalid-icon,
+.cds--select--inline.cds--select--invalid
+  .cds--select-input
+  ~ .cds--select__invalid-icon {
+  right: 2rem;
+}
+@media screen and (prefers-contrast) {
+  .cds--combo-box--input--focus.cds--text-input,
+  .cds--contained-list-item--clickable
+    .cds--contained-list-item__content:focus:after {
+    outline-style: dotted;
+  }
+}
+.cds--contained-list-item--with-action .cds--contained-list-item__content {
+  padding-inline-end: 4rem;
+}
+.cds--contained-list-item__action,
+.cds--contained-list__action {
+  display: flex;
+  justify-content: flex-end;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.cds--contained-list-item__action > *,
+.cds--contained-list__action > * {
+  pointer-events: all;
+}
+.cds--contained-list-item--with-icon .cds--contained-list-item__content {
+  -moz-column-gap: 0.75rem;
+  column-gap: 0.75rem;
+  display: grid;
+  grid-template-columns: 1rem 1fr;
+}
+.cds--contained-list-item__icon {
+  display: inline-flex;
+  padding-top: 0.125rem;
+}
+.cds--content-switcher {
+  display: flex;
+  height: 2.5rem;
+  justify-content: space-evenly;
+  width: 100%;
+}
+.cds--content-switcher--icon-only.cds--content-switcher--sm .cds--btn--sm,
+.cds--content-switcher--sm {
+  height: 2rem;
+}
+.cds--content-switcher--lg {
+  height: 3rem;
+}
+.cds--content-switcher-btn {
+  align-items: center;
+  border: none;
+  border-bottom: 0.0625rem solid var(--cds-border-inverse, #161616);
+  border-top: 0.0625rem solid var(--cds-border-inverse, #161616);
+  color: var(--cds-text-secondary, #525252);
+  display: inline-flex;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  margin: 0;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  overflow: hidden;
+  padding: 0.5rem 1rem;
+  position: relative;
+  text-align: left;
+  text-decoration: none;
+  transition: 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+  white-space: nowrap;
+  width: 100%;
+}
+.cds--content-switcher-btn html {
+  font-size: 100%;
+}
+.cds--content-switcher-btn body {
+  font-weight: 400;
+}
+.cds--content-switcher-btn code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--content-switcher-btn strong {
+  font-weight: 600;
+}
+.cds--content-switcher-btn:after {
+  background-color: var(--cds-layer-selected-inverse, #161616);
+  content: '';
+  display: block;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  transform: scaleY(0);
+  transform-origin: bottom;
+  transition: 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--skeleton.cds--text-input:before {
+    animation: none;
+  }
+  .cds--content-switcher-btn:after {
+    transition: none;
+  }
+}
+.cds--content-switcher-btn:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow:
+    inset 0 0 0 2px var(--cds-focus, #0f62fe),
+    inset 0 0 0 3px var(--cds-focus-inset, #fff);
+  z-index: 3;
+}
+.cds--content-switcher-btn:disabled,
+.cds--content-switcher-btn:disabled:first-child,
+.cds--content-switcher-btn:disabled:last-child {
+  border-color: var(--cds-border-disabled, #c6c6c6);
+}
+.cds--content-switcher-btn:focus:after {
+  clip-path: inset(3px 3px 3px 3px);
+}
+.cds--content-switcher-btn:hover {
+  color: var(--cds-text-primary, #161616);
+  cursor: pointer;
+}
+.cds--content-switcher-btn:active,
+.cds--content-switcher-btn:hover {
+  background-color: var(--cds-layer-hover);
+  color: var(--cds-text-primary, #161616);
+  z-index: 3;
+}
+.cds--content-switcher-btn:disabled {
+  background-color: transparent;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--content-switcher-btn:disabled:hover {
+  cursor: not-allowed;
+}
+.cds--content-switcher:not(.cds--content-switcher--icon-only)
+  .cds--content-switcher-btn:first-child {
+  border-bottom-left-radius: 0.25rem;
+  border-left: 0.0625rem solid var(--cds-border-inverse, #161616);
+  border-top-left-radius: 0.25rem;
+}
+.cds--content-switcher:not(.cds--content-switcher--icon-only)
+  .cds--content-switcher-btn:first-child:disabled {
+  border-color: var(--cds-border-disabled, #c6c6c6);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--content-switcher:not(.cds--content-switcher--icon-only)
+  .cds--content-switcher-btn:last-child {
+  border-bottom-right-radius: 0.25rem;
+  border-right: 0.0625rem solid var(--cds-border-inverse, #161616);
+  border-top-right-radius: 0.25rem;
+}
+.cds--content-switcher:not(.cds--content-switcher--icon-only)
+  .cds--content-switcher-btn:last-child:disabled {
+  border-color: var(--cds-border-disabled, #c6c6c6);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--content-switcher
+  .cds--content-switcher-btn.cds--content-switcher--selected,
+.cds--content-switcher
+  .cds--content-switcher-btn.cds--content-switcher--selected:first-child,
+.cds--content-switcher
+  .cds--content-switcher-btn.cds--content-switcher--selected:last-child {
+  border: 0;
+}
+.cds--content-switcher-btn:before {
+  background-color: var(--cds-border-subtle);
+  content: '';
+  display: block;
+  height: 1rem;
+  left: 0;
+  position: absolute;
+  width: 0.0625rem;
+  z-index: 2;
+}
+.cds--table-toolbar:not(.cds--table-toolbar--sm)
+  .cds--toolbar-search-container-persistent.cds--search--lg
+  .cds--search-magnifier-icon,
+.cds--toolbar-search-container-persistent .cds--search-magnifier-icon {
+  left: 1rem;
+}
+.cds--content-switcher--selected + .cds--content-switcher-btn:before,
+.cds--content-switcher--selected:before,
+.cds--content-switcher-btn.cds--content-switcher--selected:disabled
+  + .cds--content-switcher-btn:before,
+.cds--content-switcher-btn.cds--content-switcher--selected:disabled:hover
+  + .cds--content-switcher-btn:before,
+.cds--content-switcher-btn:focus + .cds--content-switcher-btn:before,
+.cds--content-switcher-btn:focus:before,
+.cds--content-switcher-btn:hover + .cds--content-switcher-btn:before,
+.cds--content-switcher-btn:hover:before {
+  background-color: transparent;
+}
+.cds--content-switcher-btn:disabled:before,
+.cds--content-switcher-btn:disabled:hover
+  + .cds--content-switcher-btn:disabled:before {
+  background-color: var(--cds-border-disabled, #c6c6c6);
+}
+.cds--content-switcher__icon {
+  fill: var(--cds-icon-secondary, #525252);
+  transition: fill 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--content-switcher--icon-only .cds--content-switcher-btn svg,
+.cds--content-switcher-btn:focus .cds--content-switcher__icon,
+.cds--content-switcher-btn:hover .cds--content-switcher__icon,
+.cds--toolbar-action__icon {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--content-switcher__icon + span {
+  margin-left: 0.5rem;
+}
+.cds--content-switcher__label {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  z-index: 1;
+}
+.cds--content-switcher-btn.cds--content-switcher--selected {
+  background-color: var(--cds-layer-selected-inverse, #161616);
+  color: var(--cds-text-inverse, #fff);
+  z-index: 3;
+}
+.cds--content-switcher-btn.cds--content-switcher--selected:disabled {
+  background-color: var(--cds-layer-selected-disabled, #8d8d8d);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--data-table tr:hover .cds--link,
+.cds--data-table--selected .cds--link:not(.cds--link--disabled) {
+  color: var(--cds-link-secondary, #0043ce);
+}
+.cds--content-switcher-btn.cds--content-switcher--selected:after {
+  transform: scaleY(1);
+}
+.cds--content-switcher-btn.cds--content-switcher--selected
+  .cds--content-switcher__icon {
+  fill: var(--cds-icon-inverse, #fff);
+}
+.cds--content-switcher--icon-only {
+  justify-content: flex-start;
+}
+.cds--content-switcher--icon-only
+  .cds--content-switcher-popover__wrapper:first-child
+  .cds--content-switcher-btn {
+  border-bottom-left-radius: 0.25rem;
+  border-left: 0.0625rem solid var(--cds-border-inverse, #161616);
+  border-top-left-radius: 0.25rem;
+}
+.cds--content-switcher--icon-only
+  .cds--content-switcher-popover__wrapper:first-child
+  .cds--content-switcher--selected[disabled],
+.cds--content-switcher--icon-only
+  .cds--content-switcher-popover__wrapper:last-child
+  .cds--content-switcher--selected[disabled] {
+  border-color: var(--cds-layer-selected-disabled, #8d8d8d);
+}
+.cds--content-switcher--icon-only
+  .cds--content-switcher-popover__wrapper:last-child
+  .cds--content-switcher-btn {
+  border-bottom-right-radius: 0.25rem;
+  border-right: 0.0625rem solid var(--cds-border-inverse, #161616);
+  border-top-right-radius: 0.25rem;
+}
+.cds--content-switcher--icon-only
+  .cds--content-switcher-popover__wrapper:first-child
+  .cds--content-switcher-btn.cds--content-switcher--selected,
+.cds--content-switcher--icon-only
+  .cds--content-switcher-popover__wrapper:last-child
+  .cds--content-switcher-btn.cds--content-switcher--selected {
+  border-color: var(--cds-background, #fff);
+}
+.cds--content-switcher--lg .cds--content-switcher-btn {
+  padding-left: 0.875rem;
+  padding-right: 0.875rem;
+}
+.cds--content-switcher--lg .cds--content-switcher-btn svg {
+  height: 20px;
+  width: 20px;
+}
+.cds--content-switcher--icon-only
+  .cds--content-switcher-btn.cds--content-switcher--selected
+  svg {
+  fill: var(--cds-icon-inverse, #fff);
+  z-index: 1;
+}
+.cds--content-switcher--selected:before,
+.cds--content-switcher-btn:focus:before,
+.cds--content-switcher-btn:hover:before,
+.cds--content-switcher-popover--selected
+  + .cds--content-switcher-popover__wrapper
+  .cds--content-switcher-btn:before,
+.cds--content-switcher-popover__wrapper:focus-within
+  + .cds--content-switcher-popover__wrapper
+  .cds--content-switcher-btn:before,
+.cds--content-switcher-popover__wrapper:not(
+    .cds--content-switcher-popover--disabled
+  ):hover
+  + .cds--content-switcher-popover__wrapper
+  .cds--content-switcher-btn:before {
+  background-color: transparent;
+}
+.cds--content-switcher--icon-only .cds--content-switcher-btn[disabled] {
+  border-color: var(--cds-border-inverse, #161616);
+}
+.cds--content-switcher--icon-only .cds--content-switcher-btn[disabled] svg,
+.flatpickr-next-month.disabled:hover svg,
+.flatpickr-prev-month.disabled:hover svg {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--content-switcher--icon-only
+  .cds--content-switcher-btn[disabled]:not(
+    .cds--content-switcher--selected
+  ):hover,
+.cds--content-switcher--icon-only
+  .cds--content-switcher-popover--selected
+  + .cds--content-switcher-popover--disabled
+  .cds--content-switcher-btn[disabled]:hover:before {
+  background-color: transparent;
+}
+.cds--content-switcher--icon-only
+  .cds--content-switcher-btn[disabled]:hover:before {
+  background-color: var(--cds-border-subtle);
+}
+.cds--number
+  input[type='number'][data-invalid]:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn.up-icon:after,
+.cds--number
+  input[type='number'][data-invalid]
+  ~ .cds--number__controls
+  .cds--number__control-btn.up-icon:focus:after,
+.cds--toolbar-search-container-expandable.cds--search
+  .cds--search-close:focus:before {
+  background-color: var(--cds-focus, #0f62fe);
+}
+.cds--data-table-container {
+  padding-top: 0.125rem;
+  position: relative;
+}
+.cds--data-table-content {
+  display: block;
+  overflow-x: auto;
+}
+.cds--data-table-header {
+  background: var(--cds-layer);
+  padding: 1rem 0 1.5rem 1rem;
+}
+.cds--data-table-header__title {
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-heading-03-font-size, 1.25rem);
+  font-weight: var(--cds-heading-03-font-weight, 400);
+  letter-spacing: var(--cds-heading-03-letter-spacing, 0);
+  line-height: var(--cds-heading-03-line-height, 1.4);
+}
+.cds--data-table-header__description {
+  color: var(--cds-text-secondary, #525252);
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+@media (min-width: 42rem) {
+  .cds--data-table-header__description {
+    max-width: 50ch;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--data-table-header__description {
+    max-width: 80ch;
+  }
+}
+.cds--data-table {
+  width: 100%;
+}
+.cds--data-table thead {
+  background-color: var(--cds-layer-accent);
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+}
+.cds--batch-summary__para,
+.cds--data-table tbody {
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--data-table tbody {
+  background-color: var(--cds-layer);
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  width: 100%;
+}
+.cds--data-table tr {
+  border: none;
+  height: 3rem;
+  width: 100%;
+}
+.cds--data-table tbody tr:hover td,
+.cds--data-table tbody tr:hover th {
+  background: var(--cds-layer-hover);
+  border-bottom: 1px solid var(--cds-layer-hover);
+  border-top: 1px solid var(--cds-layer-hover);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--data-table tr:hover .cds--link--disabled {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--data-table td,
+.cds--data-table th {
+  text-align: left;
+  vertical-align: middle;
+}
+.cds--data-table td[align='right'],
+.cds--data-table th[align='right'] {
+  text-align: right;
+}
+.cds--data-table td[align='center'],
+.cds--data-table th[align='center'] {
+  text-align: center;
+}
+.cds--data-table th {
+  background-color: var(--cds-layer-accent);
+  color: var(--cds-text-primary, #161616);
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.cds--data-table th:last-of-type {
+  position: static;
+  width: auto;
+}
+.cds--data-table .cds--table-header-label {
+  text-align: left;
+}
+.cds--data-table tbody th,
+.cds--data-table td {
+  background: var(--cds-layer);
+  border-bottom: 1px solid var(--cds-border-subtle);
+  border-top: 1px solid var(--cds-layer);
+  color: var(--cds-text-secondary, #525252);
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.cds--data-table tbody th + td:first-of-type,
+.cds--data-table td + td:first-of-type {
+  padding-left: 0.75rem;
+}
+@supports (-moz-appearance: none) {
+  .cds--data-table td {
+    background-clip: padding-box;
+  }
+}
+.cds--data-table .cds--dropdown,
+.cds--data-table .cds--list-box,
+.cds--data-table .cds--list-box input[role='combobox'],
+.cds--data-table .cds--list-box input[type='text'],
+.cds--data-table .cds--number input[type='number'],
+.cds--data-table .cds--number__control-btn:after,
+.cds--data-table .cds--number__control-btn:before,
+.cds--data-table .cds--select-input,
+.cds--data-table .cds--text-input {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--data-table
+  td.cds--table-column-menu
+  .cds--overflow-menu[aria-expanded='false']:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--data-table
+    td.cds--table-column-menu
+    .cds--overflow-menu[aria-expanded='false']:focus {
+    outline-style: dotted;
+  }
+}
+.cds--data-table
+  td.cds--table-column-menu
+  .cds--overflow-menu[aria-expanded='true']:focus {
+  outline: 0;
+}
+@media (-ms-high-contrast: active),
+  (-ms-high-contrast: none),
+  screen and (hover: hover) {
+  .cds--data-table
+    td.cds--table-column-menu
+    .cds--overflow-menu
+    .cds--overflow-menu__icon {
+    opacity: 0;
+  }
+}
+.cds--data-table
+  td.cds--table-column-menu
+  .cds--overflow-menu.cds--overflow-menu--open
+  .cds--overflow-menu__icon,
+.cds--data-table
+  td.cds--table-column-menu
+  .cds--overflow-menu:focus
+  .cds--overflow-menu__icon,
+.cds--data-table
+  td.cds--table-column-menu
+  .cds--overflow-menu:hover
+  .cds--overflow-menu__icon,
+.cds--data-table
+  tr:hover
+  td.cds--table-column-menu
+  .cds--overflow-menu
+  .cds--overflow-menu__icon,
+.cds--data-table.cds--data-table--visible-overflow-menu
+  td.cds--table-column-menu
+  .cds--overflow-menu
+  .cds--overflow-menu__icon {
+  opacity: 1;
+}
+.cds--table-row--menu-option
+  .cds--overflow-menu-options__btn
+  .cds--overflow-menu-options__option-content
+  svg {
+  margin-right: 0.5rem;
+  position: relative;
+  top: 0.1875rem;
+}
+.cds--data-table .cds--overflow-menu:hover,
+.cds--data-table .cds--overflow-menu__trigger:hover {
+  background-color: var(--cds-layer-selected-hover);
+}
+.cds--data-table--selected .cds--overflow-menu:hover,
+.cds--data-table--selected .cds--overflow-menu__trigger:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--data-table--sm td.cds--table-column-menu,
+.cds--data-table--xs td.cds--table-column-menu {
+  height: 1.5rem;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+.cds--data-table--sm td.cds--table-column-menu {
+  height: 2rem;
+}
+.cds--data-table--md td.cds--table-column-menu {
+  height: 2.5rem;
+}
+.cds--data-table--xl .cds--table-column-menu {
+  padding-top: 0.5rem;
+}
+.cds--data-table--zebra tbody tr:not(.cds--parent-row):nth-child(odd) td {
+  border-bottom: 1px solid var(--cds-layer);
+}
+.cds--data-table--zebra tbody tr:not(.cds--parent-row):nth-child(2n) td {
+  background-color: var(--cds-layer-accent);
+  border-bottom: 1px solid var(--cds-layer-accent);
+  border-top: 1px solid var(--cds-layer-accent);
+}
+.cds--data-table--zebra tbody tr:not(.cds--parent-row):hover td {
+  background-color: var(--cds-layer-hover);
+  border-bottom: 1px solid var(--cds-layer-hover);
+  border-top: 1px solid var(--cds-layer-hover);
+}
+.cds--table-column-checkbox .cds--checkbox-label {
+  padding-left: 0;
+}
+.cds--data-table th.cds--table-column-checkbox {
+  background: var(--cds-layer-accent);
+  position: static;
+  width: 2rem;
+}
+.cds--data-table tbody td.cds--table-column-checkbox,
+.cds--data-table tbody td.cds--table-expand,
+.cds--data-table thead th.cds--table-column-checkbox,
+.cds--data-table thead th.cds--table-expand {
+  min-width: 0;
+}
+.cds--data-table tbody td.cds--table-column-checkbox,
+.cds--data-table thead th.cds--table-column-checkbox {
+  min-width: 2.5rem;
+  padding-left: 1rem;
+  padding-right: 0.25rem;
+}
+.cds--data-table tbody td.cds--table-expand,
+.cds--data-table thead th.cds--table-expand {
+  height: 2rem;
+  width: 2rem;
+}
+.cds--data-table--xs tbody td.cds--table-expand,
+.cds--data-table--xs thead th.cds--table-expand {
+  height: 1.5rem;
+  padding: 0 0 0 0.5rem;
+  width: 1.5rem;
+}
+.cds--data-table--sm tbody td.cds--table-expand,
+.cds--data-table--sm thead th.cds--table-expand {
+  height: 2rem;
+  padding: 0 0 0 0.5rem;
+  width: 2rem;
+}
+.cds--data-table--md tbody td.cds--table-expand,
+.cds--data-table--md thead th.cds--table-expand {
+  height: 2.5rem;
+  padding: 0.25rem 0 0.25rem 0.5rem;
+  width: 2.5rem;
+}
+.cds--data-table--xl tbody td.cds--table-expand,
+.cds--data-table--xl thead th.cds--table-expand {
+  height: 4rem;
+  padding-bottom: 1.375rem;
+  padding-top: 0.625rem;
+}
+.cds--data-table--xl .cds--table-column-checkbox {
+  padding-top: 0.8125rem;
+}
+.cds--data-table--xl .cds--table-column-radio {
+  padding-top: 1rem;
+}
+.cds--table-column-radio {
+  width: 48px;
+}
+.cds--table-column-radio .cds--radio-button__appearance {
+  margin-right: -0.125rem;
+}
+.cds--data-table--zebra tbody tr:nth-child(odd).cds--data-table--selected td,
+tr.cds--data-table--selected td {
+  background-color: var(--cds-layer-selected);
+  border-bottom: 1px solid var(--cds-layer-active);
+  border-top: 1px solid var(--cds-layer-selected);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--data-table--zebra
+  tbody
+  tr:first-of-type:nth-child(odd).cds--data-table--selected
+  td,
+tr.cds--data-table--selected:first-of-type td {
+  border-top: 1px solid var(--cds-border-subtle-selected);
+}
+.cds--data-table--zebra
+  tbody
+  tr:last-of-type:nth-child(2n).cds--data-table--selected
+  td,
+.cds--data-table--zebra
+  tbody
+  tr:last-of-type:nth-child(odd).cds--data-table--selected
+  td,
+tr.cds--data-table--selected:last-of-type td {
+  border-bottom: 1px solid var(--cds-layer-selected);
+  border-top: 1px solid var(--cds-layer-selected);
+}
+.cds--data-table--sticky-header thead tr th,
+.cds--data-table--zebra tbody tr:nth-child(2n).cds--data-table--selected td {
+  border-bottom: 1px solid var(--cds-layer-active);
+}
+.cds--data-table--zebra
+  tbody
+  tr:nth-child(2n).cds--data-table--selected:hover
+  td {
+  border-bottom: 1px solid var(--cds-layer-selected-hover);
+}
+.cds--data-table tbody .cds--data-table--selected:hover td,
+.cds--data-table--zebra
+  tbody
+  tr:nth-child(odd).cds--data-table--selected:hover
+  td {
+  background: var(--cds-layer-selected-hover);
+  border-bottom: 1px solid var(--cds-layer-selected-hover);
+  border-top: 1px solid var(--cds-layer-selected-hover);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--data-table--selected .cds--overflow-menu .cds--overflow-menu__icon {
+  opacity: 1;
+}
+.cds--data-table--xs tbody tr,
+.cds--data-table--xs tbody tr th,
+.cds--data-table--xs thead tr {
+  height: 1.5rem;
+}
+.cds--data-table--xs .cds--table-header-label,
+.cds--data-table--xs tbody tr th,
+.cds--data-table--xs td {
+  padding-bottom: 0.125rem;
+  padding-top: 0.125rem;
+}
+.cds--data-table--md tbody tr th,
+.cds--data-table--md td,
+.cds--data-table--sm tbody tr th,
+.cds--data-table--sm td {
+  padding-bottom: 0.375rem;
+  padding-top: 0.4375rem;
+}
+.cds--data-table--xs .cds--overflow-menu {
+  height: calc(100% + 1px);
+  width: 2rem;
+}
+.cds--data-table.cds--data-table--xs .cds--table-column-checkbox {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+.cds--data-table.cds--data-table--xs
+  .cds--table-column-checkbox
+  .cds--checkbox-label {
+  height: 1.4375rem;
+  min-height: 1.4375rem;
+}
+.cds--data-table--sm tbody tr,
+.cds--data-table--sm tbody tr th,
+.cds--data-table--sm thead tr {
+  height: 2rem;
+}
+.cds--data-table--sm .cds--table-header-label {
+  padding-bottom: 0.4375rem;
+  padding-top: 0.4375rem;
+}
+.cds--data-table.cds--data-table--sm .cds--table-column-checkbox {
+  padding-bottom: 0.1875rem;
+  padding-top: 0.1875rem;
+}
+.cds--data-table--sm .cds--overflow-menu {
+  height: calc(100% + 1px);
+}
+.cds--data-table--md tbody tr,
+.cds--data-table--md tbody tr th,
+.cds--data-table--md thead tr {
+  height: 2.5rem;
+}
+.cds--data-table--md .cds--table-header-label {
+  padding-bottom: 0.4375rem;
+  padding-top: 0.4375rem;
+}
+.cds--data-table--md .cds--table-column-menu,
+.cds--data-table.cds--data-table--md .cds--table-column-checkbox {
+  padding-bottom: 0.1875rem;
+  padding-top: 0.1875rem;
+}
+.cds--data-table--xl tbody tr,
+.cds--data-table--xl tbody tr th,
+.cds--data-table--xl thead tr {
+  height: 4rem;
+}
+.cds--data-table--xl .cds--table-header-label {
+  padding-bottom: 1rem;
+  padding-top: 1rem;
+}
+.cds--data-table--xl tbody tr th,
+.cds--data-table--xl td {
+  padding-top: 1rem;
+}
+.cds--data-table--xl td,
+.cds--data-table--xl th {
+  vertical-align: top;
+}
+.cds--data-table--xl .cds--data-table--cell-secondary-text {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+}
+.cds--data-table--static,
+.flatpickr-calendar.hasWeeks {
+  width: auto;
+}
+.cds--data-table-container--static {
+  width: -moz-fit-content;
+  width: fit-content;
+}
+.cds--data-table_inner-container {
+  background-color: var(--cds-layer-accent);
+  transform: translateZ(0);
+}
+.cds--data-table--sticky-header {
+  display: block;
+  max-height: rem(300px);
+  overflow-y: scroll;
+}
+.flatpickr-calendar,
+tr.cds--parent-row:not(.cds--expandable-row)
+  + tr[data-child-row]
+  td
+  .cds--child-row-inner-container {
+  max-height: 0;
+  overflow: hidden;
+}
+.cds--data-table--sticky-header tbody,
+.cds--data-table--sticky-header td,
+.cds--data-table--sticky-header th,
+.cds--data-table--sticky-header thead,
+.cds--data-table--sticky-header tr {
+  display: flex;
+}
+.cds--data-table--sticky-header thead {
+  -ms-overflow-style: none;
+  overflow: scroll;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  will-change: transform;
+  z-index: 1;
+}
+.cds--data-table--sticky-header tbody {
+  -ms-overflow-style: none;
+  flex-direction: column;
+  overflow-x: scroll;
+  will-change: transform;
+}
+.cds--data-table--sticky-header tr.cds--parent-row.cds--expandable-row {
+  height: auto;
+  min-height: 3rem;
+}
+.cds--data-table--sticky-header tr.cds--expandable-row:not(.cds--parent-row),
+.cds--data-table--sticky-header.cds--data-table--sm
+  tr:not(.cds--expandable-row),
+.cds--data-table--sticky-header.cds--data-table--xl
+  tr:not(.cds--expandable-row),
+.cds--data-table--sticky-header.cds--data-table--xs
+  tr:not(.cds--expandable-row),
+.flatpickr-calendar.noCalendar.hasTime .flatpickr-time {
+  height: auto;
+}
+.cds--data-table--sticky-header .cds--table-expand {
+  max-width: 3rem;
+}
+.cds--data-table--sticky-header thead .cds--table-expand {
+  align-items: center;
+}
+.cds--data-table--sticky-header .cds--parent-row {
+  min-height: 3rem;
+}
+.cds--data-table--sticky-header:not(.cds--data-table--xs):not(
+    .cds--data-table--xl
+  ):not(.cds--data-table--sm)
+  td:not(.cds--table-column-menu):not(.cds--table-column-checkbox) {
+  padding-top: 0.875rem;
+}
+.cds--data-table--sticky-header
+  tr.cds--parent-row.cds--expandable-row:hover
+  + tr[data-child-row]
+  td {
+  border-top: 1px solid var(--cds-layer-hover);
+}
+.cds--data-table--sticky-header tr.cds--expandable-row:last-of-type {
+  overflow: hidden;
+}
+.cds--data-table--sticky-header tr.cds--data-table--selected:first-of-type td {
+  border-top: none;
+}
+.cds--data-table--sticky-header tbody tr td.cds--table-column-checkbox,
+.cds--data-table--sticky-header thead th.cds--table-column-checkbox {
+  align-items: center;
+  min-width: 2.25rem;
+  width: 2.25rem;
+}
+.cds--data-table--sticky-header.cds--data-table--xl
+  td.cds--table-column-checkbox,
+.cds--data-table--sticky-header.cds--data-table--xl
+  thead
+  th.cds--table-column-checkbox {
+  align-items: flex-start;
+}
+.cds--data-table--sticky-header
+  th.cds--table-column-checkbox
+  ~ th:last-of-type:empty {
+  max-width: 4rem;
+}
+.cds--data-table--sticky-header th:empty:not(.cds--table-expand) {
+  max-width: 2.25rem;
+}
+.cds--data-table--sticky-header td.cds--table-column-menu {
+  align-items: center;
+  height: auto;
+  padding-top: 0;
+}
+.cds--data-table--sticky-header tbody::-webkit-scrollbar,
+.cds--data-table--sticky-header thead::-webkit-scrollbar {
+  display: none;
+}
+.cds--data-table--sticky-header tbody tr:last-of-type {
+  border-bottom: 0;
+}
+.cds--data-table--sticky-header
+  td:not(.cds--table-column-checkbox):not(.cds--table-column-menu):not(
+    .cds--table-expand
+  ):not(.cds--table-column-icon),
+.cds--data-table--sticky-header
+  th:not(.cds--table-column-checkbox):not(.cds--table-column-menu):not(
+    .cds--table-expand
+  ):not(.cds--table-column-icon) {
+  min-width: 0;
+  width: 100%;
+}
+.cds--data-table--sticky-header.cds--data-table--xs
+  tr:not(.cds--expandable-row) {
+  min-height: 1.5rem;
+}
+.cds--data-table--sticky-header.cds--data-table--sm
+  tr:not(.cds--expandable-row) {
+  min-height: 2rem;
+}
+.cds--data-table--sticky-header.cds--data-table--xl
+  tr:not(.cds--expandable-row) {
+  min-height: 4rem;
+}
+.cds--data-table--sticky-header.cds--data-table--xs tr td.cds--table-expand {
+  padding-top: 0.25rem;
+}
+.cds--data-table--sticky-header.cds--data-table--sm tr td.cds--table-expand {
+  padding-top: 0.5rem;
+}
+.cds--data-table--sticky-header .cds--table-header-label {
+  display: block;
+  max-width: calc(100% - 10px);
+  overflow-x: hidden;
+  overflow-y: hidden;
+  padding-bottom: 1rem;
+  padding-top: 0.9375rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--data-table--sticky-header.cds--data-table--xs
+  th
+  .cds--table-header-label {
+  padding-bottom: 0;
+  padding-top: 0.1875rem;
+}
+.cds--data-table--sticky-header.cds--data-table--sm
+  th
+  .cds--table-header-label {
+  padding-bottom: 0;
+  padding-top: 0.5rem;
+}
+.cds--data-table--sticky-header.cds--data-table--xl
+  th
+  .cds--table-header-label {
+  padding-top: 1rem;
+}
+.cds--data-table--sticky-header.cds--data-table--xl th.cds--table-expand {
+  align-items: flex-start;
+  display: flex;
+}
+.cds--data-table--sticky-header.cds--data-table--sm
+  tr.cds--parent-row
+  .cds--table-column-checkbox,
+.cds--data-table--sticky-header.cds--data-table--xs
+  tr.cds--parent-row
+  .cds--table-column-checkbox {
+  align-items: flex-start;
+}
+.cds--data-table--max-width {
+  max-width: 100%;
+}
+.cds--data-table .cds--form-item.cds--checkbox-wrapper:last-of-type {
+  margin: 0;
+}
+.cds--data-table--sm .cds--form-item.cds--checkbox-wrapper:last-of-type,
+.cds--data-table--xs .cds--form-item.cds--checkbox-wrapper:last-of-type {
+  margin: -0.1875rem 0;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--content-switcher-btn:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--data-table-content {
+    outline: 1px solid transparent;
+  }
+}
+.cds--table-toolbar {
+  background-color: var(--cds-layer);
+  display: flex;
+  min-height: 3rem;
+  position: relative;
+  width: 100%;
+}
+.cds--toolbar-content {
+  display: flex;
+  height: 3rem;
+  justify-content: flex-end;
+  transform: translateZ(0);
+  transition:
+    transform 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    clip-path 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--batch-actions ~ .cds--toolbar-content {
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+}
+.cds--toolbar-content .cds--search .cds--search-input {
+  background-color: transparent;
+  height: 3rem;
+  padding: 0 3rem;
+}
+.cds--toolbar-content .cds--overflow-menu {
+  height: 3rem;
+  width: 3rem;
+}
+.cds--batch-actions ~ .cds--toolbar-search-container {
+  align-items: center;
+  display: flex;
+  opacity: 1;
+  transition: opacity 0.11s;
+}
+.cds--toolbar-search-container-expandable {
+  box-shadow: none;
+  cursor: pointer;
+  height: 3rem;
+  position: relative;
+  transition:
+    width 0.3s cubic-bezier(0.5, 0, 0.1, 1),
+    background-color 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+  width: 3rem;
+}
+.cds--toolbar-search-container-expandable:hover {
+  background-color: var(--cds-field-hover);
+}
+.cds--search.cds--toolbar-search-container-expandable {
+  width: 3rem;
+}
+.cds--toolbar-search-container-expandable .cds--search-input {
+  cursor: pointer;
+  height: 100%;
+  opacity: 0;
+}
+.cds--toolbar-search-container-expandable:not(
+    .cds--toolbar-search-container-active
+  )
+  .cds--search-input {
+  padding: 0;
+}
+.cds--toolbar-search-container-disabled .cds--search-input {
+  cursor: not-allowed;
+}
+.cds--toolbar-search-container-expandable.cds--search .cds--label {
+  visibility: hidden;
+}
+.cds--toolbar-search-container-expandable.cds--search .cds--search-close {
+  height: 3rem;
+  width: 3rem;
+}
+.cds--toolbar-search-container-expandable.cds--search
+  .cds--search-close:before {
+  background-color: var(--cds-field-hover);
+  height: calc(100% - 0.25rem);
+  top: 0.125rem;
+}
+.cds--table-toolbar .cds--search--lg .cds--search-magnifier-icon,
+.cds--table-toolbar.cds--table-toolbar--sm
+  .cds--search--sm:not(.cds--toolbar-search-container-active):not(
+    .cds--toolbar-search-container-persistent
+  )
+  .cds--search-magnifier-icon {
+  left: 0;
+}
+.cds--table-toolbar
+  .cds--toolbar-search-container-persistent.cds--search--sm
+  .cds--search-magnifier-icon,
+.cds--table-toolbar.cds--table-toolbar--sm
+  .cds--search--sm.cds--toolbar-search-container-active
+  .cds--search-magnifier-icon {
+  left: 0.5rem;
+}
+.cds--toolbar-search-container-expandable .cds--search-magnifier-icon {
+  height: 3rem;
+  padding: 1rem;
+  width: 3rem;
+}
+.cds--toolbar-search-container-expandable.cds--search--disabled
+  .cds--search-magnifier-icon {
+  background-color: var(--cds-layer);
+  cursor: not-allowed;
+}
+.cds--toolbar-search-container-active .cds--search-magnifier-icon:active,
+.cds--toolbar-search-container-active .cds--search-magnifier-icon:focus,
+.cds--toolbar-search-container-active .cds--search-magnifier-icon:hover {
+  background-color: transparent;
+  border: none;
+  outline: 0;
+}
+.cds--toolbar-search-container-active.cds--search {
+  width: 100%;
+}
+.cds--toolbar-search-container-active .cds--search-input {
+  opacity: 1;
+}
+.cds--toolbar-search-container-active .cds--label,
+.cds--toolbar-search-container-active .cds--search-input {
+  cursor: text;
+  padding: 0 3rem;
+}
+.cds--toolbar-search-container-active
+  .cds--search-input:focus
+  + .cds--search-close {
+  border: none;
+  box-shadow: none;
+  outline: 0;
+}
+.cds--toolbar-search-container-active
+  .cds--search-input:not(:-moz-placeholder) {
+  background-color: var(--cds-field-hover);
+  border: none;
+}
+.cds--toolbar-search-container-active
+  .cds--search-input:not(:placeholder-shown) {
+  background-color: var(--cds-field-hover);
+  border: none;
+}
+.cds--toolbar-search-container-active .cds--search-close,
+.cds--toolbar-search-container-active .cds--search-close:hover,
+.cds--toolbar-search-container-persistent .cds--search-close,
+.cds--toolbar-search-container-persistent .cds--search-close:hover {
+  background-color: transparent;
+  border: none;
+}
+.cds--overflow-menu.cds--toolbar-action,
+.cds--toolbar-action {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  font-family: inherit;
+  font-size: 100%;
+  height: 3rem;
+  margin: 0;
+  text-align: start;
+  transition: background 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+  vertical-align: baseline;
+  width: 3rem;
+}
+.cds--overflow-menu.cds--toolbar-action {
+  display: flex;
+  padding: 1rem;
+}
+.cds--overflow-menu.cds--toolbar-action *,
+.cds--overflow-menu.cds--toolbar-action :after,
+.cds--overflow-menu.cds--toolbar-action :before {
+  box-sizing: inherit;
+}
+.cds--overflow-menu.cds--toolbar-action::-moz-focus-inner {
+  border: 0;
+}
+.cds--toolbar-action {
+  display: flex;
+  padding: 0;
+}
+.cds--batch-actions,
+.cds--batch-summary {
+  background-color: var(--cds-background-brand, #0f62fe);
+  display: flex;
+  left: 0;
+}
+.cds--toolbar-action *,
+.cds--toolbar-action :after,
+.cds--toolbar-action :before {
+  box-sizing: inherit;
+}
+.cds--toolbar-action::-moz-focus-inner {
+  border: 0;
+}
+.cds--toolbar-action:hover:not([disabled]) {
+  background-color: var(--cds-field-hover);
+}
+.cds--toolbar-action:hover[aria-expanded='true'] {
+  background-color: var(--cds-layer);
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-active
+  .cds--search-input:not(:-moz-placeholder),
+.cds--toolbar-search-container-persistent
+  .cds--search-input:not(:-moz-placeholder) {
+  background-color: var(--cds-field-hover);
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-active
+  .cds--search-input:active,
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-active
+  .cds--search-input:not(:placeholder-shown),
+.cds--toolbar-search-container-persistent
+  .cds--search-input:active:not([disabled]),
+.cds--toolbar-search-container-persistent
+  .cds--search-input:hover:not([disabled]),
+.cds--toolbar-search-container-persistent
+  .cds--search-input:not(:placeholder-shown) {
+  background-color: var(--cds-field-hover);
+}
+.cds--toolbar-action[disabled] {
+  cursor: not-allowed;
+}
+.cds--toolbar-action[disabled] .cds--toolbar-action__icon,
+.flatpickr-next-month.disabled svg,
+.flatpickr-prev-month.disabled svg {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--toolbar-action:active:not([disabled]),
+.cds--toolbar-action:focus:not([disabled]) {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--toolbar-action:active:not(
+    [disabled]
+  ).cds--toolbar-search-container-expandable,
+.cds--toolbar-action:focus:not(
+    [disabled]
+  ).cds--toolbar-search-container-expandable,
+.flatpickr-calendar:focus,
+.flatpickr-days:focus {
+  outline: 0;
+}
+.cds--toolbar-action ~ .cds--btn {
+  margin: 0;
+  max-width: none;
+  white-space: nowrap;
+}
+.cds--overflow-menu--data-table {
+  height: 3rem;
+}
+.cds--toolbar-action__icon {
+  height: 1rem;
+  max-width: 1rem;
+  width: auto;
+}
+.cds--toolbar-search-container-persistent {
+  height: 3rem;
+  opacity: 1;
+  position: relative;
+  width: 100%;
+}
+.cds--toolbar-search-container-persistent + .cds--toolbar-content {
+  position: relative;
+  width: auto;
+}
+.cds--toolbar-search-container-persistent .cds--search {
+  position: static;
+}
+.cds--toolbar-search-container-persistent .cds--search-input {
+  border: none;
+  height: 3rem;
+  padding: 0 3rem;
+}
+.cds--toolbar-search-container-persistent
+  .cds--search-input:focus:not([disabled]) {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--toolbar-action:active:not([disabled]),
+  .cds--toolbar-action:focus:not([disabled]),
+  .cds--toolbar-search-container-persistent
+    .cds--search-input:focus:not([disabled]) {
+    outline-style: dotted;
+  }
+}
+.cds--toolbar-search-container-persistent .cds--search-close {
+  height: 3rem;
+  width: 3rem;
+}
+.cds--batch-actions--active ~ .cds--toolbar-content,
+.cds--batch-actions--active ~ .cds--toolbar-search-container {
+  clip-path: polygon(0 0, 100% 0, 100% 0, 0 0);
+  transform: translate3d(0, 48px, 0);
+  transition:
+    transform 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    clip-path 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--menu-button__trigger--open svg,
+.cds--table-sort--descending .cds--table-sort__icon,
+.cds--tile--is-expanded .cds--tile__chevron svg {
+  transform: rotate(180deg);
+}
+.cds--batch-actions {
+  align-items: center;
+  bottom: 0;
+  clip-path: polygon(0 0, 100% 0, 100% 0, 0 0);
+  justify-content: space-between;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  transform: translate3d(0, 48px, 0);
+  transition:
+    transform 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    clip-path 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    opacity 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  will-change: transform;
+}
+.cds--batch-actions:focus,
+.flatpickr-calendar.open:focus,
+.numInputWrapper .numInput:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+.cds--batch-actions--active {
+  clip-path: polygon(0 0, 200% 0, 200% 200%, 0 200%);
+  pointer-events: all;
+  transform: translateZ(0);
+}
+.cds--action-list {
+  align-items: center;
+  display: flex;
+}
+.cds--action-list .cds--btn {
+  color: var(--cds-text-on-color, #fff);
+  padding: calc(0.875rem - 3px) 1rem;
+  white-space: nowrap;
+}
+.cds--action-list .cds--btn:disabled {
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--cds-text-on-color, #fff);
+  opacity: 0.5;
+}
+.cds--data-table tr.cds--parent-row:first-of-type td,
+tr.cds--expandable-row--hover td,
+tr.cds--parent-row.cds--expandable-row:hover td {
+  border-top: 1px solid var(--cds-border-subtle);
+}
+.cds--action-list
+  .cds--btn--primary:nth-child(3):focus
+  + .cds--btn--primary.cds--batch-summary__cancel:before,
+.cds--action-list
+  .cds--btn--primary:nth-child(3):hover
+  + .cds--btn--primary.cds--batch-summary__cancel:before,
+.cds--table-sort__icon-unsorted,
+.numInputWrapper:hover .numInput[disabled] ~ .arrowDown,
+.numInputWrapper:hover .numInput[disabled] ~ .arrowUp {
+  opacity: 0;
+}
+.cds--action-list .cds--btn .cds--btn__icon {
+  fill: var(--cds-icon-on-color, #fff);
+  margin-left: 0.5rem;
+  position: static;
+}
+.cds--action-list .cds--btn .cds--btn__icon .st0 {
+  fill: none;
+}
+.cds--batch-download {
+  padding: 0.0625rem;
+}
+.cds--action-list .cds--btn--primary:focus {
+  outline: 2px solid var(--cds-layer);
+  outline-offset: -0.125rem;
+}
+.cds--btn--primary.cds--batch-summary__cancel:before {
+  background-color: var(--cds-text-on-color, #fff);
+  border: none;
+  content: '';
+  display: block;
+  height: 1rem;
+  left: 0;
+  opacity: 1;
+  position: absolute;
+  top: 0.9375rem;
+  transition: opacity 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 0.0625rem;
+}
+.cds--btn--primary.cds--batch-summary__cancel:hover:before {
+  opacity: 0;
+  transition: opacity 0.25s cubic-bezier(0.5, 0, 0.1, 1);
+}
+.cds--batch-summary {
+  align-items: center;
+  color: var(--cds-text-on-color, #fff);
+  min-height: 3rem;
+  padding: 0 1rem;
+  position: sticky;
+  z-index: 100000;
+}
+.cds--batch-summary__scroll {
+  box-shadow: 0.5px 0 0.2px var(--cds-link-primary-hover, #0043ce);
+}
+.cds--batch-summary__para {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+}
+.cds--table-toolbar--sm {
+  height: 2rem;
+  min-height: 2rem;
+}
+.cds--table-toolbar--sm .cds--toolbar-search-container-expandable,
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-expandable
+  .cds--search-input,
+.cds--table-toolbar--sm .cds--toolbar-search-container-persistent,
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-persistent
+  .cds--search-input {
+  height: 2rem;
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-expandable
+  .cds--search-close,
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-persistent
+  .cds--search-close {
+  height: 2rem;
+  width: 2rem;
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-expandable
+  .cds--search-magnifier-icon,
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-persistent
+  .cds--search-magnifier-icon {
+  height: 2rem;
+  padding: 0.5rem;
+  width: 2rem;
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-action.cds--toolbar-search-container-persistent {
+  width: 100%;
+}
+.cds--table-toolbar--sm .cds--toolbar-search-container-expandable {
+  width: 2rem;
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-expandable
+  .cds--search
+  .cds--search-input {
+  padding: 0 3rem;
+}
+.cds--table-toolbar--sm .cds--toolbar-search-container-active {
+  flex: auto;
+  transition: flex 175ms cubic-bezier(0.5, 0, 0.1, 1);
+}
+.cds--table-expand__button,
+.cds--table-sort {
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 100%;
+  margin: 0;
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-active
+  .cds--search-input {
+  visibility: inherit;
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-active
+  .cds--search-input:focus {
+  background-color: var(--cds-field-hover);
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--batch-actions:focus,
+  .cds--table-toolbar--sm
+    .cds--toolbar-search-container-active
+    .cds--search-input:focus {
+    outline-style: dotted;
+  }
+}
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-active
+  .cds--search-magnifier-icon:active,
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-active
+  .cds--search-magnifier-icon:focus,
+.cds--table-toolbar--sm
+  .cds--toolbar-search-container-active
+  .cds--search-magnifier-icon:hover {
+  background-color: transparent;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+.cds--table-toolbar--sm .cds--overflow-menu.cds--toolbar-action {
+  height: 2rem;
+  min-width: 2rem;
+  width: 2rem;
+}
+.cds--table-toolbar--sm .cds--toolbar-content {
+  height: 2rem;
+}
+.cds--table-toolbar--sm .cds--toolbar-content .cds--overflow-menu {
+  height: 2rem;
+  width: 2rem;
+}
+.cds--search--disabled .cds--search-magnifier-icon:hover,
+.flatpickr-day.flatpickr-disabled:hover {
+  background-color: transparent;
+}
+.cds--table-toolbar--sm .cds--batch-actions .cds--action-list {
+  height: 2rem;
+}
+.cds--table-toolbar--sm .cds--toolbar-action {
+  height: 2rem;
+  padding: 0.5rem 0;
+  width: 2rem;
+}
+.cds--table-toolbar--sm .cds--btn--primary {
+  height: 2rem;
+  min-height: auto;
+  padding-bottom: calc(0.375rem - 3px);
+  padding-top: calc(0.375rem - 3px);
+}
+.cds--table-toolbar--sm .cds--btn--primary.cds--batch-summary__cancel:before {
+  top: 0.5rem;
+}
+.cds--table-toolbar--sm .cds--toolbar-action ~ .cds--btn {
+  height: 2rem;
+  overflow: hidden;
+}
+.cds--table-toolbar--sm .cds--batch-summary {
+  min-height: 2rem;
+}
+.cds--expandable-row--hidden td {
+  border-top: 0;
+  padding: 1rem;
+  width: auto;
+}
+tr.cds--parent-row:not(.cds--expandable-row) + tr[data-child-row] {
+  height: 0;
+  transition: height 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+tr.cds--parent-row:not(.cds--expandable-row) + tr[data-child-row] td {
+  background-color: var(--cds-layer-hover);
+  border: 0;
+  padding-bottom: 0;
+  padding-top: 0;
+  transition:
+    padding 0.15s cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+tr.cds--parent-row.cds--expandable-row + tr[data-child-row] {
+  transition: height 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+tr.cds--parent-row.cds--expandable-row + tr[data-child-row] td {
+  border-bottom: 1px solid var(--cds-border-subtle);
+  padding-left: 4rem;
+  transition:
+    padding-bottom 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    transform 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+tr.cds--parent-row.cds--expandable-row
+  + tr[data-child-row]
+  td
+  .cds--child-row-inner-container {
+  max-height: 100%;
+}
+.cds--parent-row.cds--expandable-row + tr[data-child-row] > td,
+.cds--parent-row.cds--expandable-row > td {
+  border-bottom: 1px solid var(--cds-border-subtle);
+  box-shadow: 0 1px var(--cds-border-subtle);
+}
+.cds--parent-row.cds--expandable-row > td:first-of-type,
+.cds--parent-row:not(.cds--expandable-row) + tr[data-child-row] > td {
+  box-shadow: none;
+}
+tr.cds--parent-row.cds--expandable-row,
+tr.cds--parent-row.cds--expandable-row td,
+tr.cds--parent-row:not(.cds--expandable-row) td {
+  transition:
+    height 0.24s cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+tr.cds--parent-row:not(.cds--expandable-row):first-of-type:hover td {
+  border-bottom: 1px solid var(--cds-border-subtle);
+  border-top: 1px solid var(--cds-border-subtle);
+}
+tr.cds--parent-row.cds--expandable-row:hover td {
+  background-color: var(--cds-layer-hover);
+  border-bottom: 1px solid var(--cds-border-subtle);
+  color: var(--cds-text-primary, #161616);
+}
+tr.cds--parent-row.cds--expandable-row:hover td:first-of-type {
+  border-bottom: 1px solid var(--cds-layer-hover);
+}
+.cds--data-table td.cds--table-expand[data-previous-value='collapsed'],
+tr.cds--parent-row.cds--expandable-row.cds--expandable-row--hover
+  td:first-of-type {
+  border-bottom: 1px solid transparent;
+}
+tr.cds--parent-row.cds--expandable-row:hover + tr[data-child-row] td {
+  background-color: var(--cds-layer-hover);
+  border-bottom: 1px solid var(--cds-border-subtle);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--data-table td.cds--table-expand,
+tr.cds--expandable-row--hover + tr[data-child-row] td {
+  border-bottom: 1px solid var(--cds-border-subtle);
+}
+.flatpickr-current-month .cur-month:hover,
+.flatpickr-next-month:hover,
+.flatpickr-prev-month:hover,
+tr.cds--expandable-row--hover,
+tr.cds--expandable-row--hover td {
+  background-color: var(--cds-layer-hover);
+}
+tr.cds--expandable-row--hover td {
+  border-bottom: 1px solid var(--cds-border-subtle);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--data-table td.cds--table-expand + .cds--table-column-checkbox,
+.cds--data-table th.cds--table-expand + .cds--table-column-checkbox {
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+}
+.cds--data-table td.cds--table-expand + .cds--table-column-checkbox + td,
+.cds--data-table th.cds--table-expand + .cds--table-column-checkbox + th {
+  padding-left: 0.5rem;
+}
+.cds--data-table td.cds--table-expand,
+.cds--data-table th.cds--table-expand {
+  padding: 0.5rem 0 0.5rem 0.5rem;
+}
+.cds--table-expand[data-previous-value='collapsed'] .cds--table-expand__svg {
+  transform: rotate(270deg);
+  transition: transform 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--table-expand__button {
+  background: 0 0;
+  box-sizing: border-box;
+  display: inline-block;
+  display: inline-flex;
+  height: calc(100% + 1px);
+  justify-content: center;
+  padding: 0 0.5rem;
+  text-align: start;
+  vertical-align: baseline;
+  vertical-align: inherit;
+  width: 100%;
+}
+.cds--table-sort__description,
+tr.cds--parent-row.cds--data-table--selected td.cds--table-expand + td:after {
+  display: none;
+}
+.cds--table-expand__button *,
+.cds--table-expand__button :after,
+.cds--table-expand__button :before {
+  box-sizing: inherit;
+}
+.cds--table-expand__button::-moz-focus-inner {
+  border: 0;
+}
+.cds--table-expand__button:focus {
+  box-shadow: inset 0 0 0 2px var(--cds-focus, #0f62fe);
+  outline: 0;
+}
+.cds--table-expand__svg {
+  fill: var(--cds-layer-selected-inverse, #161616);
+  transform: rotate(90deg);
+  transition: transform 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--data-table--xl .cds--table-expand__button {
+  padding: 0;
+  width: 2rem;
+}
+tr.cds--parent-row.cds--expandable-row td.cds--table-expand + td:after {
+  background: var(--cds-layer-accent);
+  bottom: -0.0625rem;
+  content: '';
+  height: 0.0625rem;
+  left: 0;
+  position: absolute;
+  width: 0.5rem;
+}
+.flatpickr-day:hover,
+tr.cds--parent-row.cds--expandable-row.cds--expandable-row--hover
+  td.cds--table-expand
+  + td:after,
+tr.cds--parent-row.cds--expandable-row:hover td.cds--table-expand + td:after {
+  background: var(--cds-layer-hover);
+}
+.cds--data-table--zebra tbody tr[data-child-row]:nth-child(4n + 4) td,
+.cds--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 3) td {
+  border-bottom: 1px solid var(--cds-layer);
+}
+.cds--data-table--zebra tbody tr[data-child-row]:nth-child(4n + 2) td,
+.cds--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 1) td {
+  background-color: var(--cds-layer-accent);
+  border-bottom: 1px solid var(--cds-layer-accent);
+  border-top: 1px solid var(--cds-layer-accent);
+}
+.cds--data-table--zebra tr.cds--parent-row td,
+.cds--data-table--zebra
+  tr.cds--parent-row.cds--expandable-row
+  + tr[data-child-row]
+  td {
+  transition:
+    transform 0.15s cubic-bezier(0.2, 0, 0.38, 0.9),
+    border-bottom 0.15s cubic-bezier(0.2, 0, 0.38, 0.9),
+    border-top 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--data-table--zebra tbody tr[data-child-row]:hover td,
+.cds--data-table--zebra tbody tr[data-parent-row]:hover td,
+.cds--data-table--zebra
+  tbody
+  tr[data-parent-row]:hover
+  + tr[data-child-row]
+  td {
+  background-color: var(--cds-layer-hover);
+  border-bottom: 1px solid var(--cds-layer-hover);
+  border-top: 1px solid var(--cds-layer-hover);
+}
+.cds--data-table--zebra
+  tr.cds--parent-row.cds--expandable-row.cds--expandable-row--hover
+  td {
+  background: var(--cds-layer-hover);
+  border-bottom: 1px solid var(--cds-layer-hover);
+  border-top: 1px solid var(--cds-layer-hover);
+}
+tr.cds--parent-row.cds--data-table--selected:first-of-type td {
+  background: var(--cds-layer-selected);
+  border-bottom: 1px solid var(--cds-border-subtle);
+  border-top: 1px solid var(--cds-layer-active);
+  box-shadow: 0 1px var(--cds-layer-active);
+}
+tr.cds--parent-row.cds--data-table--selected td {
+  background: var(--cds-layer-selected);
+  border-bottom: 1px solid transparent;
+  box-shadow: 0 1px var(--cds-layer-active);
+  color: var(--cds-text-primary, #161616);
+}
+tr.cds--parent-row.cds--data-table--selected:last-of-type td {
+  background: var(--cds-layer-selected);
+  border-bottom: 1px solid transparent;
+  box-shadow: 0 1px var(--cds-border-subtle);
+}
+.cds--table-sort.cds--table-sort--active,
+.cds--table-sort:hover,
+tr.cds--parent-row.cds--data-table--selected:not(.cds--expandable-row):hover
+  td {
+  background: var(--cds-layer-selected-hover);
+}
+tr.cds--parent-row.cds--data-table--selected:not(.cds--expandable-row):hover
+  td {
+  border-bottom: 1px solid var(--cds-border-subtle);
+  border-top: 1px solid var(--cds-layer-selected-hover);
+  box-shadow: 0 1px var(--cds-layer-selected-hover);
+}
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row td,
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row
+  td:first-of-type {
+  border-bottom: 1px solid transparent;
+  box-shadow: 0 1px var(--cds-layer-selected);
+}
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row--hover td,
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row--hover
+  td:first-of-type,
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row:hover td,
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row:hover
+  td:first-of-type {
+  background: var(--cds-layer-selected-hover);
+  border-bottom: 1px solid transparent;
+  border-top: 1px solid var(--cds-layer-selected-hover);
+  box-shadow: 0 1px var(--cds-layer-selected-hover);
+}
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row
+  + tr[data-child-row]
+  td {
+  background-color: var(--cds-layer-hover);
+  border-bottom: 1px solid var(--cds-border-subtle);
+  border-top: 1px solid var(--cds-layer-active);
+  box-shadow: 0 1px var(--cds-layer-active);
+  color: var(--cds-text-primary, #161616);
+}
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row
+  + tr[data-child-row]:last-of-type
+  td {
+  box-shadow: inset 0 -1px var(--cds-layer-active);
+  padding-bottom: 1.5rem;
+}
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row--hover
+  + tr[data-child-row]
+  td,
+tr.cds--parent-row.cds--data-table--selected.cds--expandable-row:hover
+  + tr[data-child-row]
+  td {
+  background: var(--cds-layer-selected);
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--table-expand__button:focus .cds--table-expand__svg {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--table-expand__svg {
+    fill: ButtonText;
+  }
+}
+.cds--data-table.cds--skeleton th {
+  padding-left: 1rem;
+  vertical-align: middle;
+}
+.cds--data-table.cds--skeleton td span,
+.cds--data-table.cds--skeleton th span {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  display: block;
+  height: 1rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 4rem;
+}
+.cds--data-table.cds--skeleton td span:active,
+.cds--data-table.cds--skeleton td span:focus,
+.cds--data-table.cds--skeleton td span:hover,
+.cds--data-table.cds--skeleton th span:active,
+.cds--data-table.cds--skeleton th span:focus,
+.cds--data-table.cds--skeleton th span:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--data-table.cds--skeleton td span:before,
+.cds--data-table.cds--skeleton th span:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+.cds--data-table.cds--skeleton tr:hover td {
+  background: 0 0;
+  border-color: var(--cds-border-subtle);
+}
+.cds--data-table.cds--skeleton tr:hover td:first-of-type,
+.cds--data-table.cds--skeleton tr:hover td:last-of-type {
+  border-color: var(--cds-border-subtle);
+}
+.cds--data-table.cds--skeleton .cds--table-sort {
+  pointer-events: none;
+}
+.cds--data-table.cds--skeleton th span {
+  background: var(--cds-skeleton-element, #c6c6c6);
+}
+.cds--data-table.cds--skeleton th span:before {
+  background: var(--cds-skeleton-background, #e8e8e8);
+}
+.cds--data-table-container.cds--skeleton .cds--data-table-header__title {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  height: 1.5rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 7.5rem;
+}
+.cds--data-table-container.cds--skeleton .cds--data-table-header__title:active,
+.cds--data-table-container.cds--skeleton .cds--data-table-header__title:focus,
+.cds--data-table-container.cds--skeleton .cds--data-table-header__title:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--data-table-container.cds--skeleton .cds--data-table-header__title:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--data-table-container.cds--skeleton
+    .cds--data-table-header__title:before,
+  .cds--data-table.cds--skeleton td span:before,
+  .cds--data-table.cds--skeleton th span:before {
+    animation: none;
+  }
+}
+.cds--data-table-container.cds--skeleton .cds--data-table-header__description {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  height: 1rem;
+  margin-top: 0.5rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 10rem;
+}
+.cds--data-table-container.cds--skeleton
+  .cds--data-table-header__description:active,
+.cds--data-table-container.cds--skeleton
+  .cds--data-table-header__description:focus,
+.cds--data-table-container.cds--skeleton
+  .cds--data-table-header__description:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--data-table-container.cds--skeleton
+  .cds--data-table-header__description:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+.cds--data-table th[aria-sort],
+.cds--data-table--sort th {
+  border-bottom: none;
+  border-top: none;
+  height: 3rem;
+  padding: 0;
+}
+.cds--table-sort {
+  background: 0 0;
+  background-color: var(--cds-layer-accent);
+  box-sizing: border-box;
+  color: var(--cds-text-primary, #161616);
+  display: inline-block;
+  display: flex;
+  font: inherit;
+  justify-content: space-between;
+  line-height: 1;
+  min-height: 100%;
+  padding: 0 0 0 1rem;
+  text-align: left;
+  transition:
+    background-color 70ms cubic-bezier(0, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0, 0, 0.38, 0.9);
+  vertical-align: baseline;
+  width: 100%;
+}
+.cds--table-sort__icon,
+.cds--table-sort__icon-unsorted {
+  fill: var(--cds-icon-primary, #161616);
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  min-width: 1rem;
+  width: 1.25rem;
+}
+.flatpickr-current-month,
+.flatpickr-month {
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+}
+.cds--table-sort *,
+.cds--table-sort :after,
+.cds--table-sort :before {
+  box-sizing: inherit;
+}
+.cds--table-sort::-moz-focus-inner {
+  border: 0;
+}
+.cds--table-sort:focus,
+.flatpickr-day.today.selected {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--table-sort:focus svg,
+.cds--table-sort:hover svg,
+.numInputWrapper:hover .arrowDown,
+.numInputWrapper:hover .arrowUp {
+  opacity: 1;
+}
+.cds--data-table.cds--data-table--sort th > .cds--table-header-label {
+  line-height: 1;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+th .cds--table-sort__flex {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: space-between;
+  min-height: 3rem;
+  width: 100%;
+}
+@media screen and (-ms-high-contrast: active),
+  screen and (-ms-high-contrast: none) {
+  .cds--data-table--sort:not(.cds--data-table--xs):not(
+      .cds--data-table--sm
+    ):not(.cds--data-table--md):not(.cds--data-table--xl)
+    th
+    .cds--table-sort__flex {
+    height: 2.99rem;
+  }
+}
+.cds--data-table--xs.cds--data-table--sort th .cds--table-sort__flex {
+  min-height: 1.5rem;
+}
+.cds--data-table--sm.cds--data-table--sort th .cds--table-sort__flex {
+  min-height: 2rem;
+}
+.cds--data-table--md.cds--data-table--sort th .cds--table-sort__flex {
+  min-height: 2.5rem;
+}
+.cds--data-table--xl.cds--data-table--sort th .cds--table-sort__flex {
+  align-items: flex-start;
+  min-height: 4rem;
+}
+.cds--table-sort .cds--table-sort__icon-inactive {
+  display: block;
+}
+.cds--table-sort .cds--table-sort__icon,
+.cds--table-sort.cds--table-sort--active .cds--table-sort__icon-unsorted,
+.flatpickr-day.today.selected:after {
+  display: none;
+}
+.cds--table-sort.cds--table-sort--active .cds--table-sort__icon {
+  display: block;
+  opacity: 1;
+}
+.cds--table-sort__icon {
+  opacity: 1;
+  transform: rotate(0);
+  transition: transform 0.25s cubic-bezier(0.5, 0, 0.1, 1);
+}
+.cds--data-table--xs.cds--data-table--sort th {
+  height: 1.5rem;
+}
+.cds--data-table--sm.cds--data-table--sort th {
+  height: 2rem;
+}
+.cds--data-table--md.cds--data-table--sort th {
+  height: 2.5rem;
+}
+.cds--data-table--xl.cds--data-table--sort th {
+  height: 4rem;
+}
+.cds--data-table--xl.cds--data-table--sort th .cds--table-sort {
+  display: inline-block;
+  height: 4rem;
+}
+.cds--data-table--xl .cds--table-sort__icon,
+.cds--data-table--xl .cds--table-sort__icon-unsorted {
+  margin-top: 0.8125rem;
+}
+@keyframes fp-fade-in-down {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, -20px, 0);
+  }
+  to {
+    opacity: 1;
+    transform: translateZ(0);
+  }
+}
+@keyframes fp-slide-left {
+  0% {
+    transform: translateZ(0);
+  }
+  to {
+    transform: translate3d(-100%, 0, 0);
+  }
+}
+@keyframes fp-slide-left-new {
+  0% {
+    transform: translate3d(100%, 0, 0);
+  }
+  to {
+    transform: translateZ(0);
+  }
+}
+@keyframes fp-slide-right {
+  0% {
+    transform: translateZ(0);
+  }
+  to {
+    transform: translate3d(100%, 0, 0);
+  }
+}
+@keyframes fp-slide-right-new {
+  0% {
+    transform: translate3d(-100%, 0, 0);
+  }
+  to {
+    transform: translateZ(0);
+  }
+}
+@keyframes fp-fade-out {
+  0% {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@keyframes fp-fade-in {
+  0% {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.flatpickr-calendar {
+  animation: none;
+  border: 0;
+  border-radius: 0;
+  box-sizing: border-box;
+  direction: ltr;
+  opacity: 0;
+  padding: 0;
+  position: absolute;
+  text-align: center;
+  touch-action: manipulation;
+  visibility: hidden;
+  width: 19.6875rem;
+}
+.flatpickr-calendar.inline,
+.flatpickr-calendar.open {
+  max-height: 40rem;
+  opacity: 1;
+  overflow: visible;
+  visibility: inherit;
+}
+.flatpickr-calendar.open {
+  align-items: center;
+  background-color: var(--cds-layer-01, #f4f4f4);
+  border: none;
+  box-shadow: 0 2px 6px var(--cds-shadow, rgba(0, 0, 0, 0.3));
+  display: flex;
+  flex-direction: column;
+  height: 21rem;
+  justify-content: center;
+  margin-top: -0.125rem;
+  overflow: hidden;
+  padding: 0.25rem 0.25rem 0.5rem;
+  width: 18rem;
+  z-index: 99999;
+}
+.flatpickr-calendar.animate.open {
+  animation: fp-fade-in-down 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+}
+.flatpickr-calendar.inline {
+  display: block;
+  position: relative;
+  top: 0.125rem;
+}
+.flatpickr-calendar.static {
+  position: absolute;
+  top: calc(100% + 2px);
+}
+.flatpickr-calendar.static.open {
+  display: block;
+  z-index: 999;
+}
+.dayContainer {
+  display: flex;
+  flex-wrap: wrap;
+  height: 15.375rem;
+  justify-content: space-around;
+  outline: 0;
+  padding: 0;
+}
+.flatpickr-calendar .hasTime .dayContainer,
+.flatpickr-calendar .hasWeeks .dayContainer {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.flatpickr-calendar .hasWeeks .dayContainer {
+  border-left: 0;
+}
+.flatpickr-calendar.showTimeInput.hasTime .flatpickr-time {
+  border-top: 1px solid #e6e6e6;
+  height: 2.5rem;
+}
+.flatpickr-month {
+  align-items: center;
+  background-color: transparent;
+  color: var(--cds-text-primary, #161616);
+  display: flex;
+  height: 2.5rem;
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  line-height: 1;
+  text-align: center;
+}
+.flatpickr-next-month,
+.flatpickr-prev-month {
+  fill: var(--cds-icon-primary, #161616);
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: 2.5rem;
+  justify-content: center;
+  line-height: 16px;
+  padding: 0;
+  text-decoration: none;
+  transform: scale(1);
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  width: 2.5rem;
+  z-index: 3;
+}
+.cds--date-picker__input,
+.flatpickr-day {
+  transition: 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.flatpickr-current-month {
+  align-items: center;
+  display: flex;
+  height: 1.75rem;
+  justify-content: center;
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  text-align: center;
+}
+.flatpickr-day,
+.flatpickr-weekday {
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.flatpickr-current-month .cur-month {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+.numInputWrapper {
+  position: relative;
+  width: 3.75rem;
+}
+.numInputWrapper:hover {
+  background-color: var(--cds-background-hover, hsla(0, 0%, 55%, 0.12));
+}
+.numInputWrapper .numInput {
+  background-color: var(--cds-field-01, #f4f4f4);
+  border: none;
+  color: var(--cds-text-primary, #161616);
+  cursor: default;
+  display: inline-block;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 600;
+  margin: 0;
+  padding: 0.25rem;
+  width: 100%;
+}
+.numInputWrapper .numInput::-webkit-inner-spin-button,
+.numInputWrapper .numInput::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.numInputWrapper .numInput[disabled],
+.numInputWrapper .numInput[disabled]:hover {
+  background-color: var(--cds-layer-01, #f4f4f4);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  pointer-events: none;
+}
+.numInputWrapper .arrowUp {
+  border-bottom: 0;
+  top: 0.25rem;
+}
+.numInputWrapper .arrowUp:after {
+  border-bottom: 0.25rem solid var(--cds-icon-primary, #161616);
+}
+.numInputWrapper .arrowDown {
+  top: 0.6875rem;
+}
+.numInputWrapper .arrowDown:after {
+  border-top: 0.25rem solid var(--cds-icon-primary, #161616);
+}
+.numInputWrapper .arrowDown,
+.numInputWrapper .arrowUp {
+  border: none;
+  cursor: pointer;
+  height: 50%;
+  left: 2.6rem;
+  line-height: 50%;
+  opacity: 0;
+  padding: 0 0.25rem 0 0.125rem;
+  position: absolute;
+  width: 0.75rem;
+}
+.cds--date-picker__icon ~ .cds--date-picker__input,
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--list-box[data-invalid]:not(.cds--combo-box)
+  .cds--list-box__field {
+  padding-right: 3rem;
+}
+.numInputWrapper .arrowDown:after,
+.numInputWrapper .arrowUp:after {
+  border-left: 0.25rem solid transparent;
+  border-right: 0.25rem solid transparent;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 33%;
+}
+.numInputWrapper .arrowDown:hover:after,
+.numInputWrapper .arrowUp:hover:after {
+  border-bottom-color: var(--cds-button-primary, #0f62fe);
+  border-top-color: var(--cds-button-primary, #0f62fe);
+}
+.numInputWrapper .arrowDown:active:after,
+.numInputWrapper .arrowUp:active:after {
+  border-bottom-color: var(--cds-border-interactive, #0f62fe);
+  border-top-color: var(--cds-border-interactive, #0f62fe);
+}
+.numInput[disabled] ~ .arrowUp:after {
+  border-bottom-color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--date-picker__input:disabled,
+.cds--date-picker__input:disabled:hover {
+  border-bottom: 1px solid transparent;
+}
+.numInput[disabled] ~ .arrowDown:after {
+  border-top-color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.flatpickr-weekdays {
+  align-items: center;
+  display: flex;
+  height: 2.5rem;
+}
+.flatpickr-weekdaycontainer {
+  display: flex;
+  width: 100%;
+}
+.flatpickr-weekday {
+  cursor: default;
+  flex: 1;
+}
+.flatpickr-calendar.animate .dayContainer.slideLeft {
+  animation:
+    fp-fade-out 0.4s cubic-bezier(0.23, 1, 0.32, 1),
+    fp-slide-left 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+}
+.flatpickr-calendar.animate .dayContainer.slideLeft,
+.flatpickr-calendar.animate .dayContainer.slideLeftNew {
+  transform: translate3d(-100%, 0, 0);
+}
+.flatpickr-calendar.animate .dayContainer.slideLeftNew {
+  animation:
+    fp-fade-in 0.4s cubic-bezier(0.23, 1, 0.32, 1),
+    fp-slide-left 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+}
+.flatpickr-calendar.animate .dayContainer.slideRight {
+  animation:
+    fp-fade-out 0.4s cubic-bezier(0.23, 1, 0.32, 1),
+    fp-slide-right 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+  transform: translate3d(100%, 0, 0);
+}
+.flatpickr-calendar.animate .dayContainer.slideRightNew {
+  animation:
+    fp-fade-in 0.4s cubic-bezier(0.23, 1, 0.32, 1),
+    fp-slide-right-new 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+}
+.flatpickr-day {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: 2.5rem;
+  justify-content: center;
+  width: 2.5rem;
+}
+.flatpickr-day:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-color: var(--cds-button-primary, #0f62fe);
+  outline-offset: -2px;
+}
+.nextMonthDay,
+.prevMonthDay {
+  color: var(--cds-text-helper, #6f6f6f);
+}
+.flatpickr-day.today {
+  color: var(--cds-link-primary, #0f62fe);
+  font-weight: 600;
+  position: relative;
+}
+.cds--date-picker
+  .cds--date-picker-input__wrapper--warn
+  ~ .cds--form-requirement,
+.cds--date-picker__input,
+.cds--dropdown,
+.flatpickr-day.endRange:hover,
+.flatpickr-day.inRange {
+  color: var(--cds-text-primary, #161616);
+}
+.flatpickr-day.today:after {
+  background-color: var(--cds-link-primary, #0f62fe);
+  bottom: 0.4375rem;
+  content: '';
+  display: block;
+  height: 0.25rem;
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
+  width: 0.25rem;
+}
+.flatpickr-day.inRange {
+  background-color: var(--cds-highlight, #d0e2ff);
+}
+.flatpickr-day.selected {
+  background-color: var(--cds-button-primary, #0f62fe);
+  color: var(--cds-text-on-color, #fff);
+}
+.flatpickr-day.selected:focus {
+  outline: 0.0625rem solid var(--cds-layer-02, #fff);
+  outline-offset: -0.1875rem;
+}
+.flatpickr-day.startRange.selected {
+  box-shadow: none;
+  z-index: 2;
+}
+.flatpickr-day.endRange.inRange,
+.flatpickr-day.startRange.inRange:not(.selected) {
+  z-index: 3;
+}
+.flatpickr-day.endRange.inRange,
+.flatpickr-day.endRange:hover,
+.flatpickr-day.startRange.inRange:not(.selected) {
+  background: var(--cds-layer-01, #f4f4f4);
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--table-sort:focus,
+  .flatpickr-calendar.open:focus,
+  .flatpickr-day.endRange.inRange,
+  .flatpickr-day.endRange:hover,
+  .flatpickr-day.startRange.inRange:not(.selected),
+  .flatpickr-day.today.selected,
+  .flatpickr-day:focus,
+  .numInputWrapper .numInput:focus {
+    outline-style: dotted;
+  }
+}
+.flatpickr-day.endRange.inRange.selected {
+  background: var(--cds-button-primary, #0f62fe);
+  color: var(--cds-text-on-color, #fff);
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--table-sort__icon,
+  .cds--table-sort__icon-unsorted,
+  .flatpickr-next-month,
+  .flatpickr-prev-month {
+    fill: ButtonText;
+  }
+  .flatpickr-calendar {
+    outline: 1px solid transparent;
+  }
+  .flatpickr-day.selected {
+    color: Highlight;
+    outline: 1px dotted Highlight;
+  }
+  .flatpickr-day.inRange,
+  .flatpickr-day.today {
+    color: Highlight;
+  }
+}
+.cds--date-picker {
+  display: flex;
+}
+.cds--date-picker--light .cds--date-picker__input {
+  background: var(--cds-field-02, #fff);
+}
+.cds--date-picker-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+}
+.cds--date-picker-container .cds--label {
+  display: flex;
+}
+.cds--date-picker-input__wrapper {
+  align-items: center;
+  display: flex;
+  position: relative;
+}
+.cds--date-picker.cds--date-picker--simple .cds--date-picker__input,
+.cds--date-picker.cds--date-picker--simple .cds--label {
+  width: 7.5rem;
+}
+.cds--date-picker.cds--date-picker--simple
+  .cds--date-picker-input__wrapper--invalid
+  .cds--date-picker__input,
+.cds--date-picker.cds--date-picker--simple
+  .cds--date-picker-input__wrapper--invalid
+  ~ .cds--form-requirement,
+.cds--date-picker.cds--date-picker--simple
+  .cds--date-picker-input__wrapper--warn
+  .cds--date-picker__input,
+.cds--date-picker.cds--date-picker--simple
+  .cds--date-picker-input__wrapper--warn
+  ~ .cds--form-requirement {
+  width: 9.5rem;
+}
+.cds--date-picker.cds--date-picker--simple.cds--date-picker--short
+  .cds--date-picker__input {
+  width: 5.7rem;
+}
+.cds--date-picker.cds--date-picker--single .cds--date-picker__input {
+  width: 18rem;
+}
+.cds--date-picker__input {
+  background-color: var(--cds-field);
+  border: none;
+  border-bottom: 1px solid var(--cds-border-strong);
+  box-sizing: border-box;
+  display: block;
+  font-family: inherit;
+  font-family: var(
+    --cds-code-02-font-family,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    '.SFNSText-Regular',
+    monospace
+  );
+  font-size: 100%;
+  font-size: var(--cds-code-02-font-size, 0.875rem);
+  font-weight: var(--cds-code-02-font-weight, 400);
+  height: 2.5rem;
+  letter-spacing: var(--cds-code-02-letter-spacing, 0.32px);
+  line-height: var(--cds-code-02-line-height, 1.42857);
+  margin: 0;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0 1rem;
+  position: relative;
+}
+.cds--file__drop-container,
+.cds--loading,
+.cds--number__control-btn,
+.cds--search-input {
+  font-family: inherit;
+  vertical-align: baseline;
+}
+.cds--dropdown-list,
+.cds--dropdown-text,
+.cds--dropdown__wrapper--inline .cds--label {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--dropdown,
+.cds--dropdown-list {
+  list-style: none;
+  outline: 2px solid transparent;
+}
+.cds--date-picker__input *,
+.cds--date-picker__input :after,
+.cds--date-picker__input :before {
+  box-sizing: inherit;
+}
+.cds--date-picker__input.cds--focused,
+.cds--date-picker__input:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--date-picker__input:disabled {
+  background-color: var(--cds-field);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--date-picker__input:disabled::-moz-placeholder {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--date-picker__input:disabled::placeholder {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--date-picker__input::-moz-placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  opacity: 1;
+}
+.cds--date-picker__input::placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  opacity: 1;
+}
+.cds--date-picker__input--lg {
+  height: 3rem;
+}
+.cds--date-picker__input--sm {
+  height: 2rem;
+}
+.cds--date-picker__icon {
+  fill: var(--cds-icon-primary, #161616);
+  pointer-events: none;
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+.cds--date-picker__icon--invalid,
+.cds--date-picker__icon--warn {
+  cursor: auto;
+}
+.cds--date-picker__icon--warn {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--date-picker__icon--warn path:first-of-type {
+  fill: #000;
+  opacity: 1;
+}
+.cds--date-picker__input[readonly] + .cds--date-picker__icon,
+.cds--dropdown--disabled .cds--dropdown__arrow,
+.cds--dropdown--disabled .cds--list-box__menu-icon svg,
+.cds--dropdown--readonly .cds--list-box__menu-icon svg,
+.cds--list-box__wrapper--fluid .cds--label--disabled .cds--toggletip-button svg,
+.cds--number input[type='number']:disabled ~ .cds--number__controls svg {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--date-picker__icon--invalid {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--date-picker__input:disabled ~ .cds--date-picker__icon {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--date-picker.cds--skeleton .cds--label:active,
+.cds--date-picker.cds--skeleton .cds--label:focus,
+.cds--date-picker.cds--skeleton .cds--label:hover,
+.cds--date-picker.cds--skeleton input:active,
+.cds--date-picker.cds--skeleton input:focus,
+.cds--date-picker.cds--skeleton input:hover,
+.cds--date-picker__input.cds--skeleton:active,
+.cds--date-picker__input.cds--skeleton:focus,
+.cds--date-picker__input.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--date-picker--range > .cds--date-picker-container:first-child {
+  margin-right: 0.0625rem;
+}
+.cds--date-picker--range .cds--date-picker-container,
+.cds--date-picker--range .cds--date-picker__input {
+  width: 8.96875rem;
+}
+.cds--date-picker.cds--skeleton input,
+.cds--date-picker__input.cds--skeleton {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 100%;
+}
+.cds--dropdown--inline.cds--dropdown--open:focus .cds--dropdown-list,
+.cds--dropdown--open .cds--dropdown-list,
+.cds--dropdown-list,
+.cds--menu {
+  box-shadow: 0 2px 6px var(--cds-shadow, rgba(0, 0, 0, 0.3));
+}
+.cds--date-picker.cds--skeleton input:before,
+.cds--date-picker__input.cds--skeleton:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--data-table-container.cds--skeleton
+    .cds--data-table-header__description:before,
+  .cds--date-picker.cds--skeleton input:before,
+  .cds--date-picker__input.cds--skeleton:before {
+    animation: none;
+  }
+}
+.cds--date-picker.cds--skeleton input::-moz-placeholder,
+.cds--date-picker__input.cds--skeleton::-moz-placeholder {
+  color: transparent;
+}
+.cds--date-picker.cds--skeleton input::placeholder,
+.cds--date-picker__input.cds--skeleton::placeholder {
+  color: transparent;
+}
+.cds--date-picker.cds--skeleton .cds--label {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  height: 0.875rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 4.6875rem;
+}
+.cds--dropdown--inline.cds--dropdown--invalid .cds--dropdown-text,
+.cds--dropdown--invalid .cds--dropdown-text {
+  padding-right: 3.5rem;
+}
+.cds--date-picker.cds--skeleton .cds--label:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--date-picker__icon {
+    fill: ButtonText;
+  }
+}
+.cds--date-picker__input[readonly] {
+  background: 0 0;
+  border-bottom-color: var(--cds-border-subtle);
+  cursor: text;
+}
+.cds--dropdown__wrapper--inline {
+  grid-gap: 0 1.5rem;
+  align-items: center;
+  display: inline-grid;
+  grid-template: auto auto/auto min-content;
+}
+.cds--dropdown__wrapper--inline .cds--form-requirement,
+.cds--dropdown__wrapper--inline .cds--form__helper-text,
+.cds--dropdown__wrapper--inline .cds--label {
+  margin: 0;
+}
+.cds--dropdown {
+  background-color: var(--cds-field);
+  border: none;
+  border-bottom: 1px solid var(--cds-border-strong);
+  cursor: pointer;
+  display: block;
+  height: 2.5rem;
+  outline-offset: -2px;
+  position: relative;
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--dropdown--disabled.cds--dropdown--light:hover,
+.cds--dropdown--light {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--dropdown__arrow,
+.cds--menu-button__trigger svg {
+  transition: transform 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--dropdown html {
+  font-size: 100%;
+}
+.cds--dropdown body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--dropdown code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--dropdown strong {
+  font-weight: 600;
+}
+.cds--dropdown:hover {
+  background-color: var(--cds-field-hover);
+}
+.cds--dropdown .cds--list-box__field {
+  text-align: left;
+}
+.cds--dropdown--lg {
+  height: 3rem;
+  max-height: 3rem;
+}
+.cds--dropdown--lg .cds--dropdown__arrow {
+  top: 1rem;
+}
+.cds--dropdown--sm {
+  height: 2rem;
+  max-height: 2rem;
+}
+.cds--dropdown--sm .cds--dropdown__arrow {
+  top: 0.5rem;
+}
+.cds--dropdown--open {
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--dropdown--invalid {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--date-picker__input.cds--focused,
+  .cds--date-picker__input:focus,
+  .cds--dropdown--invalid {
+    outline-style: dotted;
+  }
+}
+.cds--dropdown--invalid + .cds--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+  display: inline-block;
+  max-height: 12.5rem;
+}
+.cds--dropdown__invalid-icon {
+  fill: var(--cds-support-error, #da1e28);
+  position: absolute;
+  right: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.cds--dropdown--open:hover {
+  background-color: var(--cds-field);
+}
+.cds--dropdown--open:focus {
+  outline: 1px solid transparent;
+}
+.cds--dropdown--open .cds--dropdown-list {
+  max-height: 13.75rem;
+  transition: max-height 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+}
+.cds--dropdown--light:hover {
+  background-color: var(--cds-field-hover);
+}
+.cds--dropdown--light .cds--dropdown-list,
+.cds--dropdown-list {
+  background-color: var(--cds-layer);
+}
+.cds--dropdown--up .cds--dropdown-list {
+  bottom: 2rem;
+}
+.cds--dropdown__arrow {
+  fill: var(--cds-icon-primary, #161616);
+  pointer-events: none;
+  position: absolute;
+  right: 1rem;
+  top: 0.8125rem;
+  transform-origin: 50% 45%;
+}
+button.cds--dropdown-text {
+  background: 0 0;
+  border: none;
+  color: var(--cds-text-primary, #161616);
+  text-align: left;
+  width: 100%;
+}
+button.cds--dropdown-text:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--dropdown-text {
+  display: block;
+  height: calc(100% + 1px);
+  overflow: hidden;
+  padding-left: 1rem;
+  padding-right: 2.625rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--dropdown-list {
+  display: flex;
+  flex-direction: column;
+  max-height: 0;
+  outline-offset: -2px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: absolute;
+  transition: max-height 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+  z-index: 9100;
+}
+.cds--dropdown-list html,
+.cds--file--label html,
+.cds--label-description html,
+.cds--loading {
+  font-size: 100%;
+}
+.cds--dropdown-list body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--dropdown-list code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--dropdown-list strong {
+  font-weight: 600;
+}
+.cds--dropdown:not(.cds--dropdown--open) .cds--dropdown-item {
+  visibility: hidden;
+}
+.cds--dropdown-item {
+  opacity: 0;
+  position: relative;
+  transition:
+    visibility 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  visibility: inherit;
+}
+.cds--dropdown-item:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--dropdown-item:hover + .cds--dropdown-item .cds--dropdown-link {
+  border-color: transparent;
+}
+.cds--dropdown-item:active {
+  background-color: var(--cds-layer-selected);
+}
+.cds--dropdown-item:first-of-type .cds--dropdown-link {
+  border-top-color: transparent;
+}
+.cds--dropdown-item:last-of-type .cds--dropdown-link {
+  border-bottom: none;
+}
+.cds--dropdown-link {
+  border: 1px solid transparent;
+  border-top: 1px solid var(--cds-border-subtle);
+  color: var(--cds-text-secondary, #525252);
+  display: block;
+  font-weight: 400;
+  height: 2.5rem;
+  line-height: 1rem;
+  margin: 0 1rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  overflow: hidden;
+  padding: 0.6875rem 0;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--dropdown--disabled,
+.cds--dropdown--inline {
+  border-bottom-color: transparent;
+}
+.cds--dropdown-link:hover {
+  border-color: transparent;
+  color: var(--cds-text-primary, #161616);
+}
+.cds--dropdown--disabled .cds--dropdown-text,
+.cds--dropdown--disabled .cds--list-box__label,
+.cds--dropdown--inline.cds--dropdown--disabled .cds--dropdown-text {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--dropdown--light .cds--dropdown-link {
+  border-top-color: var(--cds-border-subtle-02, #e0e0e0);
+}
+.cds--dropdown--sm .cds--dropdown-link {
+  height: 2rem;
+  padding-bottom: 0.4375rem;
+  padding-top: 0.4375rem;
+}
+.cds--dropdown--focused,
+.cds--dropdown-link:focus {
+  margin: 0;
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  padding: 0.6875rem 1rem;
+}
+.cds--dropdown-list[aria-activedescendant] .cds--dropdown-link:focus {
+  margin: 0 1rem;
+  outline: 0;
+  padding: 0.6875rem 0;
+}
+.cds--date-picker--fluid
+  .cds--date-picker--range
+  > .cds--date-picker-container:first-child,
+.cds--file__selected-file .cds--inline-loading__animation .cds--loading {
+  margin-right: 0;
+}
+.cds--dropdown-list[aria-activedescendant] .cds--dropdown--focused:focus {
+  margin: 0;
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  padding: 0.6875rem 1rem;
+}
+@media screen and (prefers-contrast) {
+  .cds--dropdown--focused,
+  .cds--dropdown-link:focus,
+  .cds--dropdown-list[aria-activedescendant] .cds--dropdown--focused:focus,
+  button.cds--dropdown-text:focus {
+    outline-style: dotted;
+  }
+}
+.cds--dropdown--disabled:focus,
+.cds--dropdown--inline.cds--dropdown--disabled:focus .cds--dropdown-text {
+  outline: 0;
+}
+.cds--dropdown-list[aria-activedescendant] .cds--dropdown-item:active {
+  background-color: inherit;
+}
+.cds--dropdown-item:hover .cds--dropdown-link {
+  border-bottom-color: var(--cds-layer-hover);
+}
+.cds--dropdown--open .cds--dropdown__arrow {
+  transform: rotate(-180deg);
+}
+.cds--dropdown--open .cds--dropdown-item {
+  opacity: 1;
+}
+.cds--dropdown--disabled:hover {
+  background-color: var(--cds-field);
+}
+.cds--dropdown--inline .cds--dropdown-text,
+.cds--file--label,
+.cds--file-browse-btn:active {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--dropdown--disabled .cds--list-box__field,
+.cds--dropdown--disabled .cds--list-box__menu-icon {
+  cursor: not-allowed;
+}
+.cds--dropdown--auto-width {
+  max-width: 25rem;
+  width: auto;
+}
+.cds--dropdown--inline {
+  background-color: transparent;
+  display: inline-block;
+  justify-self: start;
+  transition: background 70ms cubic-bezier(0, 0, 0.38, 0.9);
+  width: auto;
+}
+.cds--dropdown--inline:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--dropdown--inline.cds--dropdown--disabled,
+.cds--dropdown--inline.cds--dropdown--open {
+  background-color: transparent;
+}
+.cds--dropdown--inline .cds--dropdown__arrow {
+  right: 0.5rem;
+  top: 0.5rem;
+}
+.cds--dropdown--inline .cds--dropdown-text {
+  display: inline-block;
+  height: 2rem;
+  overflow: visible;
+  padding: 0.4375rem 2rem 0.4375rem 0.75rem;
+}
+.cds--dropdown--inline .cds--dropdown-link {
+  font-weight: 400;
+}
+.cds--dropdown--show-selected .cds--dropdown--selected {
+  background-color: var(--cds-layer-selected);
+  color: var(--cds-text-primary, #161616);
+  display: block;
+}
+.cds--dropdown--show-selected .cds--dropdown--selected:hover {
+  background-color: var(--cds-layer-selected-hover);
+}
+.cds--dropdown--show-selected .cds--dropdown--selected .cds--dropdown-link,
+.cds--dropdown--show-selected
+  .cds--dropdown--selected
+  + .cds--dropdown-item
+  .cds--dropdown-link {
+  border-top-color: transparent;
+}
+.cds--dropdown--show-selected
+  .cds--dropdown--selected
+  .cds--list-box__menu-item__selected-icon {
+  display: block;
+}
+.cds--dropdown-v2.cds--skeleton,
+.cds--dropdown.cds--skeleton {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+}
+.cds--dropdown-v2.cds--skeleton:active,
+.cds--dropdown-v2.cds--skeleton:focus,
+.cds--dropdown-v2.cds--skeleton:hover,
+.cds--dropdown.cds--skeleton:active,
+.cds--dropdown.cds--skeleton:focus,
+.cds--dropdown.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--dropdown-v2.cds--skeleton:before,
+.cds--dropdown.cds--skeleton:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--date-picker.cds--skeleton .cds--label:before,
+  .cds--dropdown-v2.cds--skeleton:before,
+  .cds--dropdown.cds--skeleton:before {
+    animation: none;
+  }
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--dropdown .cds--list-box__field {
+    outline: 1px solid transparent;
+  }
+  .cds--list-box__menu-item__option {
+    outline: 0;
+  }
+  .cds--list-box__menu-item__selected-icon {
+    fill: ButtonText;
+  }
+}
+.cds--dropdown--readonly,
+.cds--dropdown--readonly:hover {
+  background-color: transparent;
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--dropdown--readonly .cds--list-box__field,
+.cds--dropdown--readonly .cds--list-box__menu-icon {
+  cursor: default;
+}
+.cds--loading {
+  animation-duration: 0.69s;
+  animation-fill-mode: forwards;
+  animation-iteration-count: infinite;
+  animation-name: rotate;
+  animation-timing-function: linear;
+  border: 0;
+  box-sizing: border-box;
+  height: 5.5rem;
+  margin: 0;
+  padding: 0;
+  width: 5.5rem;
+}
+.cds--loading *,
+.cds--loading :after,
+.cds--loading :before {
+  box-sizing: inherit;
+}
+.cds--loading svg circle {
+  animation-duration: 10ms;
+  animation-name: init-stroke;
+  animation-timing-function: cubic-bezier(0.5, 0, 0.1, 1);
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--loading svg circle,
+  .flatpickr-calendar.animate.open {
+    animation: none;
+  }
+  .flatpickr-next-month,
+  .flatpickr-prev-month {
+    transition: none;
+  }
+}
+.cds--loading__svg {
+  fill: transparent;
+}
+.cds--loading__svg circle {
+  stroke-dasharray: 276.4608 276.4608;
+  stroke-linecap: butt;
+  stroke-width: 10;
+}
+.cds--loading__stroke {
+  stroke: var(--cds-interactive, #0f62fe);
+  stroke-dashoffset: 52.527552;
+}
+.cds--loading--small .cds--loading__stroke {
+  stroke-dashoffset: 143.759616;
+}
+.cds--loading--stop {
+  animation:
+    rotate-end-p1 0.7s cubic-bezier(0, 0, 0.25, 1) forwards,
+    rotate-end-p2 0.7s cubic-bezier(0, 0, 0.25, 1) 0.7s forwards;
+}
+.cds--loading--stop svg circle {
+  animation-delay: 0.7s;
+  animation-duration: 0.7s;
+  animation-fill-mode: forwards;
+  animation-name: stroke-end;
+  animation-timing-function: cubic-bezier(0, 0, 0.25, 1);
+}
+.cds--loading--small {
+  height: 1rem;
+  width: 1rem;
+}
+.cds--loading--small circle {
+  stroke-width: 16;
+}
+.cds--loading--small .cds--loading__svg {
+  stroke: var(--cds-interactive, #0f62fe);
+}
+.cds--loading__background {
+  stroke: var(--cds-layer-accent);
+  stroke-dashoffset: -22;
+}
+.cds--loading-overlay {
+  align-items: center;
+  background-color: var(--cds-overlay, hsla(0, 0%, 9%, 0.5));
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  transition: background-color 0.7s cubic-bezier(0.4, 0.14, 0.3, 1);
+  width: 100%;
+  z-index: 6000;
+}
+.cds--loading-overlay--stop {
+  display: none;
+}
+@keyframes rotate {
+  0% {
+    transform: rotate(0);
+  }
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes rotate-end-p1 {
+  to {
+    transform: rotate(1turn);
+  }
+}
+@keyframes rotate-end-p2 {
+  to {
+    transform: rotate(-1turn);
+  }
+}
+@keyframes init-stroke {
+  0% {
+    stroke-dashoffset: 276.4608;
+  }
+  to {
+    stroke-dashoffset: 52.527552;
+  }
+}
+@keyframes stroke-end {
+  0% {
+    stroke-dashoffset: 52.527552;
+  }
+  to {
+    stroke-dashoffset: 276.4608;
+  }
+}
+.cds--file {
+  width: 100%;
+}
+.cds--file--invalid {
+  fill: var(--cds-support-error, #da1e28);
+  margin-right: 0.5rem;
+}
+.cds--file--label {
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  margin-bottom: 0.5rem;
+}
+.cds--file__selected-file .cds--file-filename,
+.cds--label-description,
+.cds--number input[type='number'] {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+}
+.cds--file__drop-container,
+.cds--file__selected-file .cds--file-filename,
+.cds--label-description,
+.cds--number input[type='number'] {
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--file--label body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--file--label code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--file--label strong {
+  font-weight: 600;
+}
+.cds--file--label--disabled {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--file-input {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  width: 1px;
+}
+.cds--file-btn {
+  display: inline-flex;
+  margin: 0;
+  padding-right: 4rem;
+}
+.cds--file-browse-btn {
+  color: var(--cds-link-primary, #0f62fe);
+  cursor: pointer;
+  display: inline-block;
+  max-width: 20rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  transition: 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--file-browse-btn:focus,
+.cds--file-browse-btn:hover {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+}
+.cds--actionable-notification a,
+.cds--file-browse-btn--disabled,
+.cds--inline-notification a,
+.cds--pagination-nav__page,
+.cds--tabs .cds--tabs__nav-link,
+.cds--toast-notification a {
+  text-decoration: none;
+}
+.cds--file-browse-btn--disabled {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: no-drop;
+}
+.cds--file-browse-btn--disabled:focus,
+.cds--file-browse-btn--disabled:hover {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  outline: 0;
+  text-decoration: none;
+}
+.cds--file-browse-btn--disabled .cds--file__drop-container {
+  border: 1px dashed var(--cds-button-disabled, #c6c6c6);
+}
+.cds--label-description {
+  color: var(--cds-text-secondary, #525252);
+  margin-bottom: 1rem;
+}
+.cds--file__selected-file,
+.cds--file__selected-file--invalid__wrapper {
+  background-color: var(--cds-layer);
+  margin-bottom: 0.5rem;
+  max-width: 20rem;
+}
+.cds--label-description body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--label-description code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--label-description strong {
+  font-weight: 600;
+}
+.cds--label-description--disabled {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--file-container--drop {
+  width: 100%;
+}
+.cds--file-btn ~ .cds--file-container {
+  margin-top: 1.5rem;
+}
+.cds--btn ~ .cds--file-container {
+  margin-top: 1rem;
+}
+.cds--file .cds--file-container,
+.cds--file ~ .cds--file-container {
+  margin-top: 0.5rem;
+}
+.cds--file__selected-file {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem 1rem;
+  grid-auto-rows: auto;
+  grid-template-columns: 1fr auto;
+  min-height: 3rem;
+  word-break: break-word;
+}
+.cds--file__selected-file:last-child,
+div.container.tutorial ul li:last-child {
+  margin-bottom: 0;
+}
+.cds--file__selected-file .cds--form-requirement {
+  display: block;
+  grid-column: 1/-1;
+  margin: 0;
+  max-height: none;
+}
+.cds--file__selected-file .cds--file-filename {
+  margin-left: 1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--file__selected-file--invalid .cds--form-requirement__supplement,
+.cds--file__selected-file--invalid .cds--form-requirement__title,
+.cds--file__selected-file--invalid + .cds--form-requirement {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+}
+.cds--file__selected-file--md {
+  gap: 0.5rem 1rem;
+  min-height: 2.5rem;
+}
+.cds--file__selected-file--sm {
+  gap: 0.25rem 1rem;
+  min-height: 2rem;
+}
+.cds--file__selected-file--invalid__wrapper {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+  outline-width: 1px;
+}
+@media screen and (prefers-contrast) {
+  .cds--file__selected-file--invalid__wrapper {
+    outline-style: dotted;
+  }
+}
+.cds--file__selected-file--invalid {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+  padding: 0.75rem 0;
+}
+.cds--file__selected-file--invalid.cds--file__selected-file--sm {
+  padding: 0.25rem 0;
+}
+.cds--file__selected-file--invalid.cds--file__selected-file--md {
+  padding: 0.5rem 0;
+}
+.cds--file__selected-file--invalid .cds--form-requirement {
+  border-top: 1px solid var(--cds-border-subtle);
+  padding-top: 1rem;
+}
+.cds--file__selected-file--invalid.cds--file__selected-file--sm
+  .cds--form-requirement {
+  padding-top: 0.4375rem;
+}
+.cds--file__selected-file--invalid.cds--file__selected-file--md
+  .cds--form-requirement {
+  padding-top: 0.6875rem;
+}
+.cds--file__selected-file--invalid .cds--form-requirement__supplement,
+.cds--file__selected-file--invalid .cds--form-requirement__title {
+  padding: 0 1rem;
+}
+.cds--file__selected-file--invalid .cds--form-requirement__title {
+  color: var(--cds-text-error, #da1e28);
+}
+.cds--file__selected-file--invalid .cds--form-requirement__supplement,
+.cds--number input[type='number'] {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--file__selected-file--invalid + .cds--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+  display: block;
+  font-weight: 400;
+  max-height: 12.5rem;
+  overflow: visible;
+  padding: 0.5rem 1rem;
+}
+.cds--file__selected-file--invalid
+  + .cds--form-requirement
+  .cds--form-requirement__supplement {
+  color: var(--cds-text-primary, #161616);
+  padding-bottom: 0.5rem;
+}
+.cds--list-box__wrapper--fluid .cds--label--disabled .cds--toggletip-label,
+.cds--number input[type='number']:disabled {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--file__state-container {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-width: 1.5rem;
+  padding-right: 1rem;
+}
+.cds--menu,
+.cds--menu-button__trigger:not(.cds--btn--ghost) {
+  min-width: 10rem;
+}
+.cds--file__state-container .cds--loading__svg {
+  stroke: var(--cds-icon-primary, #161616);
+}
+.cds--inline-loading__checkmark,
+.cds--loading--small .cds--inline-loading__svg {
+  stroke: var(--cds-interactive, #0f62fe);
+}
+.cds--file__state-container .cds--file-complete {
+  fill: var(--cds-interactive, #0f62fe);
+}
+.cds--number__invalid,
+.cds--select-input__wrapper[data-invalid]
+  .cds--select-input
+  ~ .cds--select__invalid-icon {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--file__state-container .cds--file-complete:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+@media screen and (prefers-contrast) {
+  .cds--file__selected-file--invalid,
+  .cds--file__state-container .cds--file-complete:focus {
+    outline-style: dotted;
+  }
+}
+.cds--file__state-container .cds--file-complete [data-icon-path='inner-path'] {
+  fill: var(--cds-icon-inverse, #fff);
+  opacity: 1;
+}
+.cds--file__state-container .cds--file-invalid {
+  fill: var(--cds-support-error, #da1e28);
+  height: 1rem;
+  width: 1rem;
+}
+.cds--file__state-container .cds--file-close {
+  fill: var(--cds-icon-primary, #161616);
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  height: 1.5rem;
+  justify-content: center;
+  padding: 0;
+  width: 1.5rem;
+}
+.cds--file__state-container .cds--file-close:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--file__state-container .cds--file-close svg path {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--file__state-container .cds--inline-loading__animation {
+  margin-right: -0.5rem;
+}
+.cds--file__drop-container {
+  align-items: flex-start;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  border: 1px dashed var(--cds-border-strong);
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  display: flex;
+  font-size: 100%;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  height: 6rem;
+  justify-content: space-between;
+  margin: 0;
+  overflow: hidden;
+  padding: 1rem;
+  text-align: start;
+  width: 100%;
+}
+.cds--number html,
+.cds--number__controls html,
+.cds--search-input {
+  font-size: 100%;
+}
+.cds--file__drop-container *,
+.cds--file__drop-container :after,
+.cds--file__drop-container :before {
+  box-sizing: inherit;
+}
+.cds--file__drop-container::-moz-focus-inner {
+  border: 0;
+}
+.cds--list-box__wrapper--fluid
+  .cds--combo-box.cds--list-box--warning
+  .cds--text-input,
+.cds--list-box__wrapper--fluid .cds--list-box--warning,
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--focus
+  .cds--list-box
+  .cds--text-input,
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--focus
+  .cds--list-box:not(.cds--list-box--invalid),
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--list-box,
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--list-box
+  .cds--text-input {
+  border-bottom: 1px solid transparent;
+}
+.cds--file__drop-container--drag-over {
+  background: 0 0;
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper {
+  background: var(--cds-field);
+  height: 100%;
+  position: relative;
+  transition:
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--list-box__wrapper--fluid .cds--list-box {
+  min-height: 4rem;
+  padding: 0;
+}
+.cds--list-box__wrapper--fluid .cds--label {
+  align-items: center;
+  display: flex;
+  height: 1rem;
+  left: 1rem;
+  margin: 0;
+  position: absolute;
+  top: 0.8125rem;
+  width: calc(100% - 2rem);
+  z-index: 1;
+}
+.cds--list-box__wrapper--fluid
+  .cds--label
+  .cds--toggletip-label::-webkit-scrollbar,
+.cds--list-box__wrapper--fluid .cds--label::-webkit-scrollbar {
+  display: none;
+}
+.cds--list-box__wrapper--fluid .cds--label .cds--toggletip-label,
+.cds--list-box__wrapper--fluid .cds--label:not(:has(.cds--toggletip-label)) {
+  -ms-overflow-style: none;
+  overflow-x: scroll;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+.cds--list-box__wrapper--fluid .cds--list-box__field {
+  padding-bottom: 0.8125rem;
+  padding-left: 1rem;
+  padding-top: 2.0625rem;
+}
+.cds--list-box__wrapper--fluid .cds--list-box__menu-icon {
+  height: 1rem;
+  width: 1rem;
+}
+.cds--list-box__wrapper--fluid:not(.cds--list-box__wrapper--fluid--condensed)
+  .cds--list-box__menu-item {
+  height: 4rem;
+}
+.cds--list-box__wrapper--fluid:not(.cds--list-box__wrapper--fluid--condensed)
+  .cds--list-box__menu-item__selected-icon {
+  top: 1.25rem;
+}
+.cds--list-box__wrapper--fluid .cds--label--disabled .cds--toggletip-button {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  outline-offset: 0;
+  z-index: 2;
+}
+@media screen and (prefers-contrast) {
+  .cds--file__state-container .cds--file-close:focus,
+  .cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--focus {
+    outline-style: dotted;
+  }
+}
+.cds--list-box__wrapper--fluid .cds--list-box__field:focus {
+  outline: 0;
+  outline-offset: 0;
+}
+.cds--list-box__wrapper--fluid :not(.cds--list-box--up) .cds--list-box__menu {
+  top: calc(100% + 0.1875rem);
+}
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid:not(
+    .cds--list-box__wrapper--fluid--focus
+  ) {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+  outline-offset: 0;
+  z-index: 2;
+}
+@media screen and (prefers-contrast) {
+  .cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid:not(
+      .cds--list-box__wrapper--fluid--focus
+    ) {
+    outline-style: dotted;
+  }
+}
+.cds--date-picker--fluid
+  .cds--date-picker-container.cds--date-picker--fluid--invalid
+  .cds--date-picker__input--invalid,
+.cds--list-box__wrapper--fluid .cds--combo-box .cds--text-input:focus {
+  outline: 0;
+}
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--combo-box[data-invalid]
+  .cds--text-input,
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--list-box,
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--list-box__field:focus {
+  outline: 0;
+  outline-offset: 0;
+}
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid:focus-within {
+  outline-offset: 0;
+}
+.cds--list-box__wrapper--fluid .cds--list-box--warning ~ .cds--form-requirement,
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--form-requirement {
+  margin-top: 0;
+  padding: 0.5rem 4rem 0.5rem 1rem;
+}
+.cds--list-box__wrapper--fluid
+  .cds--list-box--warning
+  ~ .cds--form-requirement {
+  border-bottom: 1px solid var(--cds-border-strong);
+}
+.cds--list-box__wrapper--fluid
+  .cds--list-box--warning
+  .cds--list-box__invalid-icon,
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--list-box__invalid-icon {
+  pointer-events: none;
+  right: 1rem;
+  top: 5.0625rem;
+}
+.cds--list-box__wrapper--fluid.cds--list-box__wrapper--fluid--invalid
+  .cds--list-box[data-invalid].cds--combo-box
+  .cds--text-input {
+  padding-right: 4rem;
+}
+.cds--list-box__wrapper--fluid .cds--list-box__divider {
+  display: none;
+  transition: border-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--date-picker--fluid .cds--date-picker,
+.cds--number input[type='number'] {
+  transition:
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--list-box__wrapper--fluid
+  .cds--list-box--invalid
+  ~ .cds--list-box__divider,
+.cds--list-box__wrapper--fluid
+  .cds--list-box--warning
+  ~ .cds--list-box__divider {
+  border: none;
+  border-bottom: 1px solid var(--cds-border-subtle);
+  display: block;
+  margin: 0 1rem;
+}
+.cds--date-picker--fluid .cds--date-picker--simple .cds--date-picker__icon,
+.cds--number.cds--skeleton input[type='number'] {
+  display: none;
+}
+.cds--list-box__wrapper--fluid
+  .cds--list-box--invalid:hover:not(.cds--combo-box)
+  ~ .cds--list-box__divider,
+.cds--list-box__wrapper--fluid
+  .cds--list-box--warning:hover:not(.cds--combo-box)
+  ~ .cds--list-box__divider {
+  border-color: transparent;
+}
+.cds--list-box__wrapper--fluid .cds--list-box--up .cds--list-box__menu {
+  bottom: 4rem;
+}
+.cds--list-box__wrapper--fluid .cds--skeleton {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border-bottom: 1px solid var(--cds-skeleton-element, #c6c6c6);
+}
+.cds--list-box__wrapper--fluid .cds--skeleton .cds--list-box__field {
+  height: 0.5rem;
+  left: 1rem;
+  padding: 0;
+  position: absolute;
+  top: 2.25rem;
+  width: 50%;
+}
+.cds--list-box__wrapper--fluid .cds--skeleton .cds--list-box__label {
+  height: 0.5rem;
+  left: 1rem;
+  position: absolute;
+  top: 1rem;
+  width: 25%;
+}
+.cds--list-box__wrapper--fluid .cds--skeleton .cds--list-box__field,
+.cds--list-box__wrapper--fluid .cds--skeleton .cds--list-box__label {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+}
+.cds--list-box__wrapper--fluid .cds--combo-box .cds--list-box__field {
+  overflow: visible;
+  padding: 0;
+}
+.cds--list-box__wrapper--fluid .cds--combo-box .cds--text-input {
+  overflow: hidden;
+  padding: 2.0625rem 4rem 0.8125rem 1rem;
+  text-overflow: ellipsis;
+  transition: none;
+  white-space: nowrap;
+}
+.cds--list-box__wrapper--fluid .cds--combo-box .cds--list-box__selection {
+  bottom: 0.625rem;
+  top: auto;
+  transform: none;
+}
+.cds--date-picker--fluid.cds--date-picker--fluid--invalid
+  .cds--date-picker--range
+  + .cds--date-picker__icon,
+.cds--date-picker--fluid.cds--date-picker--fluid--warn
+  .cds--date-picker--range
+  + .cds--date-picker__icon,
+.cds--date-picker-container.cds--date-picker--fluid--invalid
+  .cds--date-picker__icon--invalid,
+.cds--date-picker-container.cds--date-picker--fluid--warn
+  .cds--date-picker__icon--warn {
+  top: 5rem;
+}
+.cds--list-box__wrapper--fluid .cds--combo-box .cds--list-box__menu-icon {
+  bottom: 0.875rem;
+}
+.cds--list-box__wrapper--fluid
+  .cds--list-box--warning
+  .cds--list-box__field
+  .cds--text-input
+  + .cds--list-box__invalid-icon,
+.cds--list-box__wrapper--fluid
+  .cds--list-box[data-invalid]
+  .cds--list-box__field
+  .cds--text-input
+  + .cds--list-box__invalid-icon {
+  right: 1rem;
+}
+.cds--date-picker--fluid {
+  background: var(--cds-field);
+  display: inline-flex;
+}
+.cds--date-picker--fluid .cds--date-picker {
+  height: 100%;
+  position: relative;
+  width: 100%;
+}
+.cds--date-picker--fluid .cds--label {
+  align-items: center;
+  display: flex;
+  height: 1rem;
+  left: 1rem;
+  margin: 0;
+  position: absolute;
+  top: 0.8125rem;
+  width: calc(100% - 2rem);
+  z-index: 1;
+}
+.cds--date-picker--fluid .cds--label .cds--toggletip-label::-webkit-scrollbar,
+.cds--date-picker--fluid .cds--label::-webkit-scrollbar {
+  display: none;
+}
+.cds--date-picker--fluid .cds--label .cds--toggletip-label,
+.cds--date-picker--fluid .cds--label:not(:has(.cds--toggletip-label)) {
+  -ms-overflow-style: none;
+  overflow-x: scroll;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+.cds--date-picker--fluid
+  .cds--date-picker-input__wrapper
+  .cds--date-picker__input {
+  background: 0 0;
+  border-bottom: none;
+  min-height: 4rem;
+  min-width: 9rem;
+  padding: 2rem 1rem 0.8125rem;
+}
+.cds--date-picker--fluid
+  .cds--date-picker--simple
+  .cds--date-picker--fluid--warn,
+.cds--date-picker--fluid
+  .cds--date-picker--simple
+  .cds--date-picker__input:not(.cds--date-picker__input--invalid):not(
+    .cds--date-picker__input--warn
+  ) {
+  border-bottom: 1px solid var(--cds-border-strong);
+}
+.cds--date-picker--fluid .cds--date-picker__icon {
+  top: 2.6875rem;
+}
+.cds--date-picker--fluid .cds--date-picker--single .cds--date-picker__input {
+  width: 100%;
+}
+.cds--date-picker--fluid .cds--date-picker--single {
+  border-bottom: none;
+}
+.cds--date-picker--fluid
+  .cds--date-picker--single
+  .cds--date-picker__input:not(.cds--date-picker__input--invalid),
+.cds--date-picker--fluid:not(.cds--date-picker--fluid--invalid):not(
+    .cds--date-picker--fluid--warn
+  )
+  .cds--date-picker--range
+  .cds--date-picker-container:not(.cds--date-picker--fluid--invalid),
+.cds--date-picker--single .cds--date-picker--fluid--warn {
+  border-bottom: 1px solid var(--cds-border-strong);
+}
+.cds--date-picker--fluid .cds--date-picker--range .cds--date-picker-container,
+.cds--date-picker--fluid .cds--date-picker--range .cds--date-picker__input {
+  min-height: 3.9375rem;
+  min-width: 9rem;
+  width: 100%;
+}
+.cds--date-picker--fluid
+  .cds--date-picker--range
+  > .cds--date-picker-container:last-child
+  .cds--date-picker__input {
+  border-left: 1px solid var(--cds-border-strong);
+}
+.cds--date-picker--fluid.cds--date-picker--fluid--invalid,
+.cds--date-picker-container.cds--date-picker--fluid--invalid {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+.cds--date-picker--fluid
+  .cds--date-picker-container.cds--date-picker--fluid--invalid
+  + .cds--date-picker-container
+  .cds--date-picker__input,
+.cds--date-picker--fluid
+  .cds--date-picker-container:last-child.cds--date-picker--fluid--invalid
+  .cds--date-picker__input--invalid {
+  border-left: none;
+}
+.cds--date-picker-container.cds--date-picker--fluid--invalid
+  .cds--form-requirement,
+.cds--date-picker-container.cds--date-picker--fluid--warn
+  .cds--form-requirement {
+  margin: 0;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+}
+.cds--date-picker--fluid
+  .cds--date-picker--single
+  .cds--date-picker--fluid--warn
+  .cds--date-picker__input,
+.cds--date-picker--fluid.cds--date-picker--fluid--invalid .cds--date-picker,
+.cds--date-picker--fluid.cds--date-picker--fluid--warn
+  .cds--date-picker--range
+  .cds--date-picker-container,
+.cds--date-picker-container.cds--date-picker--fluid--invalid
+  .cds--date-picker--fluid.cds--date-picker--fluid--invalid
+  .cds--date-picker {
+  border-bottom: 1px solid transparent;
+}
+.cds--date-picker--fluid
+  .cds--date-picker--fluid--warn
+  + .cds--date-picker-container:last-child
+  .cds--date-picker__input,
+.cds--date-picker--fluid
+  .cds--date-picker--fluid--warn.cds--date-picker-container:last-child
+  .cds--date-picker__input,
+.cds--date-picker--fluid.cds--date-picker--fluid--invalid
+  .cds--date-picker--range
+  > .cds--date-picker-container:last-child
+  .cds--date-picker__input,
+.cds--date-picker--fluid.cds--date-picker--fluid--warn
+  .cds--date-picker--range
+  > .cds--date-picker-container:last-child
+  .cds--date-picker__input {
+  border-left: 1px solid transparent;
+}
+.cds--date-picker--fluid
+  .cds--date-picker--range
+  .cds--date-picker--fluid--warn.cds--date-picker-container:first-child:after,
+.cds--date-picker--fluid
+  .cds--date-picker--range
+  .cds--date-picker--fluid--warn.cds--date-picker-container:last-child:after,
+.cds--date-picker--fluid.cds--date-picker--fluid--invalid
+  .cds--date-picker--range
+  > .cds--date-picker-container:first-child:after,
+.cds--date-picker--fluid.cds--date-picker--fluid--warn
+  .cds--date-picker--range
+  > .cds--date-picker-container:first-child:after {
+  background: var(--cds-border-strong);
+  content: '';
+  display: block;
+  height: calc(100% - 1rem);
+  position: absolute;
+  right: 0;
+  top: 0.5rem;
+  width: 1px;
+}
+.cds--date-picker--fluid
+  .cds--date-picker--fluid--warn.cds--date-picker-container:last-child:after {
+  left: 0;
+}
+.cds--date-picker--fluid .cds--date-picker__divider {
+  border-color: var(--cds-border-subtle);
+  border-style: solid;
+  border-bottom: none;
+  margin: 0 1rem;
+  width: calc(100% - 2rem);
+}
+.cds--date-picker--fluid
+  .cds--date-picker--simple
+  .cds--date-picker--fluid--invalid
+  .cds--date-picker__icon--invalid,
+.cds--date-picker--fluid
+  .cds--date-picker--simple
+  .cds--date-picker--fluid--warn
+  .cds--date-picker__icon--warn {
+  display: block;
+}
+.cds--date-picker-container.cds--date-picker--fluid--invalid
+  .cds--date-picker__input:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--date-picker--fluid.cds--date-picker--fluid--invalid,
+  .cds--date-picker-container.cds--date-picker--fluid--invalid,
+  .cds--date-picker-container.cds--date-picker--fluid--invalid
+    .cds--date-picker__input:focus {
+    outline-style: dotted;
+  }
+}
+.cds--date-picker--fluid.cds--date-picker--fluid--invalid
+  .cds--date-picker--range
+  ~ .cds--form-requirement,
+.cds--date-picker--fluid.cds--date-picker--fluid--warn
+  .cds--date-picker--range
+  ~ .cds--form-requirement {
+  display: block;
+  margin-top: 0;
+  max-height: 100%;
+  overflow: visible;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+}
+.cds--date-picker--fluid.cds--date-picker--fluid--invalid
+  .cds--date-picker--range
+  ~ .cds--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+}
+.cds--date-picker--fluid.cds--date-picker--fluid--invalid,
+.cds--date-picker--fluid.cds--date-picker--fluid--warn {
+  position: relative;
+}
+.cds--date-picker--fluid__skeleton {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border-bottom: 1px solid var(--cds-skeleton-element, #c6c6c6);
+  height: 4rem;
+}
+.cds--date-picker--fluid__skeleton--container {
+  height: 100%;
+  position: relative;
+  width: 100%;
+}
+.cds--date-picker--fluid__skeleton .cds--skeleton {
+  height: 0.5rem;
+  left: 1rem;
+  position: absolute;
+  top: 1rem;
+  width: 25%;
+}
+.cds--date-picker--fluid__skeleton .cds--label {
+  margin-bottom: 0.25rem;
+}
+.cds--date-picker--fluid__skeleton .cds--text-input {
+  height: 0.5rem;
+  left: 1rem;
+  padding: 0;
+  position: absolute;
+  top: 2.25rem;
+  width: 50%;
+}
+.cds--date-picker--fluid__skeleton--container .cds--date-picker__icon {
+  bottom: 0.5rem;
+  top: auto;
+}
+.cds--date-picker--fluid__skeleton--range {
+  display: flex;
+  flex-direction: row;
+}
+.cds--date-picker--fluid__skeleton--range
+  .cds--date-picker--fluid__skeleton--container {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+}
+.cds--date-picker--fluid__skeleton--range
+  .cds--date-picker--fluid__skeleton--container:first-of-type {
+  border-right: 1px solid var(--cds-skeleton-element, #c6c6c6);
+}
+.cds--date-picker--fluid__skeleton--range
+  .cds--date-picker--fluid__skeleton--container
+  .cds--date-picker__icon {
+  bottom: 0.5rem;
+}
+.cds--date-picker--fluid.cds--date-picker--fluid--readonly:not(
+    .cds--date-picker--fluid--invalid
+  ):not(.cds--date-picker--fluid--warn)
+  .cds--date-picker
+  .cds--date-picker__input,
+.cds--date-picker--fluid.cds--date-picker--fluid--readonly:not(
+    .cds--date-picker--fluid--invalid
+  ):not(.cds--date-picker--fluid--warn)
+  .cds--date-picker
+  > .cds--date-picker-container {
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--date-picker--fluid.cds--date-picker--fluid--readonly:not(
+    .cds--date-picker--fluid--invalid
+  ):not(.cds--date-picker--fluid--warn)
+  .cds--date-picker--range
+  > .cds--date-picker-container:last-child
+  .cds--date-picker__input {
+  border-left-color: var(--cds-border-subtle);
+}
+.cds--multi-select__wrapper.cds--list-box__wrapper--fluid--focus:not(
+    .cds--multi-select--filterable__wrapper
+  )
+  .cds--list-box__field--wrapper--input-focused {
+  outline: 0;
+}
+.cds--list-box__wrapper--fluid .cds--tag.cds--tag--filter {
+  margin-top: 1.25rem;
+}
+.cds--list-box__wrapper--fluid .cds--multi-select--filterable--input-focused {
+  outline: 0;
+  outline-offset: 0;
+}
+.cds--list-box__wrapper--fluid
+  .cds--multi-select--filterable
+  .cds--list-box__field
+  .cds--text-input {
+  border-bottom: 1px solid transparent;
+}
+.cds--list-box__wrapper--fluid
+  .cds--multi-select--filterable.cds--combo-box
+  .cds--list-box__field {
+  align-items: baseline;
+}
+.cds--number {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+}
+.cds--number body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--number code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--number input[type='number'],
+.cds--number__controls body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+}
+.cds--number strong {
+  font-weight: 600;
+}
+.cds--number input[type='number'] {
+  -moz-appearance: textfield;
+  background-color: var(--cds-field);
+  border: 0;
+  border-bottom: 0.0625rem solid var(--cds-border-strong);
+  border-radius: 0;
+  box-sizing: border-box;
+  display: inline-flex;
+  font-weight: 400;
+  height: 2.5rem;
+  min-width: 9.375rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding-left: 1rem;
+  padding-right: 8rem;
+  width: 100%;
+}
+.cds--number input[type='number']:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--number input[type='number']:disabled ~ .cds--number__controls {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.cds--number input[type='number']::-ms-clear {
+  display: none;
+}
+.cds--number input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+.cds--number--lg.cds--number input[type='number'] {
+  padding-right: 9rem;
+}
+.cds--number--sm.cds--number input[type='number'] {
+  padding-right: 7rem;
+}
+.cds--number input[type='number']:disabled {
+  background-color: var(--cds-field);
+  border-bottom-color: transparent;
+  cursor: not-allowed;
+}
+.cds--number__input-wrapper {
+  align-items: center;
+  display: flex;
+  position: relative;
+}
+.cds--number__controls {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  justify-content: center;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 5rem;
+}
+.cds--number__controls body {
+  font-weight: 400;
+}
+.cds--number__controls code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--number__controls strong {
+  font-weight: 600;
+}
+.cds--number__control-btn {
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  border-bottom: 0.0625rem solid var(--cds-border-strong);
+  box-sizing: border-box;
+  color: var(--cds-icon-primary, #161616);
+  cursor: pointer;
+  display: inline-block;
+  display: inline-flex;
+  font-size: 100%;
+  height: 100%;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  text-align: start;
+  width: 100%;
+}
+.cds--search-input,
+.cds--select-input {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  color: var(--cds-text-primary, #161616);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--number__control-btn *,
+.cds--number__control-btn :after,
+.cds--number__control-btn :before {
+  box-sizing: inherit;
+}
+.cds--number__control-btn::-moz-focus-inner {
+  border: 0;
+}
+.cds--number__control-btn:after,
+.cds--number__control-btn:before {
+  background-color: var(--cds-field);
+  content: '';
+  display: block;
+  height: 2.25rem;
+  position: absolute;
+  top: 0.125rem;
+  width: 0.125rem;
+}
+.cds--number__control-btn:hover,
+.cds--number__control-btn:hover:after,
+.cds--number__control-btn:hover:before {
+  background-color: var(--cds-field-hover);
+}
+.cds--number__control-btn:before {
+  left: 0;
+}
+.cds--number__control-btn:after {
+  right: 0;
+}
+.cds--number__control-btn svg {
+  fill: currentColor;
+}
+.cds--number__control-btn:focus {
+  color: var(--cds-icon-primary, #161616);
+  outline: 1px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  outline-width: 2px;
+}
+.cds--number__control-btn:hover {
+  color: var(--cds-icon-primary, #161616);
+  cursor: pointer;
+}
+.cds--number
+  input[type='number']:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn.up-icon:after,
+.cds--number__control-btn:focus:after,
+.cds--number__control-btn:focus:before,
+.cds--number__control-btn:hover:focus:after,
+.cds--number__control-btn:hover:focus:before {
+  background-color: transparent;
+}
+.cds--number__invalid
+  + .cds--number__controls
+  .cds--number__rule-divider:first-of-type,
+.cds--number__rule-divider {
+  background-color: var(--cds-border-subtle);
+}
+.cds--number__control-btn:disabled {
+  border-bottom-color: transparent;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--number__control-btn.up-icon {
+  order: 2;
+}
+.cds--number
+  input[type='number']:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn,
+.cds--number
+  input[type='number'][data-invalid]
+  ~ .cds--number__controls
+  .cds--number__control-btn {
+  border-bottom-color: transparent;
+}
+.cds--number
+  input[type='number']:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn:hover {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--number
+  input[type='number'][data-invalid]:not(:focus)
+  ~ .cds--number__controls
+  .cds--number__control-btn:hover {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--number input[type='number']:focus,
+  .cds--number
+    input[type='number']:focus
+    ~ .cds--number__controls
+    .cds--number__control-btn:hover,
+  .cds--number
+    input[type='number'][data-invalid]:not(:focus)
+    ~ .cds--number__controls
+    .cds--number__control-btn:hover,
+  .cds--number__control-btn:focus {
+    outline-style: dotted;
+  }
+}
+.cds--number
+  input[type='number'][data-invalid]
+  ~ .cds--number__controls
+  .cds--number__control-btn.up-icon:after {
+  background-color: var(--cds-support-error, #da1e28);
+}
+.cds--number__rule-divider {
+  height: 1rem;
+  position: absolute;
+  width: 0.0625rem;
+  z-index: 6000;
+}
+.cds--number__rule-divider:first-of-type {
+  order: 0;
+}
+.cds--number__controls .cds--number__rule-divider:first-of-type {
+  background-color: transparent;
+  left: 0;
+}
+.cds--number
+  input[type='number']:disabled
+  + .cds--number__controls
+  .cds--number__rule-divider:first-of-type,
+.cds--number--light .cds--number__control-btn:focus:after,
+.cds--number--light .cds--number__control-btn:focus:before,
+.cds--number__control-btn.down-icon:focus ~ .cds--number__rule-divider,
+.cds--number__control-btn.down-icon:hover ~ .cds--number__rule-divider,
+.cds--number__control-btn.up-icon:focus + .cds--number__rule-divider,
+.cds--number__control-btn.up-icon:hover + .cds--number__rule-divider,
+.cds--number__control-btn:focus ~ .cds--number__rule-divider {
+  background-color: transparent;
+}
+.cds--number--light
+  .cds--number__invalid
+  + .cds--number__controls
+  .cds--number__rule-divider:first-of-type,
+.cds--number--light .cds--number__rule-divider {
+  background-color: var(--cds-border-subtle-02, #e0e0e0);
+}
+.cds--number
+  input[type='number']:disabled
+  + .cds--number__controls
+  .cds--number__rule-divider {
+  background-color: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--number__invalid {
+  position: absolute;
+  right: 6rem;
+}
+.cds--number--lg .cds--number__invalid {
+  right: 7rem;
+}
+.cds--number--sm .cds--number__invalid {
+  right: 5rem;
+}
+.cds--number__invalid + .cds--number__rule-divider {
+  position: absolute;
+  right: 5rem;
+}
+.cds--number--lg .cds--number__invalid + .cds--number__rule-divider {
+  right: 6rem;
+}
+.cds--number--sm .cds--number__invalid + .cds--number__rule-divider {
+  right: 4rem;
+}
+.cds--number__invalid--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--search--expandable.cds--search--expanded .cds--search-magnifier-icon,
+.cds--search-magnifier-icon {
+  fill: var(--cds-icon-secondary, #525252);
+}
+.cds--number__invalid--warning path:first-of-type {
+  fill: #000;
+  opacity: 1;
+}
+.cds--number--light .cds--number__control-btn:after,
+.cds--number--light .cds--number__control-btn:before,
+.cds--number--light input[type='number'],
+.cds--number--light input[type='number']:disabled {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--number--light .cds--number__control-btn:hover,
+.cds--number--light .cds--number__control-btn:not(:focus):hover:after,
+.cds--number--light .cds--number__control-btn:not(:focus):hover:before {
+  background-color: var(--cds-layer-hover-02, #e8e8e8);
+}
+.cds--number--readonly .cds--number__control-btn:hover:after,
+.cds--number--readonly .cds--number__control-btn:hover:before,
+.cds--number-input--fluid--disabled.cds--number-input--fluid--invalid
+  .cds--number
+  input[type='number']:disabled {
+  background-color: transparent;
+}
+.cds--number--lg input[type='number'] {
+  height: 3rem;
+}
+.cds--number--lg .cds--number__controls {
+  width: 6rem;
+}
+.cds--number--lg .cds--number__control-btn {
+  width: 3rem;
+}
+.cds--number--lg .cds--number__control-btn:after,
+.cds--number--lg .cds--number__control-btn:before {
+  height: 2.75rem;
+}
+.cds--number--sm input[type='number'] {
+  height: 2rem;
+}
+.cds--number--sm .cds--number__controls {
+  width: 4rem;
+}
+.cds--number--sm .cds--number__control-btn {
+  width: 2rem;
+}
+.cds--number--sm .cds--number__control-btn:after,
+.cds--number--sm .cds--number__control-btn:before {
+  height: 1.75rem;
+}
+.cds--number--nolabel .cds--label + .cds--form__helper-text {
+  margin-top: 0;
+}
+.cds--number--nosteppers input[type='number'] {
+  padding-right: 3rem;
+}
+.cds--number--nosteppers .cds--number__invalid {
+  right: 1rem;
+}
+.cds--number--readonly input[type='number'] {
+  background: 0 0;
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--number--readonly .cds--number__control-btn {
+  color: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  pointer-events: none;
+}
+.cds--number--readonly .cds--number__control-btn:hover {
+  background-color: transparent;
+  cursor: pointer;
+}
+.cds--number--readonly
+  input[type='number']:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn:hover {
+  outline: 0;
+}
+.cds--number--readonly .cds--number__control-btn:after,
+.cds--number--readonly .cds--number__control-btn:before {
+  background: 0 0;
+}
+.cds--number--readonly
+  .cds--number__controls:hover
+  .cds--number__rule-divider:not(:first-of-type) {
+  background-color: var(--cds-border-subtle);
+}
+.cds--number.cds--skeleton {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  height: 2.5rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 100%;
+}
+.cds--number-input--fluid .cds--number__control-btn,
+.cds--number-input--fluid
+  .cds--number__input-wrapper--warning
+  input[type='number'],
+.cds--number-input--fluid
+  input[type='number']:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn,
+.cds--number-input--fluid--invalid
+  .cds--number[data-invalid]
+  input[type='number'] {
+  border-bottom: 1px solid transparent;
+}
+.cds--number.cds--skeleton:active,
+.cds--number.cds--skeleton:focus,
+.cds--number.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--number.cds--skeleton:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--file__selected-file {
+    outline: 1px solid transparent;
+  }
+  .cds--file__state-container .cds--file-close svg path {
+    fill: ButtonText;
+  }
+  .cds--number__control-btn:focus,
+  .cds--number__control-btn:hover {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--number__control-btn {
+    outline: 1px solid transparent;
+  }
+  .cds--number__control-btn svg {
+    fill: ButtonText;
+  }
+}
+.cds--number-input--fluid:not(.cds--number-input--fluid--invalid)
+  .cds--number
+  .cds--number__input-wrapper:not(.cds--number__input-wrapper--warning)
+  input[type='number']:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn:hover,
+.cds--search-close,
+.cds--search-input {
+  outline: 2px solid transparent;
+}
+.cds--number-input--fluid {
+  background: var(--cds-field);
+  height: 100%;
+  position: relative;
+}
+.cds--number-input--fluid .cds--label {
+  align-items: center;
+  display: flex;
+  height: 1rem;
+  left: 1rem;
+  margin: 0;
+  position: absolute;
+  top: 0.8125rem;
+  width: calc(100% - 2rem);
+  z-index: 1;
+}
+.cds--number-input--fluid .cds--number-input__divider,
+.cds--number-input--fluid
+  .cds--number__controls
+  .cds--number__rule-divider:first-of-type {
+  display: none;
+}
+.cds--number-input--fluid .cds--label .cds--toggletip-label::-webkit-scrollbar,
+.cds--number-input--fluid .cds--label::-webkit-scrollbar {
+  display: none;
+}
+.cds--number-input--fluid .cds--label .cds--toggletip-label,
+.cds--number-input--fluid .cds--label:not(:has(.cds--toggletip-label)) {
+  -ms-overflow-style: none;
+  overflow-x: scroll;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+.cds--number-input--fluid .cds--number__input-wrapper {
+  position: static;
+}
+.cds--number-input--fluid input[type='number'] {
+  background: 0 0;
+  min-height: 4rem;
+  outline: 0;
+  padding: 2rem 5rem 0.8125rem 1rem;
+}
+.cds--modal-container--sm .cds--modal-content > p,
+.cds--modal-container--xs .cds--modal-content > p {
+  padding-right: 0;
+}
+.cds--number-input--fluid .cds--number__controls {
+  height: 2.5rem;
+  top: 1.4375rem;
+  transform: translate(0);
+}
+.cds--number-input--fluid.cds--number-input--fluid--focus .cds--number {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--number-input--fluid:not(.cds--number-input--fluid--invalid)
+  .cds--number
+  .cds--number__input-wrapper:not(.cds--number__input-wrapper--warning)
+  input[type='number']:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn:hover:before {
+  background: var(--cds-focus, #0f62fe);
+  bottom: 0;
+  height: 1px;
+  left: 0;
+  top: auto;
+  width: 100%;
+}
+.cds--number-input--fluid:not(.cds--number-input--fluid--invalid)
+  .cds--number-input-wrapper:not(.cds--number-input-wrapper__warning)
+  input[type='number']:focus
+  ~ .cds--number__controls
+  .cds--number__control-btn:hover {
+  border-bottom: 1px solid var(--cds-focus, #0f62fe);
+  outline: 0;
+}
+.cds--number-input--fluid
+  input[type='number']
+  ~ .cds--number__controls
+  .cds--number__control-btn:after {
+  height: calc(100% - 0.0625rem);
+  top: 0;
+}
+.cds--number-input--fluid.cds--number-input--fluid--focus
+  input[type='number']
+  ~ .cds--number__controls
+  .cds--number__control-btn.up-icon:after {
+  background: var(--cds-focus, #0f62fe);
+}
+.cds--number-input--fluid
+  input[type='number']
+  ~ .cds--number__controls
+  .cds--number__control-btn.up-icon:after {
+  height: 100%;
+}
+.cds--number-input--fluid.cds--number-input--fluid--focus
+  input[type='number']
+  ~ .cds--number__controls
+  .cds--number__control-btn.up-icon:hover:after {
+  background-color: var(--cds-focus, #0f62fe);
+  height: 100%;
+}
+.cds--number-input--fluid--invalid
+  .cds--number
+  input[type='number'][data-invalid]
+  ~ .cds--number__controls
+  .cds--number__control-btn:focus:hover,
+.cds--number-input--fluid--invalid
+  input[type='number'][data-invalid]
+  ~ .cds--number__controls
+  .cds--number__control-btn:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--number-input--fluid .cds--number__invalid {
+  pointer-events: none;
+  right: 1rem;
+  top: 4.5625rem;
+}
+.cds--number-input--fluid
+  .cds--number__input-wrapper--warning
+  input[type='number']:focus {
+  outline: 0;
+}
+.cds--number-input--fluid
+  .cds--number__input-wrapper--warning
+  + .cds--number-input__divider,
+.cds--number-input--fluid.cds--number-input--fluid--invalid
+  .cds--number-input__divider {
+  border: none;
+  border-bottom: 1px solid var(--cds-border-subtle);
+  display: block;
+  height: 0.0625rem;
+  margin: 0 1rem;
+  position: absolute;
+  top: 3.9375rem;
+  width: calc(100% - 2rem);
+}
+.cds--number-input--fluid .cds--form-requirement {
+  margin: 0;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+}
+.cds--number-input--fluid.cds--number-input--fluid--invalid:not(
+    .cds--number-input--fluid--focus
+  )
+  .cds--number {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+.cds--number-input--fluid
+  .cds--number__input-wrapper--warning
+  input[type='number']
+  ~ .cds--number__controls
+  .cds--number__control-btn:hover:not(:focus),
+.cds--number-input--fluid--invalid
+  .cds--number
+  input[type='number'][data-invalid]
+  ~ .cds--number__controls
+  .cds--number__control-btn:hover,
+.cds--number-input--fluid--invalid
+  .cds--number[data-invalid]
+  input[type='number'] {
+  outline: 0;
+}
+.cds--number-input--fluid
+  .cds--number__input-wrapper--warning
+  input[type='number']
+  ~ .cds--number__controls
+  .cds--number__control-btn,
+.cds--number-input--fluid.cds--number-input--invalid
+  .cds--number__input-wrapper
+  input[type='number']
+  ~ .cds--number__controls
+  .cds--number__control-btn {
+  border-bottom: none;
+}
+.cds--number-input--fluid
+  .cds--number
+  input[type='number']
+  ~ .cds--number__controls
+  .cds--number__control-btn,
+.cds--number-input--fluid--invalid
+  .cds--number
+  input[type='number'][data-invalid]
+  ~ .cds--number__controls
+  .cds--number__control-btn {
+  border: initial;
+  border-bottom-width: 0.0625rem;
+}
+.cds--number-input--fluid--disabled:not(.cds--number-input--fluid--invalid)
+  .cds--number {
+  border-bottom: 1px solid var(--cds-border-subtle);
+}
+.cds--search {
+  align-items: center;
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+.cds--search .cds--label {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  width: 1px;
+}
+.cds--search-input {
+  background-color: var(--cds-field);
+  border: none;
+  border-bottom: 1px solid var(--cds-border-strong);
+  box-sizing: border-box;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  margin: 0;
+  order: 1;
+  outline-offset: -2px;
+  padding: 0 2.5rem;
+  text-overflow: ellipsis;
+  transition:
+    background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--search-close,
+.cds--select {
+  font-family: inherit;
+  font-size: 100%;
+  vertical-align: baseline;
+}
+.cds--search-input *,
+.cds--search-input :after,
+.cds--search-input :before {
+  box-sizing: inherit;
+}
+.cds--search-input:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--number-input--fluid--invalid
+    .cds--number
+    input[type='number'][data-invalid]
+    ~ .cds--number__controls
+    .cds--number__control-btn:focus:hover,
+  .cds--number-input--fluid--invalid
+    input[type='number'][data-invalid]
+    ~ .cds--number__controls
+    .cds--number__control-btn:focus,
+  .cds--number-input--fluid.cds--number-input--fluid--focus .cds--number,
+  .cds--number-input--fluid.cds--number-input--fluid--invalid:not(
+      .cds--number-input--fluid--focus
+    )
+    .cds--number,
+  .cds--search-input:focus {
+    outline-style: dotted;
+  }
+}
+.cds--search-input::-moz-placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  opacity: 1;
+}
+.cds--search-input::placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  opacity: 1;
+}
+.cds--search-input::-ms-clear {
+  display: none;
+}
+.cds--search-input[disabled] {
+  background-color: var(--cds-field);
+  border-bottom: 1px solid transparent;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--search-input[disabled]::-moz-placeholder {
+  color: var(--cds-field);
+}
+.cds--search-input[disabled]::placeholder {
+  color: var(--cds-field);
+}
+.cds--search--light .cds--search-close:before,
+.cds--search--light .cds--search-input {
+  background: var(--cds-field-02, #fff);
+}
+.cds--search--sm .cds--search-input,
+.cds--search--sm.cds--search--expandable.cds--search--expanded
+  .cds--search-input {
+  height: 2rem;
+  padding: 0 2rem;
+}
+.cds--search--sm .cds--search-magnifier-icon {
+  left: 0.5rem;
+}
+.cds--search--md .cds--search-input,
+.cds--search--md.cds--search--expandable.cds--search--expanded
+  .cds--search-input {
+  height: 2.5rem;
+  padding: 0 2.5rem;
+}
+.cds--search--md .cds--search-magnifier-icon {
+  left: 0.75rem;
+}
+.cds--search--lg .cds--search-input,
+.cds--search--lg.cds--search--expandable.cds--search--expanded
+  .cds--search-input {
+  height: 3rem;
+  padding: 0 3rem;
+}
+.cds--search-magnifier-icon {
+  height: 1rem;
+  left: 1rem;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1rem;
+  z-index: 2;
+}
+.cds--body--with-modal-open .cds--modal .cds--overflow-menu-options,
+.cds--body--with-modal-open .cds--modal .cds--tooltip,
+.cds--menu,
+.cds--modal {
+  z-index: 9000;
+}
+.cds--search-close {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  display: inline-block;
+  margin: 0;
+  outline-offset: -2px;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  text-align: start;
+  top: 0;
+}
+.cds--search-button,
+.cds--search-close:before,
+.cds--select-input {
+  background-color: var(--cds-field);
+}
+.cds--search-close *,
+.cds--search-close :after,
+.cds--search-close :before {
+  box-sizing: inherit;
+}
+.cds--search-close::-moz-focus-inner {
+  border: 0;
+}
+.cds--search-close:before {
+  content: '';
+  display: block;
+  height: calc(100% - 2px);
+  left: 0;
+  position: absolute;
+  top: 0.0625rem;
+  transition: background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 2px;
+}
+.cds--search-button:hover,
+.cds--search-close:hover,
+.cds--search-close:hover:before {
+  background-color: var(--cds-field-hover);
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--loading--stop svg circle {
+    animation: none;
+  }
+  .cds--search-close:before {
+    transition: none;
+  }
+}
+.cds--search-close:hover {
+  border-bottom: 1px solid var(--cds-border-strong);
+}
+.cds--search-button {
+  flex-shrink: 0;
+  margin-left: 0.125rem;
+}
+.cds--search-button svg {
+  fill: currentColor;
+  vertical-align: middle;
+}
+.cds--search-close svg {
+  fill: inherit;
+}
+.cds--search-button,
+.cds--search-close {
+  fill: var(--cds-icon-primary, #161616);
+  align-items: center;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px 0;
+  cursor: pointer;
+  display: flex;
+  height: 2.5rem;
+  justify-content: center;
+  opacity: 1;
+  transition:
+    opacity 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    border 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  visibility: inherit;
+  width: 2.5rem;
+}
+.cds--search-button:focus,
+.cds--search-close:focus,
+.cds--search-input:focus ~ .cds--search-close:hover {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--search-button:focus,
+  .cds--search-close:focus {
+    outline-style: dotted;
+  }
+}
+.cds--search-button:active,
+.cds--search-close:active {
+  background-color: var(--cds-background-selected, hsla(0, 0%, 55%, 0.2));
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--search-button:active,
+  .cds--search-close:active,
+  .cds--search-input:focus ~ .cds--search-close:hover {
+    outline-style: dotted;
+  }
+}
+.cds--search--disabled .cds--search-close,
+.cds--search--disabled.cds--search--expandable .cds--search-magnifier {
+  cursor: not-allowed;
+  outline: 0;
+}
+.cds--search--disabled .cds--search-close:hover,
+.cds--search--disabled.cds--search--expandable .cds--search-magnifier:hover {
+  background-color: transparent;
+  border-bottom-color: transparent;
+}
+.cds--search--disabled .cds--search-close:hover:before,
+.cds--search--disabled.cds--search--expandable
+  .cds--search-magnifier:hover:before {
+  background-color: transparent;
+}
+.cds--search--disabled svg {
+  fill: var(--cds-icon-on-color-disabled, #8d8d8d);
+}
+.cds--search-close:active:before,
+.cds--search-close:focus:before {
+  background-color: var(--cds-focus, #0f62fe);
+}
+.cds--search--sm .cds--search-close,
+.cds--search--sm.cds--search--expandable,
+.cds--search--sm.cds--search--expandable .cds--search-magnifier,
+.cds--search--sm ~ .cds--search-button {
+  height: 2rem;
+  width: 2rem;
+}
+.cds--search--sm.cds--search--expandable .cds--search-input::-moz-placeholder {
+  padding: 0 2rem;
+}
+.cds--search--sm.cds--search--expandable .cds--search-input::placeholder {
+  padding: 0 2rem;
+}
+.cds--search--md .cds--search-close,
+.cds--search--md.cds--search--expandable,
+.cds--search--md.cds--search--expandable .cds--search-magnifier,
+.cds--search--md ~ .cds--search-button {
+  height: 2.5rem;
+  width: 2.5rem;
+}
+.cds--search--md.cds--search--expandable .cds--search-input::-moz-placeholder {
+  padding: 0 2.5rem;
+}
+.cds--search--md.cds--search--expandable .cds--search-input::placeholder {
+  padding: 0 2.5rem;
+}
+.cds--search--lg .cds--search-close,
+.cds--search--lg.cds--search--expandable,
+.cds--search--lg.cds--search--expandable .cds--search-magnifier,
+.cds--search--lg ~ .cds--search-button {
+  height: 3rem;
+  width: 3rem;
+}
+.cds--search--lg.cds--search--expandable .cds--search-input::-moz-placeholder {
+  padding: 0 3rem;
+}
+.cds--search--lg.cds--search--expandable .cds--search-input::placeholder {
+  padding: 0 3rem;
+}
+.cds--search-close--hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+.cds--search--lg.cds--skeleton .cds--search-input,
+.cds--search--md.cds--skeleton .cds--search-input,
+.cds--search--sm.cds--skeleton .cds--search-input {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 100%;
+}
+.cds--search--lg.cds--skeleton .cds--search-input:active,
+.cds--search--lg.cds--skeleton .cds--search-input:focus,
+.cds--search--lg.cds--skeleton .cds--search-input:hover,
+.cds--search--md.cds--skeleton .cds--search-input:active,
+.cds--search--md.cds--skeleton .cds--search-input:focus,
+.cds--search--md.cds--skeleton .cds--search-input:hover,
+.cds--search--sm.cds--skeleton .cds--search-input:active,
+.cds--search--sm.cds--skeleton .cds--search-input:focus,
+.cds--search--sm.cds--skeleton .cds--search-input:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--search--lg.cds--skeleton .cds--search-input:before,
+.cds--search--md.cds--skeleton .cds--search-input:before,
+.cds--search--sm.cds--skeleton .cds--search-input:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--number.cds--skeleton:before,
+  .cds--search--lg.cds--skeleton .cds--search-input:before,
+  .cds--search--md.cds--skeleton .cds--search-input:before,
+  .cds--search--sm.cds--skeleton .cds--search-input:before {
+    animation: none;
+  }
+}
+.cds--search--lg.cds--skeleton .cds--search-input::-moz-placeholder,
+.cds--search--md.cds--skeleton .cds--search-input::-moz-placeholder,
+.cds--search--sm.cds--skeleton .cds--search-input::-moz-placeholder {
+  color: transparent;
+}
+.cds--search--lg.cds--skeleton .cds--search-input::placeholder,
+.cds--search--md.cds--skeleton .cds--search-input::placeholder,
+.cds--search--sm.cds--skeleton .cds--search-input::placeholder {
+  color: transparent;
+}
+.cds--search--expandable {
+  transition: width 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--search--expandable.cds--search--expanded {
+  width: 100%;
+}
+.cds--search--expandable .cds--search-input {
+  padding: 0;
+  transition:
+    padding 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    width 0s linear 70ms;
+  width: 0;
+}
+.cds--search--expandable .cds--search-input::-moz-placeholder {
+  opacity: 0;
+  position: relative;
+  transition-duration: 70ms;
+  -moz-transition-property: padding, opacity;
+  transition-property: padding, opacity;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--search--expandable .cds--search-input::placeholder {
+  opacity: 0;
+  position: relative;
+  transition-duration: 70ms;
+  transition-property: padding, opacity;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--search--expandable.cds--search--expanded .cds--search-input {
+  transition: padding 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--search--expandable.cds--search--expanded
+  .cds--search-input::-moz-placeholder {
+  opacity: 1;
+  padding: 0;
+  position: relative;
+}
+.cds--search--expandable.cds--search--expanded .cds--search-input::placeholder {
+  opacity: 1;
+  padding: 0;
+  position: relative;
+}
+.cds--search--expandable .cds--search-magnifier {
+  cursor: pointer;
+  position: absolute;
+}
+.cds--search--expandable .cds--search-magnifier:hover {
+  background-color: var(--cds-background-hover, hsla(0, 0%, 55%, 0.12));
+}
+.cds--search--expandable.cds--search--expanded .cds--search-magnifier {
+  pointer-events: none;
+}
+.cds--search--expandable .cds--search-magnifier-icon {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--search--expandable.cds--search--disabled svg,
+.cds--select--fluid .cds--select--disabled .cds--toggletip-button svg,
+.cds--select--readonly .cds--select__arrow,
+.cds--select-input:disabled ~ .cds--select__arrow {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--search-close svg,
+  .cds--search-magnifier-icon {
+    fill: ButtonText;
+  }
+}
+.cds--search--fluid {
+  height: 4rem;
+}
+.cds--search--fluid .cds--label {
+  clip: auto;
+  align-items: center;
+  display: flex;
+  height: 1rem;
+  left: 1rem;
+  margin: 0;
+  overflow: initial;
+  position: absolute;
+  top: 0.8125rem;
+  white-space: normal;
+  width: calc(100% - 2rem);
+  z-index: 1;
+}
+.cds--search--fluid .cds--label .cds--toggletip-label::-webkit-scrollbar,
+.cds--search--fluid .cds--label::-webkit-scrollbar {
+  display: none;
+}
+.cds--search--fluid .cds--label .cds--toggletip-label,
+.cds--search--fluid .cds--label:not(:has(.cds--toggletip-label)) {
+  -ms-overflow-style: none;
+  overflow-x: scroll;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+.cds--search--fluid .cds--search-input {
+  height: 100%;
+  padding: 2rem 5.5rem 0.8125rem 1rem;
+}
+.cds--search--fluid .cds--search-magnifier-icon {
+  bottom: 0.8125rem;
+  left: auto;
+  right: 1rem;
+  top: auto;
+  transform: none;
+}
+.cds--search--fluid .cds--search-close {
+  border: none;
+  bottom: 0;
+  height: 2.5rem;
+  left: auto;
+  right: 3rem;
+  top: auto;
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 2.5rem;
+}
+.cds--search--fluid .cds--search-close:before {
+  background: var(--cds-border-subtle);
+  bottom: 0.875rem;
+  content: '';
+  display: block;
+  height: 1rem;
+  left: auto;
+  position: absolute;
+  right: -0.0625rem;
+  top: auto;
+  width: 0.0625rem;
+}
+.cds--search--fluid .cds--search-input:focus ~ .cds--search-close:hover {
+  outline: 0;
+}
+.cds--search--fluid .cds--search-close:after {
+  bottom: 0;
+  content: '';
+  display: block;
+  height: 0.125rem;
+  left: 0;
+  position: absolute;
+  width: 100%;
+}
+.cds--search--fluid .cds--search-input:focus ~ .cds--search-close:after {
+  background: var(--cds-focus, #0f62fe);
+}
+.cds--search--fluid
+  .cds--search-input:not(:focus)
+  ~ .cds--search-close:not([disabled]):after {
+  background: var(--cds-border-strong);
+  height: 0.0625rem;
+}
+.cds--search--fluid .cds--search-close svg {
+  margin-bottom: 0.125rem;
+}
+.cds--search--fluid
+  .cds--search-input:disabled
+  ~ .cds--search-close:hover:before {
+  background: var(--cds-border-subtle);
+}
+.cds--search--fluid.cds--search--disabled .cds--label {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--search--fluid.cds--search--disabled .cds--search-input[disabled] {
+  border-bottom: 1px solid var(--cds-border-subtle);
+}
+.cds--select {
+  align-items: flex-start;
+  border: 0;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  width: 100%;
+}
+.cds--select *,
+.cds--select :after,
+.cds--select :before {
+  box-sizing: inherit;
+}
+.cds--select-input__wrapper {
+  align-items: center;
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+.cds--select-input {
+  border: none;
+  border-bottom: 1px solid var(--cds-border-strong);
+  border-radius: 0;
+  cursor: pointer;
+  display: block;
+  font-family: inherit;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  height: 2.5rem;
+  opacity: 1;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0 3rem 0 1rem;
+  transition: outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--select-input:hover {
+  background-color: var(--cds-field-hover);
+}
+.cds--select-input::-ms-expand {
+  display: none;
+}
+@-moz-document url-prefix() {
+  .cds--data-table--sticky-header tbody,
+  .cds--data-table--sticky-header thead {
+    scrollbar-width: none;
+  }
+  .cds--select-input:-moz-focusring,
+  .cds--select-input::-moz-focus-inner {
+    background-image: none;
+    color: transparent;
+    text-shadow: 0 0 0 #000;
+  }
+}
+.cds--select-input:focus {
+  color: var(--cds-text-primary, #161616);
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--select--disabled .cds--form__helper-text,
+.cds--select--disabled .cds--label,
+.cds--select--fluid .cds--select--disabled .cds--toggletip-label,
+.cds--select--inline .cds--select-input:disabled,
+.cds--select-input:disabled,
+.cds--select-input:hover:disabled,
+.cds--select-option:disabled,
+optgroup.cds--select-optgroup:disabled {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+@media screen and (prefers-contrast) {
+  .cds--select-input:focus {
+    outline-style: dotted;
+  }
+}
+.cds--select-input:disabled,
+.cds--select-input:hover:disabled {
+  background-color: var(--cds-field);
+  border-bottom-color: transparent;
+  cursor: not-allowed;
+}
+.cds--select-input--sm {
+  height: 2rem;
+  max-height: 2rem;
+}
+.cds--select-input--lg {
+  height: 3rem;
+  max-height: 3rem;
+}
+.cds--select--warning .cds--select-input,
+.cds--select-input__wrapper[data-invalid] .cds--select-input {
+  padding-right: 4rem;
+}
+.cds--select--light .cds--select-input {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--select--light .cds--select-input:hover {
+  background-color: var(--cds-field-hover);
+}
+.cds--select--light .cds--select-input:disabled,
+.cds--select--light .cds--select-input:hover:disabled {
+  background-color: var(--cds-field-02, #fff);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--select__arrow {
+  fill: var(--cds-icon-primary, #161616);
+  height: 100%;
+  pointer-events: none;
+  position: absolute;
+  right: 1rem;
+  top: 0;
+}
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .cds--select__arrow path {
+    fill: ButtonText;
+  }
+}
+.cds--select__invalid-icon {
+  position: absolute;
+  right: 2.5rem;
+}
+.cds--select__invalid-icon--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--select__invalid-icon--warning path[fill] {
+  fill: var(--cds-icon-primary, #161616);
+  opacity: 1;
+}
+.cds--select-option,
+optgroup.cds--select-optgroup {
+  background-color: var(--cds-layer-hover);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--select--inline {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+}
+.cds--select--inline.cds--select--invalid .cds--form__helper-text,
+.cds--select--inline.cds--select--invalid .cds--label {
+  align-self: flex-start;
+  margin-top: 0.8125rem;
+}
+.cds--select--inline .cds--form__helper-text {
+  margin-bottom: 0;
+  margin-left: 0.5rem;
+}
+.cds--select--inline .cds--label {
+  margin: 0 0.5rem 0 0;
+  white-space: nowrap;
+}
+.cds--select--inline .cds--select-input {
+  background-color: transparent;
+  border-bottom: none;
+  color: var(--cds-text-primary, #161616);
+  padding-left: 0.5rem;
+  padding-right: 2rem;
+  width: auto;
+}
+.cds--select--fluid
+  .cds--select-input__wrapper[data-invalid]
+  .cds--form-requirement,
+.cds--time-picker--fluid--invalid .cds--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+}
+.cds--select--inline .cds--select-input:focus,
+.cds--select--inline .cds--select-input:focus optgroup,
+.cds--select--inline .cds--select-input:focus option {
+  background-color: var(--cds-background, #fff);
+}
+.cds--select--inline .cds--select-input[disabled],
+.cds--select--inline .cds--select-input[disabled]:hover {
+  background-color: var(--cds-field);
+}
+.cds--select--inline .cds--select__arrow {
+  right: 0.5rem;
+}
+.cds--select--inline.cds--select--invalid .cds--select-input {
+  padding-right: 3.5rem;
+}
+.cds--select--inline .cds--select-input:disabled,
+.cds--select--inline .cds--select-input:disabled ~ * {
+  cursor: not-allowed;
+}
+.cds--select--readonly .cds--select-input {
+  background-color: transparent;
+  border-bottom-color: var(--cds-border-subtle);
+  cursor: default;
+}
+.cds--select.cds--skeleton,
+.cds--text-area--fluid__skeleton,
+.cds--text-input--fluid__skeleton {
+  background: var(--cds-skeleton-background, #e8e8e8);
+}
+.cds--select.cds--skeleton {
+  border: none;
+  box-shadow: none;
+  height: 2.5rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 100%;
+}
+.cds--select.cds--skeleton:active,
+.cds--select.cds--skeleton:focus,
+.cds--select.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--select.cds--skeleton:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+.cds--modal .cds--text-area--fluid .cds--text-area__wrapper,
+.cds--modal
+  .cds--text-area--fluid
+  .cds--text-area__wrapper[data-invalid]
+  .cds--text-area__divider
+  + .cds--form-requirement {
+  background: var(--cds-field-02, #fff);
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--select.cds--skeleton:before {
+    animation: none;
+  }
+}
+.cds--select.cds--skeleton .cds--select-input {
+  display: none;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--select__arrow {
+    fill: ButtonText;
+  }
+}
+.cds--select--fluid .cds--select {
+  background: var(--cds-field);
+  height: 100%;
+  position: relative;
+  transition:
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--select--fluid .cds--label {
+  align-items: center;
+  display: flex;
+  height: 1rem;
+  left: 1rem;
+  margin: 0;
+  position: absolute;
+  top: 0.8125rem;
+  width: calc(100% - 2rem);
+  z-index: 1;
+}
+.cds--select--fluid .cds--label .cds--toggletip-label::-webkit-scrollbar,
+.cds--select--fluid .cds--label::-webkit-scrollbar {
+  display: none;
+}
+.cds--select--fluid .cds--label .cds--toggletip-label,
+.cds--select--fluid .cds--label:not(:has(.cds--toggletip-label)) {
+  -ms-overflow-style: none;
+  overflow-x: scroll;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+.cds--select--fluid .cds--select-input {
+  min-height: 4rem;
+  outline: 0;
+  padding: 2rem 2rem 0.8125rem 1rem;
+  text-overflow: ellipsis;
+}
+.cds--select--fluid .cds--select__arrow {
+  height: 1rem;
+  top: 2rem;
+}
+.cds--select--fluid .cds--select__divider {
+  display: none;
+  transition: border-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--select--fluid .cds--select--invalid .cds--select-input__wrapper {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--select--fluid .cds--select--invalid .cds--select-input__wrapper {
+    outline-style: dotted;
+  }
+}
+.cds--select--fluid .cds--select--invalid .cds--select__divider,
+.cds--select--fluid .cds--select--warning .cds--select__divider {
+  border: none;
+  border-bottom: 1px solid var(--cds-border-subtle);
+  display: block;
+  margin: 0 1rem;
+  width: calc(100% - 2rem);
+}
+.cds--select--fluid .cds--select--warning .cds--select-input,
+.cds--select--fluid
+  .cds--select-input__wrapper[data-invalid]
+  .cds--select-input {
+  border-bottom: 1px solid transparent;
+  padding-right: 2rem;
+}
+.cds--select--fluid .cds--select--warning {
+  border-bottom: 1px solid var(--cds-border-strong);
+}
+.cds--select--fluid .cds--select-input__wrapper {
+  display: block;
+}
+.cds--select--fluid .cds--select--warning .cds--select-input:not(:focus),
+.cds--select--fluid
+  .cds--select-input__wrapper[data-invalid]
+  .cds--select-input:not(:focus) {
+  outline: 0;
+}
+.cds--select--fluid .cds--select--warning .cds--form-requirement,
+.cds--select--fluid
+  .cds--select-input__wrapper[data-invalid]
+  .cds--form-requirement {
+  display: block;
+  max-height: 100%;
+  overflow: visible;
+}
+.cds--text-area--fluid .cds--label .cds--toggletip-label,
+.cds--text-area--fluid .cds--label:not(:has(.cds--toggletip-label)),
+.cds--text-input--fluid .cds--label .cds--toggletip-label,
+.cds--text-input--fluid .cds--label:not(:has(.cds--toggletip-label)) {
+  -ms-overflow-style: none;
+  overflow-x: scroll;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+.cds--select--fluid .cds--form-requirement {
+  margin: 0;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+}
+.cds--select--fluid
+  .cds--select--warning
+  .cds--select-input__wrapper:hover
+  + .cds--select__divider,
+.cds--select--fluid
+  .cds--select-input__wrapper[data-invalid]:hover
+  + .cds--select__divider {
+  border-color: transparent;
+}
+.cds--select--fluid .cds--select--fluid--focus .cds--select-input,
+.cds--select--fluid .cds--select--fluid--focus.cds--select--warning,
+.cds--text-area--fluid .cds--text-area--invalid,
+.cds--text-area--fluid .cds--text-area:focus {
+  border-bottom: 1px solid transparent;
+}
+.cds--select--fluid .cds--select--invalid .cds--select__invalid-icon,
+.cds--select--fluid .cds--select--warning .cds--select__invalid-icon {
+  pointer-events: none;
+  right: 1rem;
+  top: 4.5625rem;
+}
+.cds--select--fluid .cds--select--fluid--focus .cds--select-input__wrapper {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--select--fluid .cds--select--fluid--focus .cds--select-input__wrapper {
+    outline-style: dotted;
+  }
+}
+.cds--select--fluid .cds--select--disabled .cds--toggletip-button {
+  pointer-events: none;
+}
+.cds--text-area--fluid .cds--text-area__wrapper {
+  background: var(--cds-field);
+  flex-direction: column;
+  height: 100%;
+  position: relative;
+}
+.cds--text-area--fluid .cds--text-area__label-wrapper {
+  height: 100%;
+  position: relative;
+}
+.cds--text-area--fluid .cds--label {
+  align-items: center;
+  display: flex;
+  height: 1rem;
+  left: 1rem;
+  margin: 0;
+  position: absolute;
+  top: 0.8125rem;
+  width: calc(100% - 2rem);
+  z-index: 1;
+}
+.cds--text-area--fluid .cds--form__helper-text,
+.cds--text-area--fluid .cds--text-area__divider,
+.cds--text-area__divider {
+  display: none;
+}
+.cds--text-area--fluid .cds--label .cds--toggletip-label::-webkit-scrollbar,
+.cds--text-area--fluid .cds--label::-webkit-scrollbar {
+  display: none;
+}
+.cds--text-area--fluid div.cds--label {
+  left: auto;
+  right: 1rem;
+}
+.cds--text-area--fluid .cds--text-area {
+  margin-top: 2rem;
+  min-height: 4rem;
+  outline: 0;
+  padding: 0 1rem 0.8125rem;
+}
+.cds--inline-notification.cds--inline-notification--low-contrast a:focus,
+.cds--menu--open:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+.cds--text-area--fluid .cds--text-area--invalid,
+.cds--text-area--fluid .cds--text-area--warn {
+  resize: none;
+}
+.cds--text-area--fluid .cds--text-area--invalid {
+  margin-top: 1.875rem;
+  padding: 0 0.875rem 0.8125rem;
+}
+.cds--text-area--fluid .cds--text-area__wrapper--warn .cds--text-area__divider,
+.cds--text-area--fluid
+  .cds--text-area__wrapper[data-invalid]
+  .cds--text-area__divider {
+  border-color: var(--cds-border-subtle);
+  border-style: solid;
+  border-bottom: none;
+  display: block;
+  margin: 0 1rem;
+}
+.cds--text-area--fluid .cds--text-area--warn,
+.cds--text-input--fluid .cds--text-input--invalid,
+.cds--text-input--fluid .cds--text-input--warning {
+  border-bottom: none;
+}
+.cds--text-area--fluid
+  .cds--text-area__wrapper--warn
+  .cds--form-requirement.cds--form-requirement,
+.cds--text-area--fluid
+  .cds--text-area__wrapper[data-invalid]
+  .cds--form-requirement.cds--form-requirement {
+  background: var(--cds-field);
+  display: block;
+  margin: 0;
+  max-height: 12.5rem;
+  overflow: visible;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+  position: relative;
+}
+.cds--text-area--fluid
+  .cds--text-area__wrapper--warn
+  .cds--form-requirement.cds--form-requirement {
+  border-bottom: 1px solid var(--cds-border-strong);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--text-area--fluid
+  .cds--text-area__wrapper[data-invalid]
+  .cds--form-requirement.cds--form-requirement {
+  border-bottom: none;
+  color: var(--cds-text-error, #da1e28);
+}
+.cds--text-area--fluid .cds--text-area__invalid-icon {
+  top: 0.5rem;
+}
+.cds--text-area--fluid .cds--text-area__wrapper[data-invalid]:not(:focus) {
+  border: 2px solid var(--cds-support-error, #da1e28);
+}
+.cds--text-area--fluid .cds--text-area__wrapper:focus-within,
+.cds--text-area--fluid .cds--text-area__wrapper[data-invalid]:focus-within {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--text-area--fluid .cds--text-area__wrapper:focus-within,
+  .cds--text-area--fluid .cds--text-area__wrapper[data-invalid]:focus-within {
+    outline-style: dotted;
+  }
+}
+.cds--text-input--fluid
+  .cds--text-input__field-wrapper--warning
+  > .cds--text-input--warning,
+.cds--text-input--fluid
+  .cds--text-input__field-wrapper[data-invalid]
+  > .cds--text-input--invalid,
+.cds--text-input--fluid input[data-invalid] {
+  outline: 0;
+}
+.cds--text-area--fluid .cds--text-area__wrapper > .cds--text-area:active,
+.cds--text-area--fluid .cds--text-area__wrapper > .cds--text-area:focus,
+.cds--text-area--fluid
+  .cds--text-area__wrapper[data-invalid]
+  > .cds--text-area--invalid,
+.cds--text-area--fluid
+  .cds--text-area__wrapper[data-invalid]
+  > .cds--text-area--invalid:focus {
+  outline: 0;
+  transition: none;
+}
+.cds--text-area--fluid__skeleton {
+  border-bottom: 1px solid var(--cds-skeleton-element, #c6c6c6);
+  padding: 1rem;
+}
+.cds--text-area--fluid__skeleton .cds--skeleton,
+.cds--text-area--fluid__skeleton .cds--text-area.cds--skeleton:before {
+  height: 0.5rem;
+}
+.cds--text-area--fluid__skeleton .cds--label {
+  margin-bottom: 0.75rem;
+}
+.cds--text-area--fluid__skeleton .cds--text-area.cds--skeleton {
+  height: 4rem;
+  width: 80%;
+}
+.cds--text-input--fluid.cds--text-input-wrapper {
+  background: var(--cds-field);
+  height: 100%;
+  position: relative;
+  transition:
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--text-input--fluid .cds--label {
+  align-items: center;
+  display: flex;
+  height: 1rem;
+  left: 1rem;
+  margin: 0;
+  position: absolute;
+  top: 0.8125rem;
+  width: calc(100% - 2rem);
+  z-index: 1;
+}
+.cds--text-input--fluid .cds--form__helper-text,
+.cds--text-input--fluid .cds--text-input__divider,
+.cds--text-input__divider,
+.cds--time-picker__icon {
+  display: none;
+}
+.cds--text-input--fluid .cds--label .cds--toggletip-label::-webkit-scrollbar,
+.cds--text-input--fluid .cds--label::-webkit-scrollbar {
+  display: none;
+}
+.cds--text-input--fluid .cds--text-input {
+  min-height: 4rem;
+  padding: 2rem 1rem 0.8125rem;
+}
+.cds--text-input--fluid .cds--text-input__field-wrapper--warning,
+.cds--text-input--fluid .cds--text-input__field-wrapper[data-invalid] {
+  display: block;
+}
+.cds--inline-notification a:focus,
+.cds--toast-notification a:focus {
+  outline: 1px solid var(--cds-link-inverse, #78a9ff);
+}
+.cds--text-input--fluid .cds--form-requirement {
+  margin: 0;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+}
+.cds--text-input--fluid .cds--text-input--invalid + .cds--text-input__divider,
+.cds--text-input--fluid .cds--text-input--warning + .cds--text-input__divider {
+  border-color: var(--cds-border-subtle);
+  border-style: solid;
+  border-bottom: none;
+  display: block;
+  margin: 0 1rem;
+}
+.cds--text-input--fluid .cds--text-input__invalid-icon {
+  top: 5rem;
+}
+.cds--text-input--fluid .cds--text-input__field-wrapper--warning {
+  border-bottom: 1px solid var(--cds-border-strong);
+}
+.cds--text-input--fluid
+  .cds--text-input__field-wrapper[data-invalid]:not(:focus) {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--text-input--fluid
+    .cds--text-input__field-wrapper[data-invalid]:not(:focus) {
+    outline-style: dotted;
+  }
+}
+.cds--text-input--fluid .cds--text-input__field-wrapper--warning:focus-within,
+.cds--text-input--fluid
+  .cds--text-input__field-wrapper[data-invalid]:focus-within {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--text-input--fluid .cds--text-input__field-wrapper--warning:focus-within,
+  .cds--text-input--fluid
+    .cds--text-input__field-wrapper[data-invalid]:focus-within {
+    outline-style: dotted;
+  }
+}
+.cds--text-input--fluid
+  .cds--text-input__field-wrapper--warning
+  > .cds--text-input--warning:focus,
+.cds--text-input--fluid
+  .cds--text-input__field-wrapper[data-invalid]
+  > .cds--text-input--invalid:focus {
+  outline: 0;
+}
+.cds--text-input--fluid .cds--text-input.cds--password-input {
+  padding-right: 2.5rem;
+}
+.cds--text-input--fluid.cds--password-input-wrapper
+  .cds--text-input__invalid-icon {
+  right: 1rem;
+}
+.cds--text-input--fluid
+  .cds--btn.cds--text-input--password__visibility__toggle.cds--tooltip__trigger {
+  height: 2rem;
+  right: 0.5rem;
+  top: 1.625rem;
+  width: 2rem;
+}
+.cds--text-input--fluid__skeleton {
+  border-bottom: 1px solid var(--cds-skeleton-element, #c6c6c6);
+  height: 4rem;
+  position: relative;
+}
+.cds--text-input--fluid__skeleton .cds--skeleton {
+  height: 0.5rem;
+  left: 1rem;
+  position: absolute;
+  top: 1rem;
+  width: 25%;
+}
+.cds--text-input--fluid__skeleton .cds--label {
+  height: 0.5rem;
+  left: 1rem;
+  padding: 0;
+  position: absolute;
+  top: 2.25rem;
+  width: 50%;
+}
+.cds--time-picker--fluid {
+  background: var(--cds-field);
+}
+.cds--time-picker--fluid .cds--time-picker--fluid__wrapper {
+  display: flex;
+}
+.cds--time-picker--fluid__wrapper > :first-child,
+.cds--time-picker--fluid__wrapper > :nth-child(2) {
+  flex-basis: 25%;
+}
+.cds--time-picker--equal-width .cds--time-picker--fluid__wrapper > * {
+  flex-basis: 50%;
+}
+.cds--time-picker--fluid__wrapper
+  > :last-child
+  .cds--select-input__wrapper:before,
+.cds--time-picker--fluid__wrapper
+  > :nth-child(2):not(:last-child)
+  .cds--select-input__wrapper:before {
+  background-color: var(--cds-border-strong);
+  content: '';
+  display: block;
+  height: calc(100% - 1px);
+  opacity: 1;
+  position: absolute;
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 1px;
+}
+.cds--time-picker--fluid__wrapper .cds--select-input__wrapper:after {
+  right: 0;
+}
+.cds--time-picker--fluid__wrapper .cds--select-input__wrapper:before {
+  left: 0;
+}
+.cds--time-picker--fluid:not(.cds--time-picker--fluid--disabled)
+  .cds--time-picker--fluid__wrapper
+  > :last-child:hover
+  .cds--select-input__wrapper:before,
+.cds--time-picker--fluid:not(.cds--time-picker--fluid--disabled)
+  .cds--time-picker--fluid__wrapper
+  > :nth-child(2):hover:not(:last-child)
+  ~ *
+  .cds--select-input__wrapper:before,
+.cds--time-picker--fluid:not(.cds--time-picker--fluid--disabled)
+  .cds--time-picker--fluid__wrapper
+  > :nth-child(2):not(:last-child):hover
+  .cds--select-input__wrapper:before {
+  opacity: 0;
+}
+.cds--time-picker--fluid--disabled
+  .cds--time-picker--fluid__wrapper
+  .cds--select--disabled
+  .cds--select-input__wrapper:before {
+  background: var(--cds-border-disabled, #c6c6c6);
+}
+.cds--time-picker--fluid .cds--form-requirement {
+  background: var(--cds-field);
+  margin: 0;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+}
+.cds--time-picker--fluid--invalid {
+  outline: 2px solid var(--cds-support-error, #da1e28);
+  outline-offset: -2px;
+  position: relative;
+}
+.cds--time-picker--fluid--invalid .cds--select,
+.cds--time-picker--fluid--invalid .cds--select-input,
+.cds--time-picker--fluid--invalid .cds--text-input,
+.cds--time-picker--fluid--invalid .cds--text-input-wrapper {
+  background: 0 0;
+}
+.cds--time-picker--fluid--invalid .cds--select-input {
+  border-top: 2px solid transparent;
+  padding-top: 1.875rem;
+}
+.cds--select--fluid:last-of-type .cds--select-input {
+  border-right: 2px solid transparent;
+}
+.cds--time-picker--fluid--invalid .cds--select-input:hover:not([disabled]) {
+  background: var(--cds-field-hover);
+}
+.cds--time-picker--fluid--invalid .cds--select-input:hover {
+  border-top: 2px solid var(--cds-support-error, #da1e28);
+}
+.cds--time-picker--fluid--invalid
+  .cds--select--fluid:last-of-type
+  .cds--select-input:hover {
+  border-right: 2px solid var(--cds-support-error, #da1e28);
+}
+.cds--time-picker--fluid--warning {
+  position: relative;
+}
+.cds--time-picker--fluid--invalid .cds--time-picker__icon,
+.cds--time-picker--fluid--warning .cds--time-picker__icon {
+  display: block;
+  position: absolute;
+  right: 1rem;
+  top: 4.5rem;
+}
+.cds--time-picker--fluid--invalid .cds--time-picker__icon {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--time-picker--fluid--warning .cds--time-picker__icon {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--time-picker--fluid--warning .cds--time-picker__icon path:first-of-type {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--multi-select.cds--multi-select--readonly .cds--list-box__menu-icon svg,
+.cds--multi-select.cds--multi-select--readonly .cds--tag--filter svg {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--time-picker--fluid--invalid .cds--form-requirement,
+.cds--time-picker--fluid--warning .cds--form-requirement {
+  display: block;
+  max-height: 100%;
+  overflow: visible;
+}
+.cds--inline-loading--error[hidden],
+.cds--inline-loading__checkmark-container[hidden] {
+  display: none;
+}
+.cds--time-picker--fluid--invalid
+  .cds--time-picker--fluid__wrapper
+  > :last-child
+  .cds--select-input__wrapper:before,
+.cds--time-picker--fluid--invalid
+  .cds--time-picker--fluid__wrapper
+  > :nth-child(2):not(:last-child)
+  .cds--select-input__wrapper:before,
+.cds--time-picker--fluid--warning
+  .cds--time-picker--fluid__wrapper
+  > :last-child
+  .cds--select-input__wrapper:before,
+.cds--time-picker--fluid--warning
+  .cds--time-picker--fluid__wrapper
+  > :nth-child(2):not(:last-child)
+  .cds--select-input__wrapper:before {
+  height: calc(100% - 1rem);
+  top: 8px;
+}
+.cds--time-picker--fluid--invalid .cds--select-input,
+.cds--time-picker--fluid--invalid .cds--text-input,
+.cds--time-picker--fluid--warning .cds--select-input,
+.cds--time-picker--fluid--warning .cds--text-input {
+  border-bottom: 1px solid transparent;
+}
+.cds--time-picker--fluid.cds--time-picker--fluid--invalid
+  .cds--time-picker__divider,
+.cds--time-picker--fluid.cds--time-picker--fluid--warning
+  .cds--time-picker__divider {
+  border-color: var(--cds-border-subtle);
+  border-style: solid;
+  border-bottom: none;
+  margin: 0 1rem;
+  width: calc(100% - 2rem);
+}
+.cds--time-picker--fluid--skeleton {
+  display: flex;
+  height: 4rem;
+  width: 100%;
+}
+.cds--time-picker--fluid--skeleton > * {
+  height: 100%;
+  width: auto;
+}
+.cds--time-picker--fluid--skeleton > :first-child,
+.cds--time-picker--fluid--skeleton > :nth-child(2) {
+  width: 25%;
+}
+.cds--time-picker--fluid--skeleton.cds--time-picker--equal-width > :first-child,
+.cds--time-picker--fluid--skeleton > :last-child {
+  width: 50%;
+}
+@keyframes stroke {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+.cds--inline-loading {
+  align-items: center;
+  display: flex;
+  min-height: 2rem;
+  width: 100%;
+}
+.cds--inline-loading__text {
+  color: var(--cds-text-secondary, #525252);
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+}
+.cds--list__item,
+.cds--menu-item {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--inline-loading__animation {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin-right: 0.5rem;
+  position: relative;
+}
+.cds--inline-loading__checkmark-container {
+  fill: var(--cds-support-success, #24a148);
+}
+.cds--inline-loading__checkmark-container.cds--inline-loading__svg {
+  position: absolute;
+  top: 0.75rem;
+  width: 0.75rem;
+}
+.cds--list--ordered:not(.cds--list--nested) > .cds--list__item,
+.cds--list--unordered > .cds--list__item {
+  position: relative;
+}
+.cds--inline-loading__checkmark {
+  fill: none;
+  stroke-dasharray: 12;
+  stroke-dashoffset: 12;
+  stroke-width: 1.8;
+  animation-duration: 0.25s;
+  animation-fill-mode: forwards;
+  animation-name: stroke;
+  transform-origin: 50% 50%;
+}
+.cds--inline-loading--error,
+.cds--inline-notification--low-contrast.cds--inline-notification--error
+  .cds--actionable-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--error
+  .cds--inline-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--error
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--inline-loading--error {
+  height: 1rem;
+  width: 1rem;
+}
+@media screen and (-ms-high-contrast: active),
+  screen and (-ms-high-contrast: none) {
+  .cds--inline-loading__checkmark-container {
+    right: 0.5rem;
+    top: 1px;
+  }
+  .cds--inline-loading__checkmark {
+    stroke-dasharray: 0;
+    stroke-dashoffset: 0;
+    animation: none;
+  }
+}
+.cds--list--nested,
+.cds--list--ordered,
+.cds--list--ordered--native,
+.cds--list--unordered {
+  border: 0;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 100%;
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  vertical-align: baseline;
+}
+.cds--list--nested *,
+.cds--list--nested :after,
+.cds--list--nested :before,
+.cds--list--ordered *,
+.cds--list--ordered :after,
+.cds--list--ordered :before,
+.cds--list--ordered--native *,
+.cds--list--ordered--native :after,
+.cds--list--ordered--native :before,
+.cds--list--unordered *,
+.cds--list--unordered :after,
+.cds--list--unordered :before {
+  box-sizing: inherit;
+}
+.cds--list--expressive,
+.cds--list--expressive .cds--list--nested {
+  font-size: var(--cds-body-02-font-size, 1rem);
+  font-weight: var(--cds-body-02-font-weight, 400);
+  letter-spacing: var(--cds-body-02-letter-spacing, 0);
+  line-height: var(--cds-body-02-line-height, 1.5);
+}
+.cds--list--ordered--native {
+  list-style: decimal;
+}
+.cds--list--nested {
+  margin-left: 2rem;
+}
+.cds--list--nested .cds--list__item {
+  padding-left: 0.25rem;
+}
+.cds--list--ordered:not(.cds--list--nested) {
+  counter-reset: item;
+}
+.cds--list--ordered:not(.cds--list--nested) > .cds--list__item:before {
+  content: counter(item) '.';
+  counter-increment: item;
+  left: -1.5rem;
+  position: absolute;
+}
+.cds--list--ordered--native.cds--list--nested,
+.cds--list--ordered.cds--list--nested {
+  list-style-type: lower-latin;
+}
+.cds--list--unordered > .cds--list__item:before {
+  content: '–';
+  left: -1rem;
+  position: absolute;
+}
+.cds--list--unordered.cds--list--nested > .cds--list__item:before {
+  content: '▪';
+  left: -0.75rem;
+}
+.cds--menu {
+  background-color: var(--cds-layer);
+  max-width: 18rem;
+  opacity: 0;
+  padding: 0.25rem 0;
+  position: fixed;
+  visibility: hidden;
+}
+.cds--menu--with-icons {
+  min-width: 12rem;
+}
+.cds--menu--open {
+  visibility: visible;
+}
+.cds--menu:not(.cds--menu--open) .cds--menu--open,
+.cds--modal,
+.cds--multi-select:not(.cds--list-box--expanded) .cds--list-box__menu {
+  visibility: hidden;
+}
+@media screen and (prefers-contrast) {
+  .cds--menu--open:focus,
+  .cds--time-picker--fluid--invalid {
+    outline-style: dotted;
+  }
+}
+.cds--menu--shown {
+  opacity: 1;
+}
+.cds--menu-item {
+  align-items: center;
+  -moz-column-gap: 0.5rem;
+  column-gap: 0.5rem;
+  cursor: pointer;
+  display: grid;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  grid-template-columns: 1fr max-content;
+  height: 2rem;
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-short-01-line-height, 1.28572);
+  padding-inline: 1rem;
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--modal-content,
+.cds--modal-content > p,
+.cds--modal-content__regular-content {
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+}
+.cds--menu-item:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--menu-item:focus {
+    outline-style: dotted;
+  }
+}
+.cds--menu-item:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--menu--xs .cds--menu-item {
+  height: 1.5rem;
+}
+.cds--menu--sm .cds--menu-item {
+  height: 2rem;
+}
+.cds--menu--md .cds--menu-item {
+  height: 2.5rem;
+}
+.cds--menu--lg .cds--menu-item {
+  height: 3rem;
+}
+.cds--menu-item__icon {
+  display: none;
+}
+.cds--menu--with-icons .cds--menu-item__icon {
+  display: flex;
+}
+.cds--menu-item__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--menu--with-icons > .cds--menu-item,
+.cds--menu--with-icons > .cds--menu-item-group > ul > .cds--menu-item,
+.cds--menu--with-icons > .cds--menu-item-radio-group > ul > .cds--menu-item {
+  grid-template-columns: 1rem 1fr max-content;
+}
+.cds--menu-item--disabled {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--menu-item--disabled.cds--menu-item--danger:hover,
+.cds--menu-item--disabled:hover {
+  background-color: var(--cds-layer);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--menu-item--danger:focus,
+.cds--menu-item--danger:hover {
+  background-color: var(--cds-button-danger-primary, #da1e28);
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--menu-item-divider {
+  background-color: var(--cds-border-subtle);
+  display: block;
+  height: 0.0625rem;
+  margin-block: 0.25rem;
+  width: 100%;
+}
+.cds--modal {
+  align-items: center;
+  background-color: var(--cds-overlay, hsla(0, 0%, 9%, 0.5));
+  content: '';
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  opacity: 0;
+  position: fixed;
+  top: 0;
+  transition:
+    opacity 0.24s cubic-bezier(0.4, 0.14, 1, 1),
+    visibility 0s linear 0.24s;
+  width: 100vw;
+}
+.cds--modal.is-visible {
+  opacity: 1;
+  transition:
+    opacity 0.24s cubic-bezier(0, 0, 0.3, 1),
+    visibility linear;
+  visibility: inherit;
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--modal.is-visible {
+    transition: none;
+  }
+}
+.cds--modal .cds--date-picker__input,
+.cds--modal .cds--dropdown,
+.cds--modal .cds--dropdown-list,
+.cds--modal .cds--multi-select,
+.cds--modal .cds--number input[type='number'],
+.cds--modal .cds--number__control-btn:after,
+.cds--modal .cds--number__control-btn:before,
+.cds--modal .cds--pagination,
+.cds--modal .cds--pagination__control-buttons,
+.cds--modal .cds--search-input,
+.cds--modal .cds--select-input,
+.cds--modal .cds--text-area,
+.cds--modal .cds--text-input {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--modal .cds--number__rule-divider {
+  background-color: var(--cds-border-subtle-02, #e0e0e0);
+}
+.cds--modal
+  .cds--date-picker--fluid
+  .ccdsds--date-picker-input__wrapper
+  .cds--date-picker__input,
+.cds--modal .cds--list-box__wrapper--fluid .cds--list-box,
+.cds--modal .cds--list-box__wrapper--fluid.cds--list-box__wrapper,
+.cds--modal .cds--number-input--fluid .cds--number__control-btn:after,
+.cds--modal .cds--number-input--fluid .cds--number__control-btn:before,
+.cds--modal .cds--number-input--fluid input[type='number'],
+.cds--modal .cds--search--fluid .cds--search-input,
+.cds--modal .cds--select--fluid .cds--select-input,
+.cds--modal .cds--text-area--fluid .cds--text-area,
+.cds--modal .cds--text-area--fluid .cds--text-area__wrapper,
+.cds--modal
+  .cds--text-area--fluid
+  .cds--text-area__wrapper[data-invalid]
+  .cds--text-area__divider
+  + .cds--form-requirement,
+.cds--modal .cds--text-input--fluid .cds--text-input {
+  background-color: var(--cds-field-01, #f4f4f4);
+}
+.cds--modal .cds--number-input--fluid .cds--number__control-btn:hover:after,
+.cds--modal .cds--number-input--fluid .cds--number__control-btn:hover:before {
+  background-color: var(--cds-field-hover);
+}
+.cds--modal .cds--number-input--fluid .cds--number__control-btn:focus:after,
+.cds--modal .cds--number-input--fluid .cds--number__control-btn:focus:before {
+  border-left: 2px solid var(--cds-focus, #0f62fe);
+}
+.cds--modal.is-visible .cds--modal-container {
+  transform: translateZ(0);
+  transition: transform 0.24s cubic-bezier(0, 0, 0.3, 1);
+}
+.cds--modal-container {
+  background-color: var(--cds-layer);
+  display: grid;
+  grid-template-columns: 100%;
+  grid-template-rows: auto 1fr auto;
+  height: 100%;
+  max-height: 100%;
+  outline: 3px solid transparent;
+  outline-offset: -3px;
+  overflow: hidden;
+  position: fixed;
+  top: 0;
+  transform: translate3d(0, -24px, 0);
+  transform-origin: top center;
+  transition: transform 0.24s cubic-bezier(0.4, 0.14, 1, 1);
+  width: 100%;
+}
+@media (min-width: 42rem) {
+  .cds--modal-container {
+    height: auto;
+    max-height: 90%;
+    position: static;
+    width: 84%;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--modal-container {
+    max-height: 84%;
+    width: 60%;
+  }
+}
+@media (min-width: 82rem) {
+  .cds--xlg\:col-start-1 {
+    grid-column-start: 1;
+  }
+  .cds--xlg\:col-start-2 {
+    grid-column-start: 2;
+  }
+  .cds--xlg\:col-start-3 {
+    grid-column-start: 3;
+  }
+  .cds--xlg\:col-start-4 {
+    grid-column-start: 4;
+  }
+  .cds--xlg\:col-start-5 {
+    grid-column-start: 5;
+  }
+  .cds--xlg\:col-start-6 {
+    grid-column-start: 6;
+  }
+  .cds--xlg\:col-start-7 {
+    grid-column-start: 7;
+  }
+  .cds--xlg\:col-start-8 {
+    grid-column-start: 8;
+  }
+  .cds--xlg\:col-start-9 {
+    grid-column-start: 9;
+  }
+  .cds--xlg\:col-start-10 {
+    grid-column-start: 10;
+  }
+  .cds--xlg\:col-start-11 {
+    grid-column-start: 11;
+  }
+  .cds--xlg\:col-start-12 {
+    grid-column-start: 12;
+  }
+  .cds--xlg\:col-start-13 {
+    grid-column-start: 13;
+  }
+  .cds--xlg\:col-start-14 {
+    grid-column-start: 14;
+  }
+  .cds--xlg\:col-start-15 {
+    grid-column-start: 15;
+  }
+  .cds--xlg\:col-start-16 {
+    grid-column-start: 16;
+  }
+  .cds--xlg\:col-end-2 {
+    grid-column-end: 2;
+  }
+  .cds--xlg\:col-end-3 {
+    grid-column-end: 3;
+  }
+  .cds--xlg\:col-end-4 {
+    grid-column-end: 4;
+  }
+  .cds--xlg\:col-end-5 {
+    grid-column-end: 5;
+  }
+  .cds--xlg\:col-end-6 {
+    grid-column-end: 6;
+  }
+  .cds--xlg\:col-end-7 {
+    grid-column-end: 7;
+  }
+  .cds--xlg\:col-end-8 {
+    grid-column-end: 8;
+  }
+  .cds--xlg\:col-end-9 {
+    grid-column-end: 9;
+  }
+  .cds--xlg\:col-end-10 {
+    grid-column-end: 10;
+  }
+  .cds--xlg\:col-end-11 {
+    grid-column-end: 11;
+  }
+  .cds--xlg\:col-end-12 {
+    grid-column-end: 12;
+  }
+  .cds--xlg\:col-end-13 {
+    grid-column-end: 13;
+  }
+  .cds--xlg\:col-end-14 {
+    grid-column-end: 14;
+  }
+  .cds--xlg\:col-end-15 {
+    grid-column-end: 15;
+  }
+  .cds--xlg\:col-end-16 {
+    grid-column-end: 16;
+  }
+  .cds--xlg\:col-end-17 {
+    grid-column-end: 17;
+  }
+  .cds--xlg\:col-start-auto {
+    grid-column-start: auto;
+  }
+  .cds--xlg\:col-end-auto {
+    grid-column-end: auto;
+  }
+  .cds--modal-container {
+    width: 48%;
+  }
+}
+.cds--modal-container .cds--modal-container-body {
+  display: contents;
+}
+.cds--modal-content {
+  color: var(--cds-text-primary, #161616);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  font-weight: 400;
+  grid-column: 1/-1;
+  grid-row: 2/-2;
+  margin-bottom: 3rem;
+  overflow-y: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.5rem;
+  position: relative;
+}
+.cds--modal-content:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--modal-content:focus {
+    outline-style: dotted;
+  }
+}
+.cds--modal-content .cds--form--fluid {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+.cds--modal-content > p,
+.cds--modal-content__regular-content {
+  font-weight: var(--cds-body-01-font-weight, 400);
+  padding-right: calc(20% - 2rem);
+}
+.cds--actionable-notification html,
+.cds--inline-notification html,
+.cds--toast-notification html {
+  font-size: 100%;
+}
+.cds--modal-content--with-form {
+  padding-right: 1rem;
+}
+.carbon-chart-wrapper .cds--modal-header {
+  grid-column: 1/-1;
+  grid-row: 1/1;
+  margin-bottom: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 3rem;
+  padding-top: 1rem;
+}
+.cds--modal-container--sm .cds--modal-content__regular-content,
+.cds--modal-container--xs .cds--modal-content__regular-content {
+  padding-right: 1rem;
+}
+.cds--modal-header__label {
+  color: var(--cds-text-secondary, #525252);
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+  margin-bottom: 0.25rem;
+}
+.cds--modal-header__heading,
+.cds--multi-select
+  .cds--list-box__menu-item
+  .cds--checkbox:checked
+  ~ .cds--checkbox-label-text {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--modal-header__heading {
+  font-size: var(--cds-heading-03-font-size, 1.25rem);
+  font-weight: var(--cds-heading-03-font-weight, 400);
+  letter-spacing: var(--cds-heading-03-letter-spacing, 0);
+  line-height: var(--cds-heading-03-line-height, 1.4);
+  padding-right: calc(20% - 3rem);
+}
+@media (min-width: 42rem) {
+  .cds--modal-container--xs {
+    width: 48%;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--modal-container--xs {
+    max-height: 48%;
+    width: 32%;
+  }
+}
+@media (min-width: 82rem) {
+  .cds--modal-container--xs {
+    width: 24%;
+  }
+}
+@media (min-width: 42rem) {
+  .cds--modal-container--sm {
+    width: 60%;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--modal-container--sm {
+    max-height: 72%;
+    width: 42%;
+  }
+  .cds--modal-container--sm .cds--modal-content > p,
+  .cds--modal-container--sm .cds--modal-content__regular-content {
+    padding-right: 20%;
+  }
+}
+@media (min-width: 82rem) {
+  .cds--modal-container--sm {
+    width: 36%;
+  }
+}
+@media (min-width: 42rem) {
+  .cds--modal-container--lg {
+    width: 96%;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--modal-container--lg {
+    max-height: 96%;
+    width: 84%;
+  }
+}
+@media (min-width: 82rem) {
+  .cds--modal-container--lg {
+    width: 72%;
+  }
+}
+.cds--modal-scroll-content > :last-child {
+  padding-bottom: 2rem;
+}
+.cds--modal-content--overflow-indicator {
+  background-image: linear-gradient(to bottom, transparent, var(--cds-layer));
+  bottom: 3rem;
+  content: '';
+  grid-column: 1/-1;
+  grid-row: 2/-2;
+  height: 2rem;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  width: 100%;
+}
+@media not all and (-webkit-min-device-pixel-ratio: 0),
+  not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .cds--modal-content--overflow-indicator {
+      background-image: linear-gradient(
+        to bottom,
+        rgba(var(--cds-layer), 0),
+        var(--cds-layer)
+      );
+    }
+  }
+}
+.cds--modal-content:focus ~ .cds--modal-content--overflow-indicator {
+  margin: 0 2px 2px;
+  width: calc(100% - 4px);
+}
+@media screen and (-ms-high-contrast: active) {
+  .carbon-chart-wrapper svg {
+    fill: ButtonText;
+  }
+  .cds--modal-scroll-content > :last-child {
+    padding-bottom: 0;
+  }
+  .cds--modal-content--overflow-indicator {
+    display: none;
+  }
+}
+.cds--modal-footer {
+  display: flex;
+  grid-column: 1/-1;
+  grid-row: -1/-1;
+  height: 4rem;
+  justify-content: flex-end;
+  margin-top: auto;
+}
+.cds--modal-footer .cds--btn {
+  align-items: baseline;
+  flex: 0 1 50%;
+  height: 4rem;
+  margin: 0;
+  max-width: none;
+  padding-bottom: 2rem;
+  padding-top: 0.875rem;
+}
+.cds--modal-footer--three-button .cds--btn {
+  align-items: flex-start;
+  flex: 0 1 25%;
+}
+.cds--modal-close {
+  background-color: transparent;
+  border: 2px solid transparent;
+  cursor: pointer;
+  height: 3rem;
+  overflow: hidden;
+  padding: 0.75rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 3rem;
+  z-index: 2;
+}
+.cds--modal-close:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--modal-close:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  outline: 0;
+}
+.cds--modal-close::-moz-focus-inner {
+  border: 0;
+}
+.cds--modal-close__icon {
+  fill: var(--cds-icon-primary, #161616);
+  height: 1.25rem;
+  width: 1.25rem;
+}
+.cds--body--with-modal-open {
+  overflow: hidden;
+}
+.cds--modal-container--full-width .cds--modal-content {
+  margin: 0;
+  padding: 0;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--modal-close__icon {
+    fill: ButtonText;
+  }
+  .cds--modal-close:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+}
+.cds--multi-select .cds--list-box__field--wrapper {
+  align-items: center;
+  display: inline-flex;
+  height: calc(100% + 1px);
+  width: 100%;
+}
+.cds--multi-select .cds--list-box__field:focus {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+.cds--multi-select .cds--tag {
+  margin: 0 0.5rem 0 1rem;
+  min-width: auto;
+}
+.cds--multi-select .cds--list-box__menu {
+  min-width: auto;
+}
+.cds--multi-select .cds--list-box__menu-item__option .cds--checkbox-wrapper {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+.cds--multi-select .cds--list-box__menu-item__option .cds--checkbox-label {
+  display: inline-block;
+  overflow: hidden;
+  padding-left: 1.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+.cds--multi-select .cds--list-box__menu-item__option > .cds--form-item {
+  flex-direction: row;
+  margin: 0;
+}
+.cds--multi-select--filterable {
+  transition: outline-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--multi-select--filterable.cds--combo-box .cds--text-input {
+  background-clip: padding-box;
+  border: 0.125rem solid transparent;
+  outline: 0;
+}
+.cds--multi-select .cds--list-box__field--wrapper--input-focused,
+.cds--multi-select--filterable--input-focused {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--multi-select--filterable.cds--multi-select--selected .cds--text-input,
+.cds--multi-select.cds--multi-select--selected .cds--list-box__field {
+  padding-left: 0;
+}
+.cds--multi-select--filterable.cds--list-box--disabled:hover:not(
+    .cds--multi-select--filterable
+  )
+  .cds--text-input {
+  background-color: var(--cds-field);
+}
+.cds--multi-select--filterable .cds--list-box__selection--multi {
+  margin: 0 0 0 1rem;
+}
+.cds--multi-select--filterable.cds--multi-select--inline,
+.cds--multi-select--filterable.cds--multi-select--inline .cds--text-input {
+  background-color: transparent;
+  border-bottom: 0;
+}
+.cds--multi-select.cds--multi-select--readonly,
+.cds--multi-select.cds--multi-select--readonly:hover {
+  background-color: transparent;
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--multi-select.cds--multi-select--readonly .cds--tag--filter,
+.cds--multi-select.cds--multi-select--readonly .cds--tag__close-icon:hover {
+  background-color: transparent;
+  color: var(--cds-text-primary, #161616);
+  cursor: default;
+}
+.cds--actionable-notification__action-button.cds--btn--ghost:active,
+.cds--actionable-notification__action-button.cds--btn--ghost:hover,
+.cds--inline-notification__action-button.cds--btn--ghost:active,
+.cds--inline-notification__action-button.cds--btn--ghost:hover {
+  background-color: var(--cds-background-inverse-hover, #474747);
+}
+.cds--actionable-notification--low-contrast
+  .cds--actionable-notification__action-button.cds--btn--ghost:active,
+.cds--actionable-notification--low-contrast
+  .cds--actionable-notification__action-button.cds--btn--ghost:hover,
+.cds--inline-notification--low-contrast
+  .cds--inline-notification__action-button.cds--btn--ghost:active,
+.cds--inline-notification--low-contrast
+  .cds--inline-notification__action-button.cds--btn--ghost:hover {
+  background-color: var(--cds-notification-action-hover, #edf5ff);
+}
+.cds--inline-notification:not(.cds--inline-notification--low-contrast)
+  .cds--inline-notification__action-button.cds--btn--ghost,
+.cds--inline-notification:not(.cds--inline-notification--low-contrast) a {
+  color: var(--cds-link-inverse, #78a9ff);
+}
+.cds--multi-select.cds--multi-select--readonly .cds--tag--filter {
+  box-shadow: 0 0 0 1px var(--cds-background-inverse, #393939);
+}
+.cds--actionable-notification--warning
+  .cds--toast-notification__icon
+  path[opacity='0'],
+.cds--inline-notification--warning
+  .cds--inline-notification__icon
+  path[opacity='0'],
+.cds--toast-notification--warning
+  .cds--toast-notification__icon
+  path[opacity='0'] {
+  fill: #000;
+  opacity: 1;
+}
+.cds--multi-select.cds--multi-select--readonly .cds--list-box__field,
+.cds--multi-select.cds--multi-select--readonly .cds--list-box__menu-icon {
+  cursor: default;
+}
+.cds--inline-notification {
+  color: var(--cds-text-inverse, #fff);
+  display: flex;
+  flex-wrap: wrap;
+  height: auto;
+  max-width: 18rem;
+  min-height: 3rem;
+  min-width: 18rem;
+  position: relative;
+  width: 100%;
+}
+.cds--inline-notification body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--inline-notification code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--inline-notification strong {
+  font-weight: 600;
+}
+@media (min-width: 42rem) {
+  .cds--inline-notification {
+    flex-wrap: nowrap;
+    max-width: 38rem;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--inline-notification {
+    max-width: 46rem;
+  }
+}
+@media (min-width: 99rem) {
+  .cds--max\:col-start-1 {
+    grid-column-start: 1;
+  }
+  .cds--max\:col-start-2 {
+    grid-column-start: 2;
+  }
+  .cds--max\:col-start-3 {
+    grid-column-start: 3;
+  }
+  .cds--max\:col-start-4 {
+    grid-column-start: 4;
+  }
+  .cds--max\:col-start-5 {
+    grid-column-start: 5;
+  }
+  .cds--max\:col-start-6 {
+    grid-column-start: 6;
+  }
+  .cds--max\:col-start-7 {
+    grid-column-start: 7;
+  }
+  .cds--max\:col-start-8 {
+    grid-column-start: 8;
+  }
+  .cds--max\:col-start-9 {
+    grid-column-start: 9;
+  }
+  .cds--max\:col-start-10 {
+    grid-column-start: 10;
+  }
+  .cds--max\:col-start-11 {
+    grid-column-start: 11;
+  }
+  .cds--max\:col-start-12 {
+    grid-column-start: 12;
+  }
+  .cds--max\:col-start-13 {
+    grid-column-start: 13;
+  }
+  .cds--max\:col-start-14 {
+    grid-column-start: 14;
+  }
+  .cds--max\:col-start-15 {
+    grid-column-start: 15;
+  }
+  .cds--max\:col-start-16 {
+    grid-column-start: 16;
+  }
+  .cds--max\:col-end-2 {
+    grid-column-end: 2;
+  }
+  .cds--max\:col-end-3 {
+    grid-column-end: 3;
+  }
+  .cds--max\:col-end-4 {
+    grid-column-end: 4;
+  }
+  .cds--max\:col-end-5 {
+    grid-column-end: 5;
+  }
+  .cds--max\:col-end-6 {
+    grid-column-end: 6;
+  }
+  .cds--max\:col-end-7 {
+    grid-column-end: 7;
+  }
+  .cds--max\:col-end-8 {
+    grid-column-end: 8;
+  }
+  .cds--max\:col-end-9 {
+    grid-column-end: 9;
+  }
+  .cds--max\:col-end-10 {
+    grid-column-end: 10;
+  }
+  .cds--max\:col-end-11 {
+    grid-column-end: 11;
+  }
+  .cds--max\:col-end-12 {
+    grid-column-end: 12;
+  }
+  .cds--max\:col-end-13 {
+    grid-column-end: 13;
+  }
+  .cds--max\:col-end-14 {
+    grid-column-end: 14;
+  }
+  .cds--max\:col-end-15 {
+    grid-column-end: 15;
+  }
+  .cds--max\:col-end-16 {
+    grid-column-end: 16;
+  }
+  .cds--max\:col-end-17 {
+    grid-column-end: 17;
+  }
+  .cds--max\:col-start-auto {
+    grid-column-start: auto;
+  }
+  .cds--max\:col-end-auto {
+    grid-column-end: auto;
+  }
+  .cds--inline-notification {
+    max-width: 52rem;
+  }
+}
+@media screen and (prefers-contrast) {
+  .cds--inline-notification.cds--inline-notification--low-contrast a:focus,
+  .cds--multi-select .cds--list-box__field--wrapper--input-focused,
+  .cds--multi-select--filterable--input-focused {
+    outline-style: dotted;
+  }
+}
+.cds--inline-notification--low-contrast {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--inline-notification--low-contrast:before {
+  border-style: solid;
+  border-width: 1px 1px 1px 0;
+  box-sizing: border-box;
+  content: '';
+  filter: opacity(0.4);
+  height: 100%;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+.cds--inline-notification--error {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-error-inverse, #fa4d56);
+}
+.cds--inline-notification--error .cds--actionable-notification__icon,
+.cds--inline-notification--error .cds--inline-notification__icon,
+.cds--inline-notification--error .cds--toast-notification__icon {
+  fill: var(--cds-support-error-inverse, #fa4d56);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--error {
+  background: var(--cds-notification-background-error, #fff1f1);
+  border-left: 3px solid var(--cds-support-error, #da1e28);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--error:before {
+  border-color: var(--cds-support-error, #da1e28);
+}
+.cds--inline-notification--success {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-success-inverse, #42be65);
+}
+.cds--inline-notification--success .cds--actionable-notification__icon,
+.cds--inline-notification--success .cds--inline-notification__icon,
+.cds--inline-notification--success .cds--toast-notification__icon {
+  fill: var(--cds-support-success-inverse, #42be65);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--success {
+  background: var(--cds-notification-background-success, #defbe6);
+  border-left: 3px solid var(--cds-support-success, #24a148);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--success
+  .cds--actionable-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--success
+  .cds--inline-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--success
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-success, #24a148);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--success:before {
+  border-color: var(--cds-support-success, #24a148);
+}
+.cds--inline-notification--info,
+.cds--inline-notification--info-square {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-info-inverse, #4589ff);
+}
+.cds--inline-notification--info .cds--actionable-notification__icon,
+.cds--inline-notification--info .cds--inline-notification__icon,
+.cds--inline-notification--info .cds--toast-notification__icon,
+.cds--inline-notification--info-square .cds--actionable-notification__icon,
+.cds--inline-notification--info-square .cds--inline-notification__icon,
+.cds--inline-notification--info-square .cds--toast-notification__icon {
+  fill: var(--cds-support-info-inverse, #4589ff);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--info,
+.cds--inline-notification--low-contrast.cds--inline-notification--info-square {
+  background: var(--cds-notification-background-info, #edf5ff);
+  border-left: 3px solid var(--cds-support-info, #0043ce);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--info
+  .cds--actionable-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--info
+  .cds--inline-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--info
+  .cds--toast-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--info-square
+  .cds--actionable-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--info-square
+  .cds--inline-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--info-square
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-info, #0043ce);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--info-square:before,
+.cds--inline-notification--low-contrast.cds--inline-notification--info:before {
+  border-color: var(--cds-support-info, #0043ce);
+}
+.cds--inline-notification--warning,
+.cds--inline-notification--warning-alt {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-warning-inverse, #f1c21b);
+}
+.cds--inline-notification--warning .cds--actionable-notification__icon,
+.cds--inline-notification--warning .cds--inline-notification__icon,
+.cds--inline-notification--warning .cds--toast-notification__icon,
+.cds--inline-notification--warning-alt .cds--actionable-notification__icon,
+.cds--inline-notification--warning-alt .cds--inline-notification__icon,
+.cds--inline-notification--warning-alt .cds--toast-notification__icon {
+  fill: var(--cds-support-warning-inverse, #f1c21b);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--warning,
+.cds--inline-notification--low-contrast.cds--inline-notification--warning-alt {
+  background: var(--cds-notification-background-warning, #fdf6dd);
+  border-left: 3px solid var(--cds-support-warning, #f1c21b);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--warning
+  .cds--actionable-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--warning
+  .cds--inline-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--warning
+  .cds--toast-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--warning-alt
+  .cds--actionable-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--warning-alt
+  .cds--inline-notification__icon,
+.cds--inline-notification--low-contrast.cds--inline-notification--warning-alt
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--inline-notification--low-contrast.cds--inline-notification--warning-alt:before,
+.cds--inline-notification--low-contrast.cds--inline-notification--warning:before {
+  border-color: var(--cds-support-warning, #f1c21b);
+}
+.cds--inline-notification__details {
+  display: flex;
+  flex-grow: 1;
+  margin: 0 3rem 0 0.8125rem;
+}
+@media (min-width: 42rem) {
+  .cds--inline-notification__details {
+    margin: 0 0.8125rem;
+  }
+}
+.cds--inline-notification__icon {
+  flex-shrink: 0;
+  margin-right: 1rem;
+  margin-top: 0.875rem;
+}
+.cds--inline-notification__text-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.9375rem 0;
+}
+.cds--inline-notification__title {
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  margin: 0 0.25rem 0 0;
+}
+.cds--inline-notification__subtitle {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  word-break: break-word;
+}
+.cds--inline-notification__action-button.cds--btn--ghost {
+  height: 2rem;
+  margin-bottom: 0.5rem;
+  margin-left: 2.5rem;
+}
+.cds--inline-notification__action-button.cds--btn--ghost:focus {
+  border-color: transparent;
+  box-shadow: none;
+  outline: 2px solid var(--cds-focus-inverse, #fff);
+  outline-offset: -2px;
+}
+.cds--inline-notification--low-contrast
+  .cds--inline-notification__action-button.cds--btn--ghost:focus {
+  outline-color: var(--cds-focus, #0f62fe);
+}
+.cds--inline-notification--hide-close-button
+  .cds--inline-notification__action-button.cds--btn--ghost {
+  margin-right: 0.5rem;
+}
+.cds--inline-notification__close-button {
+  align-items: center;
+  background: 0 0;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 3rem;
+  justify-content: center;
+  max-width: 3rem;
+  min-width: 3rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition:
+    outline 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 3rem;
+}
+.cds--inline-notification__close-button:focus {
+  outline: 2px solid var(--cds-focus-inverse, #fff);
+  outline-offset: -2px;
+}
+.cds--inline-notification__close-button .cds--inline-notification__close-icon {
+  fill: var(--cds-icon-inverse, #fff);
+}
+@media (min-width: 42rem) {
+  .cds--inline-notification__action-button.cds--btn--ghost {
+    margin: 0.5rem 0;
+  }
+  .cds--inline-notification__close-button {
+    position: static;
+  }
+}
+.cds--inline-notification--low-contrast
+  .cds--inline-notification__close-button:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--inline-notification--low-contrast
+  .cds--inline-notification__close-button
+  .cds--inline-notification__close-icon {
+  fill: var(--cds-icon-primary, #161616);
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--inline-notification {
+    outline: 1px solid transparent;
+  }
+  .cds--btn.cds--btn--ghost.cds--inline-notification__action-button:focus,
+  .cds--inline-notification__close-button:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--inline-notification .cds--inline-notification__icon {
+    fill: ButtonText;
+  }
+}
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--ghost,
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  a,
+.cds--toast-notification:not(.cds--toast-notification--low-contrast) a {
+  color: var(--cds-link-inverse, #78a9ff);
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--inline-notification .cds--inline-notification__close-icon {
+    fill: ButtonText;
+  }
+}
+.cds--toast-notification {
+  box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
+  color: var(--cds-text-inverse, #fff);
+  display: flex;
+  height: auto;
+  padding-left: 0.8125rem;
+  width: 18rem;
+}
+.cds--toast-notification--low-contrast,
+.cds--toast-notification--low-contrast .cds--toast-notification__caption,
+.cds--toast-notification--low-contrast .cds--toast-notification__subtitle {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--toast-notification body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--toast-notification code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--toast-notification strong {
+  font-weight: 600;
+}
+@media (min-width: 99rem) {
+  .cds--toast-notification {
+    width: 22rem;
+  }
+}
+.cds--toast-notification.cds--toast-notification--low-contrast a:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+@media screen and (prefers-contrast) {
+  .cds--inline-notification--low-contrast
+    .cds--inline-notification__close-button:focus,
+  .cds--toast-notification.cds--toast-notification--low-contrast a:focus {
+    outline-style: dotted;
+  }
+}
+.cds--toast-notification--error {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-error-inverse, #fa4d56);
+}
+.cds--toast-notification--error .cds--actionable-notification__icon,
+.cds--toast-notification--error .cds--inline-notification__icon,
+.cds--toast-notification--error .cds--toast-notification__icon {
+  fill: var(--cds-support-error-inverse, #fa4d56);
+}
+.cds--toast-notification--low-contrast.cds--toast-notification--error {
+  background: var(--cds-notification-background-error, #fff1f1);
+  border-left: 3px solid var(--cds-support-error, #da1e28);
+}
+.cds--toast-notification--low-contrast.cds--toast-notification--error
+  .cds--actionable-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--error
+  .cds--inline-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--error
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--toast-notification--success {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-success-inverse, #42be65);
+}
+.cds--toast-notification--success .cds--actionable-notification__icon,
+.cds--toast-notification--success .cds--inline-notification__icon,
+.cds--toast-notification--success .cds--toast-notification__icon {
+  fill: var(--cds-support-success-inverse, #42be65);
+}
+.cds--toast-notification--low-contrast.cds--toast-notification--success {
+  background: var(--cds-notification-background-success, #defbe6);
+  border-left: 3px solid var(--cds-support-success, #24a148);
+}
+.cds--toast-notification--low-contrast.cds--toast-notification--success
+  .cds--actionable-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--success
+  .cds--inline-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--success
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-success, #24a148);
+}
+.cds--toast-notification--info,
+.cds--toast-notification--info-square {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-info-inverse, #4589ff);
+}
+.cds--toast-notification--info .cds--actionable-notification__icon,
+.cds--toast-notification--info .cds--inline-notification__icon,
+.cds--toast-notification--info .cds--toast-notification__icon,
+.cds--toast-notification--info-square .cds--actionable-notification__icon,
+.cds--toast-notification--info-square .cds--inline-notification__icon,
+.cds--toast-notification--info-square .cds--toast-notification__icon {
+  fill: var(--cds-support-info-inverse, #4589ff);
+}
+.cds--toast-notification--low-contrast.cds--toast-notification--info,
+.cds--toast-notification--low-contrast.cds--toast-notification--info-square {
+  background: var(--cds-notification-background-info, #edf5ff);
+  border-left: 3px solid var(--cds-support-info, #0043ce);
+}
+.cds--toast-notification--low-contrast.cds--toast-notification--info
+  .cds--actionable-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--info
+  .cds--inline-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--info
+  .cds--toast-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--info-square
+  .cds--actionable-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--info-square
+  .cds--inline-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--info-square
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-info, #0043ce);
+}
+.cds--toast-notification--warning,
+.cds--toast-notification--warning-alt {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-warning-inverse, #f1c21b);
+}
+.cds--toast-notification--warning .cds--actionable-notification__icon,
+.cds--toast-notification--warning .cds--inline-notification__icon,
+.cds--toast-notification--warning .cds--toast-notification__icon,
+.cds--toast-notification--warning-alt .cds--actionable-notification__icon,
+.cds--toast-notification--warning-alt .cds--inline-notification__icon,
+.cds--toast-notification--warning-alt .cds--toast-notification__icon {
+  fill: var(--cds-support-warning-inverse, #f1c21b);
+}
+.cds--toast-notification--low-contrast.cds--toast-notification--warning,
+.cds--toast-notification--low-contrast.cds--toast-notification--warning-alt {
+  background: var(--cds-notification-background-warning, #fdf6dd);
+  border-left: 3px solid var(--cds-support-warning, #f1c21b);
+}
+.cds--toast-notification--low-contrast.cds--toast-notification--warning
+  .cds--actionable-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--warning
+  .cds--inline-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--warning
+  .cds--toast-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--warning-alt
+  .cds--actionable-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--warning-alt
+  .cds--inline-notification__icon,
+.cds--toast-notification--low-contrast.cds--toast-notification--warning-alt
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--toast-notification__icon {
+  flex-shrink: 0;
+  margin-right: 1rem;
+  margin-top: 1rem;
+}
+.cds--toast-notification__details {
+  margin-right: 1rem;
+}
+.cds--toast-notification__close-button {
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 3rem;
+  justify-content: center;
+  margin-left: auto;
+  min-height: 3rem;
+  min-width: 3rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0;
+  transition:
+    outline 0.25s,
+    background-color 0.25s;
+  width: 3rem;
+}
+.cds--toast-notification__close-button:focus {
+  outline: 2px solid var(--cds-focus-inverse, #fff);
+  outline-offset: -2px;
+}
+.cds--toast-notification__close-button .cds--toast-notification__close-icon {
+  fill: var(--cds-icon-inverse, #fff);
+}
+.cds--toast-notification--low-contrast
+  .cds--toast-notification__close-button:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--toast-notification--low-contrast
+  .cds--toast-notification__close-button
+  .cds--toast-notification__close-icon {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--toast-notification__title {
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  font-weight: 600;
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  margin-top: 1rem;
+  word-break: break-word;
+}
+.cds--actionable-notification__content,
+.cds--toast-notification__caption,
+.cds--toast-notification__subtitle {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--toast-notification__subtitle {
+  color: var(--cds-text-inverse, #fff);
+  margin-bottom: 1rem;
+  margin-top: 0;
+  word-break: break-word;
+}
+.cds--toast-notification__caption {
+  color: var(--cds-text-inverse, #fff);
+  margin-bottom: 1rem;
+  padding-top: 0.5rem;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--toast-notification {
+    outline: 1px solid transparent;
+  }
+  .cds--toast-notification__close-button:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--toast-notification .cds--toast-notification__close-icon,
+  .cds--toast-notification .cds--toast-notification__icon {
+    fill: ButtonText;
+  }
+}
+.cds--actionable-notification {
+  color: var(--cds-text-inverse, #fff);
+  display: flex;
+  flex-wrap: wrap;
+  height: auto;
+  max-width: 18rem;
+  min-height: 3rem;
+  min-width: 18rem;
+  position: relative;
+  width: 100%;
+}
+.cds--actionable-notification--low-contrast,
+.cds--actionable-notification--low-contrast
+  .cds--actionable-notification__subtitle {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--actionable-notification body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--actionable-notification code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--actionable-notification strong {
+  font-weight: 600;
+}
+@media (min-width: 42rem) {
+  .cds--actionable-notification {
+    flex-wrap: nowrap;
+    max-width: 38rem;
+  }
+  .cds--actionable-notification:not(.cds--actionable-notification--toast)
+    .cds--actionable-notification__details {
+    margin: 0 0.8125rem;
+  }
+}
+@media (min-width: 66rem) {
+  .cds--actionable-notification {
+    max-width: 46rem;
+  }
+}
+@media (min-width: 99rem) {
+  .cds--actionable-notification {
+    max-width: 52rem;
+  }
+}
+.cds--actionable-notification--toast {
+  box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.2);
+  flex-wrap: wrap;
+  max-width: 18rem;
+  min-width: 18rem;
+}
+.cds--actionable-notification a:focus {
+  outline: 1px solid var(--cds-focus-inverse, #fff);
+}
+.cds--actionable-notification.cds--actionable-notification--low-contrast
+  a:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+@media screen and (prefers-contrast) {
+  .cds--actionable-notification.cds--actionable-notification--low-contrast
+    a:focus,
+  .cds--toast-notification--low-contrast
+    .cds--toast-notification__close-button:focus {
+    outline-style: dotted;
+  }
+}
+.cds--actionable-notification--low-contrast:not(
+    .cds--actionable-notification--toast
+  ):before {
+  border-style: solid;
+  border-width: 1px 1px 1px 0;
+  box-sizing: border-box;
+  content: '';
+  filter: opacity(0.4);
+  height: 100%;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+.cds--actionable-notification--error {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-error-inverse, #fa4d56);
+}
+.cds--actionable-notification--error .cds--actionable-notification__icon,
+.cds--actionable-notification--error .cds--inline-notification__icon,
+.cds--actionable-notification--error .cds--toast-notification__icon {
+  fill: var(--cds-support-error-inverse, #fa4d56);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--error {
+  background: var(--cds-notification-background-error, #fff1f1);
+  border-left: 3px solid var(--cds-support-error, #da1e28);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--error
+  .cds--actionable-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--error
+  .cds--inline-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--error
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--error:before {
+  border-color: var(--cds-support-error, #da1e28);
+}
+.cds--actionable-notification--success {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-success-inverse, #42be65);
+}
+.cds--actionable-notification--success .cds--actionable-notification__icon,
+.cds--actionable-notification--success .cds--inline-notification__icon,
+.cds--actionable-notification--success .cds--toast-notification__icon {
+  fill: var(--cds-support-success-inverse, #42be65);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--success {
+  background: var(--cds-notification-background-success, #defbe6);
+  border-left: 3px solid var(--cds-support-success, #24a148);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--success
+  .cds--actionable-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--success
+  .cds--inline-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--success
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-success, #24a148);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--success:before {
+  border-color: var(--cds-support-success, #24a148);
+}
+.cds--actionable-notification--info,
+.cds--actionable-notification--info-square {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-info-inverse, #4589ff);
+}
+.cds--actionable-notification--info .cds--actionable-notification__icon,
+.cds--actionable-notification--info .cds--inline-notification__icon,
+.cds--actionable-notification--info .cds--toast-notification__icon,
+.cds--actionable-notification--info-square .cds--actionable-notification__icon,
+.cds--actionable-notification--info-square .cds--inline-notification__icon,
+.cds--actionable-notification--info-square .cds--toast-notification__icon {
+  fill: var(--cds-support-info-inverse, #4589ff);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info-square {
+  background: var(--cds-notification-background-info, #edf5ff);
+  border-left: 3px solid var(--cds-support-info, #0043ce);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info
+  .cds--actionable-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info
+  .cds--inline-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info
+  .cds--toast-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info-square
+  .cds--actionable-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info-square
+  .cds--inline-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info-square
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-info, #0043ce);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info-square:before,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--info:before {
+  border-color: var(--cds-support-info, #0043ce);
+}
+.cds--actionable-notification--warning,
+.cds--actionable-notification--warning-alt {
+  background: var(--cds-background-inverse, #393939);
+  border-left: 3px solid var(--cds-support-warning-inverse, #f1c21b);
+}
+.cds--actionable-notification--warning .cds--actionable-notification__icon,
+.cds--actionable-notification--warning .cds--inline-notification__icon,
+.cds--actionable-notification--warning .cds--toast-notification__icon,
+.cds--actionable-notification--warning-alt .cds--actionable-notification__icon,
+.cds--actionable-notification--warning-alt .cds--inline-notification__icon,
+.cds--actionable-notification--warning-alt .cds--toast-notification__icon {
+  fill: var(--cds-support-warning-inverse, #f1c21b);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning-alt {
+  background: var(--cds-notification-background-warning, #fdf6dd);
+  border-left: 3px solid var(--cds-support-warning, #f1c21b);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning
+  .cds--actionable-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning
+  .cds--inline-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning
+  .cds--toast-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning-alt
+  .cds--actionable-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning-alt
+  .cds--inline-notification__icon,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning-alt
+  .cds--toast-notification__icon {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning-alt:before,
+.cds--actionable-notification--low-contrast.cds--actionable-notification--warning:before {
+  border-color: var(--cds-support-warning, #f1c21b);
+}
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary
+  .cds--btn__icon,
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary
+  .cds--btn__icon
+  path:not([data-icon-path]):not([fill='none']),
+.cds--overflow-menu-options__option--danger
+  .cds--overflow-menu-options__btn:focus
+  svg,
+.cds--overflow-menu-options__option--danger
+  .cds--overflow-menu-options__btn:hover
+  svg {
+  fill: currentColor;
+}
+.cds--actionable-notification__details {
+  display: flex;
+  flex-grow: 1;
+  margin: 0 3rem 0 0.8125rem;
+}
+.cds--actionable-notification--hide-close-button
+  .cds--actionable-notification__action-button.cds--btn--ghost,
+.cds--actionable-notification--hide-close-button
+  .cds--actionable-notification__action-button.cds--btn--tertiary {
+  margin-right: 0.5rem;
+}
+.cds--actionable-notification .cds--inline-notification__icon {
+  flex-shrink: 0;
+  margin-right: 1rem;
+  margin-top: 0.875rem;
+}
+.cds--actionable-notification .cds--toast-notification__icon {
+  flex-shrink: 0;
+  margin-right: 1rem;
+  margin-top: 1rem;
+}
+.cds--actionable-notification__text-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.9375rem 0;
+}
+.cds--actionable-notification--toast
+  .cds--actionable-notification__text-wrapper {
+  padding: 0.9375rem 0 1.4375rem;
+}
+.cds--actionable-notification__content {
+  display: flex;
+  flex-wrap: wrap;
+  word-break: break-word;
+}
+.cds--actionable-notification--toast .cds--actionable-notification__content {
+  display: block;
+}
+.cds--actionable-notification__title {
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  font-weight: 600;
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  margin-right: 0.25rem;
+  word-break: break-word;
+}
+.cds--actionable-notification__subtitle,
+.cds--overflow-menu-options__btn {
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--actionable-notification--toast .cds--actionable-notification__title {
+  margin-right: 0;
+}
+.cds--actionable-notification__subtitle {
+  color: var(--cds-text-inverse, #fff);
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  margin-top: 0;
+  word-break: break-word;
+}
+.cds--overflow-menu html,
+.cds--overflow-menu-options html,
+.cds--overflow-menu-options__option html,
+.cds--overflow-menu__trigger html {
+  font-size: 100%;
+}
+.cds--overflow-menu-options__btn,
+.cds--unstable-pagination__text,
+span.cds--pagination__text.cds--pagination__items-count {
+  color: var(--cds-text-secondary, #525252);
+}
+.cds--actionable-notification__action-button.cds--btn--ghost {
+  height: 2rem;
+  margin-bottom: 0.5rem;
+  margin-left: 2.5rem;
+}
+@media (min-width: 42rem) {
+  .cds--actionable-notification__action-button.cds--btn--ghost {
+    margin: 0.5rem 0;
+  }
+}
+.cds--actionable-notification__action-button.cds--btn--ghost:focus {
+  border-color: transparent;
+  box-shadow: none;
+  outline: 2px solid var(--cds-focus-inverse, #fff);
+  outline-offset: -2px;
+}
+.cds--actionable-notification--low-contrast
+  .cds--actionable-notification__action-button.cds--btn--ghost:focus {
+  outline-color: var(--cds-focus, #0f62fe);
+}
+.cds--actionable-notification__action-button.cds--btn--tertiary {
+  margin-bottom: 1rem;
+  margin-left: 3.125rem;
+  padding: 0 1rem;
+}
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary {
+  background-color: transparent;
+  border-color: var(--cds-notification-action-tertiary-inverse, #fff);
+  border-style: solid;
+  border-width: 1px;
+  color: var(--cds-notification-action-tertiary-inverse, #fff);
+}
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary:hover {
+  background-color: var(
+    --cds-notification-action-tertiary-inverse-hover,
+    #f4f4f4
+  );
+  color: var(--cds-notification-action-tertiary-inverse-text, #161616);
+}
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary:focus {
+  background-color: var(--cds-notification-action-tertiary-inverse, #fff);
+  border-color: var(--cds-focus-inverse, #fff);
+  box-shadow:
+    inset 0 0 0 1px var(--cds-button-focus-color, var(--cds-focus, #0f62fe)),
+    inset 0 0 0 2px var(--cds-background, #fff);
+  box-shadow:
+    inset 0 0 0 1px var(--cds-focus-inverse, #fff),
+    inset 0 0 0 2px var(--cds-background-inverse, #393939);
+  color: var(--cds-notification-action-tertiary-inverse-text, #161616);
+}
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary:active {
+  background-color: var(
+    --cds-notification-action-tertiary-inverse-active,
+    #c6c6c6
+  );
+  border-color: transparent;
+  color: var(--cds-notification-action-tertiary-inverse-text, #161616);
+}
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary.cds--btn--disabled,
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary.cds--btn--disabled:focus,
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary.cds--btn--disabled:hover,
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary:disabled,
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary:focus:disabled,
+.cds--actionable-notification:not(.cds--actionable-notification--low-contrast)
+  .cds--actionable-notification__action-button.cds--btn--tertiary:hover:disabled {
+  background: 0 0;
+  color: var(
+    --cds-notification-action-tertiary-inverse-text-on-color-disabled,
+    hsla(0, 0%, 100%, 0.25)
+  );
+  outline: 0;
+}
+.cds--actionable-notification__close-button {
+  align-items: center;
+  background: 0 0;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 3rem;
+  justify-content: center;
+  max-width: 3rem;
+  min-width: 3rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition:
+    outline 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 3rem;
+}
+.cds--actionable-notification__close-button:focus {
+  outline: 2px solid var(--cds-focus-inverse, #fff);
+  outline-offset: -2px;
+}
+.cds--actionable-notification__close-button
+  .cds--actionable-notification__close-icon {
+  fill: var(--cds-icon-inverse, #fff);
+}
+@media (min-width: 42rem) {
+  .cds--actionable-notification__close-button {
+    position: static;
+  }
+  .cds--actionable-notification--toast
+    .cds--actionable-notification__close-button {
+    position: absolute;
+  }
+}
+.cds--actionable-notification--low-contrast
+  .cds--actionable-notification__close-button:focus,
+.cds--overflow-menu:focus,
+.cds--overflow-menu__trigger:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--actionable-notification--low-contrast
+  .cds--actionable-notification__close-button
+  .cds--actionable-notification__close-icon {
+  fill: var(--cds-icon-primary, #161616);
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--actionable-notification {
+    outline: 1px solid transparent;
+  }
+  .cds--actionable-notification__close-button:focus,
+  .cds--btn.cds--btn--ghost.cds--actionable-notification__action-button:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--actionable-notification .cds--actionable-notification__close-icon,
+  .cds--actionable-notification .cds--inline-notification__icon,
+  .cds--actionable-notification .cds--toast-notification__icon {
+    fill: ButtonText;
+  }
+}
+.cds--overflow-menu-options__btn:hover,
+span.cds--pagination__text {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--overflow-menu-options__btn:hover svg,
+.cds--overflow-menu__icon {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--overflow-menu,
+.cds--overflow-menu__trigger {
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  display: flex;
+  font-family: inherit;
+  font-size: 100%;
+  height: 2.5rem;
+  justify-content: center;
+  margin: 0;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0;
+  position: relative;
+  text-align: start;
+  transition:
+    outline 0.11s cubic-bezier(0, 0, 0.38, 0.9),
+    background-color 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+  vertical-align: baseline;
+  width: 2.5rem;
+}
+.cds--overflow-menu *,
+.cds--overflow-menu :after,
+.cds--overflow-menu :before,
+.cds--overflow-menu__trigger *,
+.cds--overflow-menu__trigger :after,
+.cds--overflow-menu__trigger :before {
+  box-sizing: inherit;
+}
+.cds--overflow-menu::-moz-focus-inner,
+.cds--overflow-menu__trigger::-moz-focus-inner {
+  border: 0;
+}
+.cds--overflow-menu body,
+.cds--overflow-menu__trigger body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--overflow-menu code,
+.cds--overflow-menu__trigger code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--overflow-menu strong,
+.cds--overflow-menu__trigger strong {
+  font-weight: 600;
+}
+.cds--overflow-menu:hover,
+.cds--overflow-menu__trigger:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--overflow-menu--light.cds--overflow-menu--open,
+.cds--overflow-menu--light.cds--overflow-menu--open
+  .cds--overflow-menu__trigger,
+.cds--overflow-menu-options,
+.cds--overflow-menu-options--light,
+.cds--overflow-menu-options--light:after,
+.cds--overflow-menu-options:after,
+.cds--overflow-menu.cds--overflow-menu--light.cds--overflow-menu--open:hover,
+.cds--overflow-menu.cds--overflow-menu--open:hover {
+  background-color: var(--cds-layer);
+}
+.cds--overflow-menu--sm {
+  height: 2rem;
+  width: 2rem;
+}
+.cds--overflow-menu--lg {
+  height: 3rem;
+  width: 3rem;
+}
+.cds--overflow-menu__trigger.cds--tooltip--a11y.cds--tooltip__trigger:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--actionable-notification--low-contrast
+    .cds--actionable-notification__close-button:focus,
+  .cds--overflow-menu:focus,
+  .cds--overflow-menu__trigger.cds--tooltip--a11y.cds--tooltip__trigger:focus,
+  .cds--overflow-menu__trigger:focus {
+    outline-style: dotted;
+  }
+}
+.cds--overflow-menu__trigger.cds--tooltip--a11y.cds--tooltip__trigger:focus
+  svg {
+  outline: 0;
+}
+.cds--overflow-menu.cds--overflow-menu--open,
+.cds--overflow-menu.cds--overflow-menu--open .cds--overflow-menu__trigger {
+  background-color: var(--cds-layer);
+  box-shadow: 0 2px 6px var(--cds-shadow, rgba(0, 0, 0, 0.3));
+  transition: none;
+}
+.cds--overflow-menu__icon {
+  height: 1rem;
+  width: 1rem;
+}
+.cds--overflow-menu__wrapper {
+  line-height: 0;
+}
+.cds--overflow-menu-options {
+  align-items: flex-start;
+  box-shadow: 0 2px 6px var(--cds-shadow, rgba(0, 0, 0, 0.3));
+  display: none;
+  flex-direction: column;
+  left: 0;
+  list-style: none;
+  position: absolute;
+  top: 32px;
+  width: 10rem;
+  z-index: 6000;
+}
+.cds--overflow-menu-options body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--overflow-menu-options code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--overflow-menu-options strong {
+  font-weight: 600;
+}
+.cds--overflow-menu-options:after {
+  content: '';
+  display: block;
+  position: absolute;
+  transition: background-color 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--overflow-menu-options:after {
+    transition: none;
+  }
+}
+.cds--overflow-menu-options[data-floating-menu-direction='bottom']:not(
+    .cds--breadcrumb-menu-options
+  ):after {
+  height: 0.1875rem;
+  left: 0;
+  top: -0.1875rem;
+  width: 2.5rem;
+}
+.cds--overflow-menu-options--sm .cds--overflow-menu-options__option,
+.cds--overflow-menu-options--sm.cds--overflow-menu-options[data-floating-menu-direction='left']:after,
+.cds--overflow-menu-options--sm.cds--overflow-menu-options[data-floating-menu-direction='right']:after {
+  height: 2rem;
+}
+.cds--overflow-menu-options[data-floating-menu-direction='top']:after {
+  bottom: -0.5rem;
+  height: 0.5rem;
+  left: 0;
+  width: 2.5rem;
+}
+.cds--overflow-menu-options[data-floating-menu-direction='left']:after {
+  height: 2.5rem;
+  right: -0.375rem;
+  top: 0;
+  width: 0.375rem;
+}
+.cds--overflow-menu-options[data-floating-menu-direction='right']:after {
+  height: 2.5rem;
+  left: -0.375rem;
+  top: 0;
+  width: 0.375rem;
+}
+.cds--overflow-menu-options--sm.cds--overflow-menu-options[data-floating-menu-direction='bottom']:after,
+.cds--overflow-menu-options--sm.cds--overflow-menu-options[data-floating-menu-direction='top']:after {
+  width: 2rem;
+}
+.cds--overflow-menu-options--lg.cds--overflow-menu-options[data-floating-menu-direction='bottom']:after,
+.cds--overflow-menu-options--lg.cds--overflow-menu-options[data-floating-menu-direction='top']:after {
+  width: 3rem;
+}
+.cds--overflow-menu-options--lg.cds--overflow-menu-options[data-floating-menu-direction='left']:after,
+.cds--overflow-menu-options--lg.cds--overflow-menu-options[data-floating-menu-direction='right']:after {
+  height: 3rem;
+}
+.cds--overflow-menu--flip.cds--overflow-menu-options[data-floating-menu-direction='bottom']:after,
+.cds--overflow-menu--flip.cds--overflow-menu-options[data-floating-menu-direction='top']:after {
+  left: auto;
+  right: 0;
+}
+.cds--overflow-menu--flip.cds--overflow-menu-options[data-floating-menu-direction='left']:after,
+.cds--overflow-menu--flip.cds--overflow-menu-options[data-floating-menu-direction='right']:after {
+  bottom: 0;
+  top: auto;
+}
+.cds--overflow-menu-options--open {
+  display: flex;
+}
+.cds--overflow-menu-options__content {
+  width: 100%;
+}
+.cds--overflow-menu-options__option {
+  align-items: center;
+  background-color: transparent;
+  display: flex;
+  height: 2.5rem;
+  padding: 0;
+  transition: background-color 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--overflow-menu-options__option body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--overflow-menu-options__option code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--overflow-menu-options__option strong {
+  font-weight: 600;
+}
+.cds--overflow-menu-options--lg .cds--overflow-menu-options__option {
+  height: 3rem;
+}
+.cds--overflow-menu--divider,
+.cds--overflow-menu--light .cds--overflow-menu--divider {
+  border-top: 1px solid var(--cds-border-subtle);
+}
+a.cds--overflow-menu-options__btn:before {
+  content: '';
+  display: inline-block;
+  height: 100%;
+  vertical-align: middle;
+}
+.cds--overflow-menu-options__btn {
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: 400;
+  height: 100%;
+  max-width: 11.25rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0 1rem;
+  text-align: left;
+  transition:
+    outline 0.11s cubic-bezier(0, 0, 0.38, 0.9),
+    background-color 0.11s cubic-bezier(0, 0, 0.38, 0.9),
+    color 0.11s cubic-bezier(0, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--pagination,
+.cds--pagination .cds--select-input,
+.cds--unstable-pagination {
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--btn--ghost.cds--pagination__button,
+.cds--pagination__button,
+.cds--unstable-pagination__button {
+  transition:
+    outline 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--overflow-menu-options__btn:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--overflow-menu-options__btn:focus {
+    outline-style: dotted;
+  }
+}
+.cds--overflow-menu-options__btn::-moz-focus-inner {
+  border: none;
+}
+.cds--overflow-menu-options__btn svg {
+  fill: var(--cds-icon-secondary, #525252);
+}
+.cds--overflow-menu-options__option-content {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--overflow-menu-options__option:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--overflow-menu-options__option--danger
+  .cds--overflow-menu-options__btn:focus,
+.cds--overflow-menu-options__option--danger
+  .cds--overflow-menu-options__btn:hover {
+  background-color: var(--cds-button-danger-primary, #da1e28);
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--overflow-menu-options__option--disabled:hover {
+  background-color: var(--cds-layer);
+  cursor: not-allowed;
+}
+.cds--overflow-menu-options__option--disabled .cds--overflow-menu-options__btn {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--overflow-menu-options__option--disabled
+  .cds--overflow-menu-options__btn:active,
+.cds--overflow-menu-options__option--disabled
+  .cds--overflow-menu-options__btn:focus,
+.cds--overflow-menu-options__option--disabled
+  .cds--overflow-menu-options__btn:hover {
+  background-color: var(--cds-layer);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+.cds--overflow-menu-options__option--disabled
+  .cds--overflow-menu-options__btn
+  svg {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--overflow-menu--flip {
+  left: -140px;
+}
+.cds--overflow-menu--flip:before {
+  left: 145px;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--overflow-menu-options__btn:focus,
+  .cds--overflow-menu:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--overflow-menu svg {
+    fill: ButtonText;
+  }
+}
+.cds--data-table-container + .cds--pagination {
+  border-top: 0;
+}
+.cds--pagination {
+  align-items: center;
+  background-color: var(--cds-layer);
+  border: 0;
+  border-top: 1px solid var(--cds-border-subtle);
+  box-sizing: border-box;
+  display: flex;
+  font-family: inherit;
+  font-size: 100%;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  justify-content: space-between;
+  margin: 0;
+  min-height: 2.5rem;
+  overflow-x: auto;
+  padding: 0;
+  vertical-align: baseline;
+  width: calc(100% - 1px);
+}
+.cds--pagination *,
+.cds--pagination :after,
+.cds--pagination :before {
+  box-sizing: inherit;
+}
+@media (min-width: 42rem) {
+  .cds--pagination {
+    overflow: initial;
+  }
+  .cds--pagination .cds--pagination__control-buttons {
+    display: flex;
+  }
+}
+@media (max-width: 41.98rem) {
+  .cds--pagination .cds--pagination__left > *,
+  .cds--pagination .cds--pagination__right > * {
+    display: none;
+  }
+  .cds--pagination .cds--pagination__items-count {
+    display: initial;
+  }
+  .cds--pagination .cds--pagination__control-buttons {
+    display: flex;
+  }
+}
+.cds--pagination--sm {
+  min-height: 2rem;
+}
+.cds--pagination--lg {
+  min-height: 3rem;
+}
+.cds--pagination .cds--select {
+  align-items: center;
+  height: 100%;
+}
+.cds--pagination .cds--select-input--inline__wrapper {
+  display: flex;
+  height: 100%;
+}
+.cds--pagination .cds--select-input {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  height: 100%;
+  line-height: 2.5rem;
+  min-width: auto;
+  width: auto;
+}
+.cds--pagination .cds--select--inline .cds--select-input {
+  padding: 0 2.25rem 0 1rem;
+}
+.cds--pagination--sm .cds--select-input {
+  line-height: 2rem;
+}
+.cds--pagination--lg .cds--select-input {
+  line-height: 3rem;
+}
+.cds--pagination .cds--select-input:hover {
+  background: var(--cds-layer-hover);
+}
+.cds--pagination .cds--select--inline .cds--select-input:focus,
+.cds--pagination .cds--select--inline .cds--select-input:focus optgroup,
+.cds--pagination .cds--select--inline .cds--select-input:focus option {
+  background-color: var(--cds-layer);
+}
+.cds--pagination .cds--select__arrow {
+  top: 50%;
+  transform: translate(-0.5rem, -50%);
+}
+.cds--pagination .cds--select__item-count .cds--select-input {
+  border-right: 1px solid var(--cds-border-subtle);
+}
+.cds--pagination__right {
+  border-left: 1px solid var(--cds-border-subtle);
+}
+.cds--pagination__left,
+.cds--pagination__right {
+  align-items: center;
+  display: flex;
+  height: 100%;
+}
+.cds--pagination__left > .cds--form-item,
+.cds--pagination__right > .cds--form-item {
+  height: 100%;
+}
+.cds--pagination__left .cds--pagination__text,
+.cds--pagination__right .cds--pagination__text {
+  white-space: nowrap;
+}
+.cds--pagination__left .cds--pagination__text {
+  margin-right: 0.0625rem;
+}
+.cds--pagination__right .cds--pagination__text {
+  margin-left: 0.0625rem;
+  margin-right: 1rem;
+}
+.cds--pagination__right .cds--pagination__text.cds--pagination__page-text {
+  margin-left: 1rem;
+  margin-right: 0.0625rem;
+}
+.cds--pagination__right .cds--pagination__text:empty {
+  margin: 0;
+}
+.cds--pagination__left {
+  padding: 0 1rem 0 0;
+}
+@media (min-width: 42rem) {
+  .cds--pagination__left {
+    padding: 0 1rem;
+  }
+  .cds--pagination__text {
+    display: inline-block;
+  }
+}
+span.cds--pagination__text {
+  margin-left: 1rem;
+}
+.cds--btn--ghost.cds--pagination__button,
+.cds--pagination__button {
+  fill: var(--cds-icon-primary, #161616);
+  align-items: center;
+  background: 0 0;
+  border: none;
+  border-left: 1px solid var(--cds-border-subtle);
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  font-family: inherit;
+  font-size: 100%;
+  height: 2.5rem;
+  justify-content: center;
+  margin: 0;
+  min-height: 2rem;
+  padding: 0;
+  vertical-align: baseline;
+  width: 2.5rem;
+}
+.cds--btn--ghost.cds--pagination__button *,
+.cds--btn--ghost.cds--pagination__button :after,
+.cds--btn--ghost.cds--pagination__button :before,
+.cds--pagination__button *,
+.cds--pagination__button :after,
+.cds--pagination__button :before {
+  box-sizing: inherit;
+}
+.cds--pagination--sm .cds--btn--ghost.cds--pagination__button,
+.cds--pagination--sm .cds--pagination__button {
+  height: 2rem;
+  width: 2rem;
+}
+.cds--pagination--lg .cds--btn--ghost.cds--pagination__button,
+.cds--pagination--lg .cds--pagination__button {
+  height: 3rem;
+  width: 3rem;
+}
+.cds--btn--ghost:focus.cds--pagination__button,
+.cds--pagination__button:focus {
+  border-left: 0;
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--btn--ghost:focus.cds--pagination__button,
+  .cds--pagination__button:focus {
+    outline-style: dotted;
+  }
+}
+.cds--btn--ghost:hover.cds--pagination__button,
+.cds--pagination__button:hover {
+  background: var(--cds-layer-hover);
+}
+.cds--btn--ghost.cds--pagination__button--no-index,
+.cds--pagination__button--no-index {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--popover--tab-tip__button svg,
+.cds--unstable-pagination__button {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--btn--ghost:disabled:hover.cds--pagination__button,
+.cds--btn--ghost:hover.cds--pagination__button--no-index,
+.cds--pagination__button--no-index:hover,
+.cds--pagination__button:disabled:hover {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  background: var(--cds-layer);
+  border-color: var(--cds-border-subtle);
+  cursor: not-allowed;
+}
+.cds--pagination.cds--skeleton .cds--skeleton__text {
+  margin-bottom: 0;
+  margin-right: 1rem;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--btn--ghost.cds--pagination__button,
+  .cds--pagination__button {
+    outline: 1px solid transparent;
+  }
+}
+.cds--unstable-pagination {
+  align-items: center;
+  background-color: var(--cds-layer);
+  border: 0;
+  border-bottom: 1px solid transparent;
+  border-top: 1px solid var(--cds-border-subtle);
+  box-sizing: border-box;
+  display: flex;
+  font-family: inherit;
+  font-size: 100%;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  justify-content: space-between;
+  margin: 0;
+  min-height: 2.5rem;
+  padding: 0;
+  vertical-align: baseline;
+  width: 100%;
+}
+.cds--unstable-pagination *,
+.cds--unstable-pagination :after,
+.cds--unstable-pagination :before {
+  box-sizing: inherit;
+}
+.cds--unstable-pagination__text {
+  margin: 0 1rem;
+}
+.cds--pagination-nav__page,
+.cds--unstable-pagination__button {
+  border: 0;
+  font-family: inherit;
+  margin: 0;
+  vertical-align: baseline;
+}
+@media (min-width: 42rem) {
+  .cds--unstable-pagination__text {
+    display: inline-block;
+  }
+  .cds--unstable-pagination__page-selector .cds--select__arrow,
+  .cds--unstable-pagination__page-sizer .cds--select__arrow {
+    right: 1rem;
+  }
+}
+.cds--unstable-pagination__left,
+.cds--unstable-pagination__right {
+  align-items: center;
+  display: flex;
+  height: 100%;
+}
+.cds--unstable-pagination__left {
+  padding: 0 1rem 0 0;
+}
+.cds--unstable-pagination__left > .cds--form-item,
+.cds--unstable-pagination__right > .cds--form-item {
+  height: 100%;
+}
+.cds--unstable-pagination__left .cds--unstable-pagination__text {
+  margin-right: 0.0625rem;
+}
+.cds--unstable-pagination__right .cds--unstable-pagination__text {
+  margin-left: 0.0625rem;
+  margin-right: 1rem;
+}
+.cds--unstable-pagination__button {
+  align-items: center;
+  background: 0 0;
+  border: none;
+  border-left: 1px solid var(--cds-border-subtle);
+  box-sizing: border-box;
+  color: var(--cds-icon-primary, #161616);
+  cursor: pointer;
+  display: flex;
+  font-size: 100%;
+  height: 2.5rem;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0;
+  width: 2.5rem;
+}
+.cds--pagination-nav,
+.cds--pagination-nav__page {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+}
+.cds--unstable-pagination__button *,
+.cds--unstable-pagination__button :after,
+.cds--unstable-pagination__button :before {
+  box-sizing: inherit;
+}
+.cds--unstable-pagination__button .cds--btn__icon {
+  height: auto;
+  width: auto;
+}
+.cds--unstable-pagination__button.cds--btn--icon-only.cds--tooltip__trigger:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--unstable-pagination__button:hover {
+  background: var(--cds-layer-hover);
+  color: var(--cds-icon-primary, #161616);
+}
+.cds--unstable-pagination__button--no-index {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--progress__warning > *,
+.cds--radio-button__invalid-icon {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--unstable-pagination__button.cds--btn:disabled {
+  background: 0 0;
+  border-color: var(--cds-border-subtle);
+}
+.cds--unstable-pagination__button--no-index:hover,
+.cds--unstable-pagination__button:disabled:hover {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  background: 0 0;
+  cursor: not-allowed;
+}
+.cds--unstable-pagination__page-selector,
+.cds--unstable-pagination__page-sizer {
+  align-items: center;
+  height: 100%;
+}
+.cds--unstable-pagination__page-selector .cds--select-input--inline__wrapper,
+.cds--unstable-pagination__page-sizer .cds--select-input--inline__wrapper {
+  display: flex;
+  height: 100%;
+}
+.cds--unstable-pagination__page-selector .cds--select-input,
+.cds--unstable-pagination__page-sizer .cds--select-input {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  height: 100%;
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-short-01-line-height, 1.28572);
+  line-height: 2.5rem;
+  min-width: auto;
+  padding: 0 2.25rem 0 1rem;
+  width: auto;
+}
+.cds--unstable-pagination__page-selector .cds--select-input:hover,
+.cds--unstable-pagination__page-sizer .cds--select-input:hover {
+  background: var(--cds-layer-hover);
+}
+.cds--unstable-pagination__page-selector .cds--select__arrow,
+.cds--unstable-pagination__page-sizer .cds--select__arrow {
+  top: 50%;
+  transform: translateY(-50%);
+}
+.cds--unstable-pagination__page-selector {
+  border-left: 1px solid var(--cds-border-subtle);
+}
+.cds--unstable-pagination__page-sizer {
+  border-right: 1px solid var(--cds-border-subtle);
+}
+.cds--pagination-nav {
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  line-height: 0;
+}
+.cds--pagination-nav html {
+  font-size: 100%;
+}
+.cds--pagination-nav body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--pagination-nav code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--pagination-nav strong {
+  font-weight: 600;
+}
+.cds--pagination-nav__list {
+  align-items: center;
+  display: flex;
+  list-style: none;
+}
+.cds--pagination-nav__list-item {
+  padding: 0;
+}
+.cds--pagination-nav__list-item:first-child {
+  padding-left: 0;
+}
+.cds--pagination-nav__list-item:last-child {
+  padding-right: 0;
+}
+.cds--pagination-nav__page {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border-radius: 0;
+  box-sizing: border-box;
+  color: var(--cds-text-primary, #161616);
+  cursor: pointer;
+  display: block;
+  font-size: 100%;
+  font-weight: 400;
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  line-height: 1;
+  min-width: 3rem;
+  outline: 0;
+  padding: 1.0625rem 0.25rem;
+  position: relative;
+  text-align: center;
+  transition:
+    background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.cds--popover-caret,
+.cds--popover-content {
+  background-color: var(--cds-popover-background-color, var(--cds-layer));
+  z-index: 6000;
+}
+.cds--pagination-nav__page *,
+.cds--pagination-nav__page :after,
+.cds--pagination-nav__page :before {
+  box-sizing: inherit;
+}
+.cds--pagination-nav__page::-moz-focus-inner {
+  border: 0;
+}
+.cds--pagination-nav__page:hover {
+  background-color: var(--cds-background-hover, hsla(0, 0%, 55%, 0.12));
+  color: var(--cds-text-primary, #161616);
+}
+.cds--pagination-nav__page:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--pagination-nav__page:focus,
+  .cds--unstable-pagination__button.cds--btn--icon-only.cds--tooltip__trigger:focus {
+    outline-style: dotted;
+  }
+}
+.cds--pagination-nav__page.cds--pagination-nav__page--disabled,
+.cds--pagination-nav__page:disabled {
+  background: 0 0;
+  color: rgba(var(--cds-text-secondary, #525252), 0.5);
+  outline: 0;
+  pointer-events: none;
+}
+.cds--pagination-nav__page:not(.cds--pagination-nav__page--direction):after {
+  background-color: var(--cds-border-interactive, #0f62fe);
+  bottom: 0;
+  content: '';
+  display: block;
+  height: 0.25rem;
+  left: 50%;
+  opacity: 0;
+  position: absolute;
+  transition: width 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 0;
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--pagination-nav__page:not(.cds--pagination-nav__page--direction):after {
+    transition: none;
+  }
+}
+.cds--pagination-nav__page--active + .cds--pagination-nav__page:after,
+.cds--pagination-nav__page.cds--pagination-nav__page--active:after {
+  left: calc(50% - 0.5rem);
+  opacity: 1;
+  width: 1rem;
+}
+.cds--pagination-nav__page.cds--pagination-nav__page--active {
+  background-color: initial;
+  color: var(--cds-text-primary, #161616);
+  font-weight: 600;
+}
+.cds--pagination-nav__page .cds--pagination-nav__icon {
+  fill: currentColor;
+  pointer-events: none;
+}
+.cds--pagination-nav__page--direction {
+  align-items: center;
+  display: flex;
+  height: 3rem;
+  justify-content: center;
+  line-height: 0;
+  width: 3rem;
+}
+.cds--pagination-nav__select {
+  position: relative;
+}
+.cds--pagination-nav__page--select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  max-height: 3rem;
+  text-indent: calc(50% - 4.5px);
+}
+@-moz-document url-prefix() {
+  .cds--pagination-nav__page--select {
+    text-indent: 0;
+  }
+}
+.cds--pagination-nav__select-icon-wrapper {
+  height: 100%;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+.cds--pagination-nav__select-icon-wrapper:not(
+    .cds--pagination-nav__page--direction
+  ):after {
+  background-color: var(--cds-border-interactive, #0f62fe);
+  bottom: 0;
+  content: '';
+  display: block;
+  height: 0.25rem;
+  left: 50%;
+  opacity: 0;
+  position: absolute;
+  transition: width 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 0;
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--pagination-nav__select-icon-wrapper:not(
+      .cds--pagination-nav__page--direction
+    ):after {
+    transition: none;
+  }
+}
+.cds--pagination-nav__page--active
+  + .cds--pagination-nav__select-icon-wrapper:after,
+.cds--pagination-nav__select-icon-wrapper.cds--pagination-nav__page--active:after {
+  left: calc(50% - 0.5rem);
+  opacity: 1;
+  width: 1rem;
+}
+.cds--pagination-nav__page--active
+  + .cds--pagination-nav__select-icon-wrapper
+  .cds--pagination-nav__select-icon {
+  display: none;
+}
+.cds--popover--open .cds--popover-content,
+.cds--popover--open .cds--popover-content:before,
+.cds--popover--open.cds--popover--caret .cds--popover-caret {
+  display: block;
+}
+.cds--pagination-nav__select-icon {
+  left: calc(50% - 0.5rem);
+  pointer-events: none;
+  position: absolute;
+  top: calc(50% - 0.5rem);
+}
+.cds--pagination-nav__accessibility-label {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  width: 1px;
+}
+.cds--popover-container {
+  display: inline-block;
+  position: relative;
+}
+.cds--popover--high-contrast .cds--popover {
+  --cds-popover-background-color: var(--cds-background-inverse, #393939);
+  --cds-popover-text-color: var(--cds-text-inverse, #fff);
+}
+.cds--popover--drop-shadow .cds--popover {
+  --cds-popover-drop-shadow: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.2));
+}
+.cds--popover--caret {
+  --cds-popover-offset: 0.625rem;
+}
+.cds--popover {
+  bottom: 0;
+  filter: var(--cds-popover-drop-shadow, none);
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 6000;
+}
+.cds--popover-content {
+  border-radius: var(--cds-popover-border-radius, 2px);
+  color: var(--cds-popover-text-color, var(--cds-text-primary, #161616));
+  display: none;
+  max-width: 23rem;
+  pointer-events: auto;
+  position: absolute;
+  width: -moz-max-content;
+  width: max-content;
+}
+.cds--popover-content:before {
+  content: '';
+  display: none;
+  position: absolute;
+}
+.cds--popover-caret {
+  display: none;
+  position: absolute;
+  will-change: transform;
+}
+.cds--popover--bottom .cds--popover-content {
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, calc(100% + var(--cds-popover-offset, 0rem)));
+}
+.cds--popover--bottom-left .cds--popover-content {
+  bottom: 0;
+  left: 0;
+  transform: translate(
+    calc(var(--cds-popover-offset, 0rem) * -1),
+    calc(100% + var(--cds-popover-offset, 0rem))
+  );
+}
+.cds--popover--bottom-right .cds--popover-content {
+  bottom: 0;
+  right: 0;
+  transform: translate(
+    var(--cds-popover-offset, 0),
+    calc(100% + var(--cds-popover-offset, 0rem))
+  );
+}
+.cds--popover--bottom .cds--popover-content:before,
+.cds--popover--bottom-left .cds--popover-content:before,
+.cds--popover--bottom-right .cds--popover-content:before {
+  height: var(--cds-popover-offset, 0);
+  left: 0;
+  right: 0;
+  top: 0;
+  transform: translateY(-100%);
+}
+.cds--popover--bottom .cds--popover-caret,
+.cds--popover--bottom-left .cds--popover-caret,
+.cds--popover--bottom-right .cds--popover-caret {
+  bottom: 0;
+  clip-path: polygon(0 100%, 50% 0, 100% 100%);
+  height: var(--cds-popover-caret-height, 0.375rem);
+  left: 50%;
+  transform: translate(-50%, var(--cds-popover-offset, 0));
+  width: var(--cds-popover-caret-width, 0.75rem);
+}
+.cds--popover--top .cds--popover-content {
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, calc(-100% - var(--cds-popover-offset, 0rem)));
+}
+.cds--popover--top-left .cds--popover-content {
+  left: 0;
+  top: 0;
+  transform: translate(
+    calc(var(--cds-popover-offset, 0rem) * -1),
+    calc(-100% - var(--cds-popover-offset, 0rem))
+  );
+}
+.cds--popover--top-right .cds--popover-content {
+  right: 0;
+  top: 0;
+  transform: translate(
+    var(--cds-popover-offset, 0),
+    calc(-100% - var(--cds-popover-offset, 0rem))
+  );
+}
+.cds--popover--top .cds--popover-content:before,
+.cds--popover--top-left .cds--popover-content:before,
+.cds--popover--top-right .cds--popover-content:before {
+  bottom: 0;
+  height: var(--cds-popover-offset, 0);
+  left: 0;
+  right: 0;
+  transform: translateY(100%);
+}
+.cds--popover--top .cds--popover-caret,
+.cds--popover--top-left .cds--popover-caret,
+.cds--popover--top-right .cds--popover-caret {
+  clip-path: polygon(0 0, 50% 100%, 100% 0);
+  height: var(--cds-popover-caret-height, 0.375rem);
+  left: 50%;
+  top: 0;
+  transform: translate(-50%, calc(var(--cds-popover-offset, 0rem) * -1));
+  width: var(--cds-popover-caret-width, 0.75rem);
+}
+.cds--popover--right .cds--popover-content {
+  left: 100%;
+  top: 50%;
+  transform: translate(var(--cds-popover-offset, 0), -50%);
+}
+.cds--popover--right-top .cds--popover-content {
+  left: 100%;
+  top: 50%;
+  transform: translate(
+    var(--cds-popover-offset, 0),
+    calc(var(--cds-popover-offset, 0rem) * 0.5 * -1 - 16px)
+  );
+}
+.cds--popover--right-bottom .cds--popover-content {
+  bottom: 50%;
+  left: 100%;
+  transform: translate(
+    var(--cds-popover-offset, 0),
+    calc(var(--cds-popover-offset, 0rem) * 0.5 + 16px)
+  );
+}
+.cds--popover--right .cds--popover-content:before,
+.cds--popover--right-bottom .cds--popover-content:before,
+.cds--popover--right-top .cds--popover-content:before {
+  bottom: 0;
+  left: 0;
+  top: 0;
+  transform: translateX(-100%);
+  width: var(--cds-popover-offset, 0);
+}
+.cds--popover--right .cds--popover-caret,
+.cds--popover--right-bottom .cds--popover-caret,
+.cds--popover--right-top .cds--popover-caret {
+  clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  height: var(--cds-popover-caret-width, 0.75rem);
+  left: 100%;
+  top: 50%;
+  transform: translate(calc(var(--cds-popover-offset, 0rem) - 100%), -50%);
+  width: var(--cds-popover-caret-height, 0.375rem);
+}
+.cds--popover--left .cds--popover-content {
+  right: 100%;
+  top: 50%;
+  transform: translate(
+    calc(var(--cds-popover-offset, 0rem) * -1 + 0.1px),
+    -50%
+  );
+}
+.cds--popover--left-top .cds--popover-content {
+  right: 100%;
+  top: -50%;
+  transform: translate(
+    calc(var(--cds-popover-offset, 0rem) * -1),
+    calc(var(--cds-popover-offset, 0rem) * -0.5 + 16px)
+  );
+}
+.cds--popover--left-bottom .cds--popover-content {
+  bottom: -50%;
+  right: 100%;
+  transform: translate(
+    calc(var(--cds-popover-offset, 0rem) * -1),
+    calc(var(--cds-popover-offset, 0rem) * 0.5 - 16px)
+  );
+}
+.cds--popover--left .cds--popover-content:before,
+.cds--popover--left-bottom .cds--popover-content:before,
+.cds--popover--left-top .cds--popover-content:before {
+  bottom: 0;
+  right: 0;
+  top: 0;
+  transform: translateX(100%);
+  width: var(--cds-popover-offset, 0);
+}
+.cds--popover--left .cds--popover-caret,
+.cds--popover--left-bottom .cds--popover-caret,
+.cds--popover--left-top .cds--popover-caret {
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+  height: var(--cds-popover-caret-width, 0.75rem);
+  right: 100%;
+  top: 50%;
+  transform: translate(calc(var(--cds-popover-offset, 0rem) * -1 + 100%), -50%);
+  width: var(--cds-popover-caret-height, 0.375rem);
+}
+.cds--popover--tab-tip .cds--popover-content {
+  border-radius: 0;
+}
+.cds--popover--tab-tip__button {
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: 100%;
+  height: 2rem;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  text-align: start;
+  vertical-align: baseline;
+  width: 2rem;
+}
+.cds--icon-tooltip .cds--tooltip-content,
+.cds--progress-bar__label {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--popover--tab-tip__button *,
+.cds--popover--tab-tip__button :after,
+.cds--popover--tab-tip__button :before {
+  box-sizing: inherit;
+}
+.cds--popover--tab-tip__button::-moz-focus-inner {
+  border: 0;
+}
+.cds--popover--tab-tip__button:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--popover--tab-tip__button:focus {
+    outline-style: dotted;
+  }
+}
+.cds--popover--tab-tip__button:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--popover--tab-tip.cds--popover--open .cds--popover--tab-tip__button {
+  background: var(--cds-layer);
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
+}
+.cds--popover--tab-tip.cds--popover--open
+  .cds--popover--tab-tip__button:not(:focus):after {
+  background: var(--cds-layer);
+  bottom: 0;
+  content: '';
+  height: 2px;
+  position: absolute;
+  width: 100%;
+  z-index: 6001;
+}
+.cds--progress-bar__label {
+  color: var(--cds-text-primary, #161616);
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+  min-width: 3rem;
+}
+.cds--progress-bar__label-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--progress-bar__track {
+  background-color: var(--cds-layer);
+  height: 0.5rem;
+  min-width: 3rem;
+  position: relative;
+  width: 100%;
+}
+.cds--progress-bar--big .cds--progress-bar__track {
+  height: 0.5rem;
+}
+.cds--progress-bar--small .cds--progress-bar__track {
+  height: 0.25rem;
+}
+.cds--progress-bar__bar {
+  background-color: currentColor;
+  color: var(--cds-interactive, #0f62fe);
+  display: block;
+  height: 100%;
+  transform: scaleX(0);
+  transform-origin: 0 center;
+  transition: transform 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--progress-bar--indeterminate .cds--progress-bar__track:after {
+  animation-duration: 1.4s;
+  animation-iteration-count: infinite;
+  animation-name: progress-bar-indeterminate;
+  animation-timing-function: linear;
+  background-image: linear-gradient(
+    90deg,
+    var(--cds-interactive, #0f62fe) 12.5%,
+    transparent 12.5%
+  );
+  background-position-x: 0;
+  background-size: 200% 100%;
+  bottom: 0;
+  content: '';
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.cds--progress-bar__helper-text {
+  color: var(--cds-text-secondary, #525252);
+  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
+  letter-spacing: var(--cds-helper-text-01-letter-spacing, 0.32px);
+  line-height: var(--cds-helper-text-01-line-height, 1.33333);
+  margin-top: 0.5rem;
+}
+.cds--definition-tooltip,
+.cds--tooltip-content {
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+}
+.cds--progress-bar__status-icon {
+  flex-shrink: 0;
+  margin-left: 1rem;
+}
+.cds--definition-term,
+.cds--progress {
+  font-family: inherit;
+  margin: 0;
+  vertical-align: baseline;
+}
+.cds--progress-bar--finished .cds--progress-bar__bar,
+.cds--progress-bar--finished .cds--progress-bar__status-icon {
+  color: var(--cds-support-success, #24a148);
+}
+.cds--progress-bar--error .cds--progress-bar__bar,
+.cds--progress-bar--error .cds--progress-bar__helper-text,
+.cds--progress-bar--error .cds--progress-bar__status-icon {
+  color: var(--cds-support-error, #da1e28);
+}
+.cds--progress-bar--error .cds--progress-bar__bar,
+.cds--progress-bar--finished .cds--progress-bar__bar {
+  transform: scaleX(1);
+}
+.cds--progress-bar--error.cds--progress-bar--inline .cds--progress-bar__track,
+.cds--progress-bar--finished.cds--progress-bar--inline
+  .cds--progress-bar__track {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  width: 1px;
+}
+.cds--progress-bar--error.cds--progress-bar--inline .cds--progress-bar__label,
+.cds--progress-bar--finished.cds--progress-bar--inline
+  .cds--progress-bar__label {
+  flex-shrink: 1;
+  justify-content: flex-start;
+  margin-right: 0;
+}
+@keyframes progress-bar-indeterminate {
+  0% {
+    background-position-x: 25%;
+  }
+  80%,
+  to {
+    background-position-x: -105%;
+  }
+}
+.cds--progress-bar--inline {
+  align-items: center;
+  display: flex;
+}
+.cds--progress-bar--inline .cds--progress-bar__label {
+  flex-shrink: 0;
+  margin-bottom: 0;
+  margin-inline-end: 1rem;
+}
+.cds--progress-bar--inline .cds--progress-bar__track {
+  flex-basis: 0;
+  flex-grow: 1;
+}
+.cds--progress-bar--inline .cds--progress-bar__helper-text {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  width: 1px;
+}
+.cds--progress-bar--indented .cds--progress-bar__helper-text,
+.cds--progress-bar--indented .cds--progress-bar__label {
+  padding-inline: 1rem;
+}
+.cds--tooltip {
+  --cds-popover-offset: 12px;
+}
+.cds--tooltip-content {
+  color: var(--cds-text-inverse, #fff);
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  max-width: 18rem;
+  padding: var(--cds-tooltip-padding-block, 1rem)
+    var(--cds-tooltip-padding-inline, 1rem);
+}
+.cds--icon-tooltip {
+  --cds-tooltip-padding-block: 0.125rem;
+  --cds-popover-caret-width: 0.5rem;
+  --cds-popover-caret-height: 0.25rem;
+  --cds-popover-offset: 0.5rem;
+}
+.cds--definition-term {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  border-bottom: 1px dotted var(--cds-border-strong);
+  border-radius: 0;
+  box-sizing: border-box;
+  color: var(--cds-text-primary, #161616);
+  cursor: pointer;
+  display: inline-block;
+  font-size: 100%;
+  padding: 0;
+  text-align: start;
+  width: 100%;
+}
+.cds--definition-term *,
+.cds--definition-term :after,
+.cds--definition-term :before {
+  box-sizing: inherit;
+}
+.cds--definition-term::-moz-focus-inner {
+  border: 0;
+}
+.cds--definition-term:focus,
+.cds--definition-term:hover {
+  border-bottom-color: var(--cds-border-interactive, #0f62fe);
+}
+.cds--definition-term:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+@media screen and (prefers-contrast) {
+  .cds--definition-term:focus {
+    outline-style: dotted;
+  }
+}
+.cds--definition-tooltip {
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  max-width: 11rem;
+  padding: 0.5rem 1rem;
+}
+.cds--progress {
+  border: 0;
+  box-sizing: border-box;
+  display: flex;
+  font-size: 100%;
+  list-style: none;
+  padding: 0;
+}
+.cds--progress *,
+.cds--progress :after,
+.cds--progress :before {
+  box-sizing: inherit;
+}
+.cds--progress-step {
+  display: inline-flex;
+  flex-direction: row;
+  min-width: 7rem;
+  overflow: visible;
+  position: relative;
+  width: 8rem;
+}
+.cds--progress-step .cds--tooltip__label {
+  display: block;
+}
+.cds--progress--space-equal .cds--progress-step {
+  flex-grow: 1;
+  min-width: 8rem;
+}
+.cds--progress-line {
+  border: 1px inset transparent;
+  height: 2px;
+  left: 0;
+  position: absolute;
+  width: 8rem;
+}
+.cds--progress--space-equal .cds--progress-line {
+  min-width: 8rem;
+  width: 100%;
+}
+.cds--progress-step svg {
+  fill: var(--cds-interactive, #0f62fe);
+  border-radius: 50%;
+  flex-shrink: 0;
+  height: 1rem;
+  margin: 0.625rem 0.5rem 0 0;
+  position: relative;
+  width: 1rem;
+  z-index: 1;
+}
+.cds--progress--space-equal .cds--progress-text {
+  overflow: hidden;
+}
+.cds--progress-label {
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  line-height: 1.45;
+  margin: 0.5rem 0 0;
+  max-width: 5.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition:
+    box-shadow 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  white-space: nowrap;
+}
+.cds--progress-label:before {
+  content: '';
+  display: block;
+}
+.cds--progress-label:hover {
+  box-shadow: 0 0.0625rem var(--cds-link-primary-hover, #0043ce);
+  color: var(--cds-link-primary-hover, #0043ce);
+  cursor: pointer;
+}
+.cds--progress-step .cds--tooltip,
+.cds--progress-step .cds--tooltip_multi {
+  color: var(--cds-text-inverse, #fff);
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+}
+.cds--progress--space-equal .cds--progress-label {
+  margin-right: 0.75rem;
+  max-width: 100%;
+}
+.cds--progress-step-button:not(.cds--progress-step-button--unclickable):focus {
+  outline: 0;
+}
+.cds--progress-step-button:not(
+    .cds--progress-step-button--unclickable
+  ):focus-visible
+  .cds--progress-label {
+  color: var(--cds-focus, #0f62fe);
+  outline: 0.0625rem solid var(--cds-focus, #0f62fe);
+}
+.cds--progress-step-button:not(.cds--progress-step-button--unclickable)
+  .cds--progress-label:active {
+  box-shadow: 0 0.0625rem 0 0 var(--cds-text-primary, #161616);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--progress-label-overflow:focus ~ .cds--tooltip,
+.cds--progress-label-overflow:hover ~ .cds--tooltip {
+  visibility: inherit;
+}
+.cds--progress-step .cds--tooltip .cds--tooltip__caret {
+  margin-left: 0.625rem;
+}
+.cds--tooltip__text {
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+}
+.cds--progress-optional,
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item-secondary-label {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+}
+.cds--progress-step .cds--tooltip {
+  display: block;
+  margin-left: 1.375rem;
+  margin-top: 2.5rem;
+  min-height: 1.5rem;
+  min-width: 7.1875rem;
+  padding: 0.5rem 1rem;
+  visibility: hidden;
+  width: 7.8125rem;
+}
+.cds--progress-step .cds--tooltip_multi {
+  height: auto;
+  width: 9.375rem;
+}
+.cds--progress-optional {
+  color: var(--cds-text-secondary, #525252);
+  left: 0;
+  margin-left: 1.5rem;
+  margin-top: 1.75rem;
+  position: absolute;
+  text-align: start;
+}
+.cds--progress-step-button,
+.cds--radio-button-group {
+  border: 0;
+  font-family: inherit;
+  font-size: 100%;
+  padding: 0;
+}
+.cds--progress-step--current .cds--progress-line {
+  background-color: var(--cds-interactive, #0f62fe);
+}
+.cds--progress-step--incomplete svg {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--progress-step--incomplete .cds--progress-line {
+  background-color: var(--cds-border-subtle);
+}
+.cds--progress-step--complete .cds--progress-line {
+  background-color: var(--cds-interactive, #0f62fe);
+}
+.cds--progress-step-button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  display: flex;
+  margin: 0;
+  text-align: left;
+  vertical-align: baseline;
+  width: 100%;
+}
+.cds--progress-step-button *,
+.cds--progress-step-button :after,
+.cds--progress-step-button :before {
+  box-sizing: inherit;
+}
+.cds--progress-step-button::-moz-focus-inner {
+  border: 0;
+}
+.cds--progress-step-button--unclickable {
+  cursor: default;
+  outline: 0;
+}
+.cds--progress-step-button--unclickable .cds--progress-label:hover {
+  box-shadow: none;
+  color: var(--cds-text-primary, #161616);
+  cursor: default;
+}
+.cds--progress-step-button--unclickable .cds--tooltip__label:hover {
+  box-shadow: 0 0.0625rem var(--cds-link-primary, #0f62fe);
+  color: var(--cds-link-primary, #0f62fe);
+  cursor: pointer;
+}
+.cds--progress-step--disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.cds--progress-step--disabled svg {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--progress-step--disabled .cds--progress-label,
+.cds--progress-step--disabled .cds--progress-label:hover {
+  box-shadow: none;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--progress-step--disabled .cds--progress-line {
+  cursor: not-allowed;
+}
+.cds--progress-step--disabled
+  .cds--progress-label-overflow:hover
+  ~ .cds--tooltip--definition
+  .cds--tooltip--definition__bottom {
+  display: none;
+}
+.cds--progress.cds--skeleton .cds--progress-label {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  height: 0.875rem;
+  margin-top: 0.625rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 2.5rem;
+}
+.cds--progress.cds--skeleton .cds--progress-label:active,
+.cds--progress.cds--skeleton .cds--progress-label:focus,
+.cds--progress.cds--skeleton .cds--progress-label:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--progress.cds--skeleton .cds--progress-label:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+.cds--progress.cds--progress--vertical.cds--skeleton .cds--progress-label {
+  margin-top: 0.0625rem;
+}
+.cds--progress--vertical,
+.cds--progress-text {
+  display: flex;
+  flex-direction: column;
+}
+.cds--progress--vertical .cds--progress-step,
+.cds--progress--vertical .cds--progress-step-button {
+  align-content: flex-start;
+  min-height: 3.625rem;
+  min-width: auto;
+  width: auto;
+}
+.cds--progress--vertical .cds--progress-step svg,
+.cds--progress--vertical .cds--progress-step-button svg {
+  display: inline-block;
+  margin: 0.0625rem 0.5rem 0;
+}
+.cds--progress--vertical .cds--progress-label {
+  display: inline-block;
+  margin: 0;
+  max-width: 10rem;
+  vertical-align: top;
+  white-space: normal;
+  width: auto;
+}
+.cds--progress--vertical .cds--progress-step .cds--tooltip {
+  margin-top: 0.5rem;
+}
+.cds--progress--vertical .cds--progress-optional {
+  margin: auto 0;
+  position: static;
+  width: 100%;
+}
+.cds--progress--vertical .cds--progress-line {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 1px;
+}
+.cds--radio-button-group {
+  align-items: center;
+  box-sizing: border-box;
+  display: flex;
+  margin: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+.cds--radio-button-group *,
+.cds--radio-button-group :after,
+.cds--radio-button-group :before {
+  box-sizing: inherit;
+}
+.cds--label + .cds--form-item .cds--radio-button-group {
+  margin-top: 0;
+}
+.cds--radio-button-group--vertical {
+  align-items: flex-start;
+  flex-direction: column;
+}
+.cds--radio-button-group--vertical.cds--radio-button-group--label-left {
+  align-items: flex-end;
+}
+.cds--radio-button-group--vertical .cds--radio-button__label {
+  line-height: 1.25;
+  margin-right: 0;
+}
+.cds--radio-button-group--vertical
+  .cds--radio-button__label:not(:last-of-type) {
+  margin-bottom: 0.5rem;
+}
+.cds--radio-button {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  width: 1px;
+}
+.cds--radio-button__label {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  margin-right: 1rem;
+}
+.cds--radio-button__appearance,
+.cds--structured-list html,
+.cds--structured-list-td html,
+.cds--structured-list-th html,
+.cds--tabs .cds--tabs__nav-item html,
+.cds--tabs .cds--tabs__nav-link,
+.cds--tabs html,
+.cds--text-area html,
+.cds--tile-group html {
+  font-size: 100%;
+}
+.cds--radio-button__appearance {
+  background-color: transparent;
+  border: 0;
+  border: 1px solid var(--cds-icon-primary, #161616);
+  border-radius: 50%;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  font-family: inherit;
+  height: 1.125rem;
+  margin: 0.0625rem 0.5rem 0.125rem 0.125rem;
+  padding: 0;
+  vertical-align: baseline;
+  width: 1.125rem;
+}
+.cds--icon--skeleton,
+.cds--radio-button__label.cds--skeleton,
+.cds--skeleton__placeholder,
+.cds--skeleton__text {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  box-shadow: none;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+}
+.cds--radio-button__appearance *,
+.cds--radio-button__appearance :after,
+.cds--radio-button__appearance :before {
+  box-sizing: inherit;
+}
+.cds--radio-button:checked
+  + .cds--radio-button__label
+  .cds--radio-button__appearance {
+  align-items: center;
+  border-color: var(--cds-icon-primary, #161616);
+  display: flex;
+  justify-content: center;
+}
+.cds--radio-button:checked
+  + .cds--radio-button__label
+  .cds--radio-button__appearance:before {
+  background-color: var(--cds-icon-primary, #161616);
+  border-radius: 50%;
+  content: '';
+  display: inline-block;
+  height: 100%;
+  position: relative;
+  transform: scale(0.5);
+  width: 100%;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--radio-button:checked
+    + .cds--radio-button__label
+    .cds--radio-button__appearance:before {
+    fill: ButtonText;
+    background-color: ButtonText;
+  }
+}
+.cds--radio-button:disabled + .cds--radio-button__label {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--radio-button-group--readonly
+  .cds--radio-button
+  + .cds--radio-button__label
+  .cds--radio-button__appearance,
+.cds--radio-button:disabled
+  + .cds--radio-button__label
+  .cds--radio-button__appearance,
+.cds--radio-button:disabled:checked
+  + .cds--radio-button__label
+  .cds--radio-button__appearance {
+  border-color: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--radio-button:disabled
+  + .cds--radio-button__label
+  .cds--radio-button__appearance:before,
+.cds--radio-button:disabled:checked
+  + .cds--radio-button__label
+  .cds--radio-button__appearance:before {
+  background-color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--radio-button-group--readonly .cds--radio-button__label {
+  cursor: default;
+}
+.cds--radio-button-group--readonly .cds--radio-button__label-text {
+  cursor: text;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  user-select: text;
+}
+.cds--radio-button-group--invalid
+  .cds--radio-button
+  + .cds--radio-button__label
+  .cds--radio-button__appearance {
+  border-color: var(--cds-support-error, #da1e28);
+}
+.cds--radio-button__validation-msg {
+  align-items: flex-end;
+  display: none;
+  margin-top: 0.375rem;
+}
+.cds--radio-button__invalid-icon {
+  margin: 0 0.0625rem 0 0.1875rem;
+}
+.cds--radio-button__invalid-icon--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--radio-button__invalid-icon--warning path:first-of-type {
+  fill: #000;
+}
+.cds--structured-list-input:checked
+  + .cds--structured-list-row
+  .cds--structured-list-svg,
+.cds--structured-list-input:checked
+  + .cds--structured-list-td
+  .cds--structured-list-svg,
+.cds--tabs .cds--tab--overflow-nav-button svg {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--radio-button-group--invalid + .cds--radio-button__validation-msg,
+.cds--radio-button-group--warning + .cds--radio-button__validation-msg {
+  display: flex;
+}
+.cds--radio-button-group--invalid
+  + .cds--radio-button__validation-msg
+  .cds--form-requirement,
+.cds--radio-button-group--warning
+  + .cds--radio-button__validation-msg
+  .cds--form-requirement {
+  display: block;
+  margin-left: 0.5rem;
+  margin-top: 0;
+  max-height: 100%;
+  overflow: visible;
+}
+.cds--radio-button-group--invalid
+  + .cds--radio-button__validation-msg
+  .cds--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+}
+.cds--radio-button-group ~ .cds--form__helper-text {
+  margin-top: 0.375rem;
+}
+.cds--radio-button:focus
+  + .cds--radio-button__label
+  .cds--radio-button__appearance {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: 1.5px;
+}
+.cds--radio-button__label.cds--skeleton {
+  border: none;
+  height: 1.125rem;
+  width: 6.25rem;
+}
+.cds--icon--skeleton:before,
+.cds--radio-button__label.cds--skeleton:before {
+  animation: skeleton 3s ease-in-out infinite;
+  width: 100%;
+}
+.cds--icon--skeleton:before,
+.cds--radio-button__label.cds--skeleton:before,
+.cds--skeleton__placeholder:before,
+.cds--skeleton__text:before {
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  will-change: transform-origin, transform, opacity;
+}
+.cds--radio-button__label.cds--skeleton:active,
+.cds--radio-button__label.cds--skeleton:focus,
+.cds--radio-button__label.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--radio-button__label.cds--skeleton .cds--radio-button__appearance {
+  display: none;
+}
+.cds--radio-button-wrapper .cds--radio-button__label {
+  align-items: flex-start;
+  display: flex;
+  justify-content: center;
+  margin: 0;
+}
+.cds--radio-button-wrapper:not(:last-of-type) {
+  margin-right: 1rem;
+}
+.cds--radio-button-group--vertical
+  .cds--radio-button-wrapper:not(:last-of-type) {
+  margin-bottom: 0.5rem;
+  margin-right: 0;
+}
+.cds--radio-button-group--label-right .cds--radio-button__label,
+.cds--radio-button-wrapper.cds--radio-button-wrapper--label-right
+  .cds--radio-button__label {
+  flex-direction: row;
+}
+.cds--radio-button-group--label-left .cds--radio-button__label,
+.cds--radio-button-wrapper.cds--radio-button-wrapper--label-left
+  .cds--radio-button__label {
+  flex-direction: row-reverse;
+}
+.cds--radio-button-group--label-left .cds--radio-button__appearance,
+.cds--radio-button-wrapper.cds--radio-button-wrapper--label-left
+  .cds--radio-button__appearance {
+  margin-left: 0.5rem;
+  margin-right: 0;
+}
+.cds--icon--skeleton {
+  border: none;
+  display: inline-block;
+  height: 1rem;
+  width: 1rem;
+}
+.cds--icon--skeleton:active,
+.cds--icon--skeleton:focus,
+.cds--icon--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--icon--skeleton:before,
+  .cds--progress.cds--skeleton .cds--progress-label:before,
+  .cds--radio-button__label.cds--skeleton:before {
+    animation: none;
+  }
+}
+.cds--skeleton__placeholder {
+  border: none;
+  height: 6.25rem;
+  width: 6.25rem;
+}
+.cds--skeleton__placeholder:active,
+.cds--skeleton__placeholder:focus,
+.cds--skeleton__placeholder:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--skeleton__placeholder:before {
+  animation: skeleton 3s ease-in-out infinite;
+  width: 100%;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--skeleton__placeholder:before {
+    animation: none;
+  }
+}
+.cds--skeleton__text {
+  border: none;
+  height: 1rem;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+.cds--skeleton__text:active,
+.cds--skeleton__text:focus,
+.cds--skeleton__text:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--skeleton__text:before {
+  animation: skeleton 3s ease-in-out infinite;
+  width: 100%;
+}
+.cds--skeleton__heading {
+  height: 1.5rem;
+}
+.cds--slider__filled-track,
+.cds--slider__track {
+  height: 0.125rem;
+  transform: translateY(-50%);
+  width: 100%;
+}
+.cds--slider-container {
+  align-items: center;
+  display: flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.cds--slider {
+  cursor: pointer;
+  margin: 0 1rem;
+  max-width: 40rem;
+  min-width: 12.5rem;
+  padding: 1rem 0;
+  position: relative;
+  width: 100%;
+}
+.cds--slider__range-label {
+  color: var(--cds-text-primary, #161616);
+  font-family: var(
+    --cds-code-02-font-family,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    '.SFNSText-Regular',
+    monospace
+  );
+  font-size: var(--cds-code-02-font-size, 0.875rem);
+  font-weight: var(--cds-code-02-font-weight, 400);
+  letter-spacing: var(--cds-code-02-letter-spacing, 0.32px);
+  line-height: var(--cds-code-02-line-height, 1.42857);
+  white-space: nowrap;
+}
+.cds--slider__range-label:last-of-type {
+  margin-right: 1rem;
+}
+.cds--slider__track {
+  background: var(--cds-border-subtle);
+  position: absolute;
+}
+.cds--slider__filled-track,
+.cds--slider__thumb {
+  background: var(--cds-layer-selected-inverse, #161616);
+  position: absolute;
+}
+.cds--slider__track:before {
+  background: var(--cds-border-subtle);
+  content: '';
+  display: inline-block;
+  height: 0.25rem;
+  left: 50%;
+  position: absolute;
+  top: -0.3125rem;
+  transform: translate(-50%);
+  width: 0.125rem;
+}
+.cds--slider-text-input--hidden,
+.cds--slider__input,
+.cds--structured-list.cds--structured-list--selection.cds--skeleton
+  .cds--structured-list-th:first-child
+  span {
+  display: none;
+}
+.cds--slider__thumb:focus,
+.cds--slider__thumb:focus ~ .cds--slider__filled-track {
+  background-color: var(--cds-interactive, #0f62fe);
+}
+.cds--slider__thumb:active,
+.cds--slider__thumb:focus,
+.cds--slider__thumb:hover {
+  transform: translate(-50%, -50%) scale(1.4286);
+}
+.cds--slider__filled-track {
+  pointer-events: none;
+  transform-origin: left;
+  transition: background 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--slider__thumb {
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 0 1px transparent,
+    inset 0 0 0 2px transparent;
+  height: 0.875rem;
+  outline: 0;
+  transform: translate(-50%, -50%);
+  transition:
+    transform 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    background 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    box-shadow 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 0.875rem;
+  z-index: 3;
+}
+.cds--slider__thumb:focus {
+  box-shadow:
+    inset 0 0 0 2px var(--cds-interactive, #0f62fe),
+    inset 0 0 0 3px var(--cds-layer);
+}
+.cds--slider__thumb:active {
+  box-shadow: inset 0 0 0 2px var(--cds-interactive, #0f62fe);
+}
+.cds--slider-text-input,
+.cds-slider-text-input {
+  -moz-appearance: textfield;
+  height: 2.5rem;
+  text-align: center;
+  width: 4rem;
+}
+.cds--slider-text-input::-webkit-inner-spin-button,
+.cds--slider-text-input::-webkit-outer-spin-button,
+.cds-slider-text-input::-webkit-inner-spin-button,
+.cds-slider-text-input::-webkit-outer-spin-button {
+  display: none;
+}
+.cds--slider-text-input.cds--text-input--invalid {
+  padding-right: 1rem;
+}
+.cds--slider--disabled .cds--slider__filled-track,
+.cds--slider--disabled .cds--slider__thumb,
+.cds--slider--disabled .cds--slider__thumb:focus,
+.cds--slider--disabled .cds--slider__thumb:focus ~ .cds--slider__filled-track,
+.cds--slider--disabled .cds--slider__track {
+  background-color: var(--cds-border-disabled, #c6c6c6);
+}
+.cds--label--disabled ~ .cds--slider-container > .cds--slider__range-label {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--slider--disabled.cds--slider {
+  cursor: not-allowed;
+}
+.cds--slider--disabled .cds--slider__thumb:hover {
+  cursor: not-allowed;
+  transform: translate(-50%, -50%);
+}
+.cds--slider--disabled .cds--slider__thumb:focus {
+  box-shadow: none;
+  outline: 0;
+  transform: translate(-50%, -50%);
+}
+.cds--slider--disabled .cds--slider__thumb:active {
+  background: var(--cds-border-disabled, #c6c6c6);
+  transform: translate(-50%, -50%);
+}
+.cds--slider-container.cds--skeleton .cds--slider__range-label:before,
+.cds--structured-list.cds--skeleton span:before,
+.cds--tabs.cds--skeleton .cds--tabs__nav-link span:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+.cds--slider--disabled ~ .cds--form-item .cds--slider-text-input,
+.cds--slider--disabled ~ .cds--slider-text-input {
+  background-color: var(--cds-field);
+  border: none;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+  transition: none;
+}
+.cds--slider--readonly ~ .cds--slider-text-input,
+.cds--structured-list {
+  background-color: transparent;
+}
+.cds--slider-container.cds--skeleton .cds--slider__range-label,
+.cds--structured-list.cds--skeleton span {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  box-shadow: none;
+  pointer-events: none;
+  position: relative;
+}
+.cds--slider--disabled ~ .cds--form-item .cds--slider-text-input:active,
+.cds--slider--disabled ~ .cds--form-item .cds--slider-text-input:focus,
+.cds--slider--disabled ~ .cds--form-item .cds--slider-text-input:hover,
+.cds--slider--disabled ~ .cds--slider-text-input:active,
+.cds--slider--disabled ~ .cds--slider-text-input:focus,
+.cds--slider--disabled ~ .cds--slider-text-input:hover {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  outline: 0;
+}
+.cds--structured-list--selection
+  .cds--structured-list-row.cds--structured-list-row--selected
+  .cds--structured-list-td,
+.cds--structured-list--selection
+  .cds--structured-list-row.cds--structured-list-row--selected
+  > .cds--structured-list-td,
+.cds--structured-list--selection
+  .cds--structured-list-row:hover:not(.cds--structured-list-row--header-row)
+  > .cds--structured-list-td,
+.cds--structured-list-th {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--slider--readonly {
+  cursor: default;
+}
+.cds--slider--readonly .cds--slider__thumb {
+  height: 0;
+  width: 0;
+}
+.cds--slider-container.cds--skeleton .cds--slider__range-label {
+  border: none;
+  height: 0.75rem;
+  padding: 0;
+  width: 1.25rem;
+}
+.cds--slider-container.cds--skeleton .cds--slider__range-label:active,
+.cds--slider-container.cds--skeleton .cds--slider__range-label:focus,
+.cds--slider-container.cds--skeleton .cds--slider__range-label:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--slider-container.cds--skeleton .cds--slider__range-label:before {
+  height: 100%;
+  position: absolute;
+}
+.cds--slider-container.cds--skeleton .cds--slider__track {
+  cursor: default;
+  pointer-events: none;
+}
+.cds--slider-container.cds--skeleton .cds--slider__thumb {
+  cursor: default;
+  left: 50%;
+  pointer-events: none;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--slider__thumb {
+    outline: 1px solid transparent;
+  }
+  .cds--slider__thumb:focus {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--slider__track {
+    outline: 1px solid transparent;
+  }
+  .cds--structured-list-input:checked
+    + .cds--structured-list-td
+    .cds--structured-list-svg {
+    fill: ButtonText;
+  }
+}
+.cds--stack-horizontal {
+  -moz-column-gap: var(--cds-stack-gap, 0);
+  column-gap: var(--cds-stack-gap, 0);
+  display: inline-grid;
+  grid-auto-flow: column;
+}
+.cds--stack-vertical {
+  display: grid;
+  grid-auto-flow: row;
+  row-gap: var(--cds-stack-gap, 0);
+}
+.cds--stack-scale-1 {
+  --cds-stack-gap: 0.125rem;
+}
+.cds--stack-scale-2 {
+  --cds-stack-gap: 0.25rem;
+}
+.cds--stack-scale-3 {
+  --cds-stack-gap: 0.5rem;
+}
+.cds--stack-scale-4 {
+  --cds-stack-gap: 0.75rem;
+}
+.cds--stack-scale-5 {
+  --cds-stack-gap: 1rem;
+}
+.cds--stack-scale-6 {
+  --cds-stack-gap: 1.5rem;
+}
+.cds--stack-scale-7 {
+  --cds-stack-gap: 2rem;
+}
+.cds--stack-scale-8 {
+  --cds-stack-gap: 2.5rem;
+}
+.cds--stack-scale-9 {
+  --cds-stack-gap: 3rem;
+}
+.cds--stack-scale-10 {
+  --cds-stack-gap: 4rem;
+}
+.cds--stack-scale-11 {
+  --cds-stack-gap: 5rem;
+}
+.cds--stack-scale-12 {
+  --cds-stack-gap: 6rem;
+}
+.cds--stack-scale-13 {
+  --cds-stack-gap: 10rem;
+}
+.cds--structured-list--selection .cds--structured-list-td,
+.cds--structured-list--selection .cds--structured-list-td:first-child,
+.cds--structured-list--selection .cds--structured-list-th,
+.cds--structured-list--selection .cds--structured-list-th:first-child {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.cds--structured-list-row--focused-within {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--structured-list-row--focused-within {
+    outline-style: dotted;
+  }
+}
+.cds--text-area,
+.cds--tile {
+  outline: 2px solid transparent;
+}
+.cds--structured-list {
+  display: table;
+  overflow-x: auto;
+  width: 100%;
+}
+.cds--structured-list body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--structured-list code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--structured-list strong {
+  font-weight: 600;
+}
+.cds--structured-list.cds--structured-list--condensed .cds--structured-list-td,
+.cds--structured-list.cds--structured-list--condensed .cds--structured-list-th {
+  padding: 0.5rem;
+}
+.cds--structured-list
+  .cds--structured-list-row
+  .cds--structured-list-td:first-of-type,
+.cds--structured-list
+  .cds--structured-list-row
+  .cds--structured-list-th:first-of-type,
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item--icon {
+  padding-left: 1rem;
+}
+.cds--structured-list.cds--structured-list--flush
+  .cds--structured-list-row
+  .cds--structured-list-td,
+.cds--structured-list.cds--structured-list--flush
+  .cds--structured-list-row
+  .cds--structured-list-td:first-of-type,
+.cds--structured-list.cds--structured-list--flush
+  .cds--structured-list-row
+  .cds--structured-list-th,
+.cds--structured-list.cds--structured-list--flush
+  .cds--structured-list-row
+  .cds--structured-list-th:first-of-type {
+  padding-left: 0;
+  padding-right: 1rem;
+}
+.cds--structured-list-row {
+  border-top: 1px solid var(--cds-border-subtle);
+  display: table-row;
+  transition: background-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--structured-list-tbody .cds--structured-list-row:last-child {
+  border-bottom: 1px solid var(--cds-border-subtle);
+}
+.cds--structured-list-row--header-row {
+  border: none;
+}
+.cds--structured-list--selection
+  .cds--structured-list-row:hover:not(
+    .cds--structured-list-row--header-row
+  ):not(.cds--structured-list-row--selected) {
+  background-color: var(--cds-layer-hover);
+  border-color: var(--cds-layer-hover);
+  cursor: pointer;
+}
+.cds--structured-list--selection
+  .cds--structured-list-row:hover:not(
+    .cds--structured-list-row--header-row
+  ):not(.cds--structured-list-row--selected)
+  + .cds--structured-list-row {
+  border-color: var(--cds-layer-hover);
+}
+.cds--structured-list--selection
+  .cds--structured-list-row.cds--structured-list-row--selected {
+  background-color: var(--cds-layer-selected);
+  border-color: var(--cds-layer-selected);
+}
+.cds--structured-list--selection
+  .cds--structured-list-row--selected
+  + .cds--structured-list-row {
+  border-color: var(--cds-layer-selected);
+}
+.cds--structured-list-row.cds--structured-list-row--header-row {
+  cursor: inherit;
+}
+.cds--structured-list-thead {
+  display: table-header-group;
+  vertical-align: middle;
+}
+.cds--structured-list-th {
+  display: table-cell;
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  font-weight: 600;
+  height: 2.5rem;
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  padding: 1rem 0.5rem 0.5rem;
+  text-align: left;
+  text-transform: none;
+  vertical-align: top;
+}
+.cds--structured-list-th body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--structured-list-th code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--structured-list-th strong {
+  font-weight: 600;
+}
+.cds--structured-list-tbody {
+  display: table-row-group;
+  vertical-align: middle;
+}
+.cds--structured-list-td {
+  color: var(--cds-text-secondary, #525252);
+  display: table-cell;
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+  max-width: 36rem;
+  padding: 1rem 0.5rem 1.5rem;
+  position: relative;
+  transition: color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tabs,
+.cds--tabs .cds--tabs__nav-link {
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--structured-list-td body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--structured-list-td code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--structured-list-td strong {
+  font-weight: 600;
+}
+.cds--structured-list-content--nowrap {
+  white-space: nowrap;
+}
+.cds--structured-list-svg {
+  fill: transparent;
+  display: inline-block;
+  transition: 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+  vertical-align: middle;
+}
+.cds--tabs,
+.cds--tabs .cds--tabs__nav {
+  display: flex;
+}
+.cds--cc--meter-title g.status-indicator.status--danger circle.status,
+.cds--text-area__invalid-icon {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--structured-list.cds--skeleton .cds--structured-list-th:first-child {
+  width: 8%;
+}
+.cds--structured-list.cds--skeleton .cds--structured-list-th:nth-child(3n + 2) {
+  width: 30%;
+}
+.cds--structured-list.cds--skeleton .cds--structured-list-th:nth-child(3n + 3) {
+  width: 15%;
+}
+.cds--structured-list.cds--skeleton span {
+  border: none;
+  display: block;
+  height: 1rem;
+  padding: 0;
+  width: 75%;
+}
+.cds--structured-list.cds--skeleton span:active,
+.cds--structured-list.cds--skeleton span:focus,
+.cds--structured-list.cds--skeleton span:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--structured-list.cds--skeleton span:before {
+  height: 100%;
+  position: absolute;
+}
+.cds--structured-list.cds--structured-list--selection.cds--skeleton
+  .cds--structured-list-th:first-child {
+  width: 5%;
+}
+.cds--tabs {
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  height: auto;
+  max-height: 4rem;
+  min-height: 2.5rem;
+  position: relative;
+  width: 100%;
+}
+.cds--tabs body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+}
+.cds--tabs code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--tabs strong {
+  font-weight: 600;
+}
+.cds--tabs .cds--tabs__nav-item body,
+.cds--text-area body {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+}
+.cds--tabs.cds--tabs--contained {
+  min-height: 3rem;
+}
+.cds--tabs .cds--tab--list {
+  display: flex;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  width: auto;
+  will-change: scroll-position;
+}
+.cds--tabs .cds--tab--list::-webkit-scrollbar {
+  display: none;
+}
+.cds--tabs .cds--tab--overflow-nav-button {
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  background-color: var(--cds-background, #fff);
+  border: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  display: flex;
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 100%;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  text-align: start;
+  vertical-align: baseline;
+  width: 2.5rem;
+}
+.cds--header__action--active > svg.cds--navigation-menu-panel-expand-icon,
+.cds--header__action > svg.cds--navigation-menu-panel-collapse-icon,
+.cds--tabs .cds--tab--overflow-nav-button--hidden {
+  display: none;
+}
+.cds--tabs .cds--tab--overflow-nav-button *,
+.cds--tabs .cds--tab--overflow-nav-button :after,
+.cds--tabs .cds--tab--overflow-nav-button :before {
+  box-sizing: inherit;
+}
+.cds--tabs .cds--tabs__nav-link,
+.cds--tile__chevron--interactive {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  box-sizing: border-box;
+  font-family: inherit;
+  vertical-align: baseline;
+}
+.cds--tabs .cds--tab--overflow-nav-button::-moz-focus-inner {
+  border: 0;
+}
+.cds--tabs .cds--tab--overflow-nav-button:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--tabs .cds--tab--overflow-nav-button:focus {
+    outline-style: dotted;
+  }
+}
+.cds--tabs.cds--tabs--contained .cds--tab--overflow-nav-button {
+  background-color: var(--cds-layer-accent);
+  margin: 0;
+  width: 3rem;
+}
+.cds--tabs .cds--tab--overflow-nav-button--next {
+  bottom: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.cds--tabs .cds--tab--overflow-nav-button--next:before {
+  background: linear-gradient(
+    to right,
+    hsla(0, 0%, 100%, 0),
+    var(--cds-background, #fff)
+  );
+  content: '';
+  height: 100%;
+  left: -0.5rem;
+  position: absolute;
+  width: 0.5rem;
+  z-index: 1;
+}
+.cds--tabs.cds--tabs--contained .cds--tab--overflow-nav-button--next:before {
+  background-image: linear-gradient(
+    to right,
+    hsla(0, 0%, 100%, 0),
+    var(--cds-layer-accent)
+  );
+}
+.cds--tabs .cds--tab--overflow-nav-button--previous {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  top: 0;
+}
+.cds--tabs .cds--tab--overflow-nav-button--previous:before {
+  background: linear-gradient(
+    to left,
+    hsla(0, 0%, 100%, 0),
+    var(--cds-background, #fff)
+  );
+  content: '';
+  height: 100%;
+  position: absolute;
+  right: -0.5rem;
+  width: 0.5rem;
+  z-index: 1;
+}
+.cds--tabs.cds--tabs--contained
+  .cds--tab--overflow-nav-button--previous:before {
+  background-image: linear-gradient(
+    to left,
+    hsla(0, 0%, 100%, 0),
+    var(--cds-layer-accent)
+  );
+}
+.cds--tabs .cds--tabs--light .cds--tabs__overflow-indicator--left {
+  background-image: linear-gradient(
+    to left,
+    hsla(0, 0%, 100%, 0),
+    var(--cds-layer)
+  );
+}
+.cds--tabs .cds--tabs--light .cds--tabs__overflow-indicator--right {
+  background-image: linear-gradient(
+    to right,
+    hsla(0, 0%, 100%, 0),
+    var(--cds-layer)
+  );
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__overflow-indicator--left {
+  background-image: linear-gradient(
+    to left,
+    hsla(0, 0%, 100%, 0),
+    var(--cds-layer-accent)
+  );
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__overflow-indicator--right {
+  background-image: linear-gradient(
+    to right,
+    hsla(0, 0%, 100%, 0),
+    var(--cds-layer-accent)
+  );
+}
+@media not all and (-webkit-min-device-pixel-ratio: 0),
+  not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .cds--tabs .cds--tabs__overflow-indicator--left {
+      background-image: linear-gradient(
+        to left,
+        rgba(var(--cds-background, #fff), 0),
+        var(--cds-background, #fff)
+      );
+    }
+    .cds--tabs .cds--tabs__overflow-indicator--right {
+      background-image: linear-gradient(
+        to right,
+        rgba(var(--cds-background, #fff), 0),
+        var(--cds-background, #fff)
+      );
+    }
+    .cds--tabs.cds--tabs--contained .cds--tabs__overflow-indicator--left {
+      background-image: linear-gradient(
+        to left,
+        rgba(var(--cds-layer-accent), 0),
+        var(--cds-layer-accent)
+      );
+    }
+    .cds--tabs.cds--tabs--contained .cds--tabs__overflow-indicator--right {
+      background-image: linear-gradient(
+        to right,
+        rgba(var(--cds-layer-accent), 0),
+        var(--cds-layer-accent)
+      );
+    }
+  }
+}
+.cds--tabs .cds--tabs__nav-item-label-wrapper {
+  display: flex;
+}
+.cds--tabs .cds--tabs__nav-item {
+  cursor: pointer;
+  display: flex;
+  flex: 1 0 auto;
+  padding: 0;
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tabs .cds--tabs__nav-item code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--tabs .cds--tabs__nav-item strong {
+  font-weight: 600;
+}
+.cds--tabs .cds--tabs__nav-item + .cds--tabs__nav-item {
+  margin-left: 0.0625rem;
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item {
+  background-color: var(--cds-layer-accent);
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item + .cds--tabs__nav-item {
+  box-shadow: -0.0625rem 0 0 0 var(--cds-border-strong);
+  margin-left: 0;
+}
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item--selected
+  .cds--tabs__nav-link:active,
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item--selected
+  .cds--tabs__nav-link:focus,
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item--selected
+  + .cds--tabs__nav-item,
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item--selected:hover
+  .cds--tabs__nav-link:active,
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item--selected:hover
+  .cds--tabs__nav-link:focus,
+.cds--text-area.cds--skeleton {
+  box-shadow: none;
+}
+.cds--tabs .cds--tabs__nav-item .cds--tabs__nav-link {
+  transition:
+    color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    border-bottom-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tabs .cds--tabs__nav-item--icon {
+  align-items: center;
+  display: flex;
+  padding-left: 0.5rem;
+}
+.cds--tabs .cds--tabs__nav-link {
+  background: 0 0;
+  border: 0;
+  border-bottom: 2px solid var(--cds-border-subtle);
+  color: var(--cds-text-secondary, #525252);
+  cursor: pointer;
+  display: inline-block;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  margin: 0;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  overflow: hidden;
+  padding: 0.75rem 1rem 0.5rem;
+  text-align: left;
+  text-overflow: ellipsis;
+  transition:
+    border 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  white-space: nowrap;
+}
+.cds--tabs .cds--tabs__nav-link *,
+.cds--tabs .cds--tabs__nav-link :after,
+.cds--tabs .cds--tabs__nav-link :before {
+  box-sizing: inherit;
+}
+.cds--tabs .cds--tabs__nav-link::-moz-focus-inner {
+  border: 0;
+}
+.cds--tabs .cds--tabs__nav-link:active,
+.cds--tabs .cds--tabs__nav-link:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--tabs .cds--tabs__nav-link:active,
+  .cds--tabs .cds--tabs__nav-link:focus {
+    outline-style: dotted;
+  }
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-link {
+  border-bottom: 0;
+  height: 3rem;
+  padding: 0.5rem 1rem;
+}
+.cds--tabs.cds--tabs--contained:not(.cds--tabs--tall)
+  .cds--tabs__nav-item-label {
+  line-height: 2rem;
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item-secondary-label {
+  min-height: 1rem;
+}
+.cds--tabs.cds--tabs--contained.cds--tabs--tall .cds--tabs__nav-link {
+  height: 4rem;
+}
+.cds--tabs.cds--tabs__icon--default .cds--tab--list,
+.cds--tabs.cds--tabs__icon--lg .cds--tab--list {
+  overflow-x: visible;
+}
+.cds--tabs .cds--tabs__nav-item--icon-only,
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item--icon-only {
+  align-items: center;
+  display: flex;
+  height: var(--cds-icon-tab-size, 2.5rem);
+  justify-content: center;
+  padding: 0;
+  width: var(--cds-icon-tab-size, 2.5rem);
+}
+.cds--tabs .cds--tabs__nav-item--icon-only .cds--tabs__nav-item-label,
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item--icon-only
+  .cds--tabs__nav-item-label {
+  line-height: 0;
+}
+.cds--tabs.cds--tabs__icon--lg {
+  --cds-icon-tab-size: 3rem;
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item:hover {
+  background-color: var(--cds-layer-selected-hover);
+}
+.cds--tabs .cds--tabs__nav-item--selected {
+  border-bottom: 2px solid var(--cds-border-interactive, #0f62fe);
+  transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item.cds--tabs__nav-item--selected {
+  box-shadow: inset 0 2px 0 0 var(--cds-border-interactive, #0f62fe);
+}
+.cds--tabs .cds--tabs__nav-item--selected,
+.cds--tabs .cds--tabs__nav-item--selected:active .cds--tabs__nav-link:active,
+.cds--tabs .cds--tabs__nav-item--selected:focus .cds--tabs__nav-link:focus,
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item--selected {
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+}
+.cds--tabs .cds--tabs__nav-item--disabled,
+.cds--tabs .cds--tabs__nav-item--disabled:hover {
+  border-bottom: 2px solid var(--cds-border-disabled, #c6c6c6);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--tabs.cds--tabs--contained:not(.cds--tabs--tall)
+  .cds--tabs__nav-item--selected,
+.cds--tabs.cds--tabs--contained:not(.cds--tabs--tall)
+  .cds--tabs__nav-item--selected:hover {
+  line-height: 2rem;
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item--selected,
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item--selected:hover {
+  background-color: var(--cds-layer);
+}
+.cds--tabs.cds--tabs--light.cds--tabs--contained .cds--tabs__nav-item--selected,
+.cds--tabs.cds--tabs--light.cds--tabs--contained
+  .cds--tabs__nav-item--selected:hover {
+  background-color: var(--cds-background, #fff);
+}
+.cds--tabs .cds--tabs__nav-item:hover .cds--tabs__nav-link {
+  border-bottom: 2px solid var(--cds-border-strong);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--tabs .cds--tabs__nav-item--disabled {
+  background-color: transparent;
+  outline: 0;
+}
+.cds--tabs .cds--tabs__nav-item--disabled:hover {
+  cursor: not-allowed;
+}
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item.cds--tabs__nav-item--disabled,
+.cds--tabs.cds--tabs--contained
+  .cds--tabs__nav-item.cds--tabs__nav-item--disabled:hover {
+  background-color: var(--cds-button-disabled, #c6c6c6);
+}
+.cds--tabs .cds--tabs__nav-item--disabled:active,
+.cds--tabs .cds--tabs__nav-item--disabled:focus {
+  border-bottom: 2px solid var(--cds-border-disabled, #c6c6c6);
+  outline: 0;
+  pointer-events: none;
+}
+.cds--tabs
+  .cds--tabs--light
+  .cds--tabs__nav-item--disabled
+  .cds--tabs__nav-link,
+.cds--tabs
+  .cds--tabs--light
+  .cds--tabs__nav-item--disabled
+  .cds--tabs__nav-link:active,
+.cds--tabs
+  .cds--tabs--light
+  .cds--tabs__nav-item--disabled
+  .cds--tabs__nav-link:focus,
+.cds--tabs
+  .cds--tabs--light
+  .cds--tabs__nav-item--disabled:hover
+  .cds--tabs__nav-link {
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--tabs.cds--tabs--contained .cds--tabs__nav-item--disabled {
+  border-bottom: none;
+  color: var(--cds-text-on-color-disabled, #8d8d8d);
+}
+.cds--tab-content {
+  padding: 1rem;
+}
+.cds--tab-content:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--tab-content:focus {
+    outline-style: dotted;
+  }
+}
+.cds--tab-content--interactive:focus {
+  outline: 0;
+}
+.cds--tabs.cds--skeleton {
+  cursor: default;
+  pointer-events: none;
+}
+.cds--skeleton.cds--tabs:not(.cds--tabs--contained) .cds--tabs__nav-link {
+  border-bottom: 2px solid var(--cds-skeleton-element, #c6c6c6);
+}
+.cds--tabs.cds--skeleton .cds--tabs__nav-link {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  padding: 0 1rem;
+  width: 10rem;
+}
+.cds--tabs.cds--skeleton .cds--tabs__nav-link span {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  box-shadow: none;
+  display: block;
+  height: 0.875rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 100%;
+}
+.cds--tabs.cds--skeleton .cds--tabs__nav-link span:active,
+.cds--tabs.cds--skeleton .cds--tabs__nav-link span:focus,
+.cds--tabs.cds--skeleton .cds--tabs__nav-link span:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--tabs.cds--skeleton .cds--tabs__nav-link span:before {
+  height: 100%;
+  position: absolute;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--tabs__nav-item
+    .cds--tabs__nav-item--selected
+    .cds--tabs__nav-item--selected {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+  .cds--tabs .cds--tabs__nav-item--disabled .cds--tabs__nav-link {
+    fill: GrayText;
+    color: GrayText;
+  }
+}
+.cds--text-area {
+  background-color: var(--cds-field);
+  border: none;
+  border-bottom: 1px solid var(--cds-border-strong);
+  color: var(--cds-text-primary, #161616);
+  font-family: inherit;
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  height: 100%;
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+  min-height: 2.5rem;
+  min-width: 10rem;
+  outline-offset: -2px;
+  padding: 0.6875rem 1rem;
+  resize: vertical;
+  transition:
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tile,
+.cds--tile--expandable {
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--text-area--light,
+.cds--text-area.cds--text-area--light:disabled {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--text-area code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--text-area strong {
+  font-weight: 600;
+}
+.cds--text-area:active,
+.cds--text-area:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--text-area:active,
+  .cds--text-area:focus {
+    outline-style: dotted;
+  }
+}
+.cds--text-area::-moz-placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+  opacity: 1;
+}
+.cds--text-area::placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+  opacity: 1;
+}
+.cds--text-area--invalid {
+  padding-right: 2.5rem;
+}
+.cds--text-area__wrapper {
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+.cds--text-area__invalid-icon {
+  position: absolute;
+  right: 1rem;
+  top: 0.75rem;
+}
+.cds--text-area__invalid-icon--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--text-area__invalid-icon--warning path[fill] {
+  fill: #000;
+  opacity: 1;
+}
+.cds--text-area__counter-alert {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+.cds--text-area:disabled {
+  background-color: var(--cds-field);
+  border-bottom: 1px solid transparent;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+  outline: 0;
+  resize: none;
+}
+.cds--text-area:disabled::-moz-placeholder {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--text-area:disabled::placeholder {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--text-area__wrapper--readonly .cds--text-area {
+  background: 0 0;
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--text-area.cds--skeleton {
+  background: var(--cds-skeleton-background, #e8e8e8);
+  border: none;
+  height: 6.25rem;
+  padding: 0;
+  pointer-events: none;
+  position: relative;
+  width: 100%;
+}
+.cds--text-area.cds--skeleton:active,
+.cds--text-area.cds--skeleton:focus,
+.cds--text-area.cds--skeleton:hover {
+  border: none;
+  cursor: default;
+  outline: 0;
+}
+.cds--text-area.cds--skeleton:before {
+  animation: skeleton 3s ease-in-out infinite;
+  background: var(--cds-skeleton-element, #c6c6c6);
+  content: '';
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  will-change: transform-origin, transform, opacity;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cds--skeleton__text:before,
+  .cds--slider-container.cds--skeleton .cds--slider__range-label:before,
+  .cds--structured-list.cds--skeleton span:before,
+  .cds--tabs.cds--skeleton .cds--tabs__nav-link span:before,
+  .cds--text-area.cds--skeleton:before {
+    animation: none;
+  }
+}
+.cds--text-area.cds--skeleton::-moz-placeholder {
+  color: transparent;
+}
+.cds--text-area.cds--skeleton::placeholder {
+  color: transparent;
+}
+.cds--tile--clickable,
+.cds--tile--clickable:active,
+.cds--tile--clickable:hover,
+.cds--tile--clickable:visited,
+.cds--tile--clickable:visited:hover {
+  color: var(--cds-text-primary, #161616);
+  text-decoration: none;
+}
+.cds--text-area__label-wrapper {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+.cds--tile-group body {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+}
+.cds--tile-group code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--tile-group strong {
+  font-weight: 600;
+}
+.cds--tile {
+  background-color: var(--cds-layer);
+  display: block;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  min-height: 4rem;
+  min-width: 8rem;
+  outline-offset: -2px;
+  padding: 1rem;
+  position: relative;
+}
+.cds--tile:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--tile:focus {
+    outline-style: dotted;
+  }
+}
+.cds--tile--light {
+  background-color: var(--cds-layer-02, #fff);
+}
+.cds--tile--clickable,
+.cds--tile--selectable {
+  cursor: pointer;
+  transition: 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tile__checkmark,
+.cds--tile__chevron svg {
+  transition: 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tile--clickable:hover,
+.cds--tile--selectable:hover {
+  background: var(--cds-layer-hover);
+}
+.cds--tile--clickable html {
+  font-size: 100%;
+}
+.cds--tile--clickable body {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+}
+.cds--tile--clickable code {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    monospace;
+}
+.cds--tile--clickable strong {
+  font-weight: 600;
+}
+.cds--tile--clickable:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--tile--clickable:focus {
+    outline-style: dotted;
+  }
+}
+.cds--tile--clickable:focus .cds--tile__checkmark,
+.cds--tile--clickable:hover .cds--tile__checkmark {
+  opacity: 1;
+}
+.cds--tile--expandable::-moz-focus-inner {
+  border: 0;
+}
+.cds--tile--clickable.cds--link--disabled,
+.cds--tile--clickable:hover.cds--link--disabled {
+  background-color: var(--cds-layer);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  display: block;
+  padding: 1rem;
+}
+.cds--side-nav--fixed
+  .cds--side-nav__item:not(.cds--side-nav__item--icon)
+  .cds--side-nav__menu
+  a.cds--side-nav__link,
+.cds--tree-leaf-node.cds--tree-node--with-icon {
+  padding-left: 2rem;
+}
+.cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu
+  .cds--header__menu-item:hover,
+.cds--tile__chevron--interactive:hover {
+  background-color: var(--cds-layer-hover);
+}
+.cds--tile--selectable {
+  border: 1px solid transparent;
+  padding-right: 3rem;
+}
+.cds--tile__checkmark {
+  background: 0 0;
+  border: none;
+  height: 1rem;
+  opacity: 0;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+}
+.cds--tile__chevron,
+.cds--tile__chevron--interactive {
+  bottom: 0;
+  height: 3rem;
+  position: absolute;
+  right: 0;
+  width: 3rem;
+}
+.cds--tile--is-selected .cds--tile__checkmark,
+.cds--tile__checkmark--persistent {
+  opacity: 1;
+}
+.cds--tile__checkmark svg {
+  fill: var(--cds-icon-secondary, #525252);
+  border-radius: 50%;
+}
+.cds--tile--is-selected .cds--tile__checkmark svg,
+.cds--tile__chevron svg {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--tile__checkmark:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--tile__checkmark:focus {
+    outline-style: dotted;
+  }
+}
+.cds--tile__chevron {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+.cds--tile__chevron svg {
+  transform-origin: center;
+}
+.cds--tile__chevron--interactive {
+  align-items: center;
+  background: 0 0;
+  border: 0;
+  cursor: pointer;
+  display: inline-block;
+  display: flex;
+  font-size: 100%;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  text-align: start;
+}
+.cds--tile__chevron--interactive *,
+.cds--tile__chevron--interactive :after,
+.cds--tile__chevron--interactive :before {
+  box-sizing: inherit;
+}
+.cds--tile__chevron--interactive::-moz-focus-inner {
+  border: 0;
+}
+.cds--tile__chevron--interactive:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--tile__chevron--interactive:hover {
+  cursor: pointer;
+}
+.cds--tile--expandable {
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  overflow: hidden;
+  position: relative;
+  text-align: left;
+  transition: max-height 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 100%;
+}
+.cds--tile-input,
+.cds--toggle__button {
+  clip: rect(0, 0, 0, 0);
+  position: absolute;
+  white-space: nowrap;
+}
+.cds--tile--expandable:hover {
+  background: var(--cds-layer-hover);
+}
+.cds--tile--expandable.cds--tile--expandable--interactive {
+  cursor: default;
+  transition: max-height 0.15s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tile--is-expanded .cds--tile-content__below-the-fold,
+.cds--tile-content__below-the-fold {
+  transition:
+    opacity 0.11s cubic-bezier(0.2, 0, 0.38, 0.9),
+    visibility 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tile--expandable.cds--tile--expandable--interactive:hover {
+  background-color: var(--cds-layer);
+}
+.cds--tile--expandable.cds--tile--expandable--interactive:focus {
+  outline: 0;
+}
+.cds--tile--expandable--interactive:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--tile-content__above-the-fold {
+  display: block;
+}
+.cds--tile-content__below-the-fold {
+  display: block;
+  opacity: 0;
+  visibility: hidden;
+}
+.cds--tile--is-expanded {
+  overflow: visible;
+  transition: max-height 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tile--is-expanded .cds--tile-content__below-the-fold {
+  opacity: 1;
+  visibility: inherit;
+}
+@media not all and (-webkit-min-device-pixel-ratio: 0),
+  not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .cds--tile--is-expanded .cds--tile-content__below-the-fold {
+      overflow-y: auto;
+    }
+  }
+}
+.cds--tile--is-selected {
+  border: 1px solid var(--cds-layer-selected-inverse, #161616);
+}
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .cds--tile--is-selected .cds--tile__checkmark svg,
+  .cds--tile__chevron svg {
+    fill: ButtonText;
+  }
+}
+.cds--tile--disabled .cds--tile__checkmark svg,
+.cds--time-picker--readonly .cds--select-input + .cds--select__arrow {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--tile-content {
+  height: 100%;
+  width: 100%;
+}
+.cds--tile-input {
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  visibility: inherit;
+  width: 1px;
+}
+.cds--tile-input:focus + .cds--tile {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--tile--expandable--interactive:focus,
+  .cds--tile-input:focus + .cds--tile {
+    outline-style: dotted;
+  }
+}
+.cds--tile--disabled.cds--tile--selectable {
+  background-color: var(--cds-layer);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--tile--disabled.cds--tile--selectable.cds--tile--light {
+  background-color: var(--cds-layer-02, #fff);
+}
+.cds--tile--disabled.cds--tile--is-selected {
+  border-color: var(--cds-button-disabled, #c6c6c6);
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--tile--is-selected .cds--tile__checkmark svg,
+  .cds--tile__checkmark svg,
+  .cds--tile__chevron svg {
+    fill: ButtonText;
+  }
+}
+.cds--time-picker {
+  align-items: flex-end;
+  display: flex;
+}
+.cds--time-picker__select {
+  justify-content: center;
+}
+.cds--time-picker__select:not(:last-of-type) {
+  margin: 0 0.125rem;
+}
+.cds--time-picker__input {
+  display: flex;
+  flex-direction: column;
+}
+.cds--time-picker .cds--select-input {
+  line-height: 1;
+  margin: 0;
+  min-width: auto;
+  padding-right: 3rem;
+  width: auto;
+}
+.cds--time-picker__input-field {
+  align-items: center;
+  display: flex;
+  font-family: var(
+    --cds-code-02-font-family,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    '.SFNSText-Regular',
+    monospace
+  );
+  font-size: var(--cds-code-02-font-size, 0.875rem);
+  font-weight: var(--cds-code-02-font-weight, 400);
+  height: 2.5rem;
+  letter-spacing: var(--cds-code-02-letter-spacing, 0.32px);
+  line-height: var(--cds-code-02-line-height, 1.42857);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  transition:
+    outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  width: 4.875rem;
+}
+.cds--toggletip-content,
+.cds--toggletip-label {
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+}
+.cds--time-picker__input-field::-moz-placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  opacity: 1;
+}
+.cds--time-picker__input-field::placeholder {
+  color: var(--cds-text-placeholder, hsla(0, 0%, 9%, 0.4));
+  opacity: 1;
+}
+.cds--time-picker--light .cds--select-input {
+  background-color: var(--cds-field-02, #fff);
+}
+.cds--time-picker--light .cds--select-input:hover {
+  background-color: var(--cds-field-hover);
+}
+.cds--time-picker--light .cds--select-input:disabled,
+.cds--time-picker--light .cds--select-input:hover:disabled {
+  background-color: transparent;
+  border-bottom: 1px solid transparent;
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+  cursor: not-allowed;
+}
+.cds--time-picker--readonly .cds--select-input,
+.cds--time-picker--readonly .cds--time-picker__input-field {
+  background-color: transparent;
+  border-bottom-color: var(--cds-border-subtle);
+}
+.cds--time-picker--sm .cds--select-input,
+.cds--time-picker--sm .cds--time-picker__input-field {
+  height: 2rem;
+  max-height: 2rem;
+}
+.cds--time-picker--lg .cds--select-input,
+.cds--time-picker--lg .cds--time-picker__input-field {
+  height: 3rem;
+  max-height: 3rem;
+}
+.cds--time-picker--readonly .cds--select-input {
+  cursor: default;
+}
+.cds--toggletip--open .cds--toggletip-button svg,
+.cds--toggletip-button:hover svg,
+.cds--tree-node--selected > .cds--tree-node__label .cds--tree-node__icon,
+.cds--tree-node--selected
+  > .cds--tree-node__label
+  .cds--tree-parent-node__toggle-icon,
+.cds--tree-node__label:hover .cds--tree-node__icon,
+.cds--tree-node__label:hover .cds--tree-parent-node__toggle-icon {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--toggletip-label {
+  color: var(--cds-text-secondary, #525252);
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  margin-right: 0.5rem;
+}
+.cds--toggletip-button {
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  display: flex;
+  font-family: inherit;
+  font-size: 100%;
+  margin: 0;
+  padding: 0;
+  text-align: start;
+  vertical-align: baseline;
+  width: 100%;
+}
+.cds--toggletip-button *,
+.cds--toggletip-button :after,
+.cds--toggletip-button :before {
+  box-sizing: inherit;
+}
+.cds--toggletip-button::-moz-focus-inner {
+  border: 0;
+}
+.cds--toggletip-button svg {
+  fill: var(--cds-icon-secondary, #525252);
+}
+.cds--toggletip-button:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+@media screen and (prefers-contrast) {
+  .cds--toggletip-button:focus {
+    outline-style: dotted;
+  }
+}
+.cds--toggletip {
+  --cds-popover-offset: 0.8125rem;
+}
+.cds--toggletip-content {
+  --cds-button-focus-color: var(--cds-focus-inverse, #fff);
+  --cds-link-text-color: var(--cds-link-inverse, #78a9ff);
+  --cds-link-hover-text-color: var(--cds-link-inverse, #78a9ff);
+  --cds-link-focus-text-color: var(--cds-focus-inverse, #fff);
+  display: grid;
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  max-width: 18rem;
+  padding: 1rem;
+  row-gap: 1rem;
+}
+.cds--toggletip-actions {
+  align-items: center;
+  -moz-column-gap: 1rem;
+  column-gap: 1rem;
+  display: flex;
+  justify-content: space-between;
+}
+.cds--toggle {
+  display: inline-block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.cds--toggle__label-text {
+  color: var(--cds-text-secondary, #525252);
+  display: block;
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+  margin-bottom: 1rem;
+}
+.cds--toggle__button {
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  visibility: inherit;
+  width: 1px;
+}
+.cds--toggle__button:focus {
+  outline: 0;
+}
+.cds--toggle__appearance {
+  align-items: center;
+  -moz-column-gap: 0.5rem;
+  column-gap: 0.5rem;
+  cursor: pointer;
+  display: inline-grid;
+  grid-template-columns: max-content max-content;
+}
+.cds--toggle--disabled .cds--toggle__appearance,
+.cds--tree-node--disabled,
+.cds--tree-node--disabled .cds--tree-parent-node__toggle-icon:hover {
+  cursor: not-allowed;
+}
+.cds--toggle__switch {
+  background-color: var(--cds-toggle-off, #8d8d8d);
+  border-radius: 0.75rem;
+  height: 1.5rem;
+  position: relative;
+  transition: background-color 70ms cubic-bezier(0.2, 0, 1, 0.9);
+  width: 3rem;
+}
+.cds--toggle__switch:before {
+  background-color: var(--cds-icon-on-color, #fff);
+  border-radius: 50%;
+  content: '';
+  height: 1.125rem;
+  left: 0.1875rem;
+  position: absolute;
+  top: 0.1875rem;
+  transition: transform 70ms cubic-bezier(0.2, 0, 1, 0.9);
+  width: 1.125rem;
+}
+@media screen and (prefers-reduced-motion: reduce) {
+  .cds--tile__chevron svg,
+  .cds--toggle__switch:before {
+    transition: none;
+  }
+}
+.cds--toggle:active .cds--toggle__switch,
+.cds--toggle__button:focus + .cds--toggle__label .cds--toggle__switch,
+.cds--toggle__button:not(:disabled):active
+  + .cds--toggle__label
+  .cds--toggle__switch {
+  box-shadow:
+    0 0 0 1px var(--cds-focus-inset, #fff),
+    0 0 0 3px var(--cds-focus, #0f62fe);
+}
+.cds--toggle__switch--checked {
+  background-color: var(--cds-support-success, #24a148);
+}
+.cds--toggle__switch--checked:before {
+  transform: translateX(1.5rem);
+}
+.cds--toggle__text {
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-body-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-01-font-weight, 400);
+  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-01-line-height, 1.42857);
+}
+.cds--tree-node__label,
+a.cds--header__name {
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-compact-01-font-weight, 400);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+}
+.cds--toggle__appearance--sm .cds--toggle__switch {
+  height: 1rem;
+  width: 2rem;
+}
+.cds--toggle__appearance--sm .cds--toggle__switch:before {
+  height: 0.625rem;
+  width: 0.625rem;
+}
+.cds--toggle__appearance--sm .cds--toggle__switch--checked:before {
+  transform: translateX(1rem);
+}
+.cds--header__menu-title[aria-expanded='true'] > .cds--header__menu-arrow,
+.cds--side-nav__submenu[aria-expanded='true']
+  .cds--side-nav__submenu-chevron
+  > svg {
+  transform: rotate(180deg);
+}
+.cds--toggle__check {
+  fill: var(--cds-support-success, #24a148);
+  height: 0.3125rem;
+  position: absolute;
+  right: 0.3125rem;
+  top: 0.375rem;
+  visibility: hidden;
+  width: 0.375rem;
+}
+.cds--btn.cds--btn--icon-only.cds--header__action svg,
+.cds--tree-node__icon,
+.cds--tree-parent-node__toggle-icon {
+  fill: var(--cds-icon-secondary, #525252);
+}
+.cds--toggle__switch--checked .cds--toggle__check {
+  visibility: visible;
+}
+.cds--toggle--disabled .cds--toggle__label-text,
+.cds--toggle--disabled .cds--toggle__text {
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--toggle--disabled .cds--toggle__switch {
+  background-color: var(--cds-button-disabled, #c6c6c6);
+}
+.cds--toggle--disabled .cds--toggle__switch:before {
+  background-color: var(--cds-icon-on-color-disabled, #8d8d8d);
+}
+.cds--toggle--disabled .cds--toggle__check {
+  fill: var(--cds-button-disabled, #c6c6c6);
+}
+.cds--toggle--readonly .cds--toggle__appearance {
+  cursor: default;
+}
+.cds--toggle--readonly .cds--toggle__switch {
+  background-color: transparent;
+  border: 1px solid var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--toggle--readonly .cds--toggle__switch:before {
+  background-color: var(--cds-text-primary, #161616);
+  left: 0.125rem;
+  top: 0.125rem;
+}
+.cds--toggle--readonly .cds--toggle__check {
+  fill: var(--cds-background, #fff);
+  right: 0.25rem;
+  top: 0.3125rem;
+}
+.cds--toggle--readonly .cds--toggle__text {
+  cursor: text;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  user-select: text;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--toggle__switch,
+  .cds--toggle__switch:before {
+    outline: 1px solid transparent;
+  }
+  .cds--toggle:active .cds--toggle__switch,
+  .cds--toggle__button:focus + .cds--toggle__label .cds--toggle__switch,
+  .cds--toggle__button:not(:disabled):active
+    + .cds--toggle__label
+    .cds--toggle__switch {
+    color: Highlight;
+    outline: 1px solid Highlight;
+  }
+}
+.cds--tree {
+  overflow: hidden;
+}
+.cds--tree-node {
+  background-color: var(--cds-layer-01, #f4f4f4);
+  color: var(--cds-text-secondary, #525252);
+  padding-left: 1rem;
+}
+.cds--tree-node:focus {
+  outline: 0;
+}
+.cds--tree-node:hover {
+  cursor: pointer;
+}
+.cds--tree-node:focus > .cds--tree-node__label {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--tree-node:focus > .cds--tree-node__label {
+    outline-style: dotted;
+  }
+}
+.cds--tree-node--disabled:focus > .cds--tree-node__label,
+.cds--tree-parent-node__toggle:focus {
+  outline: 0;
+}
+.cds--tree-node--disabled,
+.cds--tree-node--disabled .cds--tree-node__label:hover,
+.cds--tree-node--disabled
+  .cds--tree-node__label:hover
+  .cds--tree-node__label__details {
+  background-color: var(--cds-field-01, #f4f4f4);
+  color: var(--cds-text-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--content,
+.cds--header__action:active,
+.cds--header__menu-item--current,
+.cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu
+  .cds--header__menu-item:hover,
+.cds--tree-node--selected > .cds--tree-node__label,
+.cds--tree-node__label:hover,
+.cds--tree-node__label:hover .cds--tree-node__label__details,
+a.cds--header__menu-item:active,
+a.cds--header__menu-item:hover,
+a.cds--header__menu-item[aria-current='page'],
+a.cds--header__name,
+a.cds--header__name:hover {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--tree-node--disabled .cds--tree-node__icon,
+.cds--tree-node--disabled .cds--tree-node__label:hover .cds--tree-node__icon,
+.cds--tree-node--disabled
+  .cds--tree-node__label:hover
+  .cds--tree-parent-node__toggle-icon,
+.cds--tree-node--disabled .cds--tree-parent-node__toggle-icon {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--tree-node__label {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  min-height: 2rem;
+}
+.cds--header__action,
+.cds--side-nav__submenu {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 100%;
+  text-align: start;
+  vertical-align: baseline;
+}
+.cds--tree-node__label__details,
+.cds--tree-parent-node__toggle {
+  align-items: center;
+  display: flex;
+}
+.cds--tree-node__label:hover {
+  background-color: var(--cds-layer-hover-01, #e8e8e8);
+}
+.cds--tree-node:not(.cds--tree-parent-node) .cds--tree-node__label {
+  padding-bottom: 0.4375rem;
+  padding-top: 0.4375rem;
+}
+.cds--tree-leaf-node {
+  display: flex;
+  padding-left: 2.5rem;
+}
+.cds--tree-node--with-icon .cds--tree-parent-node__toggle {
+  margin-right: 0;
+}
+.cds--tree-parent-node__toggle {
+  align-self: flex-start;
+  border: 0;
+  height: 1.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  padding-left: 0.25rem;
+  width: 1.5rem;
+}
+.cds--tree-parent-node__toggle:hover {
+  cursor: pointer;
+}
+.cds--cc--chart-wrapper.zoomed-in,
+.cds--cc--chart-wrapper.zoomed-in .cds--cc--circle-pack circle.node.clickable {
+  cursor: zoom-out;
+}
+.cds--tree-parent-node__toggle-icon {
+  transform: rotate(-90deg);
+  transition: 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+.cds--tree-parent-node__toggle-icon--expanded {
+  transform: rotate(0);
+}
+.cds--tree-node__icon {
+  align-self: flex-start;
+  margin-right: 0.5rem;
+  margin-top: 0.0625rem;
+  min-height: 1rem;
+  min-width: 1rem;
+}
+.cds--tree-node--selected > .cds--tree-node__label {
+  background-color: var(--cds-layer-selected-01, #e0e0e0);
+}
+.cds--header__action:hover,
+a.cds--header__menu-item:hover {
+  background-color: var(--cds-background-hover, hsla(0, 0%, 55%, 0.12));
+}
+.cds--tree-node--selected > .cds--tree-node__label:hover {
+  background-color: var(--cds-layer-selected-hover-01, #d1d1d1);
+}
+.cds--tree-node--active > .cds--tree-node__label {
+  position: relative;
+}
+.cds--tree-node--active > .cds--tree-node__label:before {
+  background-color: var(--cds-interactive, #0f62fe);
+  content: '';
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 0.25rem;
+}
+.cds--tree--xs .cds--tree-node__label {
+  min-height: 1.5rem;
+  padding-bottom: 0.25rem;
+  padding-top: 0.25rem;
+}
+.cds--header,
+a.cds--header__menu-item {
+  background-color: var(--cds-background, #fff);
+}
+.cds--chart-holder .cds--cc--toolbar div.toolbar-control.disabled button:focus,
+.cds--header__action:focus,
+a.cds--header__menu-item:focus,
+a.cds--header__name {
+  outline: 0;
+}
+.cds--content {
+  padding: 2rem;
+  will-change: margin-left;
+}
+.cds--header-panel,
+.cds--side-nav {
+  overflow: hidden;
+  will-change: width;
+  z-index: 8000;
+}
+.cds--header ~ .cds--content {
+  margin-top: 3rem;
+}
+.cds--side-nav ~ .cds--content {
+  margin-left: 3rem;
+}
+.cds--side-nav.cds--side-nav--expanded ~ .cds--content {
+  margin-left: 16rem;
+}
+.cds--header {
+  align-items: center;
+  border-bottom: 1px solid var(--cds-border-subtle);
+  display: flex;
+  height: 3rem;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 8000;
+}
+.cds--header__action {
+  background: 0 0;
+  border: 0.0625rem solid transparent;
+  box-sizing: border-box;
+  display: inline-block;
+  display: inline-flex;
+  height: 3rem;
+  margin: 0;
+  padding: 0;
+  transition:
+    background-color 0.11s,
+    border-color 0.11s;
+  width: 3rem;
+}
+.cds--header__action *,
+.cds--header__action :after,
+.cds--header__action :before {
+  box-sizing: inherit;
+}
+.cds--header__action::-moz-focus-inner {
+  border: 0;
+}
+.cds--header__action--active > svg.cds--navigation-menu-panel-collapse-icon {
+  display: inline;
+}
+.cds--header__action--active {
+  background: var(--cds-layer);
+  border-bottom: 1px solid transparent;
+  border-left: 1px solid var(--cds-border-subtle);
+  border-right: 1px solid var(--cds-border-subtle);
+}
+.cds--header__action:focus,
+a.cds--header__menu-item:focus,
+a.cds--header__name:focus {
+  border-color: var(--cds-focus, #0f62fe);
+}
+.cds--header__action--active > svg {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--header__action:active {
+  background-color: var(--cds-background-active, hsla(0, 0%, 55%, 0.5));
+}
+.cds--header__action.cds--btn--icon-only {
+  align-items: center;
+  justify-content: center;
+}
+.cds--btn.cds--btn--icon-only.cds--header__action--active svg,
+.cds--btn.cds--btn--icon-only.cds--header__action:active svg,
+.cds--btn.cds--btn--icon-only.cds--header__action:hover svg,
+.cds--header__menu-trigger:hover > svg,
+.cds--header__menu-trigger > svg,
+.cds--side-nav__item--active .cds--side-nav__icon > svg,
+a.cds--header__menu-item:active > svg,
+a.cds--header__menu-item:hover > svg {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--header__menu-arrow,
+.cds--side-nav .cds--header__menu-arrow,
+.cds--side-nav a.cds--header__menu-item:focus .cds--header__menu-arrow,
+.cds--side-nav a.cds--header__menu-item:hover .cds--header__menu-arrow,
+.cds--side-nav__icon > svg {
+  fill: var(--cds-icon-secondary, #525252);
+}
+.cds--header__menu-toggle {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+a.cds--header__name {
+  align-items: center;
+  border: 0.125rem solid transparent;
+  display: flex;
+  font-weight: 600;
+  height: 100%;
+  letter-spacing: 0.1px;
+  line-height: 1.25rem;
+  padding: 0 2rem 0 1rem;
+  text-decoration: none;
+  transition: border-color 0.11s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+@media (max-width: 41.98rem) {
+  .cds--header__action {
+    min-width: 3rem;
+  }
+  a.cds--header__name {
+    padding: 0 1rem;
+  }
+}
+.cds--header__name--prefix {
+  font-weight: 400;
+}
+.cds--header__menu-toggle:not(.cds--header__menu-toggle__hidden)
+  ~ .cds--header__name {
+  padding-left: 0.5rem;
+}
+.cds--header__nav {
+  display: none;
+  height: 100%;
+  padding-left: 1rem;
+  position: relative;
+}
+@media (min-width: 66rem) {
+  .cds--header__menu-toggle__hidden {
+    display: none;
+  }
+  .cds--header__nav {
+    display: block;
+  }
+}
+.cds--header__nav:before {
+  background-color: var(--cds-border-subtle);
+  content: '';
+  display: block;
+  height: 1.5rem;
+  left: 0;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0.0625rem;
+}
+.cds--header__menu-bar {
+  display: flex;
+  height: 100%;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+a.cds--header__menu-item {
+  align-items: center;
+  border: 2px solid transparent;
+  color: var(--cds-text-secondary, #525252);
+  display: flex;
+  font-size: 0.875rem;
+  font-weight: 400;
+  height: 100%;
+  letter-spacing: 0;
+  line-height: 1.125rem;
+  padding: 0 1rem;
+  position: relative;
+  text-decoration: none;
+  transition:
+    background-color 0.11s,
+    border-color 0.11s,
+    color 0.11s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.cds--header__action:active,
+a.cds--header__menu-item:active {
+  background-color: var(--cds-background-active, hsla(0, 0%, 55%, 0.5));
+}
+.cds--header-panel,
+.cds--header__menu-title[aria-expanded='true'],
+.cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu
+  .cds--header__menu-item {
+  background-color: var(--cds-layer);
+}
+.cds--header-panel,
+.cds--side-nav,
+.cds--skip-to-content:focus {
+  color: var(--cds-text-secondary, #525252);
+}
+.cds--header__menu-item--current:after,
+a.cds--header__menu-item[aria-current='page']:after {
+  border-bottom: 3px solid var(--cds-border-interactive, #0f62fe);
+  bottom: -2px;
+  content: '';
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+}
+.cds--header__menu-item--current:focus:after,
+a.cds--header__menu-item[aria-current='page']:focus:after {
+  border: 0;
+}
+.cds--header__submenu .cds--header__menu .cds--header__menu-item--current:after,
+.cds--header__submenu
+  .cds--header__menu
+  a.cds--header__menu-item[aria-current='page']:after {
+  border-bottom: none;
+  border-left: 3px solid var(--cds-border-interactive, #0f62fe);
+  bottom: 0;
+  left: -2px;
+}
+.cds--header__submenu
+  .cds--header__menu
+  .cds--header__menu-item--current:focus:after,
+.cds--header__submenu
+  .cds--header__menu
+  a.cds--header__menu-item[aria-current='page']:focus:after {
+  border-left: 3px solid var(--cds-border-interactive, #0f62fe);
+  left: 0;
+}
+a.cds--header__menu-item.cds--header__menu-item--current:focus,
+a.cds--header__menu-item[aria-current='page']:focus {
+  border: 2px solid var(--cds-focus, #0f62fe);
+}
+.cds--header__menu-title[aria-haspopup='true'],
+.cds--header__submenu {
+  position: relative;
+}
+.cds--header__menu-title[aria-expanded='true'] {
+  color: var(--cds-text-secondary, #525252);
+  z-index: 8002;
+}
+.cds--header__menu {
+  display: none;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.cds--header__menu-title[aria-expanded='true'] + .cds--header__menu {
+  background-color: var(--cds-layer);
+  bottom: 0;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  left: 0;
+  position: absolute;
+  transform: translateY(100%);
+  width: 12.5rem;
+  z-index: 8001;
+}
+.cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu
+  .cds--header__menu-item:active {
+  background-color: var(--cds-layer-active);
+  color: var(--cds-text-primary, #161616);
+}
+.cds--header__menu .cds--header__menu-item {
+  height: 3rem;
+}
+.cds--header__menu-arrow {
+  margin-left: 0.5rem;
+  transition:
+    transform 0.11s,
+    fill 0.11s;
+}
+.cds--header__global {
+  display: flex;
+  flex: 1 1 0%;
+  height: 100%;
+  justify-content: flex-end;
+}
+.cds--skip-to-content {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  visibility: inherit;
+  white-space: nowrap;
+  width: 1px;
+}
+.cds--cc--axes g.axis g.ticks.invisible,
+.cds--cc--heatmap g.highlighter-hidden,
+.cds--side-nav__menu {
+  visibility: hidden;
+}
+.cds--skip-to-content:focus {
+  clip: auto;
+  align-items: center;
+  background-color: var(--cds-background, #fff);
+  border: 4px solid var(--cds-focus, #0f62fe);
+  display: flex;
+  height: 3rem;
+  left: 0;
+  outline: 0;
+  padding: 0 1rem;
+  top: 0;
+  width: auto;
+  z-index: 9999;
+}
+.cds--header-panel {
+  border: none;
+  bottom: 0;
+  position: fixed;
+  right: 0;
+  top: 3rem;
+  transition: width 0.11s cubic-bezier(0.2, 0, 1, 0.9);
+  width: 0;
+}
+.cds--header-panel--expanded {
+  border-left: 1px solid var(--cds-border-subtle);
+  border-right: 1px solid var(--cds-border-subtle);
+  width: 16rem;
+}
+.cds--side-nav {
+  background-color: var(--cds-background, #fff);
+  bottom: 0;
+  left: 0;
+  max-width: 16rem;
+  position: fixed;
+  top: 0;
+  transition: width 0.11s cubic-bezier(0.2, 0, 1, 0.9);
+  width: 3rem;
+}
+.cds--side-nav--ux {
+  top: 3rem;
+  width: 16rem;
+}
+@media (max-width: 65.98rem) {
+  .cds--side-nav--ux {
+    width: 0;
+  }
+}
+.cds--side-nav--rail {
+  width: 3rem;
+}
+.cds--side-nav--hidden {
+  width: 0;
+}
+.cds--side-nav--expanded,
+.cds--side-nav.cds--side-nav--rail:not(.cds--side-nav--fixed):hover {
+  width: 16rem;
+}
+.cds--side-nav__overlay {
+  background-color: transparent;
+  height: 0;
+  left: 0;
+  opacity: 0;
+  position: fixed;
+  top: 3rem;
+  transition:
+    opacity 0.3s cubic-bezier(0.5, 0, 0.1, 1),
+    background-color 0.3s cubic-bezier(0.5, 0, 0.1, 1);
+  width: 0;
+}
+@media (max-width: 65.98rem) {
+  .cds--side-nav__overlay-active {
+    background-color: var(--cds-overlay, hsla(0, 0%, 9%, 0.5));
+    height: 100vh;
+    opacity: 1;
+    transition:
+      opacity 0.3s cubic-bezier(0.5, 0, 0.1, 1),
+      background-color 0.3s cubic-bezier(0.5, 0, 0.1, 1);
+    width: 100vw;
+  }
+}
+.cds--header ~ .cds--side-nav {
+  height: calc(100% - 48px);
+  top: 3rem;
+}
+.cds--side-nav--fixed {
+  width: 16rem;
+}
+.cds--side-nav--collapsed {
+  transform: translateX(-16rem);
+  width: 16rem;
+}
+.cds--side-nav--ux .cds--side-nav__item,
+.cds--side-nav__item {
+  height: auto;
+  width: auto;
+}
+.cds--side-nav__navigation {
+  display: flex;
+  flex-direction: column;
+}
+.cds--side-nav__items {
+  flex: 1 1 0%;
+  overflow: hidden;
+  padding: 1rem 0 0;
+}
+.cds--side-nav--expanded .cds--side-nav__items,
+.cds--side-nav--fixed .cds--side-nav__items,
+.cds--side-nav--ux .cds--side-nav__items,
+.cds--side-nav:hover .cds--side-nav__items {
+  overflow-y: auto;
+}
+.cds--side-nav__item {
+  overflow: hidden;
+}
+.cds--side-nav__item--large,
+.cds--side-nav__item--large .cds--side-nav__submenu {
+  height: 3rem;
+}
+.cds--side-nav .cds--header__menu-title[aria-expanded='true']:hover,
+.cds--side-nav a.cds--header__menu-item:hover,
+.cds--side-nav__item:not(.cds--side-nav__item--active):hover
+  .cds--side-nav__item:not(.cds--side-nav__item--active)
+  > .cds--side-nav__submenu:hover,
+.cds--side-nav__item:not(.cds--side-nav__item--active)
+  > .cds--side-nav__link:hover,
+.cds--side-nav__menu
+  a.cds--side-nav__link:not(.cds--side-nav__link--current):not(
+    [aria-current='page']
+  ):hover {
+  background-color: var(--cds-background-hover, hsla(0, 0%, 55%, 0.12));
+  color: var(--cds-text-primary, #161616);
+}
+.cds--side-nav__item--active .cds--side-nav__submenu:hover,
+.cds--side-nav__menu a.cds--side-nav__link--current,
+.cds--side-nav__menu a.cds--side-nav__link[aria-current='page'],
+a.cds--side-nav__link--current,
+a.cds--side-nav__link[aria-current='page'] {
+  background-color: var(--cds-background-selected, hsla(0, 0%, 55%, 0.2));
+}
+.cds--side-nav__item:not(.cds--side-nav__item--active)
+  .cds--side-nav__menu-item
+  > .cds--side-nav__link:hover
+  > span,
+.cds--side-nav__item:not(.cds--side-nav__item--active)
+  > .cds--side-nav__link:hover
+  > span {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--side-nav__divider {
+  background-color: var(--cds-border-subtle);
+  height: 1px;
+  margin: 0.5rem 1rem;
+}
+.cds--side-nav__submenu {
+  align-items: center;
+  background: 0 0;
+  border: 0;
+  box-sizing: border-box;
+  color: var(--cds-text-secondary, #525252);
+  display: inline-block;
+  display: flex;
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  height: 2rem;
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  margin: 0;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0 1rem;
+  transition:
+    color 0.11s,
+    background-color 0.11s,
+    outline 0.11s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  width: 100%;
+}
+.cds--cc--axes g.axis .axis-title,
+.cds--cc--axes g.axis g.tick text,
+.cds--cc--title p.title,
+.cds--cc--tooltip {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+}
+.cds--side-nav__submenu *,
+.cds--side-nav__submenu :after,
+.cds--side-nav__submenu :before {
+  box-sizing: inherit;
+}
+.cds--side-nav__submenu::-moz-focus-inner {
+  border: 0;
+}
+.cds--side-nav__submenu:hover {
+  background-color: var(--cds-background-hover, hsla(0, 0%, 55%, 0.12));
+  color: var(--cds-text-primary, #161616);
+}
+.cds--side-nav__submenu:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--side-nav__submenu-title {
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--side-nav__icon.cds--side-nav__submenu-chevron {
+  display: flex;
+  flex: 1;
+  justify-content: flex-end;
+}
+.cds--side-nav__submenu-chevron > svg {
+  height: 1rem;
+  transition: transform 0.11s;
+  width: 1rem;
+}
+.cds--side-nav__item--active .cds--side-nav__submenu:hover {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--side-nav__item--active .cds--side-nav__submenu[aria-expanded='false'] {
+  background-color: var(--cds-background-selected, hsla(0, 0%, 55%, 0.2));
+  color: var(--cds-text-primary, #161616);
+  position: relative;
+}
+.cds--side-nav__item--active
+  .cds--side-nav__submenu[aria-expanded='false']:before {
+  background-color: var(--cds-border-interactive, #0f62fe);
+  bottom: 0;
+  content: '';
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 3px;
+}
+.cds--side-nav__item--active .cds--side-nav__submenu-title {
+  color: var(--cds-text-primary, #161616);
+  font-weight: 600;
+}
+.cds--side-nav__menu {
+  display: block;
+  max-height: 0;
+}
+.cds--side-nav__submenu[aria-expanded='true'] + .cds--side-nav__menu {
+  max-height: 93.75rem;
+  visibility: inherit;
+}
+.cds--side-nav__menu a.cds--side-nav__link {
+  font-weight: 400;
+  height: 2rem;
+  min-height: 2rem;
+  padding-left: 2rem;
+}
+.cds--side-nav
+  .cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu,
+.cds--side-nav a.cds--header__menu-item,
+.cds--switcher__item-link,
+a.cds--side-nav__link {
+  font-size: var(--cds-heading-compact-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-compact-01-font-weight, 600);
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-compact-01-line-height, 1.28572);
+  text-decoration: none;
+}
+.cds--side-nav__item.cds--side-nav__item--icon a.cds--side-nav__link {
+  padding-left: 4.5rem;
+}
+.cds--side-nav__menu a.cds--side-nav__link--current > span,
+.cds--side-nav__menu a.cds--side-nav__link[aria-current='page'] > span,
+a.cds--side-nav__link--current > span {
+  color: var(--cds-text-primary, #161616);
+  font-weight: 600;
+}
+.cds--side-nav
+  .cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu,
+.cds--side-nav a.cds--header__menu-item,
+a.cds--side-nav__link {
+  align-items: center;
+  display: flex;
+  min-height: 2rem;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0 1rem;
+  position: relative;
+  transition:
+    color 0.11s,
+    background-color 0.11s,
+    outline 0.11s;
+}
+.cds--side-nav__item--large a.cds--side-nav__link {
+  height: 3rem;
+}
+.cds--side-nav a.cds--header__menu-item .cds--text-truncate-end,
+a.cds--side-nav__link > .cds--side-nav__link-text {
+  color: var(--cds-text-secondary, #525252);
+  font-size: 0.875rem;
+  letter-spacing: 0.1px;
+  line-height: 1.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  white-space: nowrap;
+}
+.cds--cc--axes,
+.cds--cc--chart-wrapper,
+.cds--cc--chart-wrapper .layout-child,
+.cds--cc--donut,
+.cds--cc--gauge,
+.cds--cc--meter-title,
+.cds--cc--pie {
+  overflow: visible;
+}
+.cds--side-nav a.cds--header__menu-item:focus,
+a.cds--side-nav__link:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--side-nav a.cds--header__menu-item:focus,
+  .cds--side-nav__submenu:focus,
+  a.cds--side-nav__link:focus {
+    outline-style: dotted;
+  }
+}
+a.cds--side-nav__link--current,
+a.cds--side-nav__link[aria-current='page'] {
+  font-weight: 600;
+}
+a.cds--side-nav__link--current .cds--side-nav__link-text,
+a.cds--side-nav__link[aria-current='page'] .cds--side-nav__link-text {
+  color: var(--cds-text-primary, #161616);
+}
+a.cds--side-nav__link--current:before,
+a.cds--side-nav__link[aria-current='page']:before {
+  background-color: var(--cds-border-interactive, #0f62fe);
+  bottom: 0;
+  content: '';
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 3px;
+}
+.cds--chart-holder .cds--cc--toolbar div.toolbar-control.disabled button:hover,
+.cds--chart-holder .cds--cc--toolbar div.toolbar-control.disabled:hover,
+.cds--chart-holder .cds--modal .cds--modal-container .cds--modal-footer,
+.cds--side-nav a.cds--header__menu-item[aria-expanded='true'] {
+  background-color: transparent;
+}
+.cds--side-nav__icon {
+  align-items: center;
+  display: flex;
+  flex: 0 0 1rem;
+  justify-content: center;
+}
+.cds--cc--axes g.axis g.tick line,
+.cds--side-nav--expanded .cds--side-nav__icon > svg.cds--side-nav-expand-icon,
+.cds--side-nav__header-navigation,
+.cds--side-nav__icon > svg.cds--side-nav-collapse-icon,
+div.container div.cds--snippet--multi .cds--snippet-container pre:after,
+div.container div.demo-desktop-only div.cp-message {
+  display: none;
+}
+.cds--side-nav__icon:not(.cds--side-nav__submenu-chevron) {
+  margin-right: 1.5rem;
+}
+.cds--side-nav__icon > svg {
+  height: 1rem;
+  width: 1rem;
+}
+.cds--side-nav--expanded
+  .cds--side-nav__icon
+  > svg.cds--side-nav-collapse-icon {
+  display: block;
+}
+.cds--side-nav--fixed .cds--side-nav__submenu,
+.cds--side-nav--fixed a.cds--side-nav__link {
+  padding-left: 1rem;
+}
+@media (max-width: 65.98rem) {
+  .cds--side-nav .cds--header__nav {
+    display: block;
+  }
+  .cds--side-nav__header-navigation {
+    display: block;
+    margin-bottom: 2rem;
+    position: relative;
+  }
+}
+.cds--side-nav__header-divider:after {
+  background: var(--cds-border-subtle);
+  bottom: -1rem;
+  content: '';
+  height: 0.0625rem;
+  left: 1rem;
+  position: absolute;
+  width: calc(100% - 32px);
+}
+.cds--side-nav a.cds--header__menu-item {
+  color: var(--cds-text-secondary, #525252);
+  justify-content: space-between;
+  white-space: nowrap;
+}
+.cds--side-nav
+  .cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu {
+  background-color: transparent;
+  bottom: inherit;
+  box-shadow: none;
+  padding: 0;
+  transform: none;
+  width: 100%;
+}
+.cds--side-nav
+  .cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu
+  li {
+  width: 100%;
+}
+.cds--side-nav
+  .cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu
+  a.cds--header__menu-item {
+  font-weight: 400;
+  padding-left: 4.25rem;
+}
+.cds--side-nav
+  .cds--header__menu-title[aria-expanded='true']
+  + .cds--header__menu
+  a.cds--header__menu-item:hover {
+  background-color: var(--cds-background-hover, hsla(0, 0%, 55%, 0.12));
+  color: var(--cds-text-primary, #161616);
+}
+.cds--side-nav .cds--header__menu a.cds--header__menu-item {
+  height: inherit;
+}
+@media (forced-colors: active), screen and (-ms-high-contrast: active) {
+  .cds--side-nav .cds--header__menu-arrow,
+  .cds--side-nav a.cds--header__menu-item:focus .cds--header__menu-arrow,
+  .cds--side-nav a.cds--header__menu-item:hover .cds--header__menu-arrow,
+  .cds--side-nav__icon > svg {
+    fill: ButtonText;
+  }
+}
+.cds--switcher {
+  align-items: center;
+  color: var(--cds-text-secondary, #525252);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.cds--switcher__item {
+  height: 2rem;
+  width: 100%;
+}
+.cds--switcher__item:first-child {
+  margin-top: 1rem;
+}
+.cds--switcher__item--divider {
+  background: var(--cds-border-subtle);
+  border: none;
+  display: block;
+  height: 1px;
+  margin: 0.5rem 1rem;
+  width: 14rem;
+}
+.cds--switcher__item-link {
+  color: var(--cds-text-secondary, #525252);
+  display: block;
+  height: 2rem;
+  padding: 0.375rem 1rem;
+}
+.cds--cc--threshold--label,
+.cds--cc--tooltip .content-box,
+.cds--switcher__item-link--selected,
+.cds--switcher__item-link:active {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--switcher__item-link:hover:not(.cds--switcher__item-link--selected) {
+  background: var(--cds-layer-hover);
+  color: var(--cds-text-primary, #161616);
+  cursor: pointer;
+}
+.cds--switcher__item-link:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+.cds--switcher__item-link:active {
+  background: var(--cds-layer-active);
+}
+.cds--switcher__item-link--selected {
+  background: var(--cds-layer-selected);
+}
+.cds--chart-holder[data-carbon-theme='g100'],
+.cds--chart-holder[data-carbon-theme='g90'] {
+  --cds-charts-1-1-1: #d4bbff;
+  --cds-charts-1-1-1-hovered: #bd97ff;
+  --cds-charts-1-2-1: #4589ff;
+  --cds-charts-1-2-1-hovered: #2172ff;
+  --cds-charts-1-3-1: #33b1ff;
+  --cds-charts-1-3-1-hovered: #0fa3ff;
+  --cds-charts-1-4-1: #08bdba;
+  --cds-charts-1-4-1-hovered: #079b98;
+  --cds-charts-2-1-1: #8a3ffc;
+  --cds-charts-2-1-1-hovered: #751cfb;
+  --cds-charts-2-1-2: #08bdba;
+  --cds-charts-2-1-2-hovered: #079b98;
+  --cds-charts-2-2-2: #ff7eb6;
+  --cds-charts-2-2-2-hovered: #ff5aa2;
+  --cds-charts-2-3-1: #ff7eb6;
+  --cds-charts-2-3-1-hovered: #ff5aa2;
+  --cds-charts-2-3-2: #fff1f1;
+  --cds-charts-2-3-2-hovered: #ffcdcd;
+  --cds-charts-2-4-1: #4589ff;
+  --cds-charts-2-4-1-hovered: #2172ff;
+  --cds-charts-2-4-2: #bae6ff;
+  --cds-charts-2-4-2-hovered: #96d9ff;
+  --cds-charts-2-5-1: #007d79;
+  --cds-charts-2-5-1-hovered: #005956;
+  --cds-charts-2-5-2: #6fdc8c;
+  --cds-charts-2-5-2-hovered: #52d575;
+  --cds-charts-3-1-1: #8a3ffc;
+  --cds-charts-3-1-1-hovered: #751cfb;
+  --cds-charts-3-1-2: #08bdba;
+  --cds-charts-3-1-2-hovered: #079b98;
+  --cds-charts-3-1-3: #bae6ff;
+  --cds-charts-3-1-3-hovered: #96d9ff;
+  --cds-charts-3-2-1: #8a3ffc;
+  --cds-charts-3-2-1-hovered: #751cfb;
+  --cds-charts-3-2-2: #ff7eb6;
+  --cds-charts-3-2-2-hovered: #ff5aa2;
+  --cds-charts-3-2-3: #fff1f1;
+  --cds-charts-3-2-3-hovered: #ffcdcd;
+  --cds-charts-3-3-1: #4589ff;
+  --cds-charts-3-3-1-hovered: #2172ff;
+  --cds-charts-3-3-2: #08bdba;
+  --cds-charts-3-3-2-hovered: #079b98;
+  --cds-charts-3-3-3: #d4bbff;
+  --cds-charts-3-3-3-hovered: #bd97ff;
+  --cds-charts-3-4-1: #4589ff;
+  --cds-charts-3-4-1-hovered: #2172ff;
+  --cds-charts-3-4-2: #6fdc8c;
+  --cds-charts-3-4-2-hovered: #52d575;
+  --cds-charts-3-4-3: #fff1f1;
+  --cds-charts-3-4-3-hovered: #ffcdcd;
+  --cds-charts-3-5-1: #007d79;
+  --cds-charts-3-5-1-hovered: #005956;
+  --cds-charts-3-5-2: #6fdc8c;
+  --cds-charts-3-5-2-hovered: #52d575;
+  --cds-charts-3-5-3: #bae6ff;
+  --cds-charts-3-5-3-hovered: #96d9ff;
+  --cds-charts-4-1-1: #8a3ffc;
+  --cds-charts-4-1-1-hovered: #751cfb;
+  --cds-charts-4-1-2: #08bdba;
+  --cds-charts-4-1-2-hovered: #079b98;
+  --cds-charts-4-1-3: #bae6ff;
+  --cds-charts-4-1-3-hovered: #96d9ff;
+  --cds-charts-4-1-4: #4589ff;
+  --cds-charts-4-1-4-hovered: #2172ff;
+  --cds-charts-4-2-1: #4589ff;
+  --cds-charts-4-2-1-hovered: #2172ff;
+  --cds-charts-4-2-2: #08bdba;
+  --cds-charts-4-2-2-hovered: #079b98;
+  --cds-charts-4-2-3: #d4bbff;
+  --cds-charts-4-2-3-hovered: #bd97ff;
+  --cds-charts-4-2-4: #fff1f1;
+  --cds-charts-4-2-4-hovered: #ffcdcd;
+  --cds-charts-4-3-1: #007d79;
+  --cds-charts-4-3-1-hovered: #005956;
+  --cds-charts-4-3-2: #fff1f1;
+  --cds-charts-4-3-2-hovered: #ffcdcd;
+  --cds-charts-4-3-3: #33b1ff;
+  --cds-charts-4-3-3-hovered: #0fa3ff;
+  --cds-charts-4-3-4: #6fdc8c;
+  --cds-charts-4-3-4-hovered: #52d575;
+  --cds-charts-5-1-1: #8a3ffc;
+  --cds-charts-5-1-1-hovered: #751cfb;
+  --cds-charts-5-1-2: #08bdba;
+  --cds-charts-5-1-2-hovered: #079b98;
+  --cds-charts-5-1-3: #bae6ff;
+  --cds-charts-5-1-3-hovered: #96d9ff;
+  --cds-charts-5-1-4: #4589ff;
+  --cds-charts-5-1-4-hovered: #2172ff;
+  --cds-charts-5-1-5: #ff7eb6;
+  --cds-charts-5-1-5-hovered: #ff5aa2;
+  --cds-charts-5-2-1: #4589ff;
+  --cds-charts-5-2-1-hovered: #2172ff;
+  --cds-charts-5-2-2: #08bdba;
+  --cds-charts-5-2-2-hovered: #079b98;
+  --cds-charts-5-2-3: #d4bbff;
+  --cds-charts-5-2-3-hovered: #bd97ff;
+  --cds-charts-5-2-4: #fff1f1;
+  --cds-charts-5-2-4-hovered: #ffcdcd;
+  --cds-charts-5-2-5: #6fdc8c;
+  --cds-charts-5-2-5-hovered: #52d575;
+  --cds-charts-14-1-1: #8a3ffc;
+  --cds-charts-14-1-1-hovered: #751cfb;
+  --cds-charts-14-1-2: #33b1ff;
+  --cds-charts-14-1-2-hovered: #0fa3ff;
+  --cds-charts-14-1-3: #007d79;
+  --cds-charts-14-1-3-hovered: #005956;
+  --cds-charts-14-1-4: #ff7eb6;
+  --cds-charts-14-1-4-hovered: #ff5aa2;
+  --cds-charts-14-1-6: #fff1f1;
+  --cds-charts-14-1-6-hovered: #ffcdcd;
+  --cds-charts-14-1-7: #6fdc8c;
+  --cds-charts-14-1-7-hovered: #52d575;
+  --cds-charts-14-1-8: #4589ff;
+  --cds-charts-14-1-8-hovered: #2172ff;
+  --cds-charts-14-1-9: #d02670;
+  --cds-charts-14-1-9-hovered: #b22060;
+  --cds-charts-14-1-10: #d2a106;
+  --cds-charts-14-1-10-hovered: #af8605;
+  --cds-charts-14-1-11: #08bdba;
+  --cds-charts-14-1-11-hovered: #079b98;
+  --cds-charts-14-1-12: #bae6ff;
+  --cds-charts-14-1-12-hovered: #96d9ff;
+  --cds-charts-14-1-13: #ba4e00;
+  --cds-charts-14-1-13-hovered: #963f00;
+  --cds-charts-14-1-14: #d4bbff;
+  --cds-charts-14-1-14-hovered: #bd97ff;
+}
+.cds--cc--chart-wrapper .fill-1-1-1 {
+  fill: var(--cds-charts-1-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-1-1-1.hovered {
+  fill: var(--cds-charts-1-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-1-1-1,
+.cds--cc--tooltip .tooltip-1-1-1 {
+  background-color: var(--cds-charts-1-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .background-1-1-1.hovered {
+  background-color: var(--cds-charts-1-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-1-1-1 {
+  stroke: var(--cds-charts-1-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-1-1-1 {
+  stop-color: var(--cds-charts-1-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-1-2-1 {
+  fill: var(--cds-charts-1-2-1, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-1-2-1.hovered {
+  fill: var(--cds-charts-1-2-1-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-1-2-1,
+.cds--cc--tooltip .tooltip-1-2-1 {
+  background-color: var(--cds-charts-1-2-1, #002d9c);
+}
+.cds--cc--chart-wrapper .background-1-2-1.hovered {
+  background-color: var(--cds-charts-1-2-1-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-1-2-1 {
+  stroke: var(--cds-charts-1-2-1, #002d9c);
+}
+.cds--cc--chart-wrapper .stop-color-1-2-1 {
+  stop-color: var(--cds-charts-1-2-1, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-1-3-1 {
+  fill: var(--cds-charts-1-3-1, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-1-3-1.hovered {
+  fill: var(--cds-charts-1-3-1-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-1-3-1,
+.cds--cc--tooltip .tooltip-1-3-1 {
+  background-color: var(--cds-charts-1-3-1, #1192e8);
+}
+.cds--cc--chart-wrapper .background-1-3-1.hovered {
+  background-color: var(--cds-charts-1-3-1-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-1-3-1 {
+  stroke: var(--cds-charts-1-3-1, #1192e8);
+}
+.cds--cc--chart-wrapper .stop-color-1-3-1 {
+  stop-color: var(--cds-charts-1-3-1, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-1-4-1 {
+  fill: var(--cds-charts-1-4-1, #007d79);
+}
+.cds--cc--chart-wrapper .fill-1-4-1.hovered {
+  fill: var(--cds-charts-1-4-1-hovered, #007d79);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-1-4-1,
+.cds--cc--tooltip .tooltip-1-4-1 {
+  background-color: var(--cds-charts-1-4-1, #007d79);
+}
+.cds--cc--chart-wrapper .background-1-4-1.hovered {
+  background-color: var(--cds-charts-1-4-1-hovered, #007d79);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-1-4-1 {
+  stroke: var(--cds-charts-1-4-1, #007d79);
+}
+.cds--cc--chart-wrapper .stop-color-1-4-1 {
+  stop-color: var(--cds-charts-1-4-1, #007d79);
+}
+.cds--cc--chart-wrapper .fill-2-1-1 {
+  fill: var(--cds-charts-2-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-2-1-1.hovered {
+  fill: var(--cds-charts-2-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-1-1,
+.cds--cc--tooltip .tooltip-2-1-1 {
+  background-color: var(--cds-charts-2-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .background-2-1-1.hovered {
+  background-color: var(--cds-charts-2-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-1-1 {
+  stroke: var(--cds-charts-2-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-2-1-1 {
+  stop-color: var(--cds-charts-2-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-2-1-2 {
+  fill: var(--cds-charts-2-1-2, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-2-1-2.hovered {
+  fill: var(--cds-charts-2-1-2-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-1-2,
+.cds--cc--tooltip .tooltip-2-1-2 {
+  background-color: var(--cds-charts-2-1-2, #009d9a);
+}
+.cds--cc--chart-wrapper .background-2-1-2.hovered {
+  background-color: var(--cds-charts-2-1-2-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-1-2 {
+  stroke: var(--cds-charts-2-1-2, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-2-1-2 {
+  stop-color: var(--cds-charts-2-1-2, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-2-2-1 {
+  fill: var(--cds-charts-2-2-1, #8a3ffc);
+}
+.cds--cc--chart-wrapper .fill-2-2-1.hovered {
+  fill: var(--cds-charts-2-2-1-hovered, #8a3ffc);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-2-1,
+.cds--cc--tooltip .tooltip-2-2-1 {
+  background-color: var(--cds-charts-2-2-1, #8a3ffc);
+}
+.cds--cc--chart-wrapper .background-2-2-1.hovered {
+  background-color: var(--cds-charts-2-2-1-hovered, #8a3ffc);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-2-1 {
+  stroke: var(--cds-charts-2-2-1, #8a3ffc);
+}
+.cds--cc--chart-wrapper .stop-color-2-2-1 {
+  stop-color: var(--cds-charts-2-2-1, #8a3ffc);
+}
+.cds--cc--chart-wrapper .fill-2-2-2 {
+  fill: var(--cds-charts-2-2-2, #520408);
+}
+.cds--cc--chart-wrapper .fill-2-2-2.hovered {
+  fill: var(--cds-charts-2-2-2-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-2-2,
+.cds--cc--tooltip .tooltip-2-2-2 {
+  background-color: var(--cds-charts-2-2-2, #520408);
+}
+.cds--cc--chart-wrapper .background-2-2-2.hovered {
+  background-color: var(--cds-charts-2-2-2-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-2-2 {
+  stroke: var(--cds-charts-2-2-2, #520408);
+}
+.cds--cc--chart-wrapper .stop-color-2-2-2 {
+  stop-color: var(--cds-charts-2-2-2, #520408);
+}
+.cds--cc--chart-wrapper .fill-2-3-1 {
+  fill: var(--cds-charts-2-3-1, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-2-3-1.hovered {
+  fill: var(--cds-charts-2-3-1-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-3-1,
+.cds--cc--tooltip .tooltip-2-3-1 {
+  background-color: var(--cds-charts-2-3-1, #9f1853);
+}
+.cds--cc--chart-wrapper .background-2-3-1.hovered {
+  background-color: var(--cds-charts-2-3-1-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-3-1 {
+  stroke: var(--cds-charts-2-3-1, #9f1853);
+}
+.cds--cc--chart-wrapper .stop-color-2-3-1 {
+  stop-color: var(--cds-charts-2-3-1, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-2-3-2 {
+  fill: var(--cds-charts-2-3-2, #520408);
+}
+.cds--cc--chart-wrapper .fill-2-3-2.hovered {
+  fill: var(--cds-charts-2-3-2-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-3-2,
+.cds--cc--tooltip .tooltip-2-3-2 {
+  background-color: var(--cds-charts-2-3-2, #520408);
+}
+.cds--cc--chart-wrapper .background-2-3-2.hovered {
+  background-color: var(--cds-charts-2-3-2-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-3-2 {
+  stroke: var(--cds-charts-2-3-2, #520408);
+}
+.cds--cc--chart-wrapper .stop-color-2-3-2 {
+  stop-color: var(--cds-charts-2-3-2, #520408);
+}
+.cds--cc--chart-wrapper .fill-2-4-1 {
+  fill: var(--cds-charts-2-4-1, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-2-4-1.hovered {
+  fill: var(--cds-charts-2-4-1-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-4-1,
+.cds--cc--tooltip .tooltip-2-4-1 {
+  background-color: var(--cds-charts-2-4-1, #1192e8);
+}
+.cds--cc--chart-wrapper .background-2-4-1.hovered {
+  background-color: var(--cds-charts-2-4-1-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-4-1 {
+  stroke: var(--cds-charts-2-4-1, #1192e8);
+}
+.cds--cc--chart-wrapper .stop-color-2-4-1 {
+  stop-color: var(--cds-charts-2-4-1, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-2-4-2 {
+  fill: var(--cds-charts-2-4-2, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-2-4-2.hovered {
+  fill: var(--cds-charts-2-4-2-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-4-2,
+.cds--cc--tooltip .tooltip-2-4-2 {
+  background-color: var(--cds-charts-2-4-2, #005d5d);
+}
+.cds--cc--chart-wrapper .background-2-4-2.hovered {
+  background-color: var(--cds-charts-2-4-2-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-4-2 {
+  stroke: var(--cds-charts-2-4-2, #005d5d);
+}
+.cds--cc--chart-wrapper .stop-color-2-4-2 {
+  stop-color: var(--cds-charts-2-4-2, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-2-5-1 {
+  fill: var(--cds-charts-2-5-1, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-2-5-1.hovered {
+  fill: var(--cds-charts-2-5-1-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-5-1,
+.cds--cc--tooltip .tooltip-2-5-1 {
+  background-color: var(--cds-charts-2-5-1, #009d9a);
+}
+.cds--cc--chart-wrapper .background-2-5-1.hovered {
+  background-color: var(--cds-charts-2-5-1-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-5-1 {
+  stroke: var(--cds-charts-2-5-1, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-2-5-1 {
+  stop-color: var(--cds-charts-2-5-1, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-2-5-2 {
+  fill: var(--cds-charts-2-5-2, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-2-5-2.hovered {
+  fill: var(--cds-charts-2-5-2-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-2-5-2,
+.cds--cc--tooltip .tooltip-2-5-2 {
+  background-color: var(--cds-charts-2-5-2, #002d9c);
+}
+.cds--cc--chart-wrapper .background-2-5-2.hovered {
+  background-color: var(--cds-charts-2-5-2-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-2-5-2 {
+  stroke: var(--cds-charts-2-5-2, #002d9c);
+}
+.cds--cc--chart-wrapper .stop-color-2-5-2 {
+  stop-color: var(--cds-charts-2-5-2, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-3-1-1 {
+  fill: var(--cds-charts-3-1-1, #ee5396);
+}
+.cds--cc--chart-wrapper .fill-3-1-1.hovered {
+  fill: var(--cds-charts-3-1-1-hovered, #ee5396);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-1-1,
+.cds--cc--tooltip .tooltip-3-1-1 {
+  background-color: var(--cds-charts-3-1-1, #ee5396);
+}
+.cds--cc--chart-wrapper .background-3-1-1.hovered {
+  background-color: var(--cds-charts-3-1-1-hovered, #ee5396);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-1-1 {
+  stroke: var(--cds-charts-3-1-1, #ee5396);
+}
+.cds--cc--chart-wrapper .stop-color-3-1-1 {
+  stop-color: var(--cds-charts-3-1-1, #ee5396);
+}
+.cds--cc--chart-wrapper .fill-3-1-2 {
+  fill: var(--cds-charts-3-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-3-1-2.hovered {
+  fill: var(--cds-charts-3-1-2-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-1-2,
+.cds--cc--tooltip .tooltip-3-1-2 {
+  background-color: var(--cds-charts-3-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .background-3-1-2.hovered {
+  background-color: var(--cds-charts-3-1-2-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-1-2 {
+  stroke: var(--cds-charts-3-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .stop-color-3-1-2 {
+  stop-color: var(--cds-charts-3-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-3-1-3 {
+  fill: var(--cds-charts-3-1-3, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-3-1-3.hovered {
+  fill: var(--cds-charts-3-1-3-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-1-3,
+.cds--cc--tooltip .tooltip-3-1-3 {
+  background-color: var(--cds-charts-3-1-3, #6929c4);
+}
+.cds--cc--chart-wrapper .background-3-1-3.hovered {
+  background-color: var(--cds-charts-3-1-3-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-1-3 {
+  stroke: var(--cds-charts-3-1-3, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-3-1-3 {
+  stop-color: var(--cds-charts-3-1-3, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-3-2-1 {
+  fill: var(--cds-charts-3-2-1, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-3-2-1.hovered {
+  fill: var(--cds-charts-3-2-1-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-2-1,
+.cds--cc--tooltip .tooltip-3-2-1 {
+  background-color: var(--cds-charts-3-2-1, #9f1853);
+}
+.cds--cc--chart-wrapper .background-3-2-1.hovered {
+  background-color: var(--cds-charts-3-2-1-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-2-1 {
+  stroke: var(--cds-charts-3-2-1, #9f1853);
+}
+.cds--cc--chart-wrapper .stop-color-3-2-1 {
+  stop-color: var(--cds-charts-3-2-1, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-3-2-2 {
+  fill: var(--cds-charts-3-2-2, #fa4d56);
+}
+.cds--cc--chart-wrapper .fill-3-2-2.hovered {
+  fill: var(--cds-charts-3-2-2-hovered, #fa4d56);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-2-2,
+.cds--cc--tooltip .tooltip-3-2-2 {
+  background-color: var(--cds-charts-3-2-2, #fa4d56);
+}
+.cds--cc--chart-wrapper .background-3-2-2.hovered {
+  background-color: var(--cds-charts-3-2-2-hovered, #fa4d56);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-2-2 {
+  stroke: var(--cds-charts-3-2-2, #fa4d56);
+}
+.cds--cc--chart-wrapper .stop-color-3-2-2 {
+  stop-color: var(--cds-charts-3-2-2, #fa4d56);
+}
+.cds--cc--chart-wrapper .fill-3-2-3 {
+  fill: var(--cds-charts-3-2-3, #520408);
+}
+.cds--cc--chart-wrapper .fill-3-2-3.hovered {
+  fill: var(--cds-charts-3-2-3-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-2-3,
+.cds--cc--tooltip .tooltip-3-2-3 {
+  background-color: var(--cds-charts-3-2-3, #520408);
+}
+.cds--cc--chart-wrapper .background-3-2-3.hovered {
+  background-color: var(--cds-charts-3-2-3-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-2-3 {
+  stroke: var(--cds-charts-3-2-3, #520408);
+}
+.cds--cc--chart-wrapper .stop-color-3-2-3 {
+  stop-color: var(--cds-charts-3-2-3, #520408);
+}
+.cds--cc--chart-wrapper .fill-3-3-1 {
+  fill: var(--cds-charts-3-3-1, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-3-3-1.hovered {
+  fill: var(--cds-charts-3-3-1-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-3-1,
+.cds--cc--tooltip .tooltip-3-3-1 {
+  background-color: var(--cds-charts-3-3-1, #a56eff);
+}
+.cds--cc--chart-wrapper .background-3-3-1.hovered {
+  background-color: var(--cds-charts-3-3-1-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-3-1 {
+  stroke: var(--cds-charts-3-3-1, #a56eff);
+}
+.cds--cc--chart-wrapper .stop-color-3-3-1 {
+  stop-color: var(--cds-charts-3-3-1, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-3-3-2 {
+  fill: var(--cds-charts-3-3-2, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-3-3-2.hovered {
+  fill: var(--cds-charts-3-3-2-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-3-2,
+.cds--cc--tooltip .tooltip-3-3-2 {
+  background-color: var(--cds-charts-3-3-2, #005d5d);
+}
+.cds--cc--chart-wrapper .background-3-3-2.hovered {
+  background-color: var(--cds-charts-3-3-2-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-3-2 {
+  stroke: var(--cds-charts-3-3-2, #005d5d);
+}
+.cds--cc--chart-wrapper .stop-color-3-3-2 {
+  stop-color: var(--cds-charts-3-3-2, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-3-3-3 {
+  fill: var(--cds-charts-3-3-3, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-3-3-3.hovered {
+  fill: var(--cds-charts-3-3-3-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-3-3,
+.cds--cc--tooltip .tooltip-3-3-3 {
+  background-color: var(--cds-charts-3-3-3, #002d9c);
+}
+.cds--cc--chart-wrapper .background-3-3-3.hovered {
+  background-color: var(--cds-charts-3-3-3-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-3-3 {
+  stroke: var(--cds-charts-3-3-3, #002d9c);
+}
+.cds--cc--chart-wrapper .stop-color-3-3-3 {
+  stop-color: var(--cds-charts-3-3-3, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-3-4-1 {
+  fill: var(--cds-charts-3-4-1, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-3-4-1.hovered {
+  fill: var(--cds-charts-3-4-1-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-4-1,
+.cds--cc--tooltip .tooltip-3-4-1 {
+  background-color: var(--cds-charts-3-4-1, #a56eff);
+}
+.cds--cc--chart-wrapper .background-3-4-1.hovered {
+  background-color: var(--cds-charts-3-4-1-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-4-1 {
+  stroke: var(--cds-charts-3-4-1, #a56eff);
+}
+.cds--cc--chart-wrapper .stop-color-3-4-1 {
+  stop-color: var(--cds-charts-3-4-1, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-3-4-2 {
+  fill: var(--cds-charts-3-4-2, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-3-4-2.hovered {
+  fill: var(--cds-charts-3-4-2-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-4-2,
+.cds--cc--tooltip .tooltip-3-4-2 {
+  background-color: var(--cds-charts-3-4-2, #005d5d);
+}
+.cds--cc--chart-wrapper .background-3-4-2.hovered {
+  background-color: var(--cds-charts-3-4-2-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-4-2 {
+  stroke: var(--cds-charts-3-4-2, #005d5d);
+}
+.cds--cc--chart-wrapper .stop-color-3-4-2 {
+  stop-color: var(--cds-charts-3-4-2, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-3-4-3 {
+  fill: var(--cds-charts-3-4-3, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-3-4-3.hovered {
+  fill: var(--cds-charts-3-4-3-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-4-3,
+.cds--cc--tooltip .tooltip-3-4-3 {
+  background-color: var(--cds-charts-3-4-3, #9f1853);
+}
+.cds--cc--chart-wrapper .background-3-4-3.hovered {
+  background-color: var(--cds-charts-3-4-3-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-4-3 {
+  stroke: var(--cds-charts-3-4-3, #9f1853);
+}
+.cds--cc--chart-wrapper .stop-color-3-4-3 {
+  stop-color: var(--cds-charts-3-4-3, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-3-5-1 {
+  fill: var(--cds-charts-3-5-1, #012749);
+}
+.cds--cc--chart-wrapper .fill-3-5-1.hovered {
+  fill: var(--cds-charts-3-5-1-hovered, #012749);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-5-1,
+.cds--cc--tooltip .tooltip-3-5-1 {
+  background-color: var(--cds-charts-3-5-1, #012749);
+}
+.cds--cc--chart-wrapper .background-3-5-1.hovered {
+  background-color: var(--cds-charts-3-5-1-hovered, #012749);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-5-1 {
+  stroke: var(--cds-charts-3-5-1, #012749);
+}
+.cds--cc--chart-wrapper .stop-color-3-5-1 {
+  stop-color: var(--cds-charts-3-5-1, #012749);
+}
+.cds--cc--chart-wrapper .fill-3-5-2 {
+  fill: var(--cds-charts-3-5-2, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-3-5-2.hovered {
+  fill: var(--cds-charts-3-5-2-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-5-2,
+.cds--cc--tooltip .tooltip-3-5-2 {
+  background-color: var(--cds-charts-3-5-2, #6929c4);
+}
+.cds--cc--chart-wrapper .background-3-5-2.hovered {
+  background-color: var(--cds-charts-3-5-2-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-5-2 {
+  stroke: var(--cds-charts-3-5-2, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-3-5-2 {
+  stop-color: var(--cds-charts-3-5-2, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-3-5-3 {
+  fill: var(--cds-charts-3-5-3, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-3-5-3.hovered {
+  fill: var(--cds-charts-3-5-3-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-3-5-3,
+.cds--cc--tooltip .tooltip-3-5-3 {
+  background-color: var(--cds-charts-3-5-3, #009d9a);
+}
+.cds--cc--chart-wrapper .background-3-5-3.hovered {
+  background-color: var(--cds-charts-3-5-3-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-3-5-3 {
+  stroke: var(--cds-charts-3-5-3, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-3-5-3 {
+  stop-color: var(--cds-charts-3-5-3, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-4-1-1 {
+  fill: var(--cds-charts-4-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-4-1-1.hovered {
+  fill: var(--cds-charts-4-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-1-1,
+.cds--cc--tooltip .tooltip-4-1-1 {
+  background-color: var(--cds-charts-4-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .background-4-1-1.hovered {
+  background-color: var(--cds-charts-4-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-1-1 {
+  stroke: var(--cds-charts-4-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-4-1-1 {
+  stop-color: var(--cds-charts-4-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-4-1-2 {
+  fill: var(--cds-charts-4-1-2, #012749);
+}
+.cds--cc--chart-wrapper .fill-4-1-2.hovered {
+  fill: var(--cds-charts-4-1-2-hovered, #012749);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-1-2,
+.cds--cc--tooltip .tooltip-4-1-2 {
+  background-color: var(--cds-charts-4-1-2, #012749);
+}
+.cds--cc--chart-wrapper .background-4-1-2.hovered {
+  background-color: var(--cds-charts-4-1-2-hovered, #012749);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-1-2 {
+  stroke: var(--cds-charts-4-1-2, #012749);
+}
+.cds--cc--chart-wrapper .stop-color-4-1-2 {
+  stop-color: var(--cds-charts-4-1-2, #012749);
+}
+.cds--cc--chart-wrapper .fill-4-1-3 {
+  fill: var(--cds-charts-4-1-3, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-4-1-3.hovered {
+  fill: var(--cds-charts-4-1-3-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-1-3,
+.cds--cc--tooltip .tooltip-4-1-3 {
+  background-color: var(--cds-charts-4-1-3, #009d9a);
+}
+.cds--cc--chart-wrapper .background-4-1-3.hovered {
+  background-color: var(--cds-charts-4-1-3-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-1-3 {
+  stroke: var(--cds-charts-4-1-3, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-4-1-3 {
+  stop-color: var(--cds-charts-4-1-3, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-4-1-4 {
+  fill: var(--cds-charts-4-1-4, #ee5396);
+}
+.cds--cc--chart-wrapper .fill-4-1-4.hovered {
+  fill: var(--cds-charts-4-1-4-hovered, #ee5396);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-1-4,
+.cds--cc--tooltip .tooltip-4-1-4 {
+  background-color: var(--cds-charts-4-1-4, #ee5396);
+}
+.cds--cc--chart-wrapper .background-4-1-4.hovered {
+  background-color: var(--cds-charts-4-1-4-hovered, #ee5396);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-1-4 {
+  stroke: var(--cds-charts-4-1-4, #ee5396);
+}
+.cds--cc--chart-wrapper .stop-color-4-1-4 {
+  stop-color: var(--cds-charts-4-1-4, #ee5396);
+}
+.cds--cc--chart-wrapper .fill-4-2-1 {
+  fill: var(--cds-charts-4-2-1, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-4-2-1.hovered {
+  fill: var(--cds-charts-4-2-1-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-2-1,
+.cds--cc--tooltip .tooltip-4-2-1 {
+  background-color: var(--cds-charts-4-2-1, #9f1853);
+}
+.cds--cc--chart-wrapper .background-4-2-1.hovered {
+  background-color: var(--cds-charts-4-2-1-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-2-1 {
+  stroke: var(--cds-charts-4-2-1, #9f1853);
+}
+.cds--cc--chart-wrapper .stop-color-4-2-1 {
+  stop-color: var(--cds-charts-4-2-1, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-4-2-2 {
+  fill: var(--cds-charts-4-2-2, #fa4d56);
+}
+.cds--cc--chart-wrapper .fill-4-2-2.hovered {
+  fill: var(--cds-charts-4-2-2-hovered, #fa4d56);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-2-2,
+.cds--cc--tooltip .tooltip-4-2-2 {
+  background-color: var(--cds-charts-4-2-2, #fa4d56);
+}
+.cds--cc--chart-wrapper .background-4-2-2.hovered {
+  background-color: var(--cds-charts-4-2-2-hovered, #fa4d56);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-2-2 {
+  stroke: var(--cds-charts-4-2-2, #fa4d56);
+}
+.cds--cc--chart-wrapper .stop-color-4-2-2 {
+  stop-color: var(--cds-charts-4-2-2, #fa4d56);
+}
+.cds--cc--chart-wrapper .fill-4-2-3 {
+  fill: var(--cds-charts-4-2-3, #520408);
+}
+.cds--cc--chart-wrapper .fill-4-2-3.hovered {
+  fill: var(--cds-charts-4-2-3-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-2-3,
+.cds--cc--tooltip .tooltip-4-2-3 {
+  background-color: var(--cds-charts-4-2-3, #520408);
+}
+.cds--cc--chart-wrapper .background-4-2-3.hovered {
+  background-color: var(--cds-charts-4-2-3-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-2-3 {
+  stroke: var(--cds-charts-4-2-3, #520408);
+}
+.cds--cc--chart-wrapper .stop-color-4-2-3 {
+  stop-color: var(--cds-charts-4-2-3, #520408);
+}
+.cds--cc--chart-wrapper .fill-4-2-4 {
+  fill: var(--cds-charts-4-2-4, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-4-2-4.hovered {
+  fill: var(--cds-charts-4-2-4-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-2-4,
+.cds--cc--tooltip .tooltip-4-2-4 {
+  background-color: var(--cds-charts-4-2-4, #a56eff);
+}
+.cds--cc--chart-wrapper .background-4-2-4.hovered {
+  background-color: var(--cds-charts-4-2-4-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-2-4 {
+  stroke: var(--cds-charts-4-2-4, #a56eff);
+}
+.cds--cc--chart-wrapper .stop-color-4-2-4 {
+  stop-color: var(--cds-charts-4-2-4, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-4-3-1 {
+  fill: var(--cds-charts-4-3-1, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-4-3-1.hovered {
+  fill: var(--cds-charts-4-3-1-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-3-1,
+.cds--cc--tooltip .tooltip-4-3-1 {
+  background-color: var(--cds-charts-4-3-1, #009d9a);
+}
+.cds--cc--chart-wrapper .background-4-3-1.hovered {
+  background-color: var(--cds-charts-4-3-1-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-3-1 {
+  stroke: var(--cds-charts-4-3-1, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-4-3-1 {
+  stop-color: var(--cds-charts-4-3-1, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-4-3-2 {
+  fill: var(--cds-charts-4-3-2, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-4-3-2.hovered {
+  fill: var(--cds-charts-4-3-2-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-3-2,
+.cds--cc--tooltip .tooltip-4-3-2 {
+  background-color: var(--cds-charts-4-3-2, #002d9c);
+}
+.cds--cc--chart-wrapper .background-4-3-2.hovered {
+  background-color: var(--cds-charts-4-3-2-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-3-2 {
+  stroke: var(--cds-charts-4-3-2, #002d9c);
+}
+.cds--cc--chart-wrapper .stop-color-4-3-2 {
+  stop-color: var(--cds-charts-4-3-2, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-4-3-3 {
+  fill: var(--cds-charts-4-3-3, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-4-3-3.hovered {
+  fill: var(--cds-charts-4-3-3-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-3-3,
+.cds--cc--tooltip .tooltip-4-3-3 {
+  background-color: var(--cds-charts-4-3-3, #a56eff);
+}
+.cds--cc--chart-wrapper .background-4-3-3.hovered {
+  background-color: var(--cds-charts-4-3-3-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-3-3 {
+  stroke: var(--cds-charts-4-3-3, #a56eff);
+}
+.cds--cc--chart-wrapper .stop-color-4-3-3 {
+  stop-color: var(--cds-charts-4-3-3, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-4-3-4 {
+  fill: var(--cds-charts-4-3-4, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-4-3-4.hovered {
+  fill: var(--cds-charts-4-3-4-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-4-3-4,
+.cds--cc--tooltip .tooltip-4-3-4 {
+  background-color: var(--cds-charts-4-3-4, #9f1853);
+}
+.cds--cc--chart-wrapper .background-4-3-4.hovered {
+  background-color: var(--cds-charts-4-3-4-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-4-3-4 {
+  stroke: var(--cds-charts-4-3-4, #9f1853);
+}
+.cds--cc--chart-wrapper .stop-color-4-3-4 {
+  stop-color: var(--cds-charts-4-3-4, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-5-1-1 {
+  fill: var(--cds-charts-5-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-5-1-1.hovered {
+  fill: var(--cds-charts-5-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-1-1,
+.cds--cc--tooltip .tooltip-5-1-1 {
+  background-color: var(--cds-charts-5-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .background-5-1-1.hovered {
+  background-color: var(--cds-charts-5-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-1-1 {
+  stroke: var(--cds-charts-5-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-5-1-1 {
+  stop-color: var(--cds-charts-5-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-5-1-2 {
+  fill: var(--cds-charts-5-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-5-1-2.hovered {
+  fill: var(--cds-charts-5-1-2-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-1-2,
+.cds--cc--tooltip .tooltip-5-1-2 {
+  background-color: var(--cds-charts-5-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .background-5-1-2.hovered {
+  background-color: var(--cds-charts-5-1-2-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-1-2 {
+  stroke: var(--cds-charts-5-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .stop-color-5-1-2 {
+  stop-color: var(--cds-charts-5-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-5-1-3 {
+  fill: var(--cds-charts-5-1-3, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-5-1-3.hovered {
+  fill: var(--cds-charts-5-1-3-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-1-3,
+.cds--cc--tooltip .tooltip-5-1-3 {
+  background-color: var(--cds-charts-5-1-3, #005d5d);
+}
+.cds--cc--chart-wrapper .background-5-1-3.hovered {
+  background-color: var(--cds-charts-5-1-3-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-1-3 {
+  stroke: var(--cds-charts-5-1-3, #005d5d);
+}
+.cds--cc--chart-wrapper .stop-color-5-1-3 {
+  stop-color: var(--cds-charts-5-1-3, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-5-1-4 {
+  fill: var(--cds-charts-5-1-4, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-5-1-4.hovered {
+  fill: var(--cds-charts-5-1-4-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-1-4,
+.cds--cc--tooltip .tooltip-5-1-4 {
+  background-color: var(--cds-charts-5-1-4, #9f1853);
+}
+.cds--cc--chart-wrapper .background-5-1-4.hovered {
+  background-color: var(--cds-charts-5-1-4-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-1-4 {
+  stroke: var(--cds-charts-5-1-4, #9f1853);
+}
+.cds--cc--chart-wrapper .stop-color-5-1-4 {
+  stop-color: var(--cds-charts-5-1-4, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-5-1-5 {
+  fill: var(--cds-charts-5-1-5, #520408);
+}
+.cds--cc--chart-wrapper .fill-5-1-5.hovered {
+  fill: var(--cds-charts-5-1-5-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-1-5,
+.cds--cc--tooltip .tooltip-5-1-5 {
+  background-color: var(--cds-charts-5-1-5, #520408);
+}
+.cds--cc--chart-wrapper .background-5-1-5.hovered {
+  background-color: var(--cds-charts-5-1-5-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-1-5 {
+  stroke: var(--cds-charts-5-1-5, #520408);
+}
+.cds--cc--chart-wrapper .stop-color-5-1-5 {
+  stop-color: var(--cds-charts-5-1-5, #520408);
+}
+.cds--cc--chart-wrapper .fill-5-2-1 {
+  fill: var(--cds-charts-5-2-1, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-5-2-1.hovered {
+  fill: var(--cds-charts-5-2-1-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-2-1,
+.cds--cc--tooltip .tooltip-5-2-1 {
+  background-color: var(--cds-charts-5-2-1, #002d9c);
+}
+.cds--cc--chart-wrapper .background-5-2-1.hovered {
+  background-color: var(--cds-charts-5-2-1-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-2-1 {
+  stroke: var(--cds-charts-5-2-1, #002d9c);
+}
+.cds--cc--chart-wrapper .stop-color-5-2-1 {
+  stop-color: var(--cds-charts-5-2-1, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-5-2-2 {
+  fill: var(--cds-charts-5-2-2, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-5-2-2.hovered {
+  fill: var(--cds-charts-5-2-2-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-2-2,
+.cds--cc--tooltip .tooltip-5-2-2 {
+  background-color: var(--cds-charts-5-2-2, #009d9a);
+}
+.cds--cc--chart-wrapper .background-5-2-2.hovered {
+  background-color: var(--cds-charts-5-2-2-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-2-2 {
+  stroke: var(--cds-charts-5-2-2, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-5-2-2 {
+  stop-color: var(--cds-charts-5-2-2, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-5-2-3 {
+  fill: var(--cds-charts-5-2-3, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-5-2-3.hovered {
+  fill: var(--cds-charts-5-2-3-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-2-3,
+.cds--cc--tooltip .tooltip-5-2-3 {
+  background-color: var(--cds-charts-5-2-3, #9f1853);
+}
+.cds--cc--chart-wrapper .background-5-2-3.hovered {
+  background-color: var(--cds-charts-5-2-3-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-2-3 {
+  stroke: var(--cds-charts-5-2-3, #9f1853);
+}
+.cds--cc--chart-wrapper .stop-color-5-2-3 {
+  stop-color: var(--cds-charts-5-2-3, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-5-2-4 {
+  fill: var(--cds-charts-5-2-4, #520408);
+}
+.cds--cc--chart-wrapper .fill-5-2-4.hovered {
+  fill: var(--cds-charts-5-2-4-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-2-4,
+.cds--cc--tooltip .tooltip-5-2-4 {
+  background-color: var(--cds-charts-5-2-4, #520408);
+}
+.cds--cc--chart-wrapper .background-5-2-4.hovered {
+  background-color: var(--cds-charts-5-2-4-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-2-4 {
+  stroke: var(--cds-charts-5-2-4, #520408);
+}
+.cds--cc--chart-wrapper .stop-color-5-2-4 {
+  stop-color: var(--cds-charts-5-2-4, #520408);
+}
+.cds--cc--chart-wrapper .fill-5-2-5 {
+  fill: var(--cds-charts-5-2-5, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-5-2-5.hovered {
+  fill: var(--cds-charts-5-2-5-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-5-2-5,
+.cds--cc--tooltip .tooltip-5-2-5 {
+  background-color: var(--cds-charts-5-2-5, #a56eff);
+}
+.cds--cc--chart-wrapper .background-5-2-5.hovered {
+  background-color: var(--cds-charts-5-2-5-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-5-2-5 {
+  stroke: var(--cds-charts-5-2-5, #a56eff);
+}
+.cds--cc--chart-wrapper .stop-color-5-2-5 {
+  stop-color: var(--cds-charts-5-2-5, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-14-1-1 {
+  fill: var(--cds-charts-14-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-14-1-1.hovered {
+  fill: var(--cds-charts-14-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-1,
+.cds--cc--tooltip .tooltip-14-1-1 {
+  background-color: var(--cds-charts-14-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .background-14-1-1.hovered {
+  background-color: var(--cds-charts-14-1-1-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-1 {
+  stroke: var(--cds-charts-14-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-1 {
+  stop-color: var(--cds-charts-14-1-1, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-14-1-2 {
+  fill: var(--cds-charts-14-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-14-1-2.hovered {
+  fill: var(--cds-charts-14-1-2-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-2,
+.cds--cc--tooltip .tooltip-14-1-2 {
+  background-color: var(--cds-charts-14-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .background-14-1-2.hovered {
+  background-color: var(--cds-charts-14-1-2-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-2 {
+  stroke: var(--cds-charts-14-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-2 {
+  stop-color: var(--cds-charts-14-1-2, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-14-1-3 {
+  fill: var(--cds-charts-14-1-3, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-14-1-3.hovered {
+  fill: var(--cds-charts-14-1-3-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-3,
+.cds--cc--tooltip .tooltip-14-1-3 {
+  background-color: var(--cds-charts-14-1-3, #005d5d);
+}
+.cds--cc--chart-wrapper .background-14-1-3.hovered {
+  background-color: var(--cds-charts-14-1-3-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-3 {
+  stroke: var(--cds-charts-14-1-3, #005d5d);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-3 {
+  stop-color: var(--cds-charts-14-1-3, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-14-1-4 {
+  fill: var(--cds-charts-14-1-4, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-14-1-4.hovered {
+  fill: var(--cds-charts-14-1-4-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-4,
+.cds--cc--tooltip .tooltip-14-1-4 {
+  background-color: var(--cds-charts-14-1-4, #9f1853);
+}
+.cds--cc--chart-wrapper .background-14-1-4.hovered {
+  background-color: var(--cds-charts-14-1-4-hovered, #9f1853);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-4 {
+  stroke: var(--cds-charts-14-1-4, #9f1853);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-4 {
+  stop-color: var(--cds-charts-14-1-4, #9f1853);
+}
+.cds--cc--chart-wrapper .fill-14-1-5 {
+  fill: var(--cds-charts-14-1-5, #fa4d56);
+}
+.cds--cc--chart-wrapper .fill-14-1-5.hovered {
+  fill: var(--cds-charts-14-1-5-hovered, #fa4d56);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-5,
+.cds--cc--tooltip .tooltip-14-1-5 {
+  background-color: var(--cds-charts-14-1-5, #fa4d56);
+}
+.cds--cc--chart-wrapper .background-14-1-5.hovered {
+  background-color: var(--cds-charts-14-1-5-hovered, #fa4d56);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-5 {
+  stroke: var(--cds-charts-14-1-5, #fa4d56);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-5 {
+  stop-color: var(--cds-charts-14-1-5, #fa4d56);
+}
+.cds--cc--chart-wrapper .fill-14-1-6 {
+  fill: var(--cds-charts-14-1-6, #520408);
+}
+.cds--cc--chart-wrapper .fill-14-1-6.hovered {
+  fill: var(--cds-charts-14-1-6-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-6,
+.cds--cc--tooltip .tooltip-14-1-6 {
+  background-color: var(--cds-charts-14-1-6, #520408);
+}
+.cds--cc--chart-wrapper .background-14-1-6.hovered {
+  background-color: var(--cds-charts-14-1-6-hovered, #520408);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-6 {
+  stroke: var(--cds-charts-14-1-6, #520408);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-6 {
+  stop-color: var(--cds-charts-14-1-6, #520408);
+}
+.cds--cc--chart-wrapper .fill-14-1-7 {
+  fill: var(--cds-charts-14-1-7, #198038);
+}
+.cds--cc--chart-wrapper .fill-14-1-7.hovered {
+  fill: var(--cds-charts-14-1-7-hovered, #198038);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-7,
+.cds--cc--tooltip .tooltip-14-1-7 {
+  background-color: var(--cds-charts-14-1-7, #198038);
+}
+.cds--cc--chart-wrapper .background-14-1-7.hovered {
+  background-color: var(--cds-charts-14-1-7-hovered, #198038);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-7 {
+  stroke: var(--cds-charts-14-1-7, #198038);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-7 {
+  stop-color: var(--cds-charts-14-1-7, #198038);
+}
+.cds--cc--chart-wrapper .fill-14-1-8 {
+  fill: var(--cds-charts-14-1-8, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-14-1-8.hovered {
+  fill: var(--cds-charts-14-1-8-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-8,
+.cds--cc--tooltip .tooltip-14-1-8 {
+  background-color: var(--cds-charts-14-1-8, #002d9c);
+}
+.cds--cc--chart-wrapper .background-14-1-8.hovered {
+  background-color: var(--cds-charts-14-1-8-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-8 {
+  stroke: var(--cds-charts-14-1-8, #002d9c);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-8 {
+  stop-color: var(--cds-charts-14-1-8, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-14-1-9 {
+  fill: var(--cds-charts-14-1-9, #ee5396);
+}
+.cds--cc--chart-wrapper .fill-14-1-9.hovered {
+  fill: var(--cds-charts-14-1-9-hovered, #ee5396);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-9,
+.cds--cc--tooltip .tooltip-14-1-9 {
+  background-color: var(--cds-charts-14-1-9, #ee5396);
+}
+.cds--cc--chart-wrapper .background-14-1-9.hovered {
+  background-color: var(--cds-charts-14-1-9-hovered, #ee5396);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-9 {
+  stroke: var(--cds-charts-14-1-9, #ee5396);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-9 {
+  stop-color: var(--cds-charts-14-1-9, #ee5396);
+}
+.cds--cc--chart-wrapper .fill-14-1-10 {
+  fill: var(--cds-charts-14-1-10, #b28600);
+}
+.cds--cc--chart-wrapper .fill-14-1-10.hovered {
+  fill: var(--cds-charts-14-1-10-hovered, #b28600);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-10 {
+  background-color: var(--cds-charts-14-1-10, #b28600);
+}
+.cds--cc--chart-wrapper .background-14-1-10.hovered {
+  background-color: var(--cds-charts-14-1-10-hovered, #b28600);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-10 {
+  stroke: var(--cds-charts-14-1-10, #b28600);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-10 {
+  stop-color: var(--cds-charts-14-1-10, #b28600);
+}
+.cds--cc--chart-wrapper .fill-14-1-11 {
+  fill: var(--cds-charts-14-1-11, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-14-1-11.hovered {
+  fill: var(--cds-charts-14-1-11-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-11 {
+  background-color: var(--cds-charts-14-1-11, #009d9a);
+}
+.cds--cc--chart-wrapper .background-14-1-11.hovered {
+  background-color: var(--cds-charts-14-1-11-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-11 {
+  stroke: var(--cds-charts-14-1-11, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-11 {
+  stop-color: var(--cds-charts-14-1-11, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-14-1-12 {
+  fill: var(--cds-charts-14-1-12, #012749);
+}
+.cds--cc--chart-wrapper .fill-14-1-12.hovered {
+  fill: var(--cds-charts-14-1-12-hovered, #012749);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-12 {
+  background-color: var(--cds-charts-14-1-12, #012749);
+}
+.cds--cc--chart-wrapper .background-14-1-12.hovered {
+  background-color: var(--cds-charts-14-1-12-hovered, #012749);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-12 {
+  stroke: var(--cds-charts-14-1-12, #012749);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-12 {
+  stop-color: var(--cds-charts-14-1-12, #012749);
+}
+.cds--cc--chart-wrapper .fill-14-1-13 {
+  fill: var(--cds-charts-14-1-13, #8a3800);
+}
+.cds--cc--chart-wrapper .fill-14-1-13.hovered {
+  fill: var(--cds-charts-14-1-13-hovered, #8a3800);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-13 {
+  background-color: var(--cds-charts-14-1-13, #8a3800);
+}
+.cds--cc--chart-wrapper .background-14-1-13.hovered {
+  background-color: var(--cds-charts-14-1-13-hovered, #8a3800);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-13 {
+  stroke: var(--cds-charts-14-1-13, #8a3800);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-13 {
+  stop-color: var(--cds-charts-14-1-13, #8a3800);
+}
+.cds--cc--chart-wrapper .fill-14-1-14 {
+  fill: var(--cds-charts-14-1-14, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-14-1-14.hovered {
+  fill: var(--cds-charts-14-1-14-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-14-1-14 {
+  background-color: var(--cds-charts-14-1-14, #a56eff);
+}
+.cds--cc--chart-wrapper .background-14-1-14.hovered {
+  background-color: var(--cds-charts-14-1-14-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-14-1-14 {
+  stroke: var(--cds-charts-14-1-14, #a56eff);
+}
+.cds--cc--chart-wrapper .stop-color-14-1-14 {
+  stop-color: var(--cds-charts-14-1-14, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-1 {
+  fill: var(--cds-charts-mono-1-1, #fff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-1.hovered {
+  fill: var(--cds-charts-mono-1-1-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-1 {
+  background-color: var(--cds-charts-mono-1-1, #fff);
+}
+.cds--cc--chart-wrapper .background-mono-1-1.hovered {
+  background-color: var(--cds-charts-mono-1-1-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-1 {
+  stroke: var(--cds-charts-mono-1-1, #fff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-1 {
+  stop-color: var(--cds-charts-mono-1-1, #fff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-2 {
+  fill: var(--cds-charts-mono-1-2, #f6f2ff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-2.hovered {
+  fill: var(--cds-charts-mono-1-2-hovered, #f6f2ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-2 {
+  background-color: var(--cds-charts-mono-1-2, #f6f2ff);
+}
+.cds--cc--chart-wrapper .background-mono-1-2.hovered {
+  background-color: var(--cds-charts-mono-1-2-hovered, #f6f2ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-2 {
+  stroke: var(--cds-charts-mono-1-2, #f6f2ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-2 {
+  stop-color: var(--cds-charts-mono-1-2, #f6f2ff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-3 {
+  fill: var(--cds-charts-mono-1-3, #e8daff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-3.hovered {
+  fill: var(--cds-charts-mono-1-3-hovered, #e8daff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-3 {
+  background-color: var(--cds-charts-mono-1-3, #e8daff);
+}
+.cds--cc--chart-wrapper .background-mono-1-3.hovered {
+  background-color: var(--cds-charts-mono-1-3-hovered, #e8daff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-3 {
+  stroke: var(--cds-charts-mono-1-3, #e8daff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-3 {
+  stop-color: var(--cds-charts-mono-1-3, #e8daff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-4 {
+  fill: var(--cds-charts-mono-1-4, #d4bbff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-4.hovered {
+  fill: var(--cds-charts-mono-1-4-hovered, #d4bbff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-4 {
+  background-color: var(--cds-charts-mono-1-4, #d4bbff);
+}
+.cds--cc--chart-wrapper .background-mono-1-4.hovered {
+  background-color: var(--cds-charts-mono-1-4-hovered, #d4bbff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-4 {
+  stroke: var(--cds-charts-mono-1-4, #d4bbff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-4 {
+  stop-color: var(--cds-charts-mono-1-4, #d4bbff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-5 {
+  fill: var(--cds-charts-mono-1-5, #be95ff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-5.hovered {
+  fill: var(--cds-charts-mono-1-5-hovered, #be95ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-5 {
+  background-color: var(--cds-charts-mono-1-5, #be95ff);
+}
+.cds--cc--chart-wrapper .background-mono-1-5.hovered {
+  background-color: var(--cds-charts-mono-1-5-hovered, #be95ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-5 {
+  stroke: var(--cds-charts-mono-1-5, #be95ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-5 {
+  stop-color: var(--cds-charts-mono-1-5, #be95ff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-6 {
+  fill: var(--cds-charts-mono-1-6, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-6.hovered {
+  fill: var(--cds-charts-mono-1-6-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-6 {
+  background-color: var(--cds-charts-mono-1-6, #a56eff);
+}
+.cds--cc--chart-wrapper .background-mono-1-6.hovered {
+  background-color: var(--cds-charts-mono-1-6-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-6 {
+  stroke: var(--cds-charts-mono-1-6, #a56eff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-6 {
+  stop-color: var(--cds-charts-mono-1-6, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-mono-1-7 {
+  fill: var(--cds-charts-mono-1-7, #8a3ffc);
+}
+.cds--cc--chart-wrapper .fill-mono-1-7.hovered {
+  fill: var(--cds-charts-mono-1-7-hovered, #8a3ffc);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-7 {
+  background-color: var(--cds-charts-mono-1-7, #8a3ffc);
+}
+.cds--cc--chart-wrapper .background-mono-1-7.hovered {
+  background-color: var(--cds-charts-mono-1-7-hovered, #8a3ffc);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-7 {
+  stroke: var(--cds-charts-mono-1-7, #8a3ffc);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-7 {
+  stop-color: var(--cds-charts-mono-1-7, #8a3ffc);
+}
+.cds--cc--chart-wrapper .fill-mono-1-8 {
+  fill: var(--cds-charts-mono-1-8, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-mono-1-8.hovered {
+  fill: var(--cds-charts-mono-1-8-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-8 {
+  background-color: var(--cds-charts-mono-1-8, #6929c4);
+}
+.cds--cc--chart-wrapper .background-mono-1-8.hovered {
+  background-color: var(--cds-charts-mono-1-8-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-8 {
+  stroke: var(--cds-charts-mono-1-8, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-8 {
+  stop-color: var(--cds-charts-mono-1-8, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-mono-1-9 {
+  fill: var(--cds-charts-mono-1-9, #491d8b);
+}
+.cds--cc--chart-wrapper .fill-mono-1-9.hovered {
+  fill: var(--cds-charts-mono-1-9-hovered, #491d8b);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-9 {
+  background-color: var(--cds-charts-mono-1-9, #491d8b);
+}
+.cds--cc--chart-wrapper .background-mono-1-9.hovered {
+  background-color: var(--cds-charts-mono-1-9-hovered, #491d8b);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-9 {
+  stroke: var(--cds-charts-mono-1-9, #491d8b);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-9 {
+  stop-color: var(--cds-charts-mono-1-9, #491d8b);
+}
+.cds--cc--chart-wrapper .fill-mono-1-10 {
+  fill: var(--cds-charts-mono-1-10, #31135e);
+}
+.cds--cc--chart-wrapper .fill-mono-1-10.hovered {
+  fill: var(--cds-charts-mono-1-10-hovered, #31135e);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-10 {
+  background-color: var(--cds-charts-mono-1-10, #31135e);
+}
+.cds--cc--chart-wrapper .background-mono-1-10.hovered {
+  background-color: var(--cds-charts-mono-1-10-hovered, #31135e);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-10 {
+  stroke: var(--cds-charts-mono-1-10, #31135e);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-10 {
+  stop-color: var(--cds-charts-mono-1-10, #31135e);
+}
+.cds--cc--chart-wrapper .fill-mono-1-11 {
+  fill: var(--cds-charts-mono-1-11, #1c0f30);
+}
+.cds--cc--chart-wrapper .fill-mono-1-11.hovered {
+  fill: var(--cds-charts-mono-1-11-hovered, #1c0f30);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-1-11 {
+  background-color: var(--cds-charts-mono-1-11, #1c0f30);
+}
+.cds--cc--chart-wrapper .background-mono-1-11.hovered {
+  background-color: var(--cds-charts-mono-1-11-hovered, #1c0f30);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-1-11 {
+  stroke: var(--cds-charts-mono-1-11, #1c0f30);
+}
+.cds--cc--chart-wrapper .stop-color-mono-1-11 {
+  stop-color: var(--cds-charts-mono-1-11, #1c0f30);
+}
+.cds--cc--chart-wrapper .fill-mono-2-1 {
+  fill: var(--cds-charts-mono-2-1, #fff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-1.hovered {
+  fill: var(--cds-charts-mono-2-1-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-1 {
+  background-color: var(--cds-charts-mono-2-1, #fff);
+}
+.cds--cc--chart-wrapper .background-mono-2-1.hovered {
+  background-color: var(--cds-charts-mono-2-1-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-1 {
+  stroke: var(--cds-charts-mono-2-1, #fff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-1 {
+  stop-color: var(--cds-charts-mono-2-1, #fff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-2 {
+  fill: var(--cds-charts-mono-2-2, #edf5ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-2.hovered {
+  fill: var(--cds-charts-mono-2-2-hovered, #edf5ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-2 {
+  background-color: var(--cds-charts-mono-2-2, #edf5ff);
+}
+.cds--cc--chart-wrapper .background-mono-2-2.hovered {
+  background-color: var(--cds-charts-mono-2-2-hovered, #edf5ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-2 {
+  stroke: var(--cds-charts-mono-2-2, #edf5ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-2 {
+  stop-color: var(--cds-charts-mono-2-2, #edf5ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-3 {
+  fill: var(--cds-charts-mono-2-3, #d0e2ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-3.hovered {
+  fill: var(--cds-charts-mono-2-3-hovered, #d0e2ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-3 {
+  background-color: var(--cds-charts-mono-2-3, #d0e2ff);
+}
+.cds--cc--chart-wrapper .background-mono-2-3.hovered {
+  background-color: var(--cds-charts-mono-2-3-hovered, #d0e2ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-3 {
+  stroke: var(--cds-charts-mono-2-3, #d0e2ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-3 {
+  stop-color: var(--cds-charts-mono-2-3, #d0e2ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-4 {
+  fill: var(--cds-charts-mono-2-4, #a6c8ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-4.hovered {
+  fill: var(--cds-charts-mono-2-4-hovered, #a6c8ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-4 {
+  background-color: var(--cds-charts-mono-2-4, #a6c8ff);
+}
+.cds--cc--chart-wrapper .background-mono-2-4.hovered {
+  background-color: var(--cds-charts-mono-2-4-hovered, #a6c8ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-4 {
+  stroke: var(--cds-charts-mono-2-4, #a6c8ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-4 {
+  stop-color: var(--cds-charts-mono-2-4, #a6c8ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-5 {
+  fill: var(--cds-charts-mono-2-5, #78a9ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-5.hovered {
+  fill: var(--cds-charts-mono-2-5-hovered, #78a9ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-5 {
+  background-color: var(--cds-charts-mono-2-5, #78a9ff);
+}
+.cds--cc--chart-wrapper .background-mono-2-5.hovered {
+  background-color: var(--cds-charts-mono-2-5-hovered, #78a9ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-5 {
+  stroke: var(--cds-charts-mono-2-5, #78a9ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-5 {
+  stop-color: var(--cds-charts-mono-2-5, #78a9ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-6 {
+  fill: var(--cds-charts-mono-2-6, #4589ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-6.hovered {
+  fill: var(--cds-charts-mono-2-6-hovered, #4589ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-6 {
+  background-color: var(--cds-charts-mono-2-6, #4589ff);
+}
+.cds--cc--chart-wrapper .background-mono-2-6.hovered {
+  background-color: var(--cds-charts-mono-2-6-hovered, #4589ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-6 {
+  stroke: var(--cds-charts-mono-2-6, #4589ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-6 {
+  stop-color: var(--cds-charts-mono-2-6, #4589ff);
+}
+.cds--cc--chart-wrapper .fill-mono-2-7 {
+  fill: var(--cds-charts-mono-2-7, #0f62fe);
+}
+.cds--cc--chart-wrapper .fill-mono-2-7.hovered {
+  fill: var(--cds-charts-mono-2-7-hovered, #0f62fe);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-7 {
+  background-color: var(--cds-charts-mono-2-7, #0f62fe);
+}
+.cds--cc--chart-wrapper .background-mono-2-7.hovered {
+  background-color: var(--cds-charts-mono-2-7-hovered, #0f62fe);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-7 {
+  stroke: var(--cds-charts-mono-2-7, #0f62fe);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-7 {
+  stop-color: var(--cds-charts-mono-2-7, #0f62fe);
+}
+.cds--cc--chart-wrapper .fill-mono-2-8 {
+  fill: var(--cds-charts-mono-2-8, #0043ce);
+}
+.cds--cc--chart-wrapper .fill-mono-2-8.hovered {
+  fill: var(--cds-charts-mono-2-8-hovered, #0043ce);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-8 {
+  background-color: var(--cds-charts-mono-2-8, #0043ce);
+}
+.cds--cc--chart-wrapper .background-mono-2-8.hovered {
+  background-color: var(--cds-charts-mono-2-8-hovered, #0043ce);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-8 {
+  stroke: var(--cds-charts-mono-2-8, #0043ce);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-8 {
+  stop-color: var(--cds-charts-mono-2-8, #0043ce);
+}
+.cds--cc--chart-wrapper .fill-mono-2-9 {
+  fill: var(--cds-charts-mono-2-9, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-mono-2-9.hovered {
+  fill: var(--cds-charts-mono-2-9-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-9 {
+  background-color: var(--cds-charts-mono-2-9, #002d9c);
+}
+.cds--cc--chart-wrapper .background-mono-2-9.hovered {
+  background-color: var(--cds-charts-mono-2-9-hovered, #002d9c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-9 {
+  stroke: var(--cds-charts-mono-2-9, #002d9c);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-9 {
+  stop-color: var(--cds-charts-mono-2-9, #002d9c);
+}
+.cds--cc--chart-wrapper .fill-mono-2-10 {
+  fill: var(--cds-charts-mono-2-10, #001d6c);
+}
+.cds--cc--chart-wrapper .fill-mono-2-10.hovered {
+  fill: var(--cds-charts-mono-2-10-hovered, #001d6c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-10 {
+  background-color: var(--cds-charts-mono-2-10, #001d6c);
+}
+.cds--cc--chart-wrapper .background-mono-2-10.hovered {
+  background-color: var(--cds-charts-mono-2-10-hovered, #001d6c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-10 {
+  stroke: var(--cds-charts-mono-2-10, #001d6c);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-10 {
+  stop-color: var(--cds-charts-mono-2-10, #001d6c);
+}
+.cds--cc--chart-wrapper .fill-mono-2-11 {
+  fill: var(--cds-charts-mono-2-11, #001141);
+}
+.cds--cc--chart-wrapper .fill-mono-2-11.hovered {
+  fill: var(--cds-charts-mono-2-11-hovered, #001141);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-2-11 {
+  background-color: var(--cds-charts-mono-2-11, #001141);
+}
+.cds--cc--chart-wrapper .background-mono-2-11.hovered {
+  background-color: var(--cds-charts-mono-2-11-hovered, #001141);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-2-11 {
+  stroke: var(--cds-charts-mono-2-11, #001141);
+}
+.cds--cc--chart-wrapper .stop-color-mono-2-11 {
+  stop-color: var(--cds-charts-mono-2-11, #001141);
+}
+.cds--cc--chart-wrapper .fill-mono-3-1 {
+  fill: var(--cds-charts-mono-3-1, #fff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-1.hovered {
+  fill: var(--cds-charts-mono-3-1-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-1 {
+  background-color: var(--cds-charts-mono-3-1, #fff);
+}
+.cds--cc--chart-wrapper .background-mono-3-1.hovered {
+  background-color: var(--cds-charts-mono-3-1-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-1 {
+  stroke: var(--cds-charts-mono-3-1, #fff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-1 {
+  stop-color: var(--cds-charts-mono-3-1, #fff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-2 {
+  fill: var(--cds-charts-mono-3-2, #e5f6ff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-2.hovered {
+  fill: var(--cds-charts-mono-3-2-hovered, #e5f6ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-2 {
+  background-color: var(--cds-charts-mono-3-2, #e5f6ff);
+}
+.cds--cc--chart-wrapper .background-mono-3-2.hovered {
+  background-color: var(--cds-charts-mono-3-2-hovered, #e5f6ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-2 {
+  stroke: var(--cds-charts-mono-3-2, #e5f6ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-2 {
+  stop-color: var(--cds-charts-mono-3-2, #e5f6ff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-3 {
+  fill: var(--cds-charts-mono-3-3, #bae6ff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-3.hovered {
+  fill: var(--cds-charts-mono-3-3-hovered, #bae6ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-3 {
+  background-color: var(--cds-charts-mono-3-3, #bae6ff);
+}
+.cds--cc--chart-wrapper .background-mono-3-3.hovered {
+  background-color: var(--cds-charts-mono-3-3-hovered, #bae6ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-3 {
+  stroke: var(--cds-charts-mono-3-3, #bae6ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-3 {
+  stop-color: var(--cds-charts-mono-3-3, #bae6ff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-4 {
+  fill: var(--cds-charts-mono-3-4, #82cfff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-4.hovered {
+  fill: var(--cds-charts-mono-3-4-hovered, #82cfff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-4 {
+  background-color: var(--cds-charts-mono-3-4, #82cfff);
+}
+.cds--cc--chart-wrapper .background-mono-3-4.hovered {
+  background-color: var(--cds-charts-mono-3-4-hovered, #82cfff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-4 {
+  stroke: var(--cds-charts-mono-3-4, #82cfff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-4 {
+  stop-color: var(--cds-charts-mono-3-4, #82cfff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-5 {
+  fill: var(--cds-charts-mono-3-5, #33b1ff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-5.hovered {
+  fill: var(--cds-charts-mono-3-5-hovered, #33b1ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-5 {
+  background-color: var(--cds-charts-mono-3-5, #33b1ff);
+}
+.cds--cc--chart-wrapper .background-mono-3-5.hovered {
+  background-color: var(--cds-charts-mono-3-5-hovered, #33b1ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-5 {
+  stroke: var(--cds-charts-mono-3-5, #33b1ff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-5 {
+  stop-color: var(--cds-charts-mono-3-5, #33b1ff);
+}
+.cds--cc--chart-wrapper .fill-mono-3-6 {
+  fill: var(--cds-charts-mono-3-6, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-mono-3-6.hovered {
+  fill: var(--cds-charts-mono-3-6-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-6 {
+  background-color: var(--cds-charts-mono-3-6, #1192e8);
+}
+.cds--cc--chart-wrapper .background-mono-3-6.hovered {
+  background-color: var(--cds-charts-mono-3-6-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-6 {
+  stroke: var(--cds-charts-mono-3-6, #1192e8);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-6 {
+  stop-color: var(--cds-charts-mono-3-6, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-mono-3-7 {
+  fill: var(--cds-charts-mono-3-7, #0072c3);
+}
+.cds--cc--chart-wrapper .fill-mono-3-7.hovered {
+  fill: var(--cds-charts-mono-3-7-hovered, #0072c3);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-7 {
+  background-color: var(--cds-charts-mono-3-7, #0072c3);
+}
+.cds--cc--chart-wrapper .background-mono-3-7.hovered {
+  background-color: var(--cds-charts-mono-3-7-hovered, #0072c3);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-7 {
+  stroke: var(--cds-charts-mono-3-7, #0072c3);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-7 {
+  stop-color: var(--cds-charts-mono-3-7, #0072c3);
+}
+.cds--cc--chart-wrapper .fill-mono-3-8 {
+  fill: var(--cds-charts-mono-3-8, #00539a);
+}
+.cds--cc--chart-wrapper .fill-mono-3-8.hovered {
+  fill: var(--cds-charts-mono-3-8-hovered, #00539a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-8 {
+  background-color: var(--cds-charts-mono-3-8, #00539a);
+}
+.cds--cc--chart-wrapper .background-mono-3-8.hovered {
+  background-color: var(--cds-charts-mono-3-8-hovered, #00539a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-8 {
+  stroke: var(--cds-charts-mono-3-8, #00539a);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-8 {
+  stop-color: var(--cds-charts-mono-3-8, #00539a);
+}
+.cds--cc--chart-wrapper .fill-mono-3-9 {
+  fill: var(--cds-charts-mono-3-9, #003a6d);
+}
+.cds--cc--chart-wrapper .fill-mono-3-9.hovered {
+  fill: var(--cds-charts-mono-3-9-hovered, #003a6d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-9 {
+  background-color: var(--cds-charts-mono-3-9, #003a6d);
+}
+.cds--cc--chart-wrapper .background-mono-3-9.hovered {
+  background-color: var(--cds-charts-mono-3-9-hovered, #003a6d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-9 {
+  stroke: var(--cds-charts-mono-3-9, #003a6d);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-9 {
+  stop-color: var(--cds-charts-mono-3-9, #003a6d);
+}
+.cds--cc--chart-wrapper .fill-mono-3-10 {
+  fill: var(--cds-charts-mono-3-10, #012749);
+}
+.cds--cc--chart-wrapper .fill-mono-3-10.hovered {
+  fill: var(--cds-charts-mono-3-10-hovered, #012749);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-10 {
+  background-color: var(--cds-charts-mono-3-10, #012749);
+}
+.cds--cc--chart-wrapper .background-mono-3-10.hovered {
+  background-color: var(--cds-charts-mono-3-10-hovered, #012749);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-10 {
+  stroke: var(--cds-charts-mono-3-10, #012749);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-10 {
+  stop-color: var(--cds-charts-mono-3-10, #012749);
+}
+.cds--cc--chart-wrapper .fill-mono-3-11 {
+  fill: var(--cds-charts-mono-3-11, #061727);
+}
+.cds--cc--chart-wrapper .fill-mono-3-11.hovered {
+  fill: var(--cds-charts-mono-3-11-hovered, #061727);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-3-11 {
+  background-color: var(--cds-charts-mono-3-11, #061727);
+}
+.cds--cc--chart-wrapper .background-mono-3-11.hovered {
+  background-color: var(--cds-charts-mono-3-11-hovered, #061727);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-3-11 {
+  stroke: var(--cds-charts-mono-3-11, #061727);
+}
+.cds--cc--chart-wrapper .stop-color-mono-3-11 {
+  stop-color: var(--cds-charts-mono-3-11, #061727);
+}
+.cds--cc--chart-wrapper .fill-mono-4-1 {
+  fill: var(--cds-charts-mono-4-1, #fff);
+}
+.cds--cc--chart-wrapper .fill-mono-4-1.hovered {
+  fill: var(--cds-charts-mono-4-1-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-1 {
+  background-color: var(--cds-charts-mono-4-1, #fff);
+}
+.cds--cc--chart-wrapper .background-mono-4-1.hovered {
+  background-color: var(--cds-charts-mono-4-1-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-1 {
+  stroke: var(--cds-charts-mono-4-1, #fff);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-1 {
+  stop-color: var(--cds-charts-mono-4-1, #fff);
+}
+.cds--cc--chart-wrapper .fill-mono-4-2 {
+  fill: var(--cds-charts-mono-4-2, #d9fbfb);
+}
+.cds--cc--chart-wrapper .fill-mono-4-2.hovered {
+  fill: var(--cds-charts-mono-4-2-hovered, #d9fbfb);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-2 {
+  background-color: var(--cds-charts-mono-4-2, #d9fbfb);
+}
+.cds--cc--chart-wrapper .background-mono-4-2.hovered {
+  background-color: var(--cds-charts-mono-4-2-hovered, #d9fbfb);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-2 {
+  stroke: var(--cds-charts-mono-4-2, #d9fbfb);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-2 {
+  stop-color: var(--cds-charts-mono-4-2, #d9fbfb);
+}
+.cds--cc--chart-wrapper .fill-mono-4-3 {
+  fill: var(--cds-charts-mono-4-3, #9ef0f0);
+}
+.cds--cc--chart-wrapper .fill-mono-4-3.hovered {
+  fill: var(--cds-charts-mono-4-3-hovered, #9ef0f0);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-3 {
+  background-color: var(--cds-charts-mono-4-3, #9ef0f0);
+}
+.cds--cc--chart-wrapper .background-mono-4-3.hovered {
+  background-color: var(--cds-charts-mono-4-3-hovered, #9ef0f0);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-3 {
+  stroke: var(--cds-charts-mono-4-3, #9ef0f0);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-3 {
+  stop-color: var(--cds-charts-mono-4-3, #9ef0f0);
+}
+.cds--cc--chart-wrapper .fill-mono-4-4 {
+  fill: var(--cds-charts-mono-4-4, #3ddbd9);
+}
+.cds--cc--chart-wrapper .fill-mono-4-4.hovered {
+  fill: var(--cds-charts-mono-4-4-hovered, #3ddbd9);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-4 {
+  background-color: var(--cds-charts-mono-4-4, #3ddbd9);
+}
+.cds--cc--chart-wrapper .background-mono-4-4.hovered {
+  background-color: var(--cds-charts-mono-4-4-hovered, #3ddbd9);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-4 {
+  stroke: var(--cds-charts-mono-4-4, #3ddbd9);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-4 {
+  stop-color: var(--cds-charts-mono-4-4, #3ddbd9);
+}
+.cds--cc--chart-wrapper .fill-mono-4-5 {
+  fill: var(--cds-charts-mono-4-5, #08bdba);
+}
+.cds--cc--chart-wrapper .fill-mono-4-5.hovered {
+  fill: var(--cds-charts-mono-4-5-hovered, #08bdba);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-5 {
+  background-color: var(--cds-charts-mono-4-5, #08bdba);
+}
+.cds--cc--chart-wrapper .background-mono-4-5.hovered {
+  background-color: var(--cds-charts-mono-4-5-hovered, #08bdba);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-5 {
+  stroke: var(--cds-charts-mono-4-5, #08bdba);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-5 {
+  stop-color: var(--cds-charts-mono-4-5, #08bdba);
+}
+.cds--cc--chart-wrapper .fill-mono-4-6 {
+  fill: var(--cds-charts-mono-4-6, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-mono-4-6.hovered {
+  fill: var(--cds-charts-mono-4-6-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-6 {
+  background-color: var(--cds-charts-mono-4-6, #009d9a);
+}
+.cds--cc--chart-wrapper .background-mono-4-6.hovered {
+  background-color: var(--cds-charts-mono-4-6-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-6 {
+  stroke: var(--cds-charts-mono-4-6, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-6 {
+  stop-color: var(--cds-charts-mono-4-6, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-mono-4-7 {
+  fill: var(--cds-charts-mono-4-7, #007d79);
+}
+.cds--cc--chart-wrapper .fill-mono-4-7.hovered {
+  fill: var(--cds-charts-mono-4-7-hovered, #007d79);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-7 {
+  background-color: var(--cds-charts-mono-4-7, #007d79);
+}
+.cds--cc--chart-wrapper .background-mono-4-7.hovered {
+  background-color: var(--cds-charts-mono-4-7-hovered, #007d79);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-7 {
+  stroke: var(--cds-charts-mono-4-7, #007d79);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-7 {
+  stop-color: var(--cds-charts-mono-4-7, #007d79);
+}
+.cds--cc--chart-wrapper .fill-mono-4-8 {
+  fill: var(--cds-charts-mono-4-8, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-mono-4-8.hovered {
+  fill: var(--cds-charts-mono-4-8-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-8 {
+  background-color: var(--cds-charts-mono-4-8, #005d5d);
+}
+.cds--cc--chart-wrapper .background-mono-4-8.hovered {
+  background-color: var(--cds-charts-mono-4-8-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-8 {
+  stroke: var(--cds-charts-mono-4-8, #005d5d);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-8 {
+  stop-color: var(--cds-charts-mono-4-8, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-mono-4-9 {
+  fill: var(--cds-charts-mono-4-9, #004144);
+}
+.cds--cc--chart-wrapper .fill-mono-4-9.hovered {
+  fill: var(--cds-charts-mono-4-9-hovered, #004144);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-9 {
+  background-color: var(--cds-charts-mono-4-9, #004144);
+}
+.cds--cc--chart-wrapper .background-mono-4-9.hovered {
+  background-color: var(--cds-charts-mono-4-9-hovered, #004144);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-9 {
+  stroke: var(--cds-charts-mono-4-9, #004144);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-9 {
+  stop-color: var(--cds-charts-mono-4-9, #004144);
+}
+.cds--cc--chart-wrapper .fill-mono-4-10 {
+  fill: var(--cds-charts-mono-4-10, #022b30);
+}
+.cds--cc--chart-wrapper .fill-mono-4-10.hovered {
+  fill: var(--cds-charts-mono-4-10-hovered, #022b30);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-10 {
+  background-color: var(--cds-charts-mono-4-10, #022b30);
+}
+.cds--cc--chart-wrapper .background-mono-4-10.hovered {
+  background-color: var(--cds-charts-mono-4-10-hovered, #022b30);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-10 {
+  stroke: var(--cds-charts-mono-4-10, #022b30);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-10 {
+  stop-color: var(--cds-charts-mono-4-10, #022b30);
+}
+.cds--cc--chart-wrapper .fill-mono-4-11 {
+  fill: var(--cds-charts-mono-4-11, #081a1c);
+}
+.cds--cc--chart-wrapper .fill-mono-4-11.hovered {
+  fill: var(--cds-charts-mono-4-11-hovered, #081a1c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-mono-4-11 {
+  background-color: var(--cds-charts-mono-4-11, #081a1c);
+}
+.cds--cc--chart-wrapper .background-mono-4-11.hovered {
+  background-color: var(--cds-charts-mono-4-11-hovered, #081a1c);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-mono-4-11 {
+  stroke: var(--cds-charts-mono-4-11, #081a1c);
+}
+.cds--cc--chart-wrapper .stop-color-mono-4-11 {
+  stop-color: var(--cds-charts-mono-4-11, #081a1c);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-1 {
+  fill: var(--cds-charts-diverge-1-1, #750e13);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-1.hovered {
+  fill: var(--cds-charts-diverge-1-1-hovered, #750e13);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-1 {
+  background-color: var(--cds-charts-diverge-1-1, #750e13);
+}
+.cds--cc--chart-wrapper .background-diverge-1-1.hovered {
+  background-color: var(--cds-charts-diverge-1-1-hovered, #750e13);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-1 {
+  stroke: var(--cds-charts-diverge-1-1, #750e13);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-1 {
+  stop-color: var(--cds-charts-diverge-1-1, #750e13);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-2 {
+  fill: var(--cds-charts-diverge-1-2, #a2191f);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-2.hovered {
+  fill: var(--cds-charts-diverge-1-2-hovered, #a2191f);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-2 {
+  background-color: var(--cds-charts-diverge-1-2, #a2191f);
+}
+.cds--cc--chart-wrapper .background-diverge-1-2.hovered {
+  background-color: var(--cds-charts-diverge-1-2-hovered, #a2191f);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-2 {
+  stroke: var(--cds-charts-diverge-1-2, #a2191f);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-2 {
+  stop-color: var(--cds-charts-diverge-1-2, #a2191f);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-3 {
+  fill: var(--cds-charts-diverge-1-3, #da1e28);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-3.hovered {
+  fill: var(--cds-charts-diverge-1-3-hovered, #da1e28);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-3 {
+  background-color: var(--cds-charts-diverge-1-3, #da1e28);
+}
+.cds--cc--chart-wrapper .background-diverge-1-3.hovered {
+  background-color: var(--cds-charts-diverge-1-3-hovered, #da1e28);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-3 {
+  stroke: var(--cds-charts-diverge-1-3, #da1e28);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-3 {
+  stop-color: var(--cds-charts-diverge-1-3, #da1e28);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-4 {
+  fill: var(--cds-charts-diverge-1-4, #fa4d56);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-4.hovered {
+  fill: var(--cds-charts-diverge-1-4-hovered, #fa4d56);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-4 {
+  background-color: var(--cds-charts-diverge-1-4, #fa4d56);
+}
+.cds--cc--chart-wrapper .background-diverge-1-4.hovered {
+  background-color: var(--cds-charts-diverge-1-4-hovered, #fa4d56);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-4 {
+  stroke: var(--cds-charts-diverge-1-4, #fa4d56);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-4 {
+  stop-color: var(--cds-charts-diverge-1-4, #fa4d56);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-5 {
+  fill: var(--cds-charts-diverge-1-5, #ff8389);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-5.hovered {
+  fill: var(--cds-charts-diverge-1-5-hovered, #ff8389);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-5 {
+  background-color: var(--cds-charts-diverge-1-5, #ff8389);
+}
+.cds--cc--chart-wrapper .background-diverge-1-5.hovered {
+  background-color: var(--cds-charts-diverge-1-5-hovered, #ff8389);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-5 {
+  stroke: var(--cds-charts-diverge-1-5, #ff8389);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-5 {
+  stop-color: var(--cds-charts-diverge-1-5, #ff8389);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-6 {
+  fill: var(--cds-charts-diverge-1-6, #ffb3b8);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-6.hovered {
+  fill: var(--cds-charts-diverge-1-6-hovered, #ffb3b8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-6 {
+  background-color: var(--cds-charts-diverge-1-6, #ffb3b8);
+}
+.cds--cc--chart-wrapper .background-diverge-1-6.hovered {
+  background-color: var(--cds-charts-diverge-1-6-hovered, #ffb3b8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-6 {
+  stroke: var(--cds-charts-diverge-1-6, #ffb3b8);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-6 {
+  stop-color: var(--cds-charts-diverge-1-6, #ffb3b8);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-7 {
+  fill: var(--cds-charts-diverge-1-7, #ffd7d9);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-7.hovered {
+  fill: var(--cds-charts-diverge-1-7-hovered, #ffd7d9);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-7 {
+  background-color: var(--cds-charts-diverge-1-7, #ffd7d9);
+}
+.cds--cc--chart-wrapper .background-diverge-1-7.hovered {
+  background-color: var(--cds-charts-diverge-1-7-hovered, #ffd7d9);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-7 {
+  stroke: var(--cds-charts-diverge-1-7, #ffd7d9);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-7 {
+  stop-color: var(--cds-charts-diverge-1-7, #ffd7d9);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-8 {
+  fill: var(--cds-charts-diverge-1-8, #fff1f1);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-8.hovered {
+  fill: var(--cds-charts-diverge-1-8-hovered, #fff1f1);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-8 {
+  background-color: var(--cds-charts-diverge-1-8, #fff1f1);
+}
+.cds--cc--chart-wrapper .background-diverge-1-8.hovered {
+  background-color: var(--cds-charts-diverge-1-8-hovered, #fff1f1);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-8 {
+  stroke: var(--cds-charts-diverge-1-8, #fff1f1);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-8 {
+  stop-color: var(--cds-charts-diverge-1-8, #fff1f1);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-9 {
+  fill: var(--cds-charts-diverge-1-9, #fff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-9.hovered {
+  fill: var(--cds-charts-diverge-1-9-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-9 {
+  background-color: var(--cds-charts-diverge-1-9, #fff);
+}
+.cds--cc--chart-wrapper .background-diverge-1-9.hovered {
+  background-color: var(--cds-charts-diverge-1-9-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-9 {
+  stroke: var(--cds-charts-diverge-1-9, #fff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-9 {
+  stop-color: var(--cds-charts-diverge-1-9, #fff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-10 {
+  fill: var(--cds-charts-diverge-1-10, #e5f6ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-10.hovered {
+  fill: var(--cds-charts-diverge-1-10-hovered, #e5f6ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-10 {
+  background-color: var(--cds-charts-diverge-1-10, #e5f6ff);
+}
+.cds--cc--chart-wrapper .background-diverge-1-10.hovered {
+  background-color: var(--cds-charts-diverge-1-10-hovered, #e5f6ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-10 {
+  stroke: var(--cds-charts-diverge-1-10, #e5f6ff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-10 {
+  stop-color: var(--cds-charts-diverge-1-10, #e5f6ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-11 {
+  fill: var(--cds-charts-diverge-1-11, #bae6ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-11.hovered {
+  fill: var(--cds-charts-diverge-1-11-hovered, #bae6ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-11 {
+  background-color: var(--cds-charts-diverge-1-11, #bae6ff);
+}
+.cds--cc--chart-wrapper .background-diverge-1-11.hovered {
+  background-color: var(--cds-charts-diverge-1-11-hovered, #bae6ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-11 {
+  stroke: var(--cds-charts-diverge-1-11, #bae6ff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-11 {
+  stop-color: var(--cds-charts-diverge-1-11, #bae6ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-12 {
+  fill: var(--cds-charts-diverge-1-12, #82cfff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-12.hovered {
+  fill: var(--cds-charts-diverge-1-12-hovered, #82cfff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-12 {
+  background-color: var(--cds-charts-diverge-1-12, #82cfff);
+}
+.cds--cc--chart-wrapper .background-diverge-1-12.hovered {
+  background-color: var(--cds-charts-diverge-1-12-hovered, #82cfff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-12 {
+  stroke: var(--cds-charts-diverge-1-12, #82cfff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-12 {
+  stop-color: var(--cds-charts-diverge-1-12, #82cfff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-13 {
+  fill: var(--cds-charts-diverge-1-13, #33b1ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-13.hovered {
+  fill: var(--cds-charts-diverge-1-13-hovered, #33b1ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-13 {
+  background-color: var(--cds-charts-diverge-1-13, #33b1ff);
+}
+.cds--cc--chart-wrapper .background-diverge-1-13.hovered {
+  background-color: var(--cds-charts-diverge-1-13-hovered, #33b1ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-13 {
+  stroke: var(--cds-charts-diverge-1-13, #33b1ff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-13 {
+  stop-color: var(--cds-charts-diverge-1-13, #33b1ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-14 {
+  fill: var(--cds-charts-diverge-1-14, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-14.hovered {
+  fill: var(--cds-charts-diverge-1-14-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-14 {
+  background-color: var(--cds-charts-diverge-1-14, #1192e8);
+}
+.cds--cc--chart-wrapper .background-diverge-1-14.hovered {
+  background-color: var(--cds-charts-diverge-1-14-hovered, #1192e8);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-14 {
+  stroke: var(--cds-charts-diverge-1-14, #1192e8);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-14 {
+  stop-color: var(--cds-charts-diverge-1-14, #1192e8);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-15 {
+  fill: var(--cds-charts-diverge-1-15, #0072c3);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-15.hovered {
+  fill: var(--cds-charts-diverge-1-15-hovered, #0072c3);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-15 {
+  background-color: var(--cds-charts-diverge-1-15, #0072c3);
+}
+.cds--cc--chart-wrapper .background-diverge-1-15.hovered {
+  background-color: var(--cds-charts-diverge-1-15-hovered, #0072c3);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-15 {
+  stroke: var(--cds-charts-diverge-1-15, #0072c3);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-15 {
+  stop-color: var(--cds-charts-diverge-1-15, #0072c3);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-16 {
+  fill: var(--cds-charts-diverge-1-16, #00539a);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-16.hovered {
+  fill: var(--cds-charts-diverge-1-16-hovered, #00539a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-16 {
+  background-color: var(--cds-charts-diverge-1-16, #00539a);
+}
+.cds--cc--chart-wrapper .background-diverge-1-16.hovered {
+  background-color: var(--cds-charts-diverge-1-16-hovered, #00539a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-16 {
+  stroke: var(--cds-charts-diverge-1-16, #00539a);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-16 {
+  stop-color: var(--cds-charts-diverge-1-16, #00539a);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-17 {
+  fill: var(--cds-charts-diverge-1-17, #003a6d);
+}
+.cds--cc--chart-wrapper .fill-diverge-1-17.hovered {
+  fill: var(--cds-charts-diverge-1-17-hovered, #003a6d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-1-17 {
+  background-color: var(--cds-charts-diverge-1-17, #003a6d);
+}
+.cds--cc--chart-wrapper .background-diverge-1-17.hovered {
+  background-color: var(--cds-charts-diverge-1-17-hovered, #003a6d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-1-17 {
+  stroke: var(--cds-charts-diverge-1-17, #003a6d);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-1-17 {
+  stop-color: var(--cds-charts-diverge-1-17, #003a6d);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-1 {
+  fill: var(--cds-charts-diverge-2-1, #491d8b);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-1.hovered {
+  fill: var(--cds-charts-diverge-2-1-hovered, #491d8b);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-1 {
+  background-color: var(--cds-charts-diverge-2-1, #491d8b);
+}
+.cds--cc--chart-wrapper .background-diverge-2-1.hovered {
+  background-color: var(--cds-charts-diverge-2-1-hovered, #491d8b);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-1 {
+  stroke: var(--cds-charts-diverge-2-1, #491d8b);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-1 {
+  stop-color: var(--cds-charts-diverge-2-1, #491d8b);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-2 {
+  fill: var(--cds-charts-diverge-2-2, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-2.hovered {
+  fill: var(--cds-charts-diverge-2-2-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-2 {
+  background-color: var(--cds-charts-diverge-2-2, #6929c4);
+}
+.cds--cc--chart-wrapper .background-diverge-2-2.hovered {
+  background-color: var(--cds-charts-diverge-2-2-hovered, #6929c4);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-2 {
+  stroke: var(--cds-charts-diverge-2-2, #6929c4);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-2 {
+  stop-color: var(--cds-charts-diverge-2-2, #6929c4);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-3 {
+  fill: var(--cds-charts-diverge-2-3, #8a3ffc);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-3.hovered {
+  fill: var(--cds-charts-diverge-2-3-hovered, #8a3ffc);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-3 {
+  background-color: var(--cds-charts-diverge-2-3, #8a3ffc);
+}
+.cds--cc--chart-wrapper .background-diverge-2-3.hovered {
+  background-color: var(--cds-charts-diverge-2-3-hovered, #8a3ffc);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-3 {
+  stroke: var(--cds-charts-diverge-2-3, #8a3ffc);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-3 {
+  stop-color: var(--cds-charts-diverge-2-3, #8a3ffc);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-4 {
+  fill: var(--cds-charts-diverge-2-4, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-4.hovered {
+  fill: var(--cds-charts-diverge-2-4-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-4 {
+  background-color: var(--cds-charts-diverge-2-4, #a56eff);
+}
+.cds--cc--chart-wrapper .background-diverge-2-4.hovered {
+  background-color: var(--cds-charts-diverge-2-4-hovered, #a56eff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-4 {
+  stroke: var(--cds-charts-diverge-2-4, #a56eff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-4 {
+  stop-color: var(--cds-charts-diverge-2-4, #a56eff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-5 {
+  fill: var(--cds-charts-diverge-2-5, #be95ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-5.hovered {
+  fill: var(--cds-charts-diverge-2-5-hovered, #be95ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-5 {
+  background-color: var(--cds-charts-diverge-2-5, #be95ff);
+}
+.cds--cc--chart-wrapper .background-diverge-2-5.hovered {
+  background-color: var(--cds-charts-diverge-2-5-hovered, #be95ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-5 {
+  stroke: var(--cds-charts-diverge-2-5, #be95ff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-5 {
+  stop-color: var(--cds-charts-diverge-2-5, #be95ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-6 {
+  fill: var(--cds-charts-diverge-2-6, #d4bbff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-6.hovered {
+  fill: var(--cds-charts-diverge-2-6-hovered, #d4bbff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-6 {
+  background-color: var(--cds-charts-diverge-2-6, #d4bbff);
+}
+.cds--cc--chart-wrapper .background-diverge-2-6.hovered {
+  background-color: var(--cds-charts-diverge-2-6-hovered, #d4bbff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-6 {
+  stroke: var(--cds-charts-diverge-2-6, #d4bbff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-6 {
+  stop-color: var(--cds-charts-diverge-2-6, #d4bbff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-7 {
+  fill: var(--cds-charts-diverge-2-7, #e8daff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-7.hovered {
+  fill: var(--cds-charts-diverge-2-7-hovered, #e8daff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-7 {
+  background-color: var(--cds-charts-diverge-2-7, #e8daff);
+}
+.cds--cc--chart-wrapper .background-diverge-2-7.hovered {
+  background-color: var(--cds-charts-diverge-2-7-hovered, #e8daff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-7 {
+  stroke: var(--cds-charts-diverge-2-7, #e8daff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-7 {
+  stop-color: var(--cds-charts-diverge-2-7, #e8daff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-8 {
+  fill: var(--cds-charts-diverge-2-8, #f6f2ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-8.hovered {
+  fill: var(--cds-charts-diverge-2-8-hovered, #f6f2ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-8 {
+  background-color: var(--cds-charts-diverge-2-8, #f6f2ff);
+}
+.cds--cc--chart-wrapper .background-diverge-2-8.hovered {
+  background-color: var(--cds-charts-diverge-2-8-hovered, #f6f2ff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-8 {
+  stroke: var(--cds-charts-diverge-2-8, #f6f2ff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-8 {
+  stop-color: var(--cds-charts-diverge-2-8, #f6f2ff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-9 {
+  fill: var(--cds-charts-diverge-2-9, #fff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-9.hovered {
+  fill: var(--cds-charts-diverge-2-9-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-9 {
+  background-color: var(--cds-charts-diverge-2-9, #fff);
+}
+.cds--cc--chart-wrapper .background-diverge-2-9.hovered {
+  background-color: var(--cds-charts-diverge-2-9-hovered, #fff);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-9 {
+  stroke: var(--cds-charts-diverge-2-9, #fff);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-9 {
+  stop-color: var(--cds-charts-diverge-2-9, #fff);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-10 {
+  fill: var(--cds-charts-diverge-2-10, #d9fbfb);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-10.hovered {
+  fill: var(--cds-charts-diverge-2-10-hovered, #d9fbfb);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-10 {
+  background-color: var(--cds-charts-diverge-2-10, #d9fbfb);
+}
+.cds--cc--chart-wrapper .background-diverge-2-10.hovered {
+  background-color: var(--cds-charts-diverge-2-10-hovered, #d9fbfb);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-10 {
+  stroke: var(--cds-charts-diverge-2-10, #d9fbfb);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-10 {
+  stop-color: var(--cds-charts-diverge-2-10, #d9fbfb);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-11 {
+  fill: var(--cds-charts-diverge-2-11, #9ef0f0);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-11.hovered {
+  fill: var(--cds-charts-diverge-2-11-hovered, #9ef0f0);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-11 {
+  background-color: var(--cds-charts-diverge-2-11, #9ef0f0);
+}
+.cds--cc--chart-wrapper .background-diverge-2-11.hovered {
+  background-color: var(--cds-charts-diverge-2-11-hovered, #9ef0f0);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-11 {
+  stroke: var(--cds-charts-diverge-2-11, #9ef0f0);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-11 {
+  stop-color: var(--cds-charts-diverge-2-11, #9ef0f0);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-12 {
+  fill: var(--cds-charts-diverge-2-12, #3ddbd9);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-12.hovered {
+  fill: var(--cds-charts-diverge-2-12-hovered, #3ddbd9);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-12 {
+  background-color: var(--cds-charts-diverge-2-12, #3ddbd9);
+}
+.cds--cc--chart-wrapper .background-diverge-2-12.hovered {
+  background-color: var(--cds-charts-diverge-2-12-hovered, #3ddbd9);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-12 {
+  stroke: var(--cds-charts-diverge-2-12, #3ddbd9);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-12 {
+  stop-color: var(--cds-charts-diverge-2-12, #3ddbd9);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-13 {
+  fill: var(--cds-charts-diverge-2-13, #08bdba);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-13.hovered {
+  fill: var(--cds-charts-diverge-2-13-hovered, #08bdba);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-13 {
+  background-color: var(--cds-charts-diverge-2-13, #08bdba);
+}
+.cds--cc--chart-wrapper .background-diverge-2-13.hovered {
+  background-color: var(--cds-charts-diverge-2-13-hovered, #08bdba);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-13 {
+  stroke: var(--cds-charts-diverge-2-13, #08bdba);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-13 {
+  stop-color: var(--cds-charts-diverge-2-13, #08bdba);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-14 {
+  fill: var(--cds-charts-diverge-2-14, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-14.hovered {
+  fill: var(--cds-charts-diverge-2-14-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-14 {
+  background-color: var(--cds-charts-diverge-2-14, #009d9a);
+}
+.cds--cc--chart-wrapper .background-diverge-2-14.hovered {
+  background-color: var(--cds-charts-diverge-2-14-hovered, #009d9a);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-14 {
+  stroke: var(--cds-charts-diverge-2-14, #009d9a);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-14 {
+  stop-color: var(--cds-charts-diverge-2-14, #009d9a);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-15 {
+  fill: var(--cds-charts-diverge-2-15, #007d79);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-15.hovered {
+  fill: var(--cds-charts-diverge-2-15-hovered, #007d79);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-15 {
+  background-color: var(--cds-charts-diverge-2-15, #007d79);
+}
+.cds--cc--chart-wrapper .background-diverge-2-15.hovered {
+  background-color: var(--cds-charts-diverge-2-15-hovered, #007d79);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-15 {
+  stroke: var(--cds-charts-diverge-2-15, #007d79);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-15 {
+  stop-color: var(--cds-charts-diverge-2-15, #007d79);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-16 {
+  fill: var(--cds-charts-diverge-2-16, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-16.hovered {
+  fill: var(--cds-charts-diverge-2-16-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-16 {
+  background-color: var(--cds-charts-diverge-2-16, #005d5d);
+}
+.cds--cc--chart-wrapper .background-diverge-2-16.hovered {
+  background-color: var(--cds-charts-diverge-2-16-hovered, #005d5d);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-16 {
+  stroke: var(--cds-charts-diverge-2-16, #005d5d);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-16 {
+  stop-color: var(--cds-charts-diverge-2-16, #005d5d);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-17 {
+  fill: var(--cds-charts-diverge-2-17, #004144);
+}
+.cds--cc--chart-wrapper .fill-diverge-2-17.hovered {
+  fill: var(--cds-charts-diverge-2-17-hovered, #004144);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .background-diverge-2-17 {
+  background-color: var(--cds-charts-diverge-2-17, #004144);
+}
+.cds--cc--chart-wrapper .background-diverge-2-17.hovered {
+  background-color: var(--cds-charts-diverge-2-17-hovered, #004144);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .stroke-diverge-2-17 {
+  stroke: var(--cds-charts-diverge-2-17, #004144);
+}
+.cds--cc--chart-wrapper .stop-color-diverge-2-17 {
+  stop-color: var(--cds-charts-diverge-2-17, #004144);
+}
+.cds--cc--tooltip .tooltip-14-1-10 {
+  background-color: var(--cds-charts-14-1-10, #b28600);
+}
+.cds--cc--tooltip .tooltip-14-1-11 {
+  background-color: var(--cds-charts-14-1-11, #009d9a);
+}
+.cds--cc--tooltip .tooltip-14-1-12 {
+  background-color: var(--cds-charts-14-1-12, #012749);
+}
+.cds--cc--tooltip .tooltip-14-1-13 {
+  background-color: var(--cds-charts-14-1-13, #8a3800);
+}
+.cds--cc--tooltip .tooltip-14-1-14 {
+  background-color: var(--cds-charts-14-1-14, #a56eff);
+}
+.cds--cc--card-node--a:focus,
+.cds--cc--card-node--a:hover,
+.cds--cc--card-node--button:focus,
+.cds--cc--card-node--button:hover,
+.cds--cc--shape-node--a:focus,
+.cds--cc--shape-node--a:hover,
+.cds--cc--shape-node--button:focus,
+.cds--cc--shape-node--button:hover {
+  background-color: var(--cds-network-diagrams-background-hover, #f1f1f1);
+}
+.cds--cc--legend .additional > .icon .area-1 {
+  fill: var(--cds-zone-fill-01, #f4f4f4);
+  stroke: var(--cds-zone-stroke-01, #8d8d8d);
+}
+.cds--cc--legend .additional > .icon .area-2 {
+  fill: var(--cds-zone-fill-02, #e0e0e0);
+  stroke: var(--cds-zone-stroke-02, #8d8d8d);
+}
+.cds--cc--legend .additional > .icon .area-3 {
+  fill: var(--cds-zone-fill-03, #c6c6c6);
+  stroke: var(--cds-zone-stroke-03, #8d8d8d);
+}
+.cds--cc--legend .additional > .icon .quartile-wrapper {
+  fill: var(--cds-zone-fill-02, #e0e0e0);
+  stroke: var(--cds-zone-stroke-01, #8d8d8d);
+}
+.cds--cc--legend .additional > .icon .quartile-line {
+  fill: var(--cds-layer-inverse-absolute, #000);
+}
+.cds--cc--axes g.axis g.tick-hover rect.axis-holder {
+  fill: transparent;
+  stroke: transparent;
+  stroke-width: 2px;
+}
+.cds--cc--axes g.axis g.tick-hover:focus rect.axis-holder,
+.cds--cc--axes g.axis g.tick-hover:hover rect.axis-holder {
+  fill: var(--cds-layer-selected-inverse, #161616);
+  stroke: var(--cds-layer-selected-inverse, #161616);
+  stroke-width: 2px;
+}
+.cds--cc--axes g.axis g.tick-hover:focus text,
+.cds--cc--axes g.axis g.tick-hover:hover text {
+  fill: var(--cds-layer-selected);
+}
+.cds--cc--axes g.axis .axis-title {
+  fill: var(--cds-text-primary, #161616);
+  font-weight: 600;
+}
+.cds--cc--chart-wrapper g.callouts {
+  stroke: var(--cds-text-secondary, #525252);
+}
+.cds--cc--grid-brush g.grid-brush rect.selection {
+  fill: none;
+  fill-opacity: 0;
+  stroke: none;
+}
+.cds--cc--grid-brush rect.frontSelection {
+  fill: var(--cds-layer-accent-01, #e0e0e0);
+  fill-opacity: 0.3;
+  stroke: var(--cds-button-tertiary, #0f62fe);
+}
+.cds--cc--grid rect.chart-grid-backdrop,
+.cds--cc--skeleton rect.chart-skeleton-backdrop,
+.cds--cc--skeleton-lines rect.chart-skeleton-backdrop {
+  fill: var(--cds-grid-bg, #fff);
+}
+.cds--cc--grid rect.chart-grid-backdrop.stroked,
+.cds--cc--grid rect.stroke {
+  stroke: var(--cds-layer-accent-01, #e0e0e0);
+}
+.cds--cc--grid g.x.grid g.tick line,
+.cds--cc--grid g.y.grid g.tick line {
+  stroke-width: 1px;
+  stroke: var(--cds-layer-accent-01, #e0e0e0);
+  pointer-events: none;
+}
+.cds--cc--grid g.x.grid g.tick.active line,
+.cds--cc--grid g.y.grid g.tick.active line {
+  stroke-dasharray: 2px;
+  stroke: var(--cds-focus, #0f62fe);
+}
+.cds--cc--ruler line.ruler-line,
+.cds--cc--ruler-binned line.ruler-line {
+  stroke: var(--cds-layer-inverse-absolute, #000);
+  stroke-width: 1px;
+  stroke-dasharray: 2;
+  pointer-events: none;
+}
+.cds--cc--skeleton .shimmer-effect-lines {
+  stroke-width: 1px;
+}
+.cds--cc--skeleton .shimmer-effect-sparkline {
+  stroke-width: 0;
+}
+.cds--cc--skeleton .empty-state-lines {
+  stroke-width: 1px;
+  stroke: var(--cds-layer-accent-01, #e0e0e0);
+}
+.cds--cc--skeleton .shimmer-lines .stop-bg-shimmer {
+  stop-color: var(--cds-layer-accent-01, #e0e0e0);
+}
+.cds--cc--skeleton .shimmer-lines .stop-shimmer {
+  stop-color: #fff;
+}
+.cds--cc--skeleton .empty-state-areas {
+  fill: hsla(0, 0%, 50%, 0.1);
+}
+.cds--cc--skeleton .shimmer-areas .stop-bg-shimmer {
+  stop-color: hsla(0, 0%, 50%, 0.1);
+}
+.cds--cc--skeleton .shimmer-areas .stop-shimmer {
+  stop-color: hsla(0, 0%, 100%, 0.15);
+}
+.cds--cc--skeleton-lines .shimmer-effect-lines {
+  stroke-width: 1px;
+}
+.cds--cc--skeleton-lines .shimmer-effect-sparkline {
+  stroke-width: 0;
+}
+.cds--cc--skeleton-lines .empty-state-lines {
+  stroke-width: 1px;
+  stroke: var(--cds-layer-accent-01, #e0e0e0);
+}
+.cds--cc--skeleton-lines .shimmer-lines .stop-bg-shimmer {
+  stop-color: var(--cds-layer-accent-01, #e0e0e0);
+}
+.cds--cc--skeleton-lines .shimmer-lines .stop-shimmer {
+  stop-color: #fff;
+}
+.cds--cc--layout-row {
+  display: flex;
+  flex-direction: row;
+}
+.cds--cc--layout-column {
+  display: flex;
+  flex-direction: column;
+}
+.cds--cc--layout-row-reverse {
+  display: flex;
+  flex-direction: row-reverse;
+}
+.cds--cc--layout-column-reverse {
+  display: flex;
+  flex-direction: column-reverse;
+}
+.cds--cc--threshold--label,
+.cds--cc--tooltip {
+  word-wrap: break-word;
+  box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.2);
+  display: inline;
+  z-index: 1059;
+}
+.cds--cc--layout-alignitems-center {
+  align-items: center;
+}
+.cds--cc--chart-wrapper svg.layout-svg-wrapper {
+  height: inherit;
+  overflow: visible;
+  width: inherit;
+}
+div.cds--cc--legend {
+  display: flex;
+  flex-wrap: wrap;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+div.cds--cc--legend[data-name='legend-items'] {
+  margin: -5px;
+  width: 100%;
+}
+div.cds--cc--legend div.legend-item {
+  align-items: center;
+  display: flex;
+  margin: 5px;
+}
+div.cds--cc--legend div.legend-item div.checkbox {
+  border: 1px solid var(--cds-background, #fff);
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px transparent;
+  height: 13px;
+  margin-right: 4px;
+  width: 13px;
+}
+div.cds--cc--legend div.legend-item div.checkbox:not(.active) {
+  background: var(--cds-background, #fff);
+  border-color: var(--cds-text-secondary, #525252);
+}
+div.cds--cc--legend div.legend-item div.checkbox svg {
+  fill: var(--cds-background, #fff);
+  stroke: var(--cds-background, #fff);
+  display: none;
+  vertical-align: text-top;
+}
+div.cds--cc--legend div.legend-item.additional svg.icon {
+  margin-right: 4px;
+}
+div.cds--cc--legend div.legend-item p {
+  font-size: 12px;
+  line-height: 1rem;
+}
+div.cds--cc--legend.center-aligned {
+  justify-content: center;
+}
+div.cds--cc--legend.right-aligned {
+  justify-content: flex-end;
+}
+div.cds--cc--legend.has-deactivated-items div.legend-item div.checkbox svg {
+  display: block;
+}
+div.cds--cc--legend.vertical {
+  flex-direction: column;
+  margin: -5px;
+}
+div.cds--cc--legend.vertical div.legend-item {
+  margin-bottom: 10px;
+  margin-right: 0;
+}
+div.cds--cc--legend.clickable div.legend-item:not(.additional):hover {
+  cursor: pointer;
+}
+div.cds--cc--legend.clickable
+  div.legend-item:not(.additional):hover
+  div.checkbox {
+  border: 1px solid var(--cds-background, #fff);
+  box-shadow: 0 0 0 2px #0f62fe;
+}
+div.cds--cc--legend.clickable
+  div.legend-item:not(.additional):hover
+  div.checkbox:not(.active) {
+  border-color: var(--cds-text-secondary, #525252);
+}
+.cds--cc--card-node--stacked:after,
+.cds--cc--card-node--stacked:before {
+  border-right: 0.125rem solid var(--cds-layer-accent-01, #e0e0e0);
+  border-top: 0.125rem solid var(--cds-layer-accent-01, #e0e0e0);
+  content: '';
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+}
+.cds--chart-holder .cds--modal.is-visible {
+  z-index: 99999;
+}
+.cds--chart-holder .cds--modal .cds--modal-container .cds--modal-header__label {
+  margin-bottom: 0;
+  margin-top: 0;
+}
+.cds--chart-holder
+  .cds--modal
+  .cds--modal-container
+  .cds--modal-header__heading {
+  margin-bottom: 1rem;
+  margin-top: 0.5rem;
+}
+.cds--chart-holder .cds--modal .cds--modal-container .cds--modal-content {
+  color-scheme: var(--cds-color-scheme, light);
+  margin-bottom: 0;
+  padding: 0;
+}
+.cds--chart-holder .cds--modal .cds--modal-container .cds--modal-content table {
+  border-collapse: collapse;
+  position: relative;
+}
+.cds--chart-holder
+  .cds--modal
+  .cds--modal-container
+  .cds--modal-content
+  table
+  th {
+  position: sticky;
+  top: 0;
+}
+.cds--chart-holder
+  .cds--modal
+  .cds--modal-container
+  .cds--modal-footer
+  .cds--cc-modal-footer-spacer {
+  width: 50%;
+}
+.cds--cc--title p.title {
+  font-size: 16px;
+  font-weight: 600;
+  overflow: hidden;
+  padding-right: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.layout-child.title {
+  height: unset !important;
+  overflow: hidden;
+}
+.cds--cc--meter-title text.meter-title,
+.cds--cc--meter-title text.percent-value,
+.cds--cc--meter-title text.proportional-meter-title,
+.cds--cc--meter-title text.proportional-meter-total {
+  fill: var(--cds-text-primary, #161616);
+}
+.cds--cc--meter-title g.status-indicator.status--warning circle.status {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--cc--meter-title g.status-indicator.status--warning path.innerFill {
+  fill: #000;
+}
+.cds--cc--meter-title g.status-indicator.status--success circle.status {
+  fill: var(--cds-support-success, #24a148);
+}
+.cds--cc--meter-title g.status-indicator path.innerFill {
+  fill: var(--cds-layer-01-absolute, #fff);
+}
+.cds--chart-holder .cds--overflow-menu,
+.cds--chart-holder .cds--overflow-menu__trigger {
+  height: 2rem;
+  width: 2rem;
+}
+.cds--chart-holder .cds--cc--toolbar {
+  display: flex;
+}
+.cds--chart-holder .cds--cc--toolbar div.toolbar-control.disabled,
+.cds--chart-holder .cds--cc--toolbar div.toolbar-control.disabled button {
+  cursor: not-allowed;
+}
+.cds--chart-holder .cds--cc--toolbar div.toolbar-control.disabled svg {
+  fill: var(--cds-icon-on-color-disabled, #8d8d8d);
+}
+.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu--flip {
+  left: unset;
+  right: 0;
+}
+.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu--flip.is-open {
+  display: table;
+}
+.cds--chart-holder .cds--cc--toolbar .cds--overflow-menu--flip ul {
+  margin: 0;
+  padding: 0;
+}
+.cds--chart-holder .cds--cc--toolbar .cds--loading__background {
+  fill: transparent;
+}
+.cds--chart-holder .cds--cc--toolbar .cds--loading__stroke {
+  stroke-dashoffset: 99;
+  fill: transparent;
+}
+.cds--cc--tooltip {
+  background-color: var(--cds-layer-02, #fff);
+  pointer-events: none;
+  position: absolute;
+  transition:
+    visibility 0s linear 0.1s,
+    opacity 0.1s;
+  visibility: visible;
+}
+.cds--cc--tooltip.hidden {
+  opacity: 0;
+  transition:
+    visibility cubic-bezier(0.4, 0.14, 0.3, 1),
+    opacity 0.1s cubic-bezier(0.4, 0.14, 0.3, 1);
+  visibility: hidden;
+}
+.cds--cc--tooltip .content-box .title-tooltip {
+  max-width: 270px;
+  min-width: 20px;
+  padding: 4px;
+  width: auto;
+}
+.cds--cc--tooltip .content-box .title-tooltip p {
+  font-size: 12px;
+  line-height: 1rem;
+  margin: 2px;
+}
+.cds--cc--tooltip .content-box .datapoint-tooltip {
+  align-items: center;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  min-width: 20px;
+  padding: 4px;
+  width: auto;
+}
+.cds--cc--tooltip .content-box .datapoint-tooltip div.label {
+  display: flex;
+  flex: 1;
+}
+.cds--cc--tooltip .content-box .datapoint-tooltip div.label p {
+  flex: 1;
+  padding-right: 8px;
+}
+.cds--cc--tooltip
+  .content-box
+  .datapoint-tooltip
+  div.label
+  span.label-icon
+  svg {
+  fill: var(--cds-layer-inverse-absolute, #000);
+  height: 12px;
+  padding-left: 4px;
+  padding-top: 3px;
+  vertical-align: top;
+  width: auto;
+}
+.cds--cc--tooltip .content-box .datapoint-tooltip.bold div.label p {
+  font-weight: 600;
+}
+.cds--cc--tooltip .content-box .datapoint-tooltip p {
+  border: 0;
+  display: inline-block;
+  font-size: 12px;
+  line-height: 16px;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cds--cc--tooltip .content-box .datapoint-tooltip p.value {
+  margin-left: 6px;
+  width: auto;
+}
+.cds--cc--tooltip .content-box ul.multi-tooltip {
+  margin: 0;
+  padding: 0;
+}
+.cds--cc--tooltip .content-box ul.multi-tooltip li {
+  list-style: none;
+  position: relative;
+}
+.cds--cc--tooltip .content-box ul.multi-tooltip li:not(:last-child) {
+  border-bottom: 1px solid var(--cds-tooltip-line-border, #e0e0e0);
+}
+.cds--cc--tooltip .content-box svg.arrow-right rect {
+  fill: none;
+}
+.cds--cc--tooltip .tooltip-color {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 4px;
+}
+@media (forced-colors: active) {
+  .cds--cc--tooltip .tooltip-color,
+  div.cds--cc--legend div.legend-item div.checkbox {
+    forced-color-adjust: none;
+  }
+}
+.cds--cc--tooltip .tooltip-color + div.label p {
+  margin-left: 4px;
+}
+.cds--cc--threshold line.threshold-line {
+  stroke: #fa4d56;
+  stroke-width: 1;
+  stroke-dasharray: 4;
+  cursor: pointer;
+  pointer-events: none;
+}
+.cds--cc--threshold line.threshold-line.active {
+  stroke-width: 2;
+}
+.cds--cc--threshold rect.threshold-hoverable-area {
+  fill: transparent;
+  cursor: pointer;
+  height: 20px;
+  transform: translateY(-10px);
+}
+.cds--cc--threshold rect.threshold-hoverable-area.rotate {
+  transform: rotate(90deg) translateY(-10px);
+}
+.cds--cc--threshold--label {
+  background-color: #fa4d56;
+  font-size: 12px;
+  line-height: 16px;
+  min-width: 20px;
+  padding: 4px;
+  pointer-events: none;
+  position: absolute;
+  transition: opacity 0.1s cubic-bezier(0.4, 0.14, 0.3, 1);
+}
+.cds--cc--card-node,
+.cds--cc--shape-node,
+.cds--cc--threshold--label {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+}
+.cds--cc--card-node,
+.cds--cc--shape-node {
+  background-color: var(--cds-layer-01, #f4f4f4);
+  box-sizing: border-box;
+  height: 100%;
+  position: relative;
+  width: 100%;
+}
+.cds--cc--threshold--label.hidden {
+  opacity: 0;
+  transition: opacity 0.1s cubic-bezier(0.4, 0.14, 0.3, 1);
+}
+.cds--cc--zoom-bar rect.zoom-bg {
+  fill: var(--cds-background, #fff);
+  stroke: var(--cds-layer-01, #f4f4f4);
+}
+.cds--cc--zoom-bar rect.zoom-slider-bg {
+  fill: var(--cds-layer-01, #f4f4f4);
+}
+.cds--cc--zoom-bar g.zoom-bar-brush rect.handle,
+.cds--cc--zoom-bar rect.zoom-slider-selected-area {
+  fill: var(--cds-icon-secondary, #525252);
+}
+.cds--cc--zoom-bar path.zoom-bg-baseline {
+  stroke-width: 2;
+}
+.cds--cc--zoom-bar path.zoom-graph-area {
+  fill: var(--cds-layer-accent-01, #e0e0e0);
+  stroke: var(--cds-border-strong-01, #8d8d8d);
+  stroke-width: 1;
+}
+.cds--cc--zoom-bar path.zoom-graph-area-unselected {
+  fill: var(--cds-layer-01, #f4f4f4);
+  stroke: none;
+}
+.cds--cc--zoom-bar g.zoom-bar-brush rect.handle-bar {
+  fill: var(--cds-layer-02, #fff);
+}
+.cds--cc--zoom-bar g.zoom-bar-brush rect.selection {
+  fill: none;
+  stroke: none;
+}
+.cds--cc--zoom-bar rect[class^='highlight-'] {
+  fill: #ee5396;
+  stroke: #ee5396;
+}
+.cds--cc--highlight rect.highlight-bar {
+  fill: #ee5396;
+  stroke: #ee5396;
+  pointer-events: none;
+}
+.cds--cc--card-node {
+  border-left: 0.25rem solid var(--cds-border-inverse, #161616);
+  display: flex;
+  padding: 1rem 0.5rem;
+  z-index: 1;
+}
+.cds--cc--card-node--a,
+.cds--cc--card-node--button {
+  border-bottom: none;
+  border-right: none;
+  border-top: none;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+.cds--cc--card-node--button {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  text-align: left;
+  width: 100%;
+}
+.cds--cc--card-node--a:focus,
+.cds--cc--card-node--button:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+@media screen and (prefers-contrast) {
+  .cds--cc--card-node--a:focus,
+  .cds--cc--card-node--button:focus {
+    outline-style: dotted;
+  }
+}
+.cds--cc--card-node--stacked:before {
+  bottom: 0.3125rem;
+  height: 100%;
+  left: 0.3125rem;
+  width: 100%;
+}
+.cds--cc--card-node--stacked:after {
+  bottom: 0.6875rem;
+  height: 100%;
+  left: 0.6875rem;
+  width: 100%;
+}
+.cds--cc--card-node__column {
+  padding: 0 0.5rem;
+}
+.cds--cc--card-node__column--farside {
+  margin-left: auto;
+}
+.cds--cc--card-node__title {
+  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-productive-heading-01-font-weight, 600);
+  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+  line-height: var(--cds-productive-heading-01-line-height, 1.28572);
+  margin: 0;
+}
+.cds--cc--card-node__subtitle {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-short-01-line-height, 1.28572);
+  margin: 0;
+}
+.cds--cc--card-node__label {
+  color: var(--cds-text-secondary, #525252);
+  display: block;
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  line-height: var(--cds-label-01-line-height, 1.33333);
+  padding-top: 1.5rem;
+}
+.cds--cc--shape-node {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+.cds--cc--shape-node--circle {
+  border-radius: 100%;
+}
+.cds--cc--shape-node--square {
+  border-radius: 0;
+}
+.cds--cc--shape-node--rounded-square {
+  border-radius: 0.5rem;
+}
+.cds--cc--shape-node--a,
+.cds--cc--shape-node--button {
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+.cds--cc--shape-node__subtitle,
+.cds--cc--shape-node__title {
+  color: var(--cds-text-primary, #161616);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  line-height: var(--cds-body-short-01-line-height, 1.28572);
+}
+.cds--cc--shape-node--button {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  text-align: left;
+  width: 100%;
+}
+.cds--chart-holder.filled,
+.cds--chart-holder.filled .cds--cc--chart-wrapper,
+.cds--chart-holder.fullscreen,
+.cds--chart-holder.fullscreen .cds--cc--chart-wrapper,
+div.container {
+  background-color: var(--cds-background, #fff);
+}
+.cds--cc--shape-node--a:focus .cds--cc--shape-node__subtitle,
+.cds--cc--shape-node--a:focus .cds--cc--shape-node__title,
+.cds--cc--shape-node--a:hover .cds--cc--shape-node__subtitle,
+.cds--cc--shape-node--a:hover .cds--cc--shape-node__title,
+.cds--cc--shape-node--button:focus .cds--cc--shape-node__subtitle,
+.cds--cc--shape-node--button:focus .cds--cc--shape-node__title,
+.cds--cc--shape-node--button:hover .cds--cc--shape-node__subtitle,
+.cds--cc--shape-node--button:hover .cds--cc--shape-node__title {
+  font-weight: 600;
+}
+.cds--cc--shape-node--a:focus:focus,
+.cds--cc--shape-node--button:focus:focus {
+  box-shadow: 0 0 0 2px var(--cds-focus, #0f62fe);
+  outline: 0;
+}
+.cds--cc--shape-node__body {
+  position: absolute;
+  text-align: center;
+  top: calc(100% + 0.125rem);
+}
+.cds--cc--shape-node__subtitle {
+  padding-bottom: 0.125rem;
+}
+.cds--cc--shape-node__icon {
+  display: flex;
+}
+.cds--cc--shape-node__title {
+  margin-bottom: 1px;
+  padding-top: 0.125rem;
+}
+.cds--cc--edge {
+  fill: transparent;
+}
+.cds--cc--edge__container {
+  stroke-width: 1.5rem;
+  stroke: transparent;
+  stroke-dasharray: none;
+}
+.cds--cc--edge__inner {
+  stroke-width: 0.0625rem;
+  stroke: var(--cds-border-strong-01, #8d8d8d);
+}
+.cds--cc--edge:hover .cds--cc--edge__inner,
+.cds--cc--edge__outer {
+  stroke-width: 0.15625rem;
+}
+.cds--cc--edge__outer {
+  stroke: transparent;
+}
+.cds--cc--edge--dash-sm {
+  stroke-dasharray: 2 4;
+}
+.cds--cc--edge--dash-md {
+  stroke-dasharray: 4 4;
+}
+.cds--cc--edge--dash-lg {
+  stroke-dasharray: 8 4;
+}
+.cds--cc--edge--dash-xl {
+  stroke-dasharray: 16 4;
+}
+.cds--cc--edge--tunnel .cds--cc--edge__outer {
+  stroke: var(--cds-layer-accent-01, #e0e0e0);
+  stroke-width: 0.375rem;
+}
+.cds--cc--edge--double .cds--cc--edge__inner {
+  stroke: var(--cds-background, #fff);
+}
+.cds--cc--edge--double .cds--cc--edge__outer {
+  stroke: var(--cds-border-inverse, #161616);
+  stroke-width: 0.28125rem;
+}
+.cds--cc--marker {
+  fill: var(--cds-border-inverse, #161616);
+}
+svg.cds--cc--color-legend {
+  display: flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+svg.cds--cc--color-legend g.legend-title text {
+  fill: var(--cds-layer-inverse-absolute, #000);
+}
+.cds--cc--area path.area,
+.cds--cc--area-stacked path.area,
+.cds--cc--bullet path.range-box {
+  pointer-events: none;
+}
+.cds--cc--bubble circle.dot.hovered {
+  fill-opacity: 1;
+  transition: 0.1s cubic-bezier(0.4, 0.14, 0.3, 1);
+}
+.cds--cc--bubble circle.dot.unfilled {
+  fill: var(--cds-layer-01, #f4f4f4);
+}
+.cds--cc--bullet path.range-box.order-1 {
+  fill: var(--cds-zone-fill-01, #f4f4f4);
+  stroke: var(--cds-zone-stroke-01, #8d8d8d);
+}
+.cds--cc--bullet path.range-box.order-2 {
+  fill: var(--cds-zone-fill-02, #e0e0e0);
+  stroke: var(--cds-zone-stroke-02, #8d8d8d);
+}
+.cds--cc--bullet path.range-box.order-3 {
+  fill: var(--cds-zone-fill-03, #c6c6c6);
+  stroke: var(--cds-zone-stroke-03, #8d8d8d);
+}
+.cds--cc--bullet path.marker,
+.cds--cc--bullet path.quartile {
+  stroke-width: 1.5px;
+  stroke: var(--cds-layer-inverse-absolute, #000);
+  pointer-events: none;
+}
+.cds--cc--bullet path.quartile.over-bar {
+  stroke: var(--cds-layer-01-absolute, #fff);
+}
+.cds--cc--line path.line {
+  fill: none;
+  stroke-width: 1.5;
+  pointer-events: none;
+}
+.cds--cc--line path.line.sparkline-loading {
+  animation: shimmer 2.5s linear infinite;
+}
+@keyframes shimmer {
+  0%,
+  to {
+    stroke: var(--cds-layer-accent-01, #e0e0e0);
+  }
+  20% {
+    stroke: #fff;
+    opacity: 0.5;
+  }
+}
+.cds--cc--scatter circle.dot.hovered {
+  fill-opacity: 1;
+  transition: 0.1s cubic-bezier(0.4, 0.14, 0.3, 1);
+}
+.cds--cc--scatter circle.dot.unfilled {
+  fill: var(--cds-layer-01, #f4f4f4);
+  stroke-width: 1.5;
+}
+.cds--cc--gauge .gauge-delta-arrow.status--danger,
+.cds--cc--meter rect.value.status--danger {
+  fill: var(--cds-support-error, #da1e28);
+}
+.cds--cc--scatter circle.dot.threshold-anomaly {
+  stroke-width: 3;
+}
+.cds--cc--meter rect.container {
+  fill: var(--cds-layer-01, #f4f4f4);
+}
+.cds--cc--meter line.rangeIndicator {
+  stroke: var(--cds-meter-range-indicator, #a8a8a8);
+  stroke-width: 1px;
+}
+.cds--cc--meter rect.value.status--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+  stroke-width: 1px;
+  stroke: var(--cds-alert-stroke, #b28600);
+}
+.cds--cc--meter rect.value.status--success {
+  fill: var(--cds-support-success, #24a148);
+}
+.cds--cc--meter line.peak {
+  stroke: var(--cds-border-inverse, #161616);
+  stroke-width: 2px;
+}
+.cds--cc--scatter-stacked circle.dot.unfilled {
+  fill: var(--cds-layer-01, #f4f4f4);
+  stroke-width: 1.5;
+}
+.cds--cc--scatter-stacked circle.dot.threshold-anomaly {
+  stroke-width: 3;
+}
+.cds--cc--radar .blobs path {
+  stroke-width: 1.5px;
+}
+.cds--cc--radar .x-axes line,
+.cds--cc--radar .y-axes path {
+  stroke-width: 1px;
+  stroke: var(--cds-layer-accent-01, #e0e0e0);
+}
+.cds--cc--radar .x-axes line.hovered {
+  stroke: var(--cds-layer-inverse-absolute, #000);
+}
+.cds--cc--chart-wrapper .cds--cc--tree g.links {
+  fill: none;
+  stroke: var(--cds-border-strong-01, #8d8d8d);
+  stroke-opacity: 0.4;
+  stroke-width: 1.5;
+}
+.cds--cc--chart-wrapper .cds--cc--tree circle.parent,
+.cds--cc--chart-wrapper text {
+  fill: var(--cds-text-secondary, #525252);
+}
+.cds--cc--chart-wrapper .cds--cc--tree g.clickable {
+  cursor: pointer;
+}
+.cds--cc--chart-wrapper .cds--cc--tree g.clickable:hover text {
+  font-weight: 600;
+}
+.cds--cc--chart-wrapper .cds--cc--tree g.clickable:hover circle {
+  fill: var(--cds-text-primary, #161616);
+  transition: 0.1s ease-out;
+}
+.cds--cc--chart-wrapper .cds--cc--tree circle.child {
+  fill: var(--cds-border-strong-01, #8d8d8d);
+}
+.cds--cc--chart-wrapper .cds--cc--tree text {
+  fill: var(--cds-text-primary, #161616);
+}
+.cds--cc--chart-wrapper .cds--cc--tree text.text-stroke {
+  stroke: var(--cds-text-inverse, #fff);
+  stroke-width: 2px;
+}
+.cds--cc--treemap text {
+  pointer-events: none;
+}
+.cds--cc--gauge path.arc-background {
+  fill: var(--cds-layer-01, #f4f4f4);
+}
+.cds--cc--gauge .gauge-delta-arrow.status--warning {
+  fill: var(--cds-support-warning, #f1c21b);
+}
+.cds--cc--gauge .gauge-delta-arrow.status--success {
+  fill: var(--cds-support-success, #24a148);
+}
+.cds--cc--lollipop line.line {
+  pointer-events: none;
+}
+.cds--cc--lollipop circle.dot {
+  stroke-width: 1.5;
+}
+.cds--cc--circle-pack circle.node {
+  stroke-width: 1.5px;
+}
+.cds--cc--circle-pack circle.node.hovered {
+  fill-opacity: 1;
+}
+.cds--cc--circle-pack circle.node.non-focal {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+  fill-opacity: 30%;
+  stroke: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--cc--circle-pack circle.node.clickable {
+  cursor: zoom-in;
+}
+.cds--cc--chart-wrapper.zoomed-in
+  .cds--cc--circle-pack
+  circle.node.hovered-child {
+  stroke: 1.5px solid initial;
+}
+.cds--cc--wordcloud text.word.light {
+  font-weight: 300;
+}
+.cds--cc--alluvial rect.node,
+.cds--cc--alluvial rect.node-text-bg {
+  fill: var(--cds-layer-inverse-absolute, #000);
+}
+.cds--cc--alluvial text.node-text {
+  fill: var(--cds-layer-01-absolute, #fff);
+}
+.cds--cc--alluvial polygon.arrow-down {
+  fill: var(--cds-layer-01, #f4f4f4);
+}
+.cds--cc--heatmap g.cell-highlight line {
+  stroke: #fff;
+  stroke-width: 1px;
+}
+.cds--cc--heatmap g.cell-2 line {
+  stroke: #fff;
+  stroke-width: 2px !important;
+}
+.cds--cc--heatmap g.multi-cell line {
+  stroke: #fff;
+  stroke-width: 2px;
+}
+.cds--cc--heatmap rect.pattern-fill {
+  fill: var(--cds-border-strong-01, #8d8d8d);
+}
+.cds--cc--heatmap g.shadows line.top {
+  filter: drop-shadow(0 -3px 2px black);
+}
+.cds--cc--heatmap g.shadows line.down {
+  filter: drop-shadow(0 3px 2px black);
+}
+.cds--cc--heatmap g.shadows line.left {
+  filter: drop-shadow(-3px 0 2px black);
+}
+.cds--cc--heatmap g.shadows line.right {
+  filter: drop-shadow(3px 0 2px black);
+}
+.cds--cc--heatmap rect.heat {
+  stroke-width: 0;
+  stroke: var(--cds-background, #fff);
+}
+.cds--cc--heatmap rect.null-state {
+  fill: var(--cds-icon-inverse, #fff);
+}
+.cds--cc--chart-wrapper {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+}
+.cds--cc--chart-wrapper p {
+  color: var(--cds-text-secondary, #525252);
+  font-size: 12px;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+}
+.cds--resource-card__subtitle,
+.cds--resource-card__title,
+div.container,
+div.container div.v10-banner {
+  color: var(--cds-text-primary, #161616);
+}
+.cds--cc--chart-wrapper text {
+  font-size: 12px;
+  font-weight: 400;
+}
+.cds--cc--chart-wrapper g.gauge-numbers text.gauge-value-number {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-weight: 300;
+}
+.cds--cc--chart-wrapper text.meter-title,
+.cds--cc--chart-wrapper text.percent-value {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    \.SFNSText-Regular,
+    sans-serif;
+  font-size: 16px;
+}
+.cds--cc--chart-wrapper text.meter-title,
+div.container div.v10-banner b {
+  font-weight: 600;
+}
+.cds--chart-holder {
+  --cds-charts-1-1-1: #6929c4;
+  --cds-charts-1-1-1-hovered: #5923a6;
+  --cds-charts-1-2-1: #002d9c;
+  --cds-charts-1-2-1-hovered: #002378;
+  --cds-charts-1-3-1: #1192e8;
+  --cds-charts-1-3-1-hovered: #0f7dc7;
+  --cds-charts-1-4-1: #007d79;
+  --cds-charts-1-4-1-hovered: #005956;
+  --cds-charts-2-1-1: #6929c4;
+  --cds-charts-2-1-1-hovered: #5923a6;
+  --cds-charts-2-1-2: #009d9a;
+  --cds-charts-2-1-2-hovered: #007977;
+  --cds-charts-2-2-2: #520408;
+  --cds-charts-2-2-2-hovered: #300205;
+  --cds-charts-2-3-1: #9f1853;
+  --cds-charts-2-3-1-hovered: #801343;
+  --cds-charts-2-3-2: #520408;
+  --cds-charts-2-3-2-hovered: #300205;
+  --cds-charts-2-4-1: #1192e8;
+  --cds-charts-2-4-1-hovered: #0f7dc7;
+  --cds-charts-2-4-2: #005d5d;
+  --cds-charts-2-4-2-hovered: #003939;
+  --cds-charts-2-5-1: #009d9a;
+  --cds-charts-2-5-1-hovered: #007977;
+  --cds-charts-2-5-2: #002d9c;
+  --cds-charts-2-5-2-hovered: #002378;
+  --cds-charts-3-1-1: #ee5396;
+  --cds-charts-3-1-1-hovered: #eb3382;
+  --cds-charts-3-1-2: #1192e8;
+  --cds-charts-3-1-2-hovered: #0f7dc7;
+  --cds-charts-3-1-3: #6929c4;
+  --cds-charts-3-1-3-hovered: #5923a6;
+  --cds-charts-3-2-1: #9f1853;
+  --cds-charts-3-2-1-hovered: #801343;
+  --cds-charts-3-2-2: #fa4d56;
+  --cds-charts-3-2-2-hovered: #f92a35;
+  --cds-charts-3-2-3: #520408;
+  --cds-charts-3-2-3-hovered: #300205;
+  --cds-charts-3-3-1: #a56eff;
+  --cds-charts-3-3-1-hovered: #8f4aff;
+  --cds-charts-3-3-2: #005d5d;
+  --cds-charts-3-3-2-hovered: #003939;
+  --cds-charts-3-3-3: #002d9c;
+  --cds-charts-3-3-3-hovered: #002378;
+  --cds-charts-3-4-1: #a56eff;
+  --cds-charts-3-4-1-hovered: #8f4aff;
+  --cds-charts-3-4-2: #005d5d;
+  --cds-charts-3-4-2-hovered: #003939;
+  --cds-charts-3-4-3: #9f1853;
+  --cds-charts-3-4-3-hovered: #801343;
+  --cds-charts-3-5-1: #012749;
+  --cds-charts-3-5-1-hovered: #011426;
+  --cds-charts-3-5-2: #6929c4;
+  --cds-charts-3-5-2-hovered: #5923a6;
+  --cds-charts-3-5-3: #009d9a;
+  --cds-charts-3-5-3-hovered: #007977;
+  --cds-charts-4-1-1: #6929c4;
+  --cds-charts-4-1-1-hovered: #5923a6;
+  --cds-charts-4-1-2: #012749;
+  --cds-charts-4-1-2-hovered: #011426;
+  --cds-charts-4-1-3: #009d9a;
+  --cds-charts-4-1-3-hovered: #007977;
+  --cds-charts-4-1-4: #ee5396;
+  --cds-charts-4-1-4-hovered: #eb3382;
+  --cds-charts-4-2-1: #9f1853;
+  --cds-charts-4-2-1-hovered: #801343;
+  --cds-charts-4-2-2: #fa4d56;
+  --cds-charts-4-2-2-hovered: #f92a35;
+  --cds-charts-4-2-3: #520408;
+  --cds-charts-4-2-3-hovered: #300205;
+  --cds-charts-4-2-4: #a56eff;
+  --cds-charts-4-2-4-hovered: #8f4aff;
+  --cds-charts-4-3-1: #009d9a;
+  --cds-charts-4-3-1-hovered: #007977;
+  --cds-charts-4-3-2: #002d9c;
+  --cds-charts-4-3-2-hovered: #002378;
+  --cds-charts-4-3-3: #a56eff;
+  --cds-charts-4-3-3-hovered: #8f4aff;
+  --cds-charts-4-3-4: #9f1853;
+  --cds-charts-4-3-4-hovered: #801343;
+  --cds-charts-5-1-1: #6929c4;
+  --cds-charts-5-1-1-hovered: #5923a6;
+  --cds-charts-5-1-2: #1192e8;
+  --cds-charts-5-1-2-hovered: #0f7dc7;
+  --cds-charts-5-1-3: #005d5d;
+  --cds-charts-5-1-3-hovered: #003939;
+  --cds-charts-5-1-4: #9f1853;
+  --cds-charts-5-1-4-hovered: #801343;
+  --cds-charts-5-1-5: #520408;
+  --cds-charts-5-1-5-hovered: #300205;
+  --cds-charts-5-2-1: #002d9c;
+  --cds-charts-5-2-1-hovered: #002378;
+  --cds-charts-5-2-2: #009d9a;
+  --cds-charts-5-2-2-hovered: #007977;
+  --cds-charts-5-2-3: #9f1853;
+  --cds-charts-5-2-3-hovered: #801343;
+  --cds-charts-5-2-4: #520408;
+  --cds-charts-5-2-4-hovered: #300205;
+  --cds-charts-5-2-5: #a56eff;
+  --cds-charts-5-2-5-hovered: #8f4aff;
+  --cds-charts-14-1-1: #6929c4;
+  --cds-charts-14-1-1-hovered: #5923a6;
+  --cds-charts-14-1-2: #1192e8;
+  --cds-charts-14-1-2-hovered: #0f7dc7;
+  --cds-charts-14-1-3: #005d5d;
+  --cds-charts-14-1-3-hovered: #003939;
+  --cds-charts-14-1-4: #9f1853;
+  --cds-charts-14-1-4-hovered: #801343;
+  --cds-charts-14-1-6: #520408;
+  --cds-charts-14-1-6-hovered: #300205;
+  --cds-charts-14-1-7: #198038;
+  --cds-charts-14-1-7-hovered: #13622b;
+  --cds-charts-14-1-8: #002d9c;
+  --cds-charts-14-1-8-hovered: #002378;
+  --cds-charts-14-1-9: #ee5396;
+  --cds-charts-14-1-9-hovered: #eb3382;
+  --cds-charts-14-1-10: #b28600;
+  --cds-charts-14-1-10-hovered: #8e6b00;
+  --cds-charts-14-1-11: #009d9a;
+  --cds-charts-14-1-11-hovered: #007977;
+  --cds-charts-14-1-12: #012749;
+  --cds-charts-14-1-12-hovered: #011426;
+  --cds-charts-14-1-13: #8a3800;
+  --cds-charts-14-1-13-hovered: #662a00;
+  --cds-charts-14-1-14: #a56eff;
+  --cds-charts-14-1-14-hovered: #8f4aff;
+  display: block;
+  height: 100%;
+  position: relative;
+  width: 100%;
+}
+.cds--chart-holder .DONT_STYLE_ME_css_styles_verifier {
+  opacity: 0;
+  overflow: hidden;
+}
+.cds--chart-holder[data-carbon-theme='g100'],
+.cds--chart-holder[data-carbon-theme='g90'],
+html[data-carbon-theme='g100'],
+html[data-carbon-theme='g90'] {
+  --cds-background-active: hsla(0, 0%, 55%, 0.4);
+  --cds-background-hover: hsla(0, 0%, 55%, 0.16);
+  --cds-background-inverse: #f4f4f4;
+  --cds-background-inverse-hover: #e8e8e8;
+  --cds-background-selected: hsla(0, 0%, 55%, 0.24);
+  --cds-border-disabled: hsla(0, 0%, 55%, 0.5);
+  --cds-border-interactive: #4589ff;
+  --cds-border-inverse: #f4f4f4;
+  --cds-focus: #fff;
+  --cds-focus-inset: #161616;
+  --cds-focus-inverse: #0f62fe;
+  --cds-icon-disabled: hsla(0, 0%, 96%, 0.25);
+  --cds-icon-interactive: #fff;
+  --cds-icon-inverse: #161616;
+  --cds-icon-on-color-disabled: hsla(0, 0%, 100%, 0.25);
+  --cds-icon-primary: #f4f4f4;
+  --cds-icon-secondary: #c6c6c6;
+  --cds-interactive: #4589ff;
+  --cds-layer-selected-disabled: #a8a8a8;
   --cds-layer-selected-inverse: #f4f4f4;
   --cds-link-inverse: #0f62fe;
   --cds-link-inverse-active: #161616;
   --cds-link-inverse-hover: #0043ce;
-  --cds-link-inverse-visited: #8a3ffc;
   --cds-link-primary: #78a9ff;
   --cds-link-primary-hover: #a6c8ff;
   --cds-link-secondary: #a6c8ff;
   --cds-link-visited: #be95ff;
   --cds-overlay: rgba(0, 0, 0, 0.65);
   --cds-shadow: rgba(0, 0, 0, 0.8);
-  --cds-skeleton-background: #333333;
-  --cds-skeleton-element: #525252;
-  --cds-support-caution-major: #ff832b;
-  --cds-support-caution-minor: #f1c21b;
   --cds-support-caution-undefined: #a56eff;
-  --cds-support-error: #ff8389;
   --cds-support-error-inverse: #da1e28;
   --cds-support-info: #4589ff;
   --cds-support-info-inverse: #0043ce;
   --cds-support-success: #42be65;
   --cds-support-success-inverse: #24a148;
-  --cds-support-warning: #f1c21b;
-  --cds-support-warning-inverse: #f1c21b;
-  --cds-text-disabled: rgba(244, 244, 244, 0.25);
-  --cds-text-error: #ffb3b8;
-  --cds-text-helper: #c6c6c6;
+  --cds-text-disabled: hsla(0, 0%, 96%, 0.25);
   --cds-text-inverse: #161616;
-  --cds-text-on-color: #ffffff;
-  --cds-text-on-color-disabled: rgba(255, 255, 255, 0.25);
-  --cds-text-placeholder: rgba(244, 244, 244, 0.4);
+  --cds-text-on-color-disabled: hsla(0, 0%, 100%, 0.25);
+  --cds-text-placeholder: hsla(0, 0%, 96%, 0.4);
   --cds-text-primary: #f4f4f4;
   --cds-text-secondary: #c6c6c6;
+  --cds-button-separator: #161616;
+  --cds-button-secondary: #6f6f6f;
+  --cds-button-tertiary: #fff;
+  --cds-button-secondary-active: #393939;
+  --cds-button-tertiary-active: #c6c6c6;
+  --cds-button-secondary-hover: #5e5e5e;
+  --cds-button-tertiary-hover: #f4f4f4;
+  --cds-button-disabled: hsla(0, 0%, 55%, 0.3);
+  --cds-tag-background-red: #a2191f;
+  --cds-tag-color-red: #ffd7d9;
+  --cds-tag-hover-red: #c21e25;
+  --cds-tag-background-magenta: #9f1853;
+  --cds-tag-color-magenta: #ffd6e8;
+  --cds-tag-hover-magenta: #bf1d63;
+  --cds-tag-background-purple: #6929c4;
+  --cds-tag-color-purple: #e8daff;
+  --cds-tag-hover-purple: #7c3dd6;
+  --cds-tag-background-blue: #0043ce;
+  --cds-tag-color-blue: #d0e2ff;
+  --cds-tag-hover-blue: #0053ff;
+  --cds-tag-background-cyan: #00539a;
+  --cds-tag-color-cyan: #bae6ff;
+  --cds-tag-hover-cyan: #0066bd;
+  --cds-tag-background-teal: #005d5d;
+  --cds-tag-color-teal: #9ef0f0;
+  --cds-tag-hover-teal: #007070;
+  --cds-tag-background-green: #0e6027;
+  --cds-tag-color-green: #a7f0ba;
+  --cds-tag-hover-green: #11742f;
+  --cds-tag-background-gray: #525252;
+  --cds-tag-color-gray: #e0e0e0;
+  --cds-tag-hover-gray: #636363;
+  --cds-tag-background-cool-gray: #4d5358;
+  --cds-tag-color-cool-gray: #dde1e6;
+  --cds-tag-hover-cool-gray: #5d646a;
+  --cds-tag-background-warm-gray: #565151;
+  --cds-tag-color-warm-gray: #e5e0df;
+  --cds-tag-hover-warm-gray: #696363;
+  --cds-notification-action-hover: var(--cds-layer-hover);
+  --cds-notification-action-tertiary-inverse: #0f62fe;
+  --cds-notification-action-tertiary-inverse-active: #002d9c;
+  --cds-notification-action-tertiary-inverse-hover: #0050e6;
+  --cds-notification-action-tertiary-inverse-text: #fff;
+  --cds-notification-action-tertiary-inverse-text-on-color-disabled: #8d8d8d;
+  --cds-color-scheme: dark;
+  --cds-alert-stroke: none;
+  --cds-layer-01-absolute: #000;
+  --cds-layer-inverse-absolute: #fff;
+  --cds-grid-bg: #161616;
+  --cds-meter-range-indicator: #6f6f6f;
+  --cds-network-diagrams-background-hover: #ededed;
+  --cds-zone-fill-01: #262626;
+  --cds-zone-stroke-01: #6f6f6f;
+  --cds-zone-fill-02: #393939;
+  --cds-zone-stroke-02: #6f6f6f;
+  --cds-zone-fill-03: #525252;
+  --cds-zone-stroke-03: #6f6f6f;
+}
+.cds--chart-holder[data-carbon-theme='g90'],
+html[data-carbon-theme='g90'] {
+  --cds-background: #262626;
+  --cds-background-brand: #0f62fe;
+  --cds-background-selected-hover: hsla(0, 0%, 55%, 0.32);
+  --cds-border-strong-01: #8d8d8d;
+  --cds-border-strong-02: #a8a8a8;
+  --cds-border-strong-03: #c6c6c6;
+  --cds-border-subtle-00: #525252;
+  --cds-border-subtle-01: #525252;
+  --cds-border-subtle-02: #6f6f6f;
+  --cds-border-subtle-03: #8d8d8d;
+  --cds-border-subtle-selected-01: #6f6f6f;
+  --cds-border-subtle-selected-02: #8d8d8d;
+  --cds-border-subtle-selected-03: #a8a8a8;
+  --cds-border-tile-01: #6f6f6f;
+  --cds-border-tile-02: #8d8d8d;
+  --cds-border-tile-03: #a8a8a8;
+  --cds-field-01: #393939;
+  --cds-field-02: #525252;
+  --cds-field-03: #6f6f6f;
+  --cds-field-hover-01: #474747;
+  --cds-field-hover-02: #636363;
+  --cds-field-hover-03: #5e5e5e;
+  --cds-highlight: #0043ce;
+  --cds-icon-on-color: #fff;
+  --cds-layer-01: #393939;
+  --cds-layer-02: #525252;
+  --cds-layer-03: #6f6f6f;
+  --cds-layer-accent-01: #525252;
+  --cds-layer-accent-02: #6f6f6f;
+  --cds-layer-accent-03: #8d8d8d;
+  --cds-layer-accent-active-01: #8d8d8d;
+  --cds-layer-accent-active-02: #393939;
+  --cds-layer-accent-active-03: #525252;
+  --cds-layer-accent-hover-01: #636363;
+  --cds-layer-accent-hover-02: #5e5e5e;
+  --cds-layer-accent-hover-03: #7a7a7a;
+  --cds-layer-active-01: #6f6f6f;
+  --cds-layer-active-02: #8d8d8d;
+  --cds-layer-active-03: #393939;
+  --cds-layer-hover-01: #474747;
+  --cds-layer-hover-02: #636363;
+  --cds-layer-hover-03: #5e5e5e;
+  --cds-layer-selected-01: #525252;
+  --cds-layer-selected-02: #6f6f6f;
+  --cds-layer-selected-03: #525252;
+  --cds-layer-selected-hover-01: #636363;
+  --cds-layer-selected-hover-02: #5e5e5e;
+  --cds-layer-selected-hover-03: #636363;
+  --cds-skeleton-background: #333;
+  --cds-skeleton-element: #525252;
+  --cds-support-caution-major: #ff832b;
+  --cds-support-caution-minor: #f1c21b;
+  --cds-support-error: #ff8389;
+  --cds-support-warning: #f1c21b;
+  --cds-support-warning-inverse: #f1c21b;
+  --cds-text-error: #ffb3b8;
+  --cds-text-helper: #c6c6c6;
+  --cds-text-on-color: #fff;
   --cds-toggle-off: #8d8d8d;
   --cds-spacing-01: 0.125rem;
   --cds-spacing-02: 0.25rem;
@@ -6570,14 +23901,6 @@ div.cds--cc--legend.clickable
   --cds-fluid-spacing-02: 2vw;
   --cds-fluid-spacing-03: 5vw;
   --cds-fluid-spacing-04: 10vw;
-  --cds-caption-01-font-size: 0.75rem;
-  --cds-caption-01-font-weight: 400;
-  --cds-caption-01-line-height: 1.33333;
-  --cds-caption-01-letter-spacing: 0.32px;
-  --cds-caption-02-font-size: 0.875rem;
-  --cds-caption-02-font-weight: 400;
-  --cds-caption-02-line-height: 1.28572;
-  --cds-caption-02-letter-spacing: 0.32px;
   --cds-label-01-font-size: 0.75rem;
   --cds-label-01-font-weight: 400;
   --cds-label-01-line-height: 1.33333;
@@ -6589,8 +23912,8 @@ div.cds--cc--legend.clickable
   --cds-helper-text-01-font-size: 0.75rem;
   --cds-helper-text-01-line-height: 1.33333;
   --cds-helper-text-01-letter-spacing: 0.32px;
-  --cds-helper-text-02-font-size: 0.875rem;
-  --cds-helper-text-02-font-weight: 400;
+  --cds-helper-text-02-font-size: carbon--type-scale(2);
+  --cds-helper-text-02-font-weight: carbon--font-weight('regular');
   --cds-helper-text-02-line-height: 1.28572;
   --cds-helper-text-02-letter-spacing: 0.16px;
   --cds-body-short-01-font-size: 0.875rem;
@@ -6610,15 +23933,13 @@ div.cds--cc--legend.clickable
   --cds-body-long-02-line-height: 1.5;
   --cds-body-long-02-letter-spacing: 0;
   --cds-code-01-font-family:
-    'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', monospace;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', monospace;
   --cds-code-01-font-size: 0.75rem;
   --cds-code-01-font-weight: 400;
   --cds-code-01-line-height: 1.33333;
   --cds-code-01-letter-spacing: 0.32px;
   --cds-code-02-font-family:
-    'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', monospace;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', monospace;
   --cds-code-02-font-size: 0.875rem;
   --cds-code-02-font-weight: 400;
   --cds-code-02-line-height: 1.42857;
@@ -6688,15 +24009,13 @@ div.cds--cc--legend.clickable
   --cds-expressive-heading-06-line-height: 1.25;
   --cds-expressive-heading-06-letter-spacing: 0;
   --cds-quotation-01-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
   --cds-quotation-01-font-size: 1.25rem;
   --cds-quotation-01-font-weight: 400;
   --cds-quotation-01-line-height: 1.3;
   --cds-quotation-01-letter-spacing: 0;
   --cds-quotation-02-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
   --cds-quotation-02-font-size: 2rem;
   --cds-quotation-02-font-weight: 300;
   --cds-quotation-02-line-height: 1.25;
@@ -6790,15 +24109,13 @@ div.cds--cc--legend.clickable
   --cds-fluid-paragraph-01-line-height: 1.334;
   --cds-fluid-paragraph-01-letter-spacing: 0;
   --cds-fluid-quotation-01-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
   --cds-fluid-quotation-01-font-size: 1.25rem;
   --cds-fluid-quotation-01-font-weight: 400;
   --cds-fluid-quotation-01-line-height: 1.3;
   --cds-fluid-quotation-01-letter-spacing: 0;
   --cds-fluid-quotation-02-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
   --cds-fluid-quotation-02-font-size: 2rem;
   --cds-fluid-quotation-02-font-weight: 300;
   --cds-fluid-quotation-02-line-height: 1.25;
@@ -6819,21 +24136,19 @@ div.cds--cc--legend.clickable
   --cds-fluid-display-04-font-weight: 300;
   --cds-fluid-display-04-line-height: 1.19;
   --cds-fluid-display-04-letter-spacing: 0;
-  --cds-color-scheme: dark;
-  --cds-alert-stroke: none;
-  --cds-layer-01-absolute: #000000;
-  --cds-layer-inverse-absolute: #ffffff;
+  --cds-button-primary: #0f62fe;
+  --cds-button-danger-primary: #da1e28;
+  --cds-button-danger-secondary: #ff8389;
+  --cds-button-danger-active: #750e13;
+  --cds-button-primary-active: #002d9c;
+  --cds-button-danger-hover: #b81921;
+  --cds-button-primary-hover: #0050e6;
+  --cds-notification-background-error: #393939;
+  --cds-notification-background-success: #393939;
+  --cds-notification-background-info: #393939;
+  --cds-notification-background-warning: #393939;
   --cds-null-state: #161616;
-  --cds-grid-bg: #161616;
-  --cds-meter-range-indicator: #6f6f6f;
-  --cds-network-diagrams-background-hover: #ededed;
   --cds-tooltip-line-border: #393939;
-  --cds-zone-fill-01: #262626;
-  --cds-zone-stroke-01: #6f6f6f;
-  --cds-zone-fill-02: #393939;
-  --cds-zone-stroke-02: #6f6f6f;
-  --cds-zone-fill-03: #525252;
-  --cds-zone-stroke-03: #6f6f6f;
   --cds-layer: var(--cds-layer-01, #f4f4f4);
   --cds-layer-active: var(--cds-layer-active-01, #c6c6c6);
   --cds-layer-hover: var(--cds-layer-hover-01, #e8e8e8);
@@ -6849,147 +24164,18 @@ div.cds--cc--legend.clickable
   --cds-border-strong: var(--cds-border-strong-01, #8d8d8d);
   --cds-border-tile: var(--cds-border-tile-01, #c6c6c6);
 }
-
-.cds--chart-holder[data-carbon-theme='g100'] {
-  --cds-ai-aura-end: rgba(0, 0, 0, 0);
-  --cds-ai-aura-hover-background: #333333;
-  --cds-ai-aura-hover-end: rgba(0, 0, 0, 0);
-  --cds-ai-aura-hover-start: rgba(69, 137, 255, 0.4);
-  --cds-ai-aura-start: rgba(69, 137, 255, 0.1);
-  --cds-ai-aura-start-sm: rgba(69, 137, 255, 0.16);
-  --cds-ai-border-end: #4589ff;
-  --cds-ai-border-start: rgba(166, 200, 255, 0.36);
-  --cds-ai-border-strong: #78a9ff;
-  --cds-ai-drop-shadow: rgba(0, 0, 0, 0.28);
-  --cds-ai-inner-shadow: rgba(69, 137, 255, 0.16);
-  --cds-ai-overlay: rgba(0, 0, 0, 0.5);
-  --cds-ai-popover-background: #161616;
-  --cds-ai-popover-caret-bottom: #4589ff;
-  --cds-ai-popover-caret-bottom-background: #202d45;
-  --cds-ai-popover-caret-bottom-background-actions: #1e283a;
-  --cds-ai-popover-caret-center: #4870b5;
-  --cds-ai-popover-shadow-outer-01: rgba(0, 0, 0, 0.12);
-  --cds-ai-popover-shadow-outer-02: rgba(0, 0, 0, 0.08);
-  --cds-ai-skeleton-background: rgba(120, 169, 255, 0.5);
-  --cds-ai-skeleton-element-background: rgba(120, 169, 255, 0.3);
-  --cds-background: #161616;
-  --cds-background-active: rgba(141, 141, 141, 0.4);
+.cds--chart-holder[data-carbon-theme='g100'],
+html,
+html[data-carbon-theme='g100'] {
   --cds-background-brand: #0f62fe;
-  --cds-background-hover: rgba(141, 141, 141, 0.16);
-  --cds-background-inverse: #f4f4f4;
-  --cds-background-inverse-hover: #e8e8e8;
-  --cds-background-selected: rgba(141, 141, 141, 0.24);
-  --cds-background-selected-hover: rgba(141, 141, 141, 0.32);
-  --cds-border-disabled: rgba(141, 141, 141, 0.5);
-  --cds-border-interactive: #4589ff;
-  --cds-border-inverse: #f4f4f4;
-  --cds-border-strong-01: #6f6f6f;
+  --cds-background-selected-hover: hsla(0, 0%, 55%, 0.32);
   --cds-border-strong-02: #8d8d8d;
-  --cds-border-strong-03: #a8a8a8;
-  --cds-border-subtle-00: #393939;
-  --cds-border-subtle-01: #525252;
-  --cds-border-subtle-02: #6f6f6f;
-  --cds-border-subtle-03: #6f6f6f;
-  --cds-border-subtle-selected-01: #6f6f6f;
-  --cds-border-subtle-selected-02: #8d8d8d;
-  --cds-border-subtle-selected-03: #8d8d8d;
-  --cds-border-tile-01: #525252;
-  --cds-border-tile-02: #6f6f6f;
-  --cds-border-tile-03: #8d8d8d;
-  --cds-chat-avatar-agent: #c6c6c6;
-  --cds-chat-avatar-bot: #8d8d8d;
-  --cds-chat-avatar-user: #4589ff;
-  --cds-chat-bubble-agent: #262626;
-  --cds-chat-bubble-border: #525252;
-  --cds-chat-bubble-user: #393939;
-  --cds-chat-button: #78a9ff;
-  --cds-chat-button-active: rgba(141, 141, 141, 0.4);
-  --cds-chat-button-hover: rgba(141, 141, 141, 0.16);
-  --cds-chat-button-selected: rgba(141, 141, 141, 0.24);
-  --cds-chat-button-text-hover: #a6c8ff;
-  --cds-chat-button-text-selected: #c6c6c6;
-  --cds-chat-header-background: #262626;
-  --cds-chat-prompt-background: #161616;
-  --cds-chat-prompt-border-end: rgba(38, 38, 38, 0);
-  --cds-chat-prompt-border-start: #262626;
-  --cds-chat-shell-background: #262626;
-  --cds-field-01: #262626;
-  --cds-field-02: #393939;
-  --cds-field-03: #525252;
-  --cds-field-hover-01: #333333;
-  --cds-field-hover-02: #474747;
-  --cds-field-hover-03: #636363;
-  --cds-focus: #ffffff;
-  --cds-focus-inset: #161616;
-  --cds-focus-inverse: #0f62fe;
-  --cds-highlight: #001d6c;
-  --cds-icon-disabled: rgba(244, 244, 244, 0.25);
-  --cds-icon-interactive: #ffffff;
-  --cds-icon-inverse: #161616;
-  --cds-icon-on-color: #ffffff;
-  --cds-icon-on-color-disabled: rgba(255, 255, 255, 0.25);
-  --cds-icon-primary: #f4f4f4;
-  --cds-icon-secondary: #c6c6c6;
-  --cds-interactive: #4589ff;
-  --cds-layer-01: #262626;
-  --cds-layer-02: #393939;
-  --cds-layer-03: #525252;
-  --cds-layer-accent-01: #393939;
-  --cds-layer-accent-02: #525252;
-  --cds-layer-accent-03: #6f6f6f;
-  --cds-layer-accent-active-01: #6f6f6f;
-  --cds-layer-accent-active-02: #8d8d8d;
-  --cds-layer-accent-active-03: #393939;
-  --cds-layer-accent-hover-01: #474747;
-  --cds-layer-accent-hover-02: #636363;
-  --cds-layer-accent-hover-03: #5e5e5e;
-  --cds-layer-active-01: #525252;
-  --cds-layer-active-02: #6f6f6f;
-  --cds-layer-active-03: #8d8d8d;
-  --cds-layer-hover-01: #333333;
-  --cds-layer-hover-02: #474747;
-  --cds-layer-hover-03: #636363;
-  --cds-layer-selected-01: #393939;
-  --cds-layer-selected-02: #525252;
-  --cds-layer-selected-03: #6f6f6f;
-  --cds-layer-selected-disabled: #a8a8a8;
-  --cds-layer-selected-hover-01: #474747;
-  --cds-layer-selected-hover-02: #636363;
-  --cds-layer-selected-hover-03: #5e5e5e;
-  --cds-layer-selected-inverse: #f4f4f4;
-  --cds-link-inverse: #0f62fe;
-  --cds-link-inverse-active: #161616;
-  --cds-link-inverse-hover: #0043ce;
-  --cds-link-inverse-visited: #8a3ffc;
-  --cds-link-primary: #78a9ff;
-  --cds-link-primary-hover: #a6c8ff;
-  --cds-link-secondary: #a6c8ff;
-  --cds-link-visited: #be95ff;
-  --cds-overlay: rgba(0, 0, 0, 0.65);
-  --cds-shadow: rgba(0, 0, 0, 0.8);
-  --cds-skeleton-background: #292929;
-  --cds-skeleton-element: #393939;
+  --cds-icon-on-color: #fff;
   --cds-support-caution-major: #ff832b;
   --cds-support-caution-minor: #f1c21b;
-  --cds-support-caution-undefined: #a56eff;
-  --cds-support-error: #fa4d56;
-  --cds-support-error-inverse: #da1e28;
-  --cds-support-info: #4589ff;
-  --cds-support-info-inverse: #0043ce;
-  --cds-support-success: #42be65;
-  --cds-support-success-inverse: #24a148;
   --cds-support-warning: #f1c21b;
   --cds-support-warning-inverse: #f1c21b;
-  --cds-text-disabled: rgba(244, 244, 244, 0.25);
-  --cds-text-error: #ff8389;
-  --cds-text-helper: #a8a8a8;
-  --cds-text-inverse: #161616;
-  --cds-text-on-color: #ffffff;
-  --cds-text-on-color-disabled: rgba(255, 255, 255, 0.25);
-  --cds-text-placeholder: rgba(244, 244, 244, 0.4);
-  --cds-text-primary: #f4f4f4;
-  --cds-text-secondary: #c6c6c6;
-  --cds-toggle-off: #6f6f6f;
+  --cds-text-on-color: #fff;
   --cds-spacing-01: 0.125rem;
   --cds-spacing-02: 0.25rem;
   --cds-spacing-03: 0.5rem;
@@ -7007,14 +24193,6 @@ div.cds--cc--legend.clickable
   --cds-fluid-spacing-02: 2vw;
   --cds-fluid-spacing-03: 5vw;
   --cds-fluid-spacing-04: 10vw;
-  --cds-caption-01-font-size: 0.75rem;
-  --cds-caption-01-font-weight: 400;
-  --cds-caption-01-line-height: 1.33333;
-  --cds-caption-01-letter-spacing: 0.32px;
-  --cds-caption-02-font-size: 0.875rem;
-  --cds-caption-02-font-weight: 400;
-  --cds-caption-02-line-height: 1.28572;
-  --cds-caption-02-letter-spacing: 0.32px;
   --cds-label-01-font-size: 0.75rem;
   --cds-label-01-font-weight: 400;
   --cds-label-01-line-height: 1.33333;
@@ -7026,8 +24204,8 @@ div.cds--cc--legend.clickable
   --cds-helper-text-01-font-size: 0.75rem;
   --cds-helper-text-01-line-height: 1.33333;
   --cds-helper-text-01-letter-spacing: 0.32px;
-  --cds-helper-text-02-font-size: 0.875rem;
-  --cds-helper-text-02-font-weight: 400;
+  --cds-helper-text-02-font-size: carbon--type-scale(2);
+  --cds-helper-text-02-font-weight: carbon--font-weight('regular');
   --cds-helper-text-02-line-height: 1.28572;
   --cds-helper-text-02-letter-spacing: 0.16px;
   --cds-body-short-01-font-size: 0.875rem;
@@ -7047,15 +24225,13 @@ div.cds--cc--legend.clickable
   --cds-body-long-02-line-height: 1.5;
   --cds-body-long-02-letter-spacing: 0;
   --cds-code-01-font-family:
-    'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', monospace;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', monospace;
   --cds-code-01-font-size: 0.75rem;
   --cds-code-01-font-weight: 400;
   --cds-code-01-line-height: 1.33333;
   --cds-code-01-letter-spacing: 0.32px;
   --cds-code-02-font-family:
-    'IBM Plex Mono', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', monospace;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', monospace;
   --cds-code-02-font-size: 0.875rem;
   --cds-code-02-font-weight: 400;
   --cds-code-02-line-height: 1.42857;
@@ -7125,15 +24301,13 @@ div.cds--cc--legend.clickable
   --cds-expressive-heading-06-line-height: 1.25;
   --cds-expressive-heading-06-letter-spacing: 0;
   --cds-quotation-01-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
   --cds-quotation-01-font-size: 1.25rem;
   --cds-quotation-01-font-weight: 400;
   --cds-quotation-01-line-height: 1.3;
   --cds-quotation-01-letter-spacing: 0;
   --cds-quotation-02-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
   --cds-quotation-02-font-size: 2rem;
   --cds-quotation-02-font-weight: 300;
   --cds-quotation-02-line-height: 1.25;
@@ -7227,15 +24401,13 @@ div.cds--cc--legend.clickable
   --cds-fluid-paragraph-01-line-height: 1.334;
   --cds-fluid-paragraph-01-letter-spacing: 0;
   --cds-fluid-quotation-01-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
   --cds-fluid-quotation-01-font-size: 1.25rem;
   --cds-fluid-quotation-01-font-weight: 400;
   --cds-fluid-quotation-01-line-height: 1.3;
   --cds-fluid-quotation-01-letter-spacing: 0;
   --cds-fluid-quotation-02-font-family:
-    'IBM Plex Serif', system-ui, -apple-system, BlinkMacSystemFont,
-    '.SFNSText-Regular', serif;
+    system-ui, -apple-system, BlinkMacSystemFont, '.SFNSText-Regular', serif;
   --cds-fluid-quotation-02-font-size: 2rem;
   --cds-fluid-quotation-02-font-weight: 300;
   --cds-fluid-quotation-02-line-height: 1.25;
@@ -7256,21 +24428,13 @@ div.cds--cc--legend.clickable
   --cds-fluid-display-04-font-weight: 300;
   --cds-fluid-display-04-line-height: 1.19;
   --cds-fluid-display-04-letter-spacing: 0;
-  --cds-color-scheme: dark;
-  --cds-alert-stroke: none;
-  --cds-layer-01-absolute: #000000;
-  --cds-layer-inverse-absolute: #ffffff;
+  --cds-button-primary: #0f62fe;
+  --cds-button-danger-primary: #da1e28;
+  --cds-button-danger-active: #750e13;
+  --cds-button-primary-active: #002d9c;
+  --cds-button-danger-hover: #b81921;
+  --cds-button-primary-hover: #0050e6;
   --cds-null-state: none;
-  --cds-grid-bg: #161616;
-  --cds-meter-range-indicator: #6f6f6f;
-  --cds-network-diagrams-background-hover: #ededed;
-  --cds-tooltip-line-border: #6f6f6f;
-  --cds-zone-fill-01: #262626;
-  --cds-zone-stroke-01: #6f6f6f;
-  --cds-zone-fill-02: #393939;
-  --cds-zone-stroke-02: #6f6f6f;
-  --cds-zone-fill-03: #525252;
-  --cds-zone-stroke-03: #6f6f6f;
   --cds-layer: var(--cds-layer-01, #f4f4f4);
   --cds-layer-active: var(--cds-layer-active-01, #c6c6c6);
   --cds-layer-hover: var(--cds-layer-hover-01, #e8e8e8);
@@ -7286,18 +24450,482 @@ div.cds--cc--legend.clickable
   --cds-border-strong: var(--cds-border-strong-01, #8d8d8d);
   --cds-border-tile: var(--cds-border-tile-01, #c6c6c6);
 }
-
-.cds--chart-holder.fullscreen {
-  width: 100% !important;
+.cds--chart-holder[data-carbon-theme='g100'],
+html[data-carbon-theme='g100'] {
+  --cds-background: #161616;
+  --cds-border-strong-01: #6f6f6f;
+  --cds-border-strong-03: #a8a8a8;
+  --cds-border-subtle-00: #393939;
+  --cds-border-subtle-01: #393939;
+  --cds-border-subtle-02: #525252;
+  --cds-border-subtle-03: #6f6f6f;
+  --cds-border-subtle-selected-01: #525252;
+  --cds-border-subtle-selected-02: #6f6f6f;
+  --cds-border-subtle-selected-03: #8d8d8d;
+  --cds-border-tile-01: #525252;
+  --cds-border-tile-02: #6f6f6f;
+  --cds-border-tile-03: #8d8d8d;
+  --cds-field-01: #262626;
+  --cds-field-02: #393939;
+  --cds-field-03: #525252;
+  --cds-field-hover-01: #333;
+  --cds-field-hover-02: #474747;
+  --cds-field-hover-03: #636363;
+  --cds-highlight: #002d9c;
+  --cds-layer-01: #262626;
+  --cds-layer-02: #393939;
+  --cds-layer-03: #525252;
+  --cds-layer-accent-01: #393939;
+  --cds-layer-accent-02: #525252;
+  --cds-layer-accent-03: #6f6f6f;
+  --cds-layer-accent-active-01: #6f6f6f;
+  --cds-layer-accent-active-02: #8d8d8d;
+  --cds-layer-accent-active-03: #393939;
+  --cds-layer-accent-hover-01: #474747;
+  --cds-layer-accent-hover-02: #636363;
+  --cds-layer-accent-hover-03: #5e5e5e;
+  --cds-layer-active-01: #525252;
+  --cds-layer-active-02: #6f6f6f;
+  --cds-layer-active-03: #8d8d8d;
+  --cds-layer-hover-01: #333;
+  --cds-layer-hover-02: #474747;
+  --cds-layer-hover-03: #636363;
+  --cds-layer-selected-01: #393939;
+  --cds-layer-selected-02: #525252;
+  --cds-layer-selected-03: #6f6f6f;
+  --cds-layer-selected-hover-01: #474747;
+  --cds-layer-selected-hover-02: #636363;
+  --cds-layer-selected-hover-03: #5e5e5e;
+  --cds-skeleton-background: #292929;
+  --cds-skeleton-element: #393939;
+  --cds-support-error: #fa4d56;
+  --cds-text-error: #ff8389;
+  --cds-text-helper: #a8a8a8;
+  --cds-toggle-off: #6f6f6f;
+  --cds-button-danger-secondary: #fa4d56;
+  --cds-notification-background-error: #262626;
+  --cds-notification-background-success: #262626;
+  --cds-notification-background-info: #262626;
+  --cds-notification-background-warning: #262626;
+  --cds-tooltip-line-border: #6f6f6f;
+}
+.cds--chart-holder.fullscreen,
+.cds--chart-holder:-webkit-full-screen {
   height: 100% !important;
-  max-width: unset !important;
   max-height: unset !important;
+  max-width: unset !important;
   padding: 2em;
+  width: 100% !important;
 }
-
-.cds--cc--chart-wrapper {
-  overflow: visible;
-  font-family: var(--cds-charts-font-family-condensed);
+div.container {
+  font-family: Arial, sans-serif;
+  padding: 30px;
 }
-
-/*# sourceMappingURL=styles.css.map */
+div.container div.v10-banner {
+  background-color: var(--cds-field, #f4f4f4);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: -30px -30px 30px;
+  padding: 1rem 30px;
+}
+div.container div#color-palette-picker {
+  margin-top: 2rem;
+  max-width: 18rem;
+}
+div.container #chart-demo {
+  max-width: 700px;
+}
+div.container .cds--grid,
+div.container.intro {
+  padding: 0;
+}
+div.container .cds--grid .cds--row .chart-demo {
+  margin-bottom: 60px;
+}
+div.container h3 {
+  font-weight: 700;
+  margin: 0;
+}
+div.container h3 b.component {
+  margin-right: 10px;
+}
+div.container h3 span.cds--tag.component-name {
+  border-radius: 1em;
+  font-size: 0.55em;
+  font-weight: 600;
+  padding: 0.25em 1em;
+  vertical-align: middle;
+}
+div.container .marginTop-15,
+div.container div.theme-picker {
+  margin-top: 15px;
+}
+div.container p.props b,
+div.container.tutorial .hljs-strong {
+  font-weight: 700;
+}
+div.container div.cds--snippet--multi {
+  background-color: #000;
+  color: #fff;
+}
+div.container div.cds--snippet--multi pre {
+  line-height: 1.4;
+  padding: 2em !important;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+}
+div.container div.cds--snippet--multi .token.tag {
+  color: #6ea6ff;
+}
+div.container div.cds--snippet--multi .token.attr-name {
+  color: #92eeee;
+}
+div.container div.cds--snippet--multi .token.attr-value {
+  color: #bb8eff;
+}
+div.container .cds--snippet--multi .cds--snippet-container pre code {
+  font-size: 14px;
+}
+div.container .cds--snippet--multi.cds--snippet--expand .cds--snippet-container,
+div.container
+  .cds--snippet--multi.cds--snippet--expand
+  .cds--snippet-container
+  pre {
+  padding-bottom: 0;
+}
+div.container.intro .container-welcome {
+  padding: 0 !important;
+}
+div.container.intro .welcome__container {
+  background-color: #000;
+  min-height: 100vh;
+  padding: 3rem 3rem 5rem;
+  width: 100vw;
+}
+@media screen and (max-width: 768px) {
+  div.container div.demo-desktop-only {
+    overflow: hidden;
+    position: relative;
+  }
+  div.container div.demo-desktop-only:before {
+    background: #f4f4f4;
+    content: ' ';
+    display: block;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 2;
+  }
+  div.container div.demo-desktop-only div.cp-message {
+    display: block;
+    font-weight: 700;
+    left: 50%;
+    position: absolute;
+    text-align: center;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 2;
+  }
+  div.container.intro .welcome__container:before {
+    background: rgba(0, 0, 0, 0.45);
+    content: ' ';
+    display: block;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 1;
+  }
+}
+div.container.intro .welcome__content {
+  position: relative;
+  z-index: 2;
+}
+div.container.intro .welcome__heading {
+  color: var(--cds-text-inverse, #fff);
+  font-size: var(--cds-productive-heading-07-font-size, 3.375rem);
+  font-weight: var(--cds-productive-heading-07-font-weight, 300);
+  letter-spacing: var(--cds-productive-heading-07-letter-spacing, 0);
+  line-height: var(--cds-productive-heading-07-line-height, 1.19);
+}
+div.container.intro .welcome__heading--subtitle {
+  font-weight: 600;
+}
+div.container.intro .welcome__heading--other {
+  color: #4587fd;
+  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-productive-heading-04-font-weight, 400);
+  font-weight: 600;
+  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+  line-height: var(--cds-productive-heading-04-line-height, 1.28572);
+}
+div.container.intro h5 {
+  margin-top: 2em;
+}
+div.container.intro span.netlify {
+  background-color: #292929;
+  border-top-right-radius: 2em;
+  bottom: 0;
+  color: #bcbcbc;
+  font-size: 13px;
+  left: 0;
+  padding: 1em 1.5em 1em 3rem;
+  position: fixed;
+  vertical-align: middle;
+}
+div.container.intro span.netlify a {
+  color: #fff;
+  font-weight: 700;
+}
+div.container.tutorial .hljs {
+  background: #000;
+  color: #f8f8f8;
+}
+div.container.tutorial .hljs-comment,
+div.container.tutorial .hljs-quote {
+  color: #aeaeae;
+  font-style: italic;
+}
+div.container.tutorial .hljs-keyword,
+div.container.tutorial .hljs-selector-tag,
+div.container.tutorial .hljs-type {
+  color: #e28964;
+}
+div.container.tutorial .hljs-string {
+  color: #65b042;
+}
+div.container.tutorial .hljs-subst {
+  color: #daefa3;
+}
+div.container.tutorial .hljs-link,
+div.container.tutorial .hljs-regexp {
+  color: #e9c062;
+}
+div.container.tutorial .hljs-name,
+div.container.tutorial .hljs-section,
+div.container.tutorial .hljs-tag,
+div.container.tutorial .hljs-title {
+  color: #89bdff;
+}
+div.container.tutorial .hljs-bullet,
+div.container.tutorial .hljs-number,
+div.container.tutorial .hljs-symbol {
+  color: #3387cc;
+}
+div.container.tutorial .hljs-params,
+div.container.tutorial .hljs-template-variable,
+div.container.tutorial .hljs-variable {
+  color: #3e87e3;
+}
+div.container.tutorial .hljs-attribute {
+  color: #cda869;
+}
+div.container.tutorial .hljs-meta {
+  color: #8996a8;
+}
+div.container.tutorial .hljs-formula {
+  background-color: #0e2231;
+  color: #f8f8f8;
+  font-style: italic;
+}
+div.container.tutorial .hljs-addition {
+  background-color: #253b22;
+  color: #f8f8f8;
+}
+div.container.tutorial .hljs-deletion {
+  background-color: #420e09;
+  color: #f8f8f8;
+}
+div.container.tutorial .hljs-selector-class {
+  color: #9b703f;
+}
+div.container.tutorial .hljs-selector-id {
+  color: #8b98ab;
+}
+div.container.tutorial h1,
+div.container.tutorial h2,
+div.container.tutorial h5,
+div.container.tutorial p {
+  margin-bottom: 15px;
+}
+div.container.tutorial pre,
+div.container.tutorial ul {
+  margin-bottom: 30px;
+}
+div.container .marginTop-30,
+div.container.tutorial h5 {
+  margin-top: 30px;
+}
+div.container.tutorial ul {
+  list-style: disc;
+  padding-inline-start: 15px;
+}
+div.container.tutorial ul li {
+  margin-bottom: 0.5em;
+}
+div.container.tutorial code {
+  background-color: #e0e0e0;
+  border-radius: 4px;
+  color: #161616;
+  padding: 0 0.5em;
+}
+div.container.tutorial pre {
+  background-color: #000;
+  color: #fff;
+  font-size: 14px;
+  line-height: 1.4;
+  margin-top: 15px;
+  padding: 15px;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+}
+div.container.tutorial pre code {
+  background-color: unset;
+  color: #fff;
+  padding: 0;
+}
+div.container .marginTop {
+  margin-top: 10px;
+}
+div.container .marginTop-45 {
+  margin-top: 45px;
+}
+div.container hr {
+  margin-bottom: 75px;
+  margin-top: 25px;
+}
+.resource-card-group {
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 30px;
+  max-width: 700px;
+}
+.resource-card-group .cds--col-md-6.cds--col-lg-6 {
+  border: 1px solid var(--cds-background, #fff);
+  padding: 0;
+}
+.resource-card-group .cds--col-lg-6 {
+  width: 100%;
+}
+@media (min-width: 42rem) {
+  .resource-card-group .cds--col-md-6 {
+    display: block;
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+}
+@media (min-width: 66rem) {
+  .resource-card-group .cds--col-lg-6 {
+    display: block;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+}
+.cds--aspect-ratio--object {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+.cds--resource-card .cds--tile {
+  background: var(--cds-layer-01, #f4f4f4);
+  height: 100%;
+  padding: 1rem 25% 1rem 1rem;
+  position: relative;
+  text-decoration: none;
+  transition: background 70ms;
+}
+.cds--resource-card--dark .cds--tile,
+.cds--resource-card--disabled.cds--resource-card--dark .cds--tile:hover {
+  background: #262626;
+}
+.cds--resource-card .cds--tile:hover {
+  background: var(--cds-background-hover, hsla(0, 0%, 55%, 0.12));
+}
+.cds--resource-card__title {
+  font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
+  font-weight: var(--cds-productive-heading-03-font-weight, 400);
+  letter-spacing: var(--cds-productive-heading-03-letter-spacing, 0);
+  line-height: var(--cds-productive-heading-03-line-height, 1.4);
+  text-decoration: none;
+}
+.cds--resource-card__subtitle {
+  font-size: var(--cds-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-heading-01-font-weight, 600);
+  font-weight: 400;
+  letter-spacing: var(--cds-heading-01-letter-spacing, 0.16px);
+  line-height: var(--cds-heading-01-line-height, 1.42857);
+  text-decoration: none;
+}
+.cds--resource-card__icon--img {
+  align-items: flex-end;
+  bottom: 1rem;
+  display: flex;
+  left: 1rem;
+  min-height: 32px;
+  min-width: 32px;
+  position: absolute;
+}
+.cds--resource-card__icon--img .gatsby-resp-image-wrapper,
+.cds--resource-card__icon--img img[src*='gif'],
+.cds--resource-card__icon--img img[src*='svg'] {
+  margin-bottom: 0;
+}
+.cds--resource-card__icon--img .gatsby-resp-image-wrapper {
+  position: static !important;
+}
+.cds--resource-card__icon--action {
+  bottom: 1rem;
+  height: 20px;
+  position: absolute;
+  right: 1rem;
+  width: 20px;
+}
+.cds--resource-card .cds--resource-card__icon--action svg {
+  fill: var(--cds-icon-primary, #161616);
+}
+.cds--resource-card--dark .cds--tile:hover {
+  background: #393939;
+}
+.cds--resource-card--dark .cds--resource-card__subtitle,
+.cds--resource-card--dark .cds--resource-card__title {
+  color: var(--cds-text-on-color, #fff);
+}
+.cds--resource-card--dark .cds--resource-card__icon--action svg {
+  fill: #f4f4f4;
+}
+.cds--resource-card--disabled .cds--tile:hover {
+  background: var(--cds-layer-01, #f4f4f4);
+  cursor: not-allowed;
+}
+.cds--resource-card--disabled .cds--resource-card__subtitle,
+.cds--resource-card--disabled .cds--resource-card__title {
+  color: var(--cds-icon-on-color-disabled, #8d8d8d);
+}
+.cds--resource-card--disabled .cds--resource-card__icon--action svg {
+  fill: var(--cds-icon-disabled, hsla(0, 0%, 9%, 0.25));
+}
+.cds--resource-card--disabled .cds--resource-card__icon--img {
+  filter: grayscale(100%);
+  opacity: 0.5;
+}
+.cds--resource-card--disabled.cds--resource-card--dark
+  .cds--resource-card__subtitle,
+.cds--resource-card--disabled.cds--resource-card--dark
+  .cds--resource-card__title {
+  color: #8d8d8d;
+}
+.cds--resource-card--disabled.cds--resource-card--dark
+  .cds--resource-card__icon--action
+  svg {
+  fill: #525252;
+}
+/*# sourceMappingURL=charts.css.map */


### PR DESCRIPTION
Closes: #2206

## What I did

**Bug fix** - Fixed magma theme styles not being properly applied to Carbon Charts components.

Added comprehensive test coverage to verify that CarbonChartWrapper styled component correctly applies theme values, including:
- Color values from theme (neutral700, primary, tertiary500, primary700, primary600, neutral100, neutral900, neutral300, focus, focusInverse)
- Typography values (bodyFont, typeScale sizes)
- Spacing values (spaceScale.spacing05)
- Border radius values
- Modal header and footer styling (both normal and inverse modes)
- Button styling (both normal and inverse modes)
- Data table styling
- Legend checkbox styling
- Tooltip styling
- Focus outline styling

## Screenshots

<img width="1066" height="1363" alt="image" src="https://github.com/user-attachments/assets/00172a08-b61e-4e87-96f7-df5975647f83" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. Run tests: `npm test packages/charts/src/components/CarbonChart/CarbonChart.test.js`
2. Verify all tests pass
3. open storybook /story/carbonchart-combo--combo-line-and-stacked-bar check styles