### PR TITLE
fix(Breadcrumb): Fix bug when last item was link and had focus (#2207)

### DIFF
--- a/.changeset/fix-Breadcrumb-last-item-focus.md
+++ b/.changeset/fix-Breadcrumb-last-item-focus.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Breadcrumb): Fix bug when last item was link and had focus

--- a/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-magma-dom/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -29,35 +29,13 @@ const StyledItem = styled.li`
   display: flex;
 `;
 
-const StyledLink = styled.a<{ isInverse?: boolean }>`
+const StyledSpan = styled.span<{ isInverse?: boolean }>`
   align-items: center;
   display: flex;
   color: ${props =>
     props.isInverse
       ? props.theme.colors.neutral100
       : props.theme.colors.neutral700};
-  text-decoration: none;
-  cursor: default;
-  &:hover,
-  &:focus {
-    color: ${props =>
-      props.isInverse
-        ? props.theme.colors.neutral100
-        : props.theme.colors.neutral700};
-  }
-  &:focus {
-    outline: 2px solid
-      ${props =>
-        props.isInverse
-          ? props.theme.colors.focusInverse
-          : props.theme.colors.focus};
-    outline-offset: 2px;
-  }
-`;
-
-const StyledSpan = styled.span<{ isInverse?: boolean }>`
-  align-items: center;
-  display: flex;
 
   svg {
     margin: 0 ${props => props.theme.spaceScale.spacing02};
@@ -89,15 +67,9 @@ export const BreadcrumbItem = React.forwardRef<
         </>
       ) : (
         <>
-          <StyledLink
-            href=""
-            aria-current="page"
-            isInverse={isInverse}
-            theme={theme}
-            onClick={e => e.preventDefault()}
-          >
+          <StyledSpan aria-current="page" isInverse={isInverse} theme={theme}>
             {children}
-          </StyledLink>
+          </StyledSpan>
         </>
       )}
     </StyledItem>


### PR DESCRIPTION
Closes: #2069
Cherry-pick #2207

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Change last item in the Breadcrumb from `a` to `span`

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook/Docs -> Breadcrumb -> Try to focus on the last item using Tab -> Turn on Screenreader (NVDA/VO) -> Check that all items are announced