### PR TITLE
fix(Combobox): Fix issue when NVDA doesn't read placeholder (#2208)

### DIFF
--- a/.changeset/fix-Combobox-not-readable-placeholder-for-NVDA.md
+++ b/.changeset/fix-Combobox-not-readable-placeholder-for-NVDA.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Combobox): Fix issue when NVDA doesn't read placeholder.

--- a/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
@@ -10,6 +10,7 @@ import {
 } from 'downshift';
 import { transparentize } from 'polished';
 
+import useDeviceDetect from '../../hooks/useDeviceDetect';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { inputBaseStyles } from '../InputBase';
@@ -122,6 +123,7 @@ interface ComboboxInputProps<T> {
   onInputKeyUp?: (event: any) => void;
   placeholder?: string;
   selectedItems?: React.ReactNode;
+  selectedItem?: React.ReactNode;
   setReference?: (node: ReferenceType) => void;
   toggleButtonRef?: React.Ref<HTMLButtonElement>;
 }
@@ -148,12 +150,14 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
     onInputKeyUp,
     placeholder,
     selectedItems,
+    selectedItem,
     setReference,
     toggleButtonRef,
   } = props;
   const theme = React.useContext(ThemeContext);
 
   const [isFocused, setIsFocused] = React.useState<boolean>(false);
+  const { isWindows } = useDeviceDetect();
 
   const { DropdownIndicator, LoadingIndicator } = defaultComponents<T>({
     ...customComponents,
@@ -193,6 +197,9 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
     return theme.colors.neutral;
   };
 
+  const selectedItemAriaLabel =
+    isWindows && !selectedItem ? placeholder : undefined;
+
   return (
     <div ref={setReference}>
       <ComboBoxContainer
@@ -216,7 +223,7 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
           theme={theme}
           ref={innerRef}
         >
-          <SelectedItemsWrapper>
+          <SelectedItemsWrapper aria-label={selectedItemAriaLabel}>
             {selectedItems}
             <StyledInput
               {...inputProps}


### PR DESCRIPTION
Closes: #2201
Cherry-pick #2208

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add `aria-label` to `<SelectedItemsWrapper>` with placeholder text for Windows 

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook/Docs -> Combobox -> Turn on NVDA/VO -> Check that placeholder is announced on Windows + NVDA and IS NOT announced TWICE on MacOS + VO