### PR TITLE
fix(Datepicker): Update aria-label for calendar widget and add annoucing for tooltip.

### DIFF
--- a/.changeset/fix-Date-Picker-issues.md
+++ b/.changeset/fix-Date-Picker-issues.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Update aria-label for calendar widget. Add announcing tooltip content for calendar widget button.

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
@@ -62,7 +62,9 @@ describe('Calendar Month', () => {
       userEvent.tab();
       expect(getByText('18')).toHaveFocus();
       userEvent.tab();
-      expect(getByLabelText(/help/i)).toHaveFocus();
+      expect(
+        getByLabelText(/Keyboard instructions for calendar widget/i)
+      ).toHaveFocus();
       userEvent.tab();
       expect(getByLabelText(/Navigate to current/i)).toHaveFocus();
       userEvent.tab();
@@ -143,7 +145,9 @@ describe('Calendar Month', () => {
       expect(getByLabelText(/Navigate to current/i)).toHaveFocus();
 
       userEvent.tab({ shift: true });
-      expect(getByLabelText(/help/i)).toHaveFocus();
+      expect(
+        getByLabelText(/Keyboard instructions for calendar widget/i)
+      ).toHaveFocus();
 
       userEvent.tab({ shift: true });
       expect(getByText('18')).toHaveFocus();
@@ -185,7 +189,9 @@ describe('Calendar Month', () => {
       </CalendarContext.Provider>
     );
 
-    fireEvent.click(getByLabelText('Calendar Widget Help'));
+    userEvent.click(
+      getByLabelText(/Keyboard instructions for calendar widget/i)
+    );
 
     expect(showHelperInformation).toHaveBeenCalled();
   });
@@ -233,7 +239,7 @@ describe('Calendar Month', () => {
       </CalendarContext.Provider>
     );
 
-    getByLabelText('Calendar Widget Help').focus();
+    getByLabelText('Keyboard instructions for calendar widget').focus();
 
     expect(setDateFocused).toHaveBeenCalledWith(false);
   });

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -257,18 +257,17 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
             </Table>
             {props.dateTimePickerContent && props.dateTimePickerContent}
             <HeaderWrapper theme={theme} isInverse={context.isInverse}>
-              <Tooltip
-                content={'Keyboard instructions'}
-                tooltipStyle={{ position: 'fixed' }}
-              >
-                <HelperButton theme={theme}>
+              <HelperButton theme={theme} onFocus={turnOffDateFocused}>
+                <Tooltip
+                  content={'Keyboard instructions'}
+                  tooltipStyle={{ position: 'fixed' }}
+                >
                   <IconButton
                     color={ButtonColor.subtle}
                     ref={helperButtonRef}
                     aria-label={i18n.datePicker.helpModal.helpButtonAriaLabel}
                     icon={<KeyboardIcon />}
                     onClick={context.showHelperInformation}
-                    onFocus={turnOffDateFocused}
                     type={ButtonType.button}
                     variant={ButtonVariant.link}
                     style={{
@@ -277,8 +276,8 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
                         : theme.colors.neutral900,
                     }}
                   />
-                </HelperButton>
-              </Tooltip>
+                </Tooltip>
+              </HelperButton>
               <TodayWrapper
                 data-testid="todayWrapper"
                 isInverse={context.isInverse}

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -774,7 +774,7 @@ describe('Date Picker', () => {
     });
 
     it('ArrowUp', () => {
-      const defaultDate = new Date();
+      const defaultDate = new Date(2019, 0, 17);
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -124,7 +124,7 @@ export const defaultI18n: I18nInterface = {
     year: 'Year',
     helpModal: {
       header: 'Keyboard Shortcuts',
-      helpButtonAriaLabel: 'Calendar Widget Help',
+      helpButtonAriaLabel: 'Keyboard instructions for calendar widget',
       enter: {
         ariaLabel: 'Enter key',
         explanation: 'Select the date in focus.',

--- a/website/react-magma-docs/src/pages/api/date-pickers.mdx
+++ b/website/react-magma-docs/src/pages/api/date-pickers.mdx
@@ -117,9 +117,15 @@ export function Example() {
   const [chosenDate, setChosenDate] = React.useState<Date | undefined>(
     undefined
   );
+  const datePickerRef = React.useRef<HTMLInputElement>(null);
 
   function handleDateChange(newChosenDate: Date | null) {
     setChosenDate(newChosenDate);
+  }
+
+  function handleClearDate() {
+    handleDateChange(null);
+    datePickerRef.current?.focus();
   }
 
   return (
@@ -135,13 +141,14 @@ export function Example() {
         )}
       </p>
       <DatePicker
+        ref={datePickerRef}
         labelText="Date"
         value={chosenDate}
         onDateChange={handleDateChange}
         isClearable
       />
       <br />
-      <Button onClick={() => handleDateChange(null)}>Clear Date</Button>
+      <Button onClick={handleClearDate}>Clear Date</Button>
     </div>
   );
 }


### PR DESCRIPTION
Closes: #2100
Cherry pick of [2227](https://github.com/cengage/react-magma/pull/2227)

## What I did
- Updated doc examples.
- Updated `aria-label="Keyboard instructions for calendar widget"`
- Added announcing tooltip content for keyboard navigation widget.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Date Picker -> Basic Usage -> Open calendar -> Turn on VO | NVDA should announce `Keyboard instructions for calendar widget` + Keyboard instructions

Go to Docs -> Components -> Date Picker -> Clearing the Date -> Open calendar -> select date -> press on `Clear Date` -> focus should move to date input.