### PR TITLE
feat(Popover): Add isFullWidth prop.

### DIFF
--- a/.changeset/feat-Popover-add-isFullWidth-prop.md
+++ b/.changeset/feat-Popover-add-isFullWidth-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Popover): Add `isFullWidth` prop to allow the trigger button and content to expand to 100% width.

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -774,7 +774,7 @@ describe('Date Picker', () => {
     });
 
     it('ArrowUp', () => {
-      const defaultDate = new Date();
+      const defaultDate = new Date(2019, 0, 17);
       const { getAllByText, container } = render(
         <DatePicker defaultDate={defaultDate} labelText={labelText} />
       );

--- a/packages/react-magma-dom/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-magma-dom/src/components/Popover/Popover.stories.tsx
@@ -526,6 +526,42 @@ export const CustomTriggerButton = {
   parameters: { controls: { exclude: ['hoverable'] } },
 };
 
+const FullWidthButtonTemplate = args => {
+  return (
+    <Card
+      style={{
+        padding: '20px',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      isInverse={args.isInverse}
+    >
+      <Popover {...args} isFullWidth>
+        <PopoverTrigger>
+          <Button isFullWidth>Full Width Button Trigger</Button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <div style={{ padding: '16px' }}>
+            This popover has a full-width button trigger. The{' '}
+            <code>isFullWidth</code> prop on the Popover component allows the
+            trigger button to expand to 100% width.
+          </div>
+        </PopoverContent>
+      </Popover>
+    </Card>
+  );
+};
+
+export const FullWidthButton = {
+  render: FullWidthButtonTemplate,
+
+  args: {
+    width: 'target',
+  },
+
+  parameters: { controls: { exclude: ['hoverable'] } },
+};
+
 const FormExampleTemplate = args => {
   return (
     <Card

--- a/packages/react-magma-dom/src/components/Popover/Popover.test.js
+++ b/packages/react-magma-dom/src/components/Popover/Popover.test.js
@@ -460,6 +460,23 @@ describe('Popover', () => {
     expect(popoverContent).toHaveStyle('max-height: 300px');
   });
 
+  it('should render the popover with isFullWidth=true', () => {
+    const { getByTestId } = render(
+      <Popover id="popoverWithFullWidth" isFullWidth width="target">
+        <PopoverTrigger>
+          <Button isFullWidth>Full Width Button Trigger</Button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <div>This popover has a full-width button trigger.</div>
+        </PopoverContent>
+      </Popover>
+    );
+    const popoverContent = getByTestId('popoverContent');
+
+    expect(popoverContent).toBeInTheDocument();
+    expect(popoverContent).toMatchSnapshot();
+  });
+
   it('should render the popover with pointer by default', () => {
     const { getByTestId } = render(
       <Popover id="popoverWithPointer">

--- a/packages/react-magma-dom/src/components/Popover/Popover.tsx
+++ b/packages/react-magma-dom/src/components/Popover/Popover.tsx
@@ -115,6 +115,12 @@ export interface PopoverProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default PopoverAlignment.center
    */
   alignment?: PopoverAlignment;
+  /**
+   * If true, the popover trigger will take the full width of its container.
+   * This allows buttons with isFullWidth prop to render at full width.
+   * @default false
+   */
+  isFullWidth?: boolean;
 }
 
 export interface PopoverContextInterface {
@@ -140,10 +146,12 @@ export interface PopoverContextInterface {
   hasPointer?: boolean;
   focusTrap?: boolean;
   hasActiveElements?: boolean;
+  isFullWidth?: boolean;
 }
 
-const StyledContainer = styled.div`
+const StyledContainer = styled.div<{ isFullWidth?: boolean }>`
   display: inline-block;
+  width: ${props => (props.isFullWidth ? '100%' : 'auto')};
 `;
 
 export const PopoverContext = React.createContext<PopoverContextInterface>({
@@ -203,6 +211,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
       apiRef,
       focusTrap,
       alignment = PopoverAlignment.center,
+      isFullWidth,
       ...other
     } = props;
 
@@ -374,6 +383,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
           hasPointer,
           focusTrap,
           hasActiveElements,
+          isFullWidth,
         }}
       >
         <StyledContainer
@@ -386,6 +396,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
           onMouseLeave={handleMouseLeave}
           id={popoverId}
           onFocus={onFocus}
+          isFullWidth={isFullWidth}
         >
           {children}
         </StyledContainer>

--- a/packages/react-magma-dom/src/components/Popover/PopoverTrigger.tsx
+++ b/packages/react-magma-dom/src/components/Popover/PopoverTrigger.tsx
@@ -124,7 +124,10 @@ export const PopoverTrigger = React.forwardRef<
 
   if (!children) {
     return (
-      <div ref={context.setReference} style={{ width: 'fit-content' }}>
+      <div
+        ref={context.setReference}
+        style={{ width: context.isFullWidth ? '100%' : 'fit-content' }}
+      >
         <IconButton
           {...other}
           shape={ButtonShape.fill}
@@ -155,7 +158,10 @@ export const PopoverTrigger = React.forwardRef<
     );
   }
   return (
-    <div ref={context.setReference} style={{ width: 'fit-content' }}>
+    <div
+      ref={context.setReference}
+      style={{ width: context.isFullWidth ? '100%' : 'fit-content' }}
+    >
       {typeof children === 'string' ? (
         <Button
           {...other}

--- a/packages/react-magma-dom/src/components/Popover/__snapshots__/Popover.test.js.snap
+++ b/packages/react-magma-dom/src/components/Popover/__snapshots__/Popover.test.js.snap
@@ -1,5 +1,152 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Popover should render the popover with isFullWidth=true 1`] = `
+.emotion-1 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: 0px;
+  position: relative;
+  background: #FFFFFF;
+  display: none;
+  max-height: 100%;
+  opacity: 0;
+  outline: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+  border: 1px solid #D4D4D4;
+  width: 0px;
+  max-width: 0px;
+}
+
+.emotion-3 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 16px;
+  height: inherit;
+  white-space: normal;
+}
+
+.emotion-1 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: 0px;
+  position: relative;
+  background: #FFFFFF;
+  display: none;
+  max-height: 100%;
+  opacity: 0;
+  outline: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+  border: 1px solid #D4D4D4;
+  width: 0px;
+  max-width: 0px;
+}
+
+.emotion-3 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 16px;
+  height: inherit;
+  white-space: normal;
+}
+
+<div
+  class="emotion-0 emotion-1 emotion-2"
+  data-testid="popoverContent"
+  tabindex="-1"
+  width="0px"
+>
+  <div
+    aria-labelledby="popoverWithFullWidth_trigger"
+    role="dialog"
+  >
+    <div
+      aria-live="polite"
+      class="emotion-3 emotion-4"
+      id="popoverWithFullWidth_content"
+      style="max-height: 100%;"
+    >
+      <div
+        class="emotion-5 emotion-6"
+      >
+        <div
+          theme="[object Object]"
+        >
+          This popover has a full-width button trigger.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Popover should render the popover with isInverse prop 1`] = `
 .emotion-1 {
   background: #292F7C;


### PR DESCRIPTION
Closes: #1897
Cherry pick of [2223](https://github.com/cengage/react-magma/pull/2223)

## What I did
- Added `isFullWidth` prop for `Popover.`

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Popover -> Full Width Button -> Popover trigger and popover content should have width=100% in a container.
