### PR TITLE
V4/feat(TreeView): create `selectParents` prop (`true` by default)

### DIFF
--- a/.changeset/feat-TreeView-selectParents-prop.md
+++ b/.changeset/feat-TreeView-selectParents-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): create `selectParents` prop (`true` by default)

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -267,8 +267,13 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
     // Consume split contexts for reduced re-render scope
     const { itemToFocus } = React.useContext(TreeViewSelectionContext);
     const { handleExpandedChange } = React.useContext(TreeViewExpansionContext);
-    const { expandIconStyles, hasIcons, isTopLevelSelectable, selectable } =
-      React.useContext(TreeViewConfigContext);
+    const {
+      expandIconStyles,
+      hasIcons,
+      isTopLevelSelectable,
+      selectable,
+      selectParents = true,
+    } = React.useContext(TreeViewConfigContext);
 
     // Pass the resolved values to useTreeItem
     const propsWithHierarchy = {
@@ -402,6 +407,7 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
       (event: React.MouseEvent) => {
         if (isDisabled) {
           event.stopPropagation();
+
           return;
         }
 
@@ -413,6 +419,21 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
         // Preventing selecting the item when clicking on interactive elements when `selectable` is `single`
         if (interactiveElement) {
           event.stopPropagation();
+
+          return;
+        }
+
+        // If selectParents is false and this is a parent item, handle expand/collapse instead of selection
+        if (
+          selectable === TreeViewSelectable.single &&
+          !selectParents &&
+          hasOwnTreeItems
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          onExpandedClicked(event);
+
           return;
         }
 
@@ -503,6 +524,7 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
     const onExpandedClicked = React.useCallback(
       (event: React.SyntheticEvent) => {
         event.preventDefault();
+        event.stopPropagation();
 
         handleExpandedChange(event, itemId);
       },
@@ -512,6 +534,9 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
     const handleExpandClick = React.useCallback(
       (event: React.SyntheticEvent) => {
         if (!isDisabled) {
+          event.preventDefault();
+          event.stopPropagation();
+
           onExpandedClicked(event);
         }
       },

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -112,6 +112,10 @@ export default {
       control: 'boolean',
       defaultValue: true,
     },
+    selectParents: {
+      control: 'boolean',
+      defaultValue: true,
+    },
     enableVirtualization: {
       control: 'boolean',
       defaultValue: false,
@@ -3638,5 +3642,119 @@ export const VirtualizedLargeTree = {
     isDisabled: false,
     testId: 'virtualized-tree-example',
     enableVirtualization: true,
+  },
+};
+
+export const SelectChildrenOnly = {
+  render: (args: TreeViewProps) => {
+    const [selectedItems, setSelectedItems] = React.useState<
+      TreeItemSelectedInterface[]
+    >([]);
+
+    function handleSelectedItemChange(items: TreeItemSelectedInterface[]) {
+      setSelectedItems(items);
+    }
+
+    const { selected } = createTags(selectedItems);
+
+    return (
+      <Card>
+        <Flex behavior={FlexBehavior.container}>
+          <Paragraph visualStyle={TypographyVisualStyle.headingSmall}>
+            Select Children Only (selectParents = false)
+          </Paragraph>
+          <Paragraph>
+            In this example, folders (parent items) can only be
+            expanded/collapsed. Only files (child items) can be selected. Click
+            anywhere on a folder to expand/collapse it.
+          </Paragraph>
+          <Spacer axis={SpacerAxis.horizontal} size={8} />
+          {selected && selected?.length > 0 && (
+            <>
+              <Paragraph
+                visualStyle={TypographyVisualStyle.bodyMedium}
+                color={TypographyColor.subdued}
+              >
+                Selected Files:
+              </Paragraph>
+              <Flex behavior={FlexBehavior.container} wrap={FlexWrap.wrap}>
+                {selected}
+              </Flex>
+              <Spacer axis={SpacerAxis.horizontal} size={8} />
+            </>
+          )}
+        </Flex>
+        <TreeView
+          {...args}
+          selectable={TreeViewSelectable.single}
+          selectParents={false}
+          onSelectedItemChange={handleSelectedItemChange}
+          ariaLabel="File browser example"
+          initialExpandedItems={['documents']}
+        >
+          <TreeItem label="Documents" itemId="documents" icon={<FolderIcon />}>
+            <TreeItem label="Projects" itemId="projects" icon={<FolderIcon />}>
+              <TreeItem
+                label="Project A"
+                itemId="project-a"
+                icon={<FolderIcon />}
+              >
+                <TreeItem
+                  label="README.md"
+                  itemId="readme"
+                  icon={<ArticleIcon />}
+                />
+                <TreeItem
+                  label="package.json"
+                  itemId="package"
+                  icon={<ArticleIcon />}
+                />
+              </TreeItem>
+              <TreeItem
+                label="Project B"
+                itemId="project-b"
+                icon={<FolderIcon />}
+              >
+                <TreeItem
+                  label="index.html"
+                  itemId="index"
+                  icon={<ArticleIcon />}
+                />
+                <TreeItem
+                  label="styles.css"
+                  itemId="styles"
+                  icon={<ArticleIcon />}
+                />
+              </TreeItem>
+            </TreeItem>
+            <TreeItem label="Images" itemId="images" icon={<FolderIcon />} o>
+              <TreeItem label="logo.png" itemId="logo" icon={<ArticleIcon />} />
+              <TreeItem
+                label="banner.jpg"
+                itemId="banner"
+                icon={<ArticleIcon />}
+              />
+            </TreeItem>
+          </TreeItem>
+          <TreeItem label="Downloads" itemId="downloads" icon={<FolderIcon />}>
+            <TreeItem
+              label="document.pdf"
+              itemId="document"
+              icon={<ArticleIcon />}
+            />
+            <TreeItem
+              label="archive.zip"
+              itemId="archive"
+              icon={<ArticleIcon />}
+            />
+          </TreeItem>
+        </TreeView>
+      </Card>
+    );
+  },
+
+  args: {
+    selectable: TreeViewSelectable.single,
+    selectParents: false,
   },
 };

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -4267,6 +4267,143 @@ describe('TreeView', () => {
     });
   });
 
+  describe('selectParents', () => {
+    it('should allow parent items to be selected when selectParents is true (default)', async () => {
+      const onSelectedItemChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.single}
+          selectParents
+          onSelectedItemChange={onSelectedItemChange}
+        >
+          <TreeItem label="Parent Item" itemId="parent" testId="parent">
+            <TreeItem label="Child Item" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parentItem = getByTestId('parent-label');
+      userEvent.click(parentItem);
+
+      expect(onSelectedItemChange).toHaveBeenCalledWith([
+        {
+          itemId: 'parent',
+          checkedStatus: IndeterminateCheckboxStatus.checked,
+        },
+      ]);
+    });
+
+    it('should prevent parent items from being selected when selectParents is false', async () => {
+      const onSelectedItemChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.single}
+          selectParents={false}
+          onSelectedItemChange={onSelectedItemChange}
+        >
+          <TreeItem label="Parent Item" itemId="parent" testId="parent">
+            <TreeItem label="Child Item" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parentItem = getByTestId('parent-label');
+      userEvent.click(parentItem);
+
+      expect(onSelectedItemChange).not.toHaveBeenCalled();
+
+      const parentElement = getByTestId('parent');
+      expect(parentElement).toHaveAttribute('aria-selected', 'false');
+
+      expect(parentElement).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should allow child items to be selected when selectParents is false', async () => {
+      const onSelectedItemChange = jest.fn();
+      const onChildClick = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.single}
+          selectParents={false}
+          onSelectedItemChange={onSelectedItemChange}
+          initialExpandedItems={['parent']}
+        >
+          <TreeItem label="Parent Item" itemId="parent" testId="parent">
+            <TreeItem
+              label="Child Item"
+              itemId="child"
+              testId="child"
+              onClick={onChildClick}
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const childItem = getByTestId('child-label');
+      userEvent.click(childItem);
+
+      expect(onSelectedItemChange).toHaveBeenCalledWith([
+        { itemId: 'child', checkedStatus: IndeterminateCheckboxStatus.checked },
+      ]);
+      expect(onChildClick).toHaveBeenCalled();
+    });
+
+    it('should handle keyboard navigation correctly with selectParents false', async () => {
+      const onSelectedItemChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.single}
+          selectParents={false}
+          onSelectedItemChange={onSelectedItemChange}
+          initialExpandedItems={['parent']}
+        >
+          <TreeItem label="Parent Item" itemId="parent" testId="parent">
+            <TreeItem label="Child Item" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parentItem = getByTestId('parent');
+
+      fireEvent.keyDown(parentItem, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(onSelectedItemChange).not.toHaveBeenCalled();
+        expect(parentItem).toHaveAttribute('aria-expanded', 'false');
+      });
+    });
+
+    it('should work correctly with multi-select mode (selectParents should only affect single-select)', async () => {
+      const onSelectedItemChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.multi}
+          selectParents={false}
+          onSelectedItemChange={onSelectedItemChange}
+        >
+          <TreeItem label="Parent Item" itemId="parent" testId="parent">
+            <TreeItem label="Child Item" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parentCheckbox = getByTestId('parent-checkbox');
+      userEvent.click(parentCheckbox);
+
+      expect(onSelectedItemChange).toHaveBeenCalled();
+    });
+  });
+
   describe('Dynamically updating tree', () => {
     it('should update when children are dynamically rendered inside an empty parent', () => {
       const DynamicChildrenTest = () => {

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewConfigContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewConfigContext.ts
@@ -14,6 +14,7 @@ export interface TreeViewConfigContextInterface {
   checkParents: boolean;
   checkChildren: boolean;
   isTopLevelSelectable?: boolean;
+  selectParents?: boolean;
   expandIconStyles?: ExpandIconInterface;
   registerTreeItem: (
     itemRefArray: React.MutableRefObject<React.MutableRefObject<Element>[]>,
@@ -29,6 +30,7 @@ export const TreeViewConfigContext =
     checkParents: true,
     checkChildren: true,
     isTopLevelSelectable: true,
+    selectParents: true,
     registerTreeItem: (elements, element) => {},
     expandIconStyles: {
       size: magma.iconSizes.medium,

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -109,6 +109,7 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     selectable,
     treeItemRefArray,
     isTopLevelSelectable,
+    selectParents = true,
   } = React.useContext(TreeViewConfigContext);
 
   const treeViewItemData = React.useMemo(() => {
@@ -184,6 +185,15 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
       selectable === TreeViewSelectable.multi &&
       topLevel &&
       !isTopLevelSelectable
+    ) {
+      return;
+    }
+
+    // If selectParents is false and this is a parent item (has children), skip selection logic and onClick
+    if (
+      selectable === TreeViewSelectable.single &&
+      !selectParents &&
+      hasOwnTreeItems
     ) {
       return;
     }
@@ -401,6 +411,21 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
           break;
         }
 
+        // If selectParents is false and this is a parent item, only toggle expand (no selection)
+        if (
+          selectable === TreeViewSelectable.single &&
+          !selectParents &&
+          hasOwnTreeItems
+        ) {
+          if (expanded) {
+            collapseFocusedNode(event);
+          } else {
+            expandFocusedNode(event);
+          }
+
+          break;
+        }
+
         if (selectable === TreeViewSelectable.single) {
           if (isChecked) {
             return;
@@ -445,6 +470,21 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
               expandFocusedNode(event);
             }
           }
+          break;
+        }
+
+        // If selectParents is false and this is a parent item, only toggle expand (no selection)
+        if (
+          selectable === TreeViewSelectable.single &&
+          !selectParents &&
+          hasOwnTreeItems
+        ) {
+          if (expanded) {
+            collapseFocusedNode(event);
+          } else {
+            expandFocusedNode(event);
+          }
+
           break;
         }
 

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -120,6 +120,13 @@ export interface UseTreeViewProps {
    */
   selectable?: TreeViewSelectable;
   /**
+   * When enabled (default), parent items (folders) can be selected in TreeViewSelectable.single mode.
+   * When disabled, parent items will only expand/collapse on click and won't trigger selection or onClick.
+   * Child items (leaves) can always be selected regardless of this setting.
+   * @default true
+   */
+  selectParents?: boolean;
+  /**
    * @internal
    */
   testId?: string;
@@ -151,6 +158,7 @@ export function useTreeView(props: UseTreeViewProps) {
     isDisabled,
     isTopLevelSelectable = true,
     expandIconStyles,
+    selectParents = true,
   } = props;
 
   const hasPreselectedItems = Boolean(preselectedItems);
@@ -617,6 +625,7 @@ export function useTreeView(props: UseTreeViewProps) {
       checkParents,
       checkChildren,
       isTopLevelSelectable,
+      selectParents,
       expandIconStyles,
       registerTreeItem,
       treeItemRefArray,
@@ -627,6 +636,7 @@ export function useTreeView(props: UseTreeViewProps) {
       checkParents,
       checkChildren,
       isTopLevelSelectable,
+      selectParents,
       expandIconStyles,
       registerTreeItem,
       treeItemRefArray,

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -524,6 +524,85 @@ export function Example() {
 }
 ```
 
+## Select Parents
+
+In a TreeView with `TreeViewSelectable.single`, you can control whether parent items (folders) can be selected or if they should only expand/collapse when clicked. The `selectParents` prop allows you to configure this behavior based on your use case.
+
+By default, the `selectParents` prop is set to `true`, allowing parent items to be selected normally. When set to `false`, clicking on parent items will only expand/collapse them, while child items (leaves) can still be selected as usual.
+
+```tsx
+import React from 'react';
+
+import {
+  TreeView,
+  TreeItem,
+  TreeViewSelectable,
+  Toggle,
+} from 'react-magma-dom';
+import { FolderIcon, ArticleIcon } from 'react-magma-icons';
+
+export function Example() {
+  const [selectedItems, setSelectedItems] = React.useState<
+    TreeItemSelectedInterface[]
+  >([]);
+
+  function handleSelectedItemChange(items: TreeItemSelectedInterface[]) {
+    setSelectedItems(items);
+  }
+
+  return (
+    <TreeView
+      selectable={TreeViewSelectable.single}
+      selectParents={false}
+      onSelectedItemChange={handleSelectedItemChange}
+      ariaLabel="File browser example"
+      initialExpandedItems={['documents', 'projects', 'project-a']}
+    >
+      <TreeItem label="Documents" itemId="documents" icon={<FolderIcon />}>
+        <TreeItem label="Projects" itemId="projects" icon={<FolderIcon />}>
+          <TreeItem label="Project A" itemId="project-a" icon={<FolderIcon />}>
+            <TreeItem
+              label="README.md"
+              itemId="readme"
+              icon={<ArticleIcon />}
+            />
+            <TreeItem
+              label="package.json"
+              itemId="package"
+              icon={<ArticleIcon />}
+            />
+          </TreeItem>
+          <TreeItem label="Project B" itemId="project-b" icon={<FolderIcon />}>
+            <TreeItem
+              label="index.html"
+              itemId="index"
+              icon={<ArticleIcon />}
+            />
+            <TreeItem
+              label="styles.css"
+              itemId="styles"
+              icon={<ArticleIcon />}
+            />
+          </TreeItem>
+        </TreeItem>
+        <TreeItem label="Images" itemId="images" icon={<FolderIcon />}>
+          <TreeItem label="logo.png" itemId="logo" icon={<ArticleIcon />} />
+          <TreeItem label="banner.jpg" itemId="banner" icon={<ArticleIcon />} />
+        </TreeItem>
+      </TreeItem>
+      <TreeItem label="Downloads" itemId="downloads" icon={<FolderIcon />}>
+        <TreeItem
+          label="document.pdf"
+          itemId="document"
+          icon={<ArticleIcon />}
+        />
+        <TreeItem label="archive.zip" itemId="archive" icon={<ArticleIcon />} />
+      </TreeItem>
+    </TreeView>
+  );
+}
+```
+
 ## Update Selected Items From Outside
 
 Use the `apiRef` prop to change items selection from outside. It exposes these functions: `selectItem`, `selectAll`, `clearAll`.
@@ -1579,6 +1658,7 @@ export function Example() {
           ],
         };
       }
+
       return item;
     });
 


### PR DESCRIPTION
Closes: #2159
Cherry-pick #2226

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Create `selectParents` prop (`true` by default)

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook -> TreeView -> Check new `selectParents` prop -> new `SelectChildrenOnly` example -> Check other examples with a new prop
Open Docs -> TreeView -> Select Parents section -> Check that everything works as expected -> Props -> TreeView props -> Check new `selectParents` prop