### PR TITLE
fix(DatePicker): Fix `cannot read properties of undefined (reading 'focus') error`.

### DIFF
--- a/.changeset/fix-DatePicker-fix-undefined-docus.md
+++ b/.changeset/fix-DatePicker-fix-undefined-docus.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Update announcing tooltip logic.

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
@@ -7,6 +7,9 @@ import { CalendarContext } from './CalendarContext';
 import { CalendarMonth } from './CalendarMonth';
 import { getCalendarMonthWeeks } from './utils';
 
+const keyBoardInstructionsText =
+  'Keyboard instructions for calendar widget Keyboard instructions';
+
 describe('Calendar Month', () => {
   describe('focus trap', () => {
     it('should handle tab and loop it through the calendar month', async () => {
@@ -54,7 +57,7 @@ describe('Calendar Month', () => {
       expect(getByText('18')).toHaveFocus();
       await userEvent.tab();
       expect(
-        getByLabelText(/Keyboard instructions for calendar widget/i)
+        getByLabelText(new RegExp(keyBoardInstructionsText, 'i'))
       ).toHaveFocus();
       await userEvent.tab();
       expect(getByLabelText(/Navigate to current/i)).toHaveFocus();
@@ -136,7 +139,7 @@ describe('Calendar Month', () => {
 
       await userEvent.tab({ shift: true });
       expect(
-        getByLabelText(/Keyboard instructions for calendar widget/i)
+        getByLabelText(new RegExp(keyBoardInstructionsText, 'i'))
       ).toHaveFocus();
 
       await userEvent.tab({ shift: true });
@@ -180,7 +183,7 @@ describe('Calendar Month', () => {
     );
 
     await userEvent.click(
-      getByLabelText('Keyboard instructions for calendar widget')
+      getByLabelText(new RegExp(keyBoardInstructionsText, 'i'))
     );
 
     expect(showHelperInformation).toHaveBeenCalled();
@@ -230,7 +233,7 @@ describe('Calendar Month', () => {
     );
 
     act(() => {
-      getByLabelText('Keyboard instructions for calendar widget').focus();
+      getByLabelText(new RegExp(keyBoardInstructionsText, 'i')).focus();
     });
 
     expect(setDateFocused).toHaveBeenCalledWith(false);

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -209,6 +209,8 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
     </Th>
   ));
 
+  const tooltipContent = 'Keyboard instructions';
+
   return (
     <>
       <CalendarContainer
@@ -257,15 +259,15 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
             </Table>
             {props.dateTimePickerContent && props.dateTimePickerContent}
             <HeaderWrapper theme={theme} isInverse={context.isInverse}>
-              <HelperButton theme={theme}>
-                <Tooltip
-                  content={'Keyboard instructions'}
-                  tooltipStyle={{ position: 'fixed' }}
-                >
+              <Tooltip
+                content={tooltipContent}
+                tooltipStyle={{ position: 'fixed' }}
+              >
+                <HelperButton theme={theme}>
                   <IconButton
                     color={ButtonColor.subtle}
                     ref={helperButtonRef}
-                    aria-label={i18n.datePicker.helpModal.helpButtonAriaLabel}
+                    aria-label={`${i18n.datePicker.helpModal.helpButtonAriaLabel} ${tooltipContent}`}
                     icon={<KeyboardIcon />}
                     onClick={context.showHelperInformation}
                     onFocus={turnOffDateFocused}
@@ -277,8 +279,8 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
                         : theme.colors.neutral900,
                     }}
                   />
-                </Tooltip>
-              </HelperButton>
+                </HelperButton>
+              </Tooltip>
               <TodayWrapper
                 data-testid="todayWrapper"
                 isInverse={context.isInverse}

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -209,8 +209,6 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
     </Th>
   ));
 
-  const tooltipContent = 'Keyboard instructions';
-
   return (
     <>
       <CalendarContainer
@@ -260,14 +258,14 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
             {props.dateTimePickerContent && props.dateTimePickerContent}
             <HeaderWrapper theme={theme} isInverse={context.isInverse}>
               <Tooltip
-                content={tooltipContent}
+                content={i18n.datePicker.helpModal.tooltipContent}
                 tooltipStyle={{ position: 'fixed' }}
               >
                 <HelperButton theme={theme}>
                   <IconButton
                     color={ButtonColor.subtle}
                     ref={helperButtonRef}
-                    aria-label={`${i18n.datePicker.helpModal.helpButtonAriaLabel} ${tooltipContent}`}
+                    aria-label={`${i18n.datePicker.helpModal.helpButtonAriaLabel} ${i18n.datePicker.helpModal.tooltipContent}`}
                     icon={<KeyboardIcon />}
                     onClick={context.showHelperInformation}
                     onFocus={turnOffDateFocused}

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -125,6 +125,7 @@ export const defaultI18n: I18nInterface = {
     helpModal: {
       header: 'Keyboard Shortcuts',
       helpButtonAriaLabel: 'Keyboard instructions for calendar widget',
+      tooltipContent: 'Keyboard instructions',
       enter: {
         ariaLabel: 'Enter key',
         explanation: 'Select the date in focus.',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -133,6 +133,7 @@ export interface I18nInterface {
     helpModal: {
       header: string;
       helpButtonAriaLabel: string;
+      tooltipContent: string;
       enter: {
         ariaLabel: string;
         explanation: string;


### PR DESCRIPTION
Closes: #2100 
Fix of [this](https://github.com/cengage/react-magma/discussions/2180#:~:text=Component%3A-,Date%20Picker,-Description%20of%20bug) bug

## What I did
- Fixed `cannot read properties of undefined (reading 'focus') error.
- Updated aria-label="Keyboard instructions for calendar widget Keyboard instructions"

## Screenshots


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Date Picker -> Basic Usage -> Open calendar -> Turn on VO | NVDA should announce Keyboard instructions for calendar widget + Keyboard instructions -> should not be changed

Go to Docs -> Components -> Date Picker -> Basic Usage -> Open calendar -> Click on Keyboard instructions -> Click on Back to Calendar button