### PR TITLE
fix(DatePicker): Fix cannot read properties of undefined (reading 'focus') error.

### DIFF
--- a/.changeset/fix-DatePicker-fix-undefined-docus.md
+++ b/.changeset/fix-DatePicker-fix-undefined-docus.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(DatePicker): Update announcing tooltip logic.

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
@@ -17,6 +17,9 @@ describe('Calendar Month', () => {
     jest.resetAllMocks();
   });
 
+  const keyBoardInstructionsText =
+    'Keyboard instructions for calendar widget Keyboard instructions';
+
   describe('focus trap', () => {
     it('should handle tab and loop it through the calendar month', () => {
       const focusedDate = new Date(2019, 0, 18);
@@ -63,7 +66,7 @@ describe('Calendar Month', () => {
       expect(getByText('18')).toHaveFocus();
       userEvent.tab();
       expect(
-        getByLabelText(/Keyboard instructions for calendar widget/i)
+        getByLabelText(new RegExp(keyBoardInstructionsText, 'i'))
       ).toHaveFocus();
       userEvent.tab();
       expect(getByLabelText(/Navigate to current/i)).toHaveFocus();
@@ -146,7 +149,7 @@ describe('Calendar Month', () => {
 
       userEvent.tab({ shift: true });
       expect(
-        getByLabelText(/Keyboard instructions for calendar widget/i)
+        getByLabelText(new RegExp(keyBoardInstructionsText, 'i'))
       ).toHaveFocus();
 
       userEvent.tab({ shift: true });
@@ -189,9 +192,7 @@ describe('Calendar Month', () => {
       </CalendarContext.Provider>
     );
 
-    userEvent.click(
-      getByLabelText(/Keyboard instructions for calendar widget/i)
-    );
+    userEvent.click(getByLabelText(new RegExp(keyBoardInstructionsText, 'i')));
 
     expect(showHelperInformation).toHaveBeenCalled();
   });
@@ -239,7 +240,7 @@ describe('Calendar Month', () => {
       </CalendarContext.Provider>
     );
 
-    getByLabelText('Keyboard instructions for calendar widget').focus();
+    getByLabelText(new RegExp(keyBoardInstructionsText, 'i')).focus();
 
     expect(setDateFocused).toHaveBeenCalledWith(false);
   });

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -257,17 +257,18 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
             </Table>
             {props.dateTimePickerContent && props.dateTimePickerContent}
             <HeaderWrapper theme={theme} isInverse={context.isInverse}>
-              <HelperButton theme={theme} onFocus={turnOffDateFocused}>
-                <Tooltip
-                  content={'Keyboard instructions'}
-                  tooltipStyle={{ position: 'fixed' }}
-                >
+              <Tooltip
+                content={i18n.datePicker.helpModal.tooltipContent}
+                tooltipStyle={{ position: 'fixed' }}
+              >
+                <HelperButton theme={theme}>
                   <IconButton
                     color={ButtonColor.subtle}
                     ref={helperButtonRef}
-                    aria-label={i18n.datePicker.helpModal.helpButtonAriaLabel}
+                    aria-label={`${i18n.datePicker.helpModal.helpButtonAriaLabel} ${i18n.datePicker.helpModal.tooltipContent}`}
                     icon={<KeyboardIcon />}
                     onClick={context.showHelperInformation}
+                    onFocus={turnOffDateFocused}
                     type={ButtonType.button}
                     variant={ButtonVariant.link}
                     style={{
@@ -276,8 +277,8 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
                         : theme.colors.neutral900,
                     }}
                   />
-                </Tooltip>
-              </HelperButton>
+                </HelperButton>
+              </Tooltip>
               <TodayWrapper
                 data-testid="todayWrapper"
                 isInverse={context.isInverse}

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -125,6 +125,7 @@ export const defaultI18n: I18nInterface = {
     helpModal: {
       header: 'Keyboard Shortcuts',
       helpButtonAriaLabel: 'Keyboard instructions for calendar widget',
+      tooltipContent: 'Keyboard instructions',
       enter: {
         ariaLabel: 'Enter key',
         explanation: 'Select the date in focus.',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -133,6 +133,7 @@ export interface I18nInterface {
     helpModal: {
       header: string;
       helpButtonAriaLabel: string;
+      tooltipContent: string;
       enter: {
         ariaLabel: string;
         explanation: string;


### PR DESCRIPTION
Closes: #2100 
Fix of [this](https://github.com/cengage/react-magma/discussions/2180#:~:text=Component%3A-,Date%20Picker,-Description%20of%20bug) bug
Cherry pick https://github.com/cengage/react-magma/pull/2233

## What I did
- Fixed `cannot read properties of undefined (reading 'focus') error.
- Updated aria-label="Keyboard instructions for calendar widget Keyboard instructions"

## Screenshots


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Date Picker -> Basic Usage -> Open calendar -> Turn on VO | NVDA should announce Keyboard instructions for calendar widget + Keyboard instructions -> should not be changed

Go to Docs -> Components -> Date Picker -> Basic Usage -> Open calendar -> Click on Keyboard instructions -> Click on Back to Calendar button