### PR TITLE
V4/fix/dropdown escape issue

### DIFF
--- a/.changeset/fix-Dropdown-escape-issue.md
+++ b/.changeset/fix-Dropdown-escape-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Fix bug with `Escape` focus behavior

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -1,12 +1,6 @@
 import React from 'react';
 
-import {
-  act,
-  fireEvent,
-  getByLabelText,
-  getByTestId,
-  render,
-} from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
 import {
@@ -540,9 +534,9 @@ describe('Dropdown', () => {
   });
 
   it('should close the menu when escape key is pressed', () => {
-    const { getByText, getByTestId } = render(
+    const { getByTestId } = render(
       <Dropdown testId="dropdown">
-        <DropdownButton>Toggle me</DropdownButton>
+        <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
         <DropdownContent>
           <DropdownMenuItem>Menu item</DropdownMenuItem>
         </DropdownContent>
@@ -551,7 +545,8 @@ describe('Dropdown', () => {
 
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
 
-    fireEvent.click(getByText('Toggle me'));
+    const button = getByTestId('dropdownButton');
+    fireEvent.click(button);
 
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'block');
 
@@ -564,6 +559,7 @@ describe('Dropdown', () => {
       code: 27,
     });
 
+    expect(button).toHaveFocus();
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
   });
 
@@ -914,7 +910,7 @@ describe('Dropdown', () => {
     it('should close the menu when escape key is pressed', () => {
       const { getByText, getByTestId } = render(
         <Dropdown testId="dropdown">
-          <DropdownButton>Toggle me</DropdownButton>
+          <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
           <DropdownContent>
             <p>test</p>
           </DropdownContent>
@@ -923,7 +919,8 @@ describe('Dropdown', () => {
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
 
-      fireEvent.click(getByText('Toggle me'));
+      const button = getByTestId('dropdownButton');
+      fireEvent.click(button);
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule(
         'display',
@@ -939,6 +936,7 @@ describe('Dropdown', () => {
         code: 27,
       });
 
+      expect(button).toHaveFocus();
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
     });
 
@@ -947,7 +945,7 @@ describe('Dropdown', () => {
       const { getByText, getByTestId } = render(
         <Modal testId="modal" isOpen>
           <Dropdown testId="dropdown">
-            <DropdownButton>Toggle me</DropdownButton>
+            <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
             <DropdownContent>
               <p>test</p>
             </DropdownContent>
@@ -957,7 +955,8 @@ describe('Dropdown', () => {
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
 
-      fireEvent.click(getByText('Toggle me'));
+      const button = getByTestId('dropdownButton');
+      fireEvent.click(button);
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule(
         'display',
@@ -974,6 +973,7 @@ describe('Dropdown', () => {
       });
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+      expect(button).toHaveFocus();
       expect(getByTestId('modal')).toBeInTheDocument();
     });
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -186,8 +186,6 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         if (!isElementInteractive(relatedTarget)) {
           toggleRef.current?.focus();
         }
-      } else if (event.key === 'Escape') {
-        toggleRef.current?.focus();
       }
 
       onClose && typeof onClose === 'function' && onClose(event);
@@ -208,6 +206,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
       if (event.key === 'Escape') {
         event.nativeEvent.stopImmediatePropagation();
         closeDropdown(event);
+        toggleRef.current?.focus();
       }
 
       if (event.key === 'ArrowDown') {

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -186,6 +186,8 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         if (!isElementInteractive(relatedTarget)) {
           toggleRef.current?.focus();
         }
+      } else if (event.key === 'Escape') {
+        toggleRef.current?.focus();
       }
 
       onClose && typeof onClose === 'function' && onClose(event);


### PR DESCRIPTION
Closes: #2243

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix the bug when focus doesn't move back to the trigger button after pressing the `Esc` putton

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Dropdown -> Any dropdown -> Click on the trigger button -> Press `Esc`
Open Dropdown -> Any dropdown -> Click on the trigger button -> Click outside the dropdown
Open Dropdown -> Any dropdown -> Click on the trigger button -> Click on another focusable/clickable element