### PR TITLE
fix(Dropdown): escape issue

### DIFF
--- a/.changeset/fix-Dropdown-escape-issue.md
+++ b/.changeset/fix-Dropdown-escape-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Fix bug with `Escape` focus behavior

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -552,7 +552,7 @@ describe('Dropdown', () => {
   });
 
   it('should close the menu when escape key is pressed', async () => {
-    const { getByText, getByTestId } = render(
+    const { getByTestId } = render(
       <Dropdown testId="dropdown">
         <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
         <DropdownContent>
@@ -909,7 +909,7 @@ describe('Dropdown', () => {
     });
 
     it('should close the menu when escape key is pressed', async () => {
-      const { getByText, getByTestId } = render(
+      const { getByTestId } = render(
         <Dropdown testId="dropdown">
           <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
           <DropdownContent>
@@ -937,7 +937,7 @@ describe('Dropdown', () => {
 
     //For Dropdowns in Modals
     it('should close the menu when escape key is pressed, and retain the active modal', async () => {
-      const { getByText, getByTestId } = render(
+      const { getByTestId } = render(
         <Modal testId="modal" isOpen>
           <Dropdown testId="dropdown">
             <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -554,7 +554,7 @@ describe('Dropdown', () => {
   it('should close the menu when escape key is pressed', async () => {
     const { getByText, getByTestId } = render(
       <Dropdown testId="dropdown">
-        <DropdownButton>Toggle me</DropdownButton>
+        <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
         <DropdownContent>
           <DropdownMenuItem>Menu item</DropdownMenuItem>
         </DropdownContent>
@@ -563,13 +563,15 @@ describe('Dropdown', () => {
 
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
 
-    await userEvent.click(getByText('Toggle me'));
+    const button = getByTestId('dropdownButton');
+    await userEvent.click(button);
 
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'block');
 
     await userEvent.keyboard('{ArrowDown}');
     await userEvent.keyboard('{Escape}');
 
+    expect(button).toHaveFocus();
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
   });
 
@@ -909,7 +911,7 @@ describe('Dropdown', () => {
     it('should close the menu when escape key is pressed', async () => {
       const { getByText, getByTestId } = render(
         <Dropdown testId="dropdown">
-          <DropdownButton>Toggle me</DropdownButton>
+          <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
           <DropdownContent>
             <p>test</p>
           </DropdownContent>
@@ -918,7 +920,8 @@ describe('Dropdown', () => {
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
 
-      await userEvent.click(getByText('Toggle me'));
+      const button = getByTestId('dropdownButton');
+      await userEvent.click(button);
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule(
         'display',
@@ -928,6 +931,7 @@ describe('Dropdown', () => {
       await userEvent.keyboard('{ArrowDown}');
       await userEvent.keyboard('{Escape}');
 
+      expect(button).toHaveFocus();
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
     });
 
@@ -936,7 +940,7 @@ describe('Dropdown', () => {
       const { getByText, getByTestId } = render(
         <Modal testId="modal" isOpen>
           <Dropdown testId="dropdown">
-            <DropdownButton>Toggle me</DropdownButton>
+            <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
             <DropdownContent>
               <p>test</p>
             </DropdownContent>
@@ -946,7 +950,8 @@ describe('Dropdown', () => {
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
 
-      await userEvent.click(getByText('Toggle me'));
+      const button = getByTestId('dropdownButton');
+      await userEvent.click(button);
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule(
         'display',
@@ -957,6 +962,7 @@ describe('Dropdown', () => {
       await userEvent.keyboard('{Escape}');
 
       expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+      expect(button).toHaveFocus();
       expect(getByTestId('modal')).toBeInTheDocument();
     });
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -206,6 +206,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
       if (event.key === 'Escape') {
         event.nativeEvent.stopImmediatePropagation();
         closeDropdown(event);
+        toggleRef.current?.focus();
       }
 
       if (event.key === 'ArrowDown') {


### PR DESCRIPTION
Closes: #2243
Cherr-pick #2249

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix the bug when focus doesn't move back to the trigger button after pressing the `Esc` putton

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Dropdown -> Any dropdown -> Click on the trigger button -> Press `Esc`
Open Dropdown -> Any dropdown -> Click on the trigger button -> Click outside the dropdown
Open Dropdown -> Any dropdown -> Click on the trigger button -> Click on another focusable/clickable element