### PR TITLE
fix(Pagination): Update aria label.

### DIFF
--- a/.changeset/fix-Pagination-aria-label.md
+++ b/.changeset/fix-Pagination-aria-label.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Pagination): Update aria-label.

--- a/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/Pagination.tsx
@@ -266,13 +266,11 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>(
                     );
                   } else if (type === 'page') {
                     return (
-                      <StyledListItem
-                        aria-current={
-                          ariaCurrent ? 'page' : Boolean(ariaCurrent)
-                        }
-                        key={index}
-                      >
+                      <StyledListItem key={index}>
                         <PageButton
+                          aria-current={
+                            ariaCurrent ? 'page' : Boolean(ariaCurrent)
+                          }
                           ref={setPageButtonRef(page)}
                           isInverse={isInverse}
                           isSelected={isSelected}

--- a/packages/react-magma-dom/src/components/Pagination/SimplePagination.tsx
+++ b/packages/react-magma-dom/src/components/Pagination/SimplePagination.tsx
@@ -186,7 +186,7 @@ export const SimplePagination = React.forwardRef<
       {count > 0 && (
         <>
           <NativeSelect
-            aria-label={i18n.select.placeholder}
+            aria-label={i18n.simplePagination.selectPageLabel}
             data-testid={testId ? `${testId}-select` : `pagination-select`}
             containerStyle={nativeSelectStyles}
             disabled={disabled}

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -280,6 +280,7 @@ export const defaultI18n: I18nInterface = {
     pagesLabel: 'pages',
     pageNumberLabel: 'Page number',
     selectedLabel: 'selected',
+    selectPageLabel: 'Select page',
   },
   skipLink: {
     buttonText: 'Skip Navigation',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -264,6 +264,7 @@ export interface I18nInterface {
     pageLabel: string;
     pagesLabel: string;
     selectedLabel: string;
+    selectPageLabel: string;
   };
   skipLink: {
     buttonText: string;


### PR DESCRIPTION
Closes: #2093
Cherry pick: [2267](https://github.com/cengage/react-magma/pull/2267)

## What I did
- Moved `aria-current="page"` attribute from `<li>` into `button`;
- Updated `aria-label` for `SimplePagination`

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Pagination -> Default -> and ensure the button has `aria-current=" page"`.

Go to Storybook -> Pagination -> Simple Pagination -> Select should have `aria-label="Select page"` attribute.