### PR TITLE
fixed Modal: accessibility fixes for WCAG 2.2 AA compliance

### DIFF
--- a/.changeset/fix-modal-accessibility-wcag.md
+++ b/.changeset/fix-modal-accessibility-wcag.md
@@ -1,0 +1,11 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal): Accessibility fixes for WCAG 2.2 AA compliance
+
+- A11Y-5089: Change modal heading from h1 to h2
+- A11Y-5090: Fix DOM order for close button
+- A11Y-5091: Improve keyboard focus sequence
+- Add headerLevel prop (defaults to 2)
+

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -620,7 +620,7 @@ describe('Modal', () => {
         </>
       );
 
-      expect(getByTestId('closeButton')).toHaveFocus();
+      expect(getByTestId('modal-closebtn')).toHaveFocus();
     });
 
     it('should not focus the first element if there is no heading and nothing else to focus', () => {

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -43,6 +43,11 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   header?: React.ReactNode;
   /**
+   * Number to indicate which level heading will render (e.g. h1, h2 etc.)
+   * @default 2
+   */
+  headerLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  /**
    * If true, clicking the backdrop will not dismiss the modal
    * @default false
    */
@@ -152,7 +157,7 @@ const ModalHeader = styled.div<{ theme?: ThemeInterface }>`
   }
 `;
 
-const H1 = styled(Heading)<{ theme?: ThemeInterface }>`
+const H2 = styled(Heading)<{ theme?: ThemeInterface }>`
   font-size: ${props =>
     props.theme.typographyVisualStyles.headingSmall.desktop.fontSize};
   line-height: ${props =>
@@ -275,6 +280,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       isBackgroundClickDisabled,
       isEscKeyDownDisabled,
       header,
+      headerLevel = 2,
       isCloseButtonHidden,
       isOpen,
       unmountOnExit = true,
@@ -336,22 +342,19 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                 {header && (
                   <ModalHeader theme={theme}>
                     {header && (
-                      <H1
+                      <H2
                         id={headingId}
-                        level={1}
+                        level={headerLevel}
                         ref={headingRef}
                         visualStyle={TypographyVisualStyle.headingSmall}
                         tabIndex={-1}
                         theme={theme}
                       >
                         {header}
-                      </H1>
+                      </H2>
                     )}
                   </ModalHeader>
                 )}
-                <ModalBody ref={bodyRef} theme={theme}>
-                  {children}
-                </ModalBody>
                 {!isCloseButtonHidden && (
                   <CloseBtn>
                     <IconButton
@@ -368,6 +371,9 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                     />
                   </CloseBtn>
                 )}
+                <ModalBody ref={bodyRef} theme={theme}>
+                  {children}
+                </ModalBody>
               </ModalContent>
             </ModalContainer>
             <ModalBackdrop


### PR DESCRIPTION
## What I did

**Bug fix** - Fixed accessibility issues in the Modal component to ensure WCAG 2.2 AA compliance.

Changes made:
- **A11Y-5089**: Changed modal heading from `<h1>` to `<h2>` (default)
- **A11Y-5090**: Fixed DOM order - close button now appears after header, before modal body content
- **A11Y-5091**: Improved keyboard focus sequence to match visual order
- Added `headerLevel` prop (accepts 1-6) to allow customization of heading level while maintaining semantic structure

These changes fix accessibility violations where:
1. Modal headings conflicted with main page `<h1>` elements, causing semantic confusion for screen reader users
2. DOM order didn't match visual layout, making screen reader navigation confusing
3. Keyboard focus order didn't follow logical sequence

## Checklist 
- [x] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test

### Manual Testing (Screen Reader):
1. Open any modal in the application
2. Use a screen reader (JAWS, NVDA, or VoiceOver)
3. Verify:
   - Modal heading is announced as "Heading level 2" (not "Heading level 1")
   - Close button is announced immediately after the heading
   - Tab order follows: Heading → Close button → Modal content

### Keyboard Testing:
1. Open a modal
2. Press Tab key
3. Verify focus order: Close button → Modal content elements (logical order)