### PR TITLE
fix(Combobox): Fix issue when focused item wasnt scrolled into view

### DIFF
--- a/.changeset/fix-Combobox-zoom-200%-issue.md
+++ b/.changeset/fix-Combobox-zoom-200%-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Combobox): Fix issue when focused item wasn't scrolled into view.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -1167,4 +1167,62 @@ describe('Combobox', () => {
       });
     });
   });
+
+  describe('Accessibility - scrollIntoView', () => {
+    it('should call scrollIntoView on focused item when navigating with keyboard', async () => {
+      const mockScrollIntoView = jest.fn();
+      Element.prototype.scrollIntoView = mockScrollIntoView;
+
+      const { getByLabelText } = render(
+        <Combobox labelText={labelText} items={items} />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, {
+        selector: 'input',
+      });
+
+      await userEvent.click(renderedCombobox);
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(mockScrollIntoView).toHaveBeenCalledWith({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(mockScrollIntoView).toHaveBeenCalledTimes(2);
+      });
+
+      mockScrollIntoView.mockRestore();
+    });
+
+    it('should add data-highlighted attribute to focused item', async () => {
+      const { getByLabelText, getByText } = render(
+        <Combobox labelText={labelText} items={items} />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, {
+        selector: 'input',
+      });
+
+      await userEvent.click(renderedCombobox);
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(getByText('Red')).toHaveAttribute('data-highlighted', 'true');
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(getByText('Red')).toHaveAttribute('data-highlighted', 'false');
+        expect(getByText('Blue')).toHaveAttribute('data-highlighted', 'true');
+      });
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -1360,4 +1360,62 @@ describe('MultiCombobox', () => {
       });
     });
   });
+
+  describe('Accessibility - scrollIntoView', () => {
+    it('should call scrollIntoView on focused item when navigating with keyboard', async () => {
+      const mockScrollIntoView = jest.fn();
+      Element.prototype.scrollIntoView = mockScrollIntoView;
+
+      const { getByLabelText } = render(
+        <MultiCombobox isMulti labelText={labelText} items={items} />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, {
+        selector: 'input',
+      });
+
+      await userEvent.click(renderedCombobox);
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(mockScrollIntoView).toHaveBeenCalledWith({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(mockScrollIntoView).toHaveBeenCalledTimes(2);
+      });
+
+      mockScrollIntoView.mockRestore();
+    });
+
+    it('should add data-highlighted attribute to focused item', async () => {
+      const { getByLabelText, getByText } = render(
+        <MultiCombobox isMulti labelText={labelText} items={items} />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, {
+        selector: 'input',
+      });
+
+      await userEvent.click(renderedCombobox);
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(getByText('Red')).toHaveAttribute('data-highlighted', 'true');
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(getByText('Red')).toHaveAttribute('data-highlighted', 'false');
+        expect(getByText('Blue')).toHaveAttribute('data-highlighted', 'true');
+      });
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -78,6 +78,29 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
 
+  // Scroll highlighted item into view for accessibility
+  React.useEffect(() => {
+    if (isOpen && highlightedIndex !== undefined && highlightedIndex >= 0) {
+      const animationFrame = requestAnimationFrame(() => {
+        const highlightedElement = document.querySelector(
+          '[data-highlighted="true"]'
+        );
+
+        if (
+          highlightedElement &&
+          typeof highlightedElement.scrollIntoView === 'function'
+        ) {
+          highlightedElement.scrollIntoView({
+            behavior: 'smooth',
+            block: 'nearest',
+          });
+        }
+      });
+
+      return () => cancelAnimationFrame(animationFrame);
+    }
+  }, [highlightedIndex, isOpen]);
+
   const hasItems = items && items.length > 0;
 
   const heightString = convertStyleValueToString(maxHeight);

--- a/packages/react-magma-dom/src/components/Select/components.tsx
+++ b/packages/react-magma-dom/src/components/Select/components.tsx
@@ -58,6 +58,7 @@ export function DefaultItem<T>({
       ref={itemRef}
       isDisabled={isDisabled}
       aria-disabled={isDisabled}
+      data-highlighted={props.isFocused}
     >
       {itemString}
     </StyledItem>


### PR DESCRIPTION
Closes: #2247

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Added useEffect with logic that scrolls the page to the element when it is focused

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook/Docs -> Combobox/Select -> Zoom 200% -> Navigate thgrough elements -> Check that the focused element is into view (page is scrolled to it)