### PR TITLE
fix(Docs): Update doc examples (Tag, Button, Combobox, Datagrid, Input, Radio)

### DIFF
--- a/.changeset/fix-tag-button-doc-issues.md
+++ b/.changeset/fix-tag-button-doc-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Tag & Button & Input & Combobox & Datagrid & RadioButton): Fix accessibility issues for examples.

--- a/website/react-magma-docs/src/pages/api/button.mdx
+++ b/website/react-magma-docs/src/pages/api/button.mdx
@@ -309,15 +309,19 @@ By default, buttons will have a type of `button`.
 import React from 'react';
 
 import {
+  Announce,
   Button,
   ButtonType,
   ButtonGroup,
   Input,
   Spacer,
+  VisuallyHidden,
 } from 'react-magma-dom';
 
 export function Example() {
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const clearedText = 'Inputs have been reset to default values.';
+  const [announcement, setAnnouncement] = React.useState('');
 
   function onFormSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -327,6 +331,10 @@ export function Example() {
   function onFormReset(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (inputRef.current) inputRef.current.value = '';
+    setAnnouncement('');
+    setTimeout(() => {
+      setAnnouncement(clearedText);
+    }, 10);
   }
 
   return (
@@ -337,6 +345,9 @@ export function Example() {
         <Button type={ButtonType.submit}>Submit</Button>
         <Button type={ButtonType.reset}>Reset</Button>
       </ButtonGroup>
+      <Announce>
+        <VisuallyHidden>{announcement}</VisuallyHidden>
+      </Announce>
     </form>
   );
 }

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -247,7 +247,7 @@ prop. If no `newItemTransform` function is passed in, the created item will be t
 ```tsx
 import React from 'react';
 
-import { Combobox } from 'react-magma-dom';
+import { Announce, Combobox, VisuallyHidden } from 'react-magma-dom';
 
 export function Example() {
   const defaultItems = [
@@ -256,6 +256,8 @@ export function Example() {
     { label: 'Green', value: 'green' },
   ];
   const [items, updateItems] = React.useState(defaultItems);
+  const clearedText = 'Inputs have been reset to default values.';
+  const [announcement, setAnnouncement] = React.useState('');
 
   function newItemTransform(item) {
     return {
@@ -266,6 +268,10 @@ export function Example() {
 
   function resetItems() {
     updateItems([...defaultItems]);
+    setAnnouncement('');
+    setTimeout(() => {
+      setAnnouncement(clearedText);
+    }, 10);
   }
 
   function onItemCreated(item) {
@@ -274,7 +280,9 @@ export function Example() {
 
   return (
     <>
-      <button onClick={resetItems}>Reset Items</button>
+      <button onClick={resetItems} style={{ marginRight: '12px' }}>
+        Reset Items
+      </button>
       <strong>Items: </strong>
       <pre>{JSON.stringify(items, null, 2)}</pre>
       <Combobox
@@ -284,6 +292,9 @@ export function Example() {
         newItemTransform={newItemTransform}
         onItemCreated={onItemCreated}
       />
+      <Announce>
+        <VisuallyHidden>{announcement}</VisuallyHidden>
+      </Announce>
     </>
   );
 }

--- a/website/react-magma-docs/src/pages/api/datagrid.mdx
+++ b/website/react-magma-docs/src/pages/api/datagrid.mdx
@@ -944,12 +944,20 @@ export function Example() {
 ```tsx
 import React from 'react';
 
-import { Button, ButtonColor, Datagrid } from 'react-magma-dom';
+import {
+  Announce,
+  Button,
+  ButtonColor,
+  Datagrid,
+  VisuallyHidden,
+} from 'react-magma-dom';
 
 export function Example() {
   const [selectedRows, updatedSelectedRows] = React.useState<
     (string | number)[]
   >([1]);
+  const clearedText = 'Inputs have been reset to default values.';
+  const [announcement, setAnnouncement] = React.useState('');
 
   const columns = [
     { field: 'col1', header: 'Col 1' },
@@ -1161,14 +1169,22 @@ export function Example() {
     },
   ];
 
+  function reset() {
+    if (selectedRows.length === 0) {
+      return;
+    }
+    updatedSelectedRows([]);
+    setAnnouncement('');
+    setTimeout(() => {
+      setAnnouncement(clearedText);
+    }, 10);
+  }
+
   return (
     <>
       <strong>Selected Rows: </strong>
       <pre>{JSON.stringify(selectedRows, null, 2)}</pre>
-      <Button
-        color={ButtonColor.danger}
-        onClick={() => updatedSelectedRows([])}
-      >
+      <Button color={ButtonColor.danger} onClick={reset}>
         Reset Selected Rows
       </Button>
       <hr />
@@ -1181,6 +1197,9 @@ export function Example() {
         tableTitle="Controlled Selectable Column table"
         hasSquareCorners
       />
+      <Announce>
+        <VisuallyHidden>{announcement}</VisuallyHidden>
+      </Announce>
     </>
   );
 }

--- a/website/react-magma-docs/src/pages/api/input.mdx
+++ b/website/react-magma-docs/src/pages/api/input.mdx
@@ -276,17 +276,21 @@ For short forms with an error, clicking submit should bring the focus back to th
 import React from 'react';
 
 import {
-  Input,
+  Announce,
   Button,
-  ButtonGroup,
   ButtonColor,
+  ButtonGroup,
+  Input,
   Spacer,
+  VisuallyHidden,
 } from 'react-magma-dom';
 
 export function Example() {
   const [hasError, setHasError] = React.useState(false);
   const [nameValue, setNameValue] = React.useState('');
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const clearedText = 'Input has been reset to default value.';
+  const [announcement, setAnnouncement] = React.useState('');
 
   function submit() {
     if (nameValue === '') {
@@ -301,6 +305,10 @@ export function Example() {
     setHasError(false);
     setNameValue('');
     inputRef.current && inputRef.current.focus();
+    setAnnouncement('');
+    setTimeout(() => {
+      setAnnouncement(clearedText);
+    }, 10);
   }
 
   return (
@@ -321,6 +329,9 @@ export function Example() {
           Reset
         </Button>
       </ButtonGroup>
+      <Announce>
+        <VisuallyHidden>{announcement}</VisuallyHidden>
+      </Announce>
     </>
   );
 }

--- a/website/react-magma-docs/src/pages/api/radio.mdx
+++ b/website/react-magma-docs/src/pages/api/radio.mdx
@@ -178,16 +178,20 @@ If an error message is present, it will replace the helper text. Can be a node o
 import React from 'react';
 
 import {
-  RadioGroup,
-  Radio,
+  Announce,
   Button,
   ButtonColor,
   ButtonGroup,
+  RadioGroup,
+  Radio,
+  VisuallyHidden,
 } from 'react-magma-dom';
 
 export function Example() {
   const [hasError, setHasError] = React.useState(false);
   const [requiredFieldsValue, setRequiredFieldsValue] = React.useState('');
+  const clearedText = 'Input has been reset to default value.';
+  const [announcement, setAnnouncement] = React.useState('');
 
   function changeValue(e) {
     setRequiredFieldsValue(e.target.value);
@@ -204,6 +208,10 @@ export function Example() {
   function reset() {
     setHasError(false);
     setRequiredFieldsValue('');
+    setAnnouncement('');
+    setTimeout(() => {
+      setAnnouncement(clearedText);
+    }, 10);
   }
 
   const errorMsg = hasError ? 'Please select a color' : null;
@@ -230,6 +238,9 @@ export function Example() {
           Reset
         </Button>
       </ButtonGroup>
+      <Announce>
+        <VisuallyHidden>{announcement}</VisuallyHidden>
+      </Announce>
     </>
   );
 }

--- a/website/react-magma-docs/src/pages/api/tag.mdx
+++ b/website/react-magma-docs/src/pages/api/tag.mdx
@@ -33,19 +33,35 @@ export function Example() {
 ```tsx
 import React from 'react';
 
-import { Spacer, SpacerAxis, Tag, TagColor, magma } from 'react-magma-dom';
+import {
+  Tag,
+  TagColor,
+  Flex,
+  FlexBehavior,
+  FlexJustify,
+  magma,
+} from 'react-magma-dom';
 
 export function Example() {
   return (
-    <>
-      <Tag>Default</Tag>
-      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
-      <Tag color={TagColor.primary}>Primary</Tag>
-      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
-      <Tag color={TagColor.lowContrast}>Low Contrast</Tag>
-      <Spacer axis={SpacerAxis.horizontal} size={magma.spaceScale.spacing03} />
-      <Tag color={TagColor.highContrast}>High Contrast</Tag>
-    </>
+    <Flex
+      behavior={FlexBehavior.container}
+      justify={FlexJustify.spaceBetween}
+      style={{ gap: magma.spaceScale.spacing02, maxWidth: '450px' }}
+    >
+      <Flex behavior={FlexBehavior.item}>
+        <Tag> Default</Tag>
+      </Flex>
+      <Flex behavior={FlexBehavior.item}>
+        <Tag color={TagColor.primary}>Primary</Tag>
+      </Flex>
+      <Flex behavior={FlexBehavior.item}>
+        <Tag color={TagColor.lowContrast}>Low Contrast</Tag>
+      </Flex>
+      <Flex behavior={FlexBehavior.item}>
+        <Tag color={TagColor.highContrast}>High Contrast</Tag>
+      </Flex>
+    </Flex>
   );
 }
 ```
@@ -289,8 +305,9 @@ import React from 'react';
 import {
   Card,
   CardBody,
-  Spacer,
-  SpacerAxis,
+  Flex,
+  FlexBehavior,
+  FlexJustify,
   Tag,
   TagColor,
   magma,
@@ -300,28 +317,30 @@ export function Example() {
   return (
     <Card isInverse>
       <CardBody>
-        <Tag isInverse>Inverse Default</Tag>
-        <Spacer
-          axis={SpacerAxis.horizontal}
-          size={magma.spaceScale.spacing03}
-        />
-        <Tag isInverse color={TagColor.primary}>
-          Inverse Primary
-        </Tag>
-        <Spacer
-          axis={SpacerAxis.horizontal}
-          size={magma.spaceScale.spacing03}
-        />
-        <Tag isInverse color={TagColor.lowContrast}>
-          Inverse Low Contrast
-        </Tag>
-        <Spacer
-          axis={SpacerAxis.horizontal}
-          size={magma.spaceScale.spacing03}
-        />
-        <Tag isInverse color={TagColor.highContrast}>
-          Inverse High Contrast
-        </Tag>
+        <Flex
+          behavior={FlexBehavior.container}
+          justify={FlexJustify.spaceBetween}
+          style={{ gap: magma.spaceScale.spacing03 }}
+        >
+          <Flex behavior={FlexBehavior.item} sx={3}>
+            <Tag isInverse>Inverse Default</Tag>
+          </Flex>
+          <Flex behavior={FlexBehavior.item} sx={3}>
+            <Tag isInverse color={TagColor.primary}>
+              Inverse Primary
+            </Tag>
+          </Flex>
+          <Flex behavior={FlexBehavior.item} sx={3}>
+            <Tag isInverse color={TagColor.lowContrast}>
+              Inverse Low Contrast
+            </Tag>
+          </Flex>
+          <Flex behavior={FlexBehavior.item} sx={3}>
+            <Tag isInverse color={TagColor.highContrast}>
+              Inverse High Contrast
+            </Tag>
+          </Flex>
+        </Flex>
       </CardBody>
     </Card>
   );


### PR DESCRIPTION
Closes: #2070
Closes: #2106
Cherry-pick: [2283](https://github.com/cengage/react-magma/pull/2283)

## What I did
- Updated doc examples for Tag, Button, Combobox, Datagrid, Input, Radio components.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Button -> Types -> Turn on NVDA/VO -> type text -> click on `Reset` -> NVDA/VO should announce 'Inputs have been reset to default values.'

Go to Docs -> Components -> Combobox -> Controlled Items -> Turn on NVDA/VO ->  type text -> click on `Reset items` -> NVDA/VO should announce 'Inputs have been reset to default values.'

Go to Docs -> Components -> Datagrid -> Controlled Selectable Column -> Turn on NVDA/VO -> select items-> click on `Reset selected rows` -> NVDA/VO should announce 'Inputs have been reset to default values.'

Go to Docs -> Components -> Input -> Error Message -> Turn on NVDA/VO -> type text-> click on `Reset` -> NVDA/VO should announce 'Inputs have been reset to default values.'

Go to Docs -> Components -> Radio Button -> Required Fields / Error Message -> Turn on NVDA/VO -> select item-> click on `Reset` -> NVDA/VO should announce 'Inputs have been reset to default values.'

Go to Docs -> Components -> Tag -> Colors & Inverse -> Zoom in to 200% -> tags should not be overlaped