### PR TITLE
fix(Dropdown): Fix update state during filtering.

### DIFF
--- a/.changeset/fix-Dropdown-sorting-issue.md
+++ b/.changeset/fix-Dropdown-sorting-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Fix state update when filtering or reordering.

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -994,3 +994,94 @@ export const Performance = {
 
   args: { ...Default.args },
 };
+
+const CustomDropdown = ({
+  onClick,
+  isFirst,
+  isLast,
+  moveUp,
+  moveDown,
+  args,
+}: {
+  onClick: VoidFunction;
+  isFirst: boolean;
+  isLast: boolean;
+  moveUp: VoidFunction;
+  moveDown: VoidFunction;
+  args: any;
+}) => {
+  return (
+    <Dropdown {...args}>
+      <DropdownButton>open</DropdownButton>
+      <DropdownContent>
+        <DropdownMenuItem disabled={isLast} onClick={moveDown}>
+          move down
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onClick}>nothing</DropdownMenuItem>
+        <DropdownMenuItem onClick={onClick}>nothing</DropdownMenuItem>
+        <DropdownMenuItem disabled={isFirst} onClick={moveUp}>
+          move up
+        </DropdownMenuItem>
+      </DropdownContent>
+    </Dropdown>
+  );
+};
+
+export const DropdownExpandableMenuWithSorting = {
+  render: args => {
+    const [templates, setTemplates] = React.useState([
+      { id: 1, title: 'test1', content: 'Some content 1 ' },
+      { id: 2, title: 'test2', content: 'Some content 2 ' },
+      { id: 3, title: 'test3', content: 'Some content 3 ' },
+    ]);
+
+    const moveDown = (id: number) => {
+      setTemplates(prev => {
+        const index = prev.findIndex(t => t.id === id);
+
+        if (index === prev.length - 1) return prev;
+
+        const newArr = [...prev];
+        const [item] = newArr.splice(index, 1);
+
+        newArr.splice(index + 1, 0, item);
+
+        return newArr;
+      });
+    };
+
+    const moveUp = (id: number) => {
+      setTemplates(prev => {
+        const index = prev.findIndex(t => t.id === id);
+
+        if (index === 0) return prev;
+
+        const newArr = [...prev];
+        const [item] = newArr.splice(index, 1);
+
+        newArr.splice(index - 1, 0, item);
+
+        return newArr;
+      });
+    };
+
+    return (
+      <div>
+        {templates.map((el, idx) => (
+          <div key={el.id}>
+            <span>{el.content}</span>
+            <CustomDropdown
+              args={args}
+              isLast={idx === templates.length - 1}
+              isFirst={idx === 0}
+              onClick={() => {}}
+              moveDown={() => moveDown(el.id)}
+              moveUp={() => moveUp(el.id)}
+            />
+            <Spacer size={16} />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
@@ -53,7 +53,7 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
   React.useEffect(() => {
     if (!expandableMenuItemContext.disabled)
       context.registerDropdownMenuItem(context.itemRefArray, ownRef);
-  }, []);
+  }, [expandableMenuItemContext.disabled]);
 
   return (
     <StyledDropdownMenuItem

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
@@ -181,7 +181,7 @@ export const DropdownMenuItem = React.forwardRef<
   React.useEffect(() => {
     if (!disabled)
       context.registerDropdownMenuItem(context.itemRefArray, ownRef);
-  }, []);
+  }, [disabled]);
 
   return (
     <StyledItem


### PR DESCRIPTION
Closes: #2293

## What I did
- Fixed updating state during filtering.

## Screenshots


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Dropdown -> DropdownExpandableMenuWithSorting -> Open `Some content 1` -> click on `move down` -> `move up` should be not disabled ->  click on `move down` -> `move down` should be  disabled -> try vice versa. 
