### PR TITLE
fix(NativeSelect): a11y additional content issue

### DIFF
--- a/.changeset/fix-NativeSelect-a11y-additional-content-issue.md
+++ b/.changeset/fix-NativeSelect-a11y-additional-content-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(NativeSelect): move `additionalContent` from `<label>`. Add internal prop to `FormFieldContainer`. Fix accessibility issue.

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.test.js
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.test.js
@@ -4,7 +4,6 @@ import { render } from '@testing-library/react';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
-import { CharacterCounter } from '../CharacterCounter';
 
 import { FormFieldContainer } from '.';
 

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -100,6 +100,10 @@ export interface FormFieldContainerBaseProps {
    * @internal
    */
   testId?: string;
+  /**
+   * @internal
+   */
+  additionalContent?: React.ReactNode;
 }
 
 const StyledFormFieldContainer = styled.div<{
@@ -139,6 +143,20 @@ function InputPositionWrapper(props) {
   return props.children;
 }
 
+const UpperWrapper = styled.div<{ labelPosition?: LabelPosition }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: ${props =>
+    props.labelPosition === LabelPosition.left
+      ? `0 ${props.theme.spaceScale.spacing03} 0 0`
+      : `0 0 ${props.theme.spaceScale.spacing03} 0`};
+
+  & > label {
+    margin: 0;
+  }
+`;
+
 export const FormFieldContainer = React.forwardRef<
   HTMLDivElement,
   FormFieldContainerProps
@@ -164,6 +182,7 @@ export const FormFieldContainer = React.forwardRef<
     maxLength,
     messageStyle,
     testId,
+    additionalContent,
     ...rest
   } = props;
   const theme = React.useContext(ThemeContext);
@@ -188,20 +207,25 @@ export const FormFieldContainer = React.forwardRef<
         theme={theme}
       >
         {labelText && (
-          <Label
-            actionable={actionable}
-            htmlFor={fieldId}
-            iconPosition={iconPosition}
-            labelPosition={labelPosition}
-            size={inputSize}
-            style={labelStyle}
-          >
-            {isLabelVisuallyHidden ? (
-              <VisuallyHidden>{labelText}</VisuallyHidden>
-            ) : (
-              labelText
-            )}
-          </Label>
+          <UpperWrapper labelPosition={labelPosition} theme={theme}>
+            <Label
+              actionable={actionable}
+              htmlFor={fieldId}
+              iconPosition={iconPosition}
+              labelPosition={labelPosition}
+              size={inputSize}
+              style={labelStyle}
+            >
+              {isLabelVisuallyHidden ? (
+                <VisuallyHidden>{labelText}</VisuallyHidden>
+              ) : (
+                labelText
+              )}
+            </Label>
+            {additionalContent &&
+              labelPosition !== LabelPosition.left &&
+              additionalContent}
+          </UpperWrapper>
         )}
         <InputPositionWrapper
           labelPosition={labelPosition}

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -190,16 +190,7 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
         hasLabel={!!labelText}
         labelPosition={labelPosition}
         labelStyle={labelStyle}
-        labelText={
-          labelPosition !== LabelPosition.left && additionalContent ? (
-            <>
-              {labelText}
-              {labelText && additionalContent}
-            </>
-          ) : (
-            labelText
-          )
-        }
+        labelText={labelText}
         labelWidth={labelWidth}
         isInverse={isInverse}
         helperMessage={helperMessage}

--- a/website/react-magma-docs/src/pages/api/native-select.mdx
+++ b/website/react-magma-docs/src/pages/api/native-select.mdx
@@ -54,7 +54,7 @@ export function Example() {
         onChange={handleChange}
         fieldId="example-uncontrolled"
       >
-        <option>Choose Color</option>
+        <option disabled>Choose Color</option>
         <option value="Red">Red</option>
         <option value="Green">Green</option>
         <option value="Blue">Blue</option>
@@ -78,7 +78,7 @@ export function Example() {
       value="Green"
       fieldId="example-controlled"
     >
-      <option>Choose Color</option>
+      <option disabled>Choose Color</option>
       <option value="Red">Red</option>
       <option value="Green">Green</option>
       <option value="Blue">Blue</option>


### PR DESCRIPTION
Closes: #2108

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix the issue with additional content and the MDX file

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
1. Open docs -> NativeSelect -> Controlled Select -> Check that `Choose color` option is disabled
2. Open docs/storybook -> NativeSelect -> Check all examples with additional content (change `labelPosition` and `labelText` props)