### PR TITLE
fix(Select & Combobox): Add announcing input changes after clearing value.

### DIFF
--- a/.changeset/fix-Select-clear-functionality.md
+++ b/.changeset/fix-Select-clear-functionality.md
@@ -1,0 +1,6 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Select & MultiSelect & Combobox & MultiCombobox): Add a state to announce changes after the input is cleared. 
+Updated doc example.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -877,6 +877,31 @@ describe('Combobox', () => {
     expect(renderedCombobox.value).toEqual(customItems[2].label);
   });
 
+  it('should have updated aria-label for selected item', async () => {
+    const { getByLabelText, getByText } = render(
+      <Combobox labelText={labelText} items={items} />
+    );
+
+    const renderedCombobox = getByLabelText(labelText, { selector: 'input' });
+
+    await userEvent.click(renderedCombobox);
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-label', 'Red');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-label', 'Blue');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Green')).toHaveAttribute('aria-label', 'Green');
+    await userEvent.keyboard('{Enter}');
+
+    await userEvent.click(renderedCombobox);
+    expect(getByText('Green')).toHaveAttribute(
+      'aria-label',
+      'Green is selected'
+    );
+  });
+
   describe('events', () => {
     it('onBlur', () => {
       const onBlur = jest.fn();

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
@@ -12,7 +12,9 @@ import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { useForkedRef } from '../../utils';
 import { ButtonShape, ButtonSize, ButtonVariant } from '../Button';
+import { ClearAnnouncer } from '../Select/ClearAnnouncer';
 import { defaultComponents } from '../Select/components';
+import { ItemListAnnouncer } from '../Select/ItemListAnnouncer';
 import { ItemsList } from '../Select/ItemsList';
 import { SelectContainer } from '../Select/SelectContainer';
 import { setFocusedItem } from '../Select/utils';
@@ -64,6 +66,7 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
 
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
+  const [clearAnnouncement, setClearAnnouncement] = React.useState('');
 
   function isCreatedItem(item) {
     return (
@@ -258,6 +261,15 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
     }
 
     reset();
+
+    setClearAnnouncement(
+      i18n.combobox.clearAnnounce.replace(/\{labelText\}/g, labelText)
+    );
+
+    // Clear the announcement after a delay to allow for re-announcements
+    setTimeout(() => {
+      setClearAnnouncement('');
+    }, 1000);
   }
 
   const clearIndicatorAriaLabel = i18n.combobox.clearIndicatorAriaLabel
@@ -375,7 +387,10 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
         maxHeight={itemListMaxHeight || theme.combobox.menu.maxHeight}
         menuStyle={menuStyle}
         setFloating={refs.setFloating}
+        selectedItem={selectedItem ? itemToString(selectedItem) : ''}
       />
+      <ItemListAnnouncer isOpen={isOpen} labelText={labelText} />
+      {isClearable && <ClearAnnouncer clearAnnouncement={clearAnnouncement} />}
     </SelectContainer>
   );
 }

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -12,7 +12,9 @@ import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { useForkedRef } from '../../utils';
 import { ButtonShape, ButtonSize, ButtonType, ButtonVariant } from '../Button';
+import { ClearAnnouncer } from '../Select/ClearAnnouncer';
 import { defaultComponents } from '../Select/components';
+import { ItemListAnnouncer } from '../Select/ItemListAnnouncer';
 import { ItemsList } from '../Select/ItemsList';
 import { SelectContainer } from '../Select/SelectContainer';
 import { IconWrapper, SelectedItemButton } from '../Select/shared';
@@ -65,6 +67,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
 
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
+  const [clearAnnouncement, setClearAnnouncement] = React.useState('');
 
   const [allItems, displayItems, setDisplayItems, updateItemsRef] =
     useComboboxItems(defaultItems, items);
@@ -327,6 +330,15 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
     }
 
     reset();
+
+    setClearAnnouncement(
+      i18n.select.clearAnnounce.replace(/\{labelText\}/g, labelText)
+    );
+
+    // Clear the announcement after a delay to allow for re-announcements
+    setTimeout(() => {
+      setClearAnnouncement('');
+    }, 1000);
   }
 
   const selectedItemsContent =
@@ -480,6 +492,8 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
         menuStyle={menuStyle}
         setFloating={refs.setFloating}
       />
+      <ItemListAnnouncer isOpen={isOpen} labelText={labelText} />
+      {isClearable && <ClearAnnouncer clearAnnouncement={clearAnnouncement} />}
     </SelectContainer>
   );
 }

--- a/packages/react-magma-dom/src/components/Select/ClearAnnouncer.tsx
+++ b/packages/react-magma-dom/src/components/Select/ClearAnnouncer.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import { Announce } from '../Announce';
+import { VisuallyHidden } from '../VisuallyHidden';
+
+export function ClearAnnouncer({ clearAnnouncement }) {
+  return (
+    <VisuallyHidden>
+      <Announce>{clearAnnouncement}</Announce>
+    </VisuallyHidden>
+  );
+}

--- a/packages/react-magma-dom/src/components/Select/ItemListAnnouncer.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemListAnnouncer.tsx
@@ -4,7 +4,7 @@ import { I18nContext } from '../../i18n';
 import { Announce } from '../Announce';
 import { VisuallyHidden } from '../VisuallyHidden';
 
-export function SelectAnnouncer({ isOpen, labelText }) {
+export function ItemListAnnouncer({ isOpen, labelText }) {
   const i18n = React.useContext(I18nContext);
 
   const announceMessage = isOpen

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -36,6 +36,7 @@ interface ItemsListProps<T> {
   menuStyle?: React.CSSProperties;
   setFloating?: (node: ReferenceType) => void;
   setHighlightedIndex?: (index: number) => void;
+  selectedItem?: string;
 }
 
 const NoItemsMessage = styled.span<{
@@ -73,6 +74,7 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
     menuStyle,
     setFloating,
     setHighlightedIndex,
+    selectedItem,
   } = props;
 
   const theme = React.useContext(ThemeContext);
@@ -128,10 +130,10 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
       >
         <StyledList
           isOpen={isOpen}
-          {...getMenuProps()}
           maxHeight={heightString}
           role="listbox"
           onMouseLeave={() => {}}
+          {...getMenuProps()}
         >
           {isOpen && hasItems ? (
             items.map((item, index) => {
@@ -147,6 +149,7 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
               });
 
               const key = `${itemString}${index}`;
+              const isSelected = selectedItem === itemToString(item);
 
               const itemProps: ItemRenderOptions<T> = {
                 isFocused: highlightedIndex === index,
@@ -160,6 +163,9 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
                 ...otherDownshiftItemProps,
                 onMouseMove: () => {},
                 role: 'option',
+                'aria-label': isSelected
+                  ? `${selectedItem} is selected`
+                  : itemString,
               };
 
               return <Item<T> {...itemProps} key={key} />;

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -4,18 +4,19 @@ import { autoUpdate } from '@floating-ui/react-dom';
 import { useMultipleSelection, useSelect } from 'downshift';
 import { CloseIcon } from 'react-magma-icons';
 
+import { ClearAnnouncer } from './ClearAnnouncer';
 import { defaultComponents } from './components';
+import { ItemListAnnouncer } from './ItemListAnnouncer';
 import { ItemsList } from './ItemsList';
-import { SelectAnnouncer } from './SelectAnnouncer';
 import { SelectContainer } from './SelectContainer';
 import { SelectTriggerButton } from './SelectTriggerButton';
 import { IconWrapper, SelectedItemButton, SelectText } from './shared';
+import { isItemDisabled } from './utils';
+import { useMagmaFloating } from '../../hooks/useMagmaFloating';
 import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { useForkedRef } from '../../utils';
 import { ButtonSize, ButtonVariant } from '../Button';
-import { isItemDisabled } from './utils';
-import { useMagmaFloating } from '../../hooks/useMagmaFloating';
 
 import { instanceOfDefaultItemObject, MultiSelectProps } from '.';
 
@@ -52,6 +53,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
     isClearable,
     initialHighlightedIndex,
   } = props;
+  const [clearAnnouncement, setClearAnnouncement] = React.useState('');
 
   function checkSelectedItemValidity(itemToCheck: T) {
     const itemIndex = items.findIndex(
@@ -275,6 +277,15 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
     }
 
     reset();
+
+    setClearAnnouncement(
+      i18n.select.clearAnnounce.replace(/\{labelText\}/g, labelText)
+    );
+
+    // Clear the announcement after a delay to allow for re-announcements
+    setTimeout(() => {
+      setClearAnnouncement('');
+    }, 1000);
   }
 
   const { floatingStyles, refs, elements, update } = useMagmaFloating();
@@ -395,7 +406,8 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
         />
       </SelectContainer>
 
-      <SelectAnnouncer isOpen={isOpen} labelText={labelText} />
+      <ItemListAnnouncer isOpen={isOpen} labelText={labelText} />
+      {isClearable && <ClearAnnouncer clearAnnouncement={clearAnnouncement} />}
     </>
   );
 }

--- a/packages/react-magma-dom/src/components/Select/Select.test.js
+++ b/packages/react-magma-dom/src/components/Select/Select.test.js
@@ -576,6 +576,31 @@ describe('Select', () => {
     expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('should have updated aria-label for selected item', async () => {
+    const { getByLabelText, getByText, getAllByText } = render(
+      <Select labelText={labelText} items={items} />
+    );
+
+    const renderedSelect = getByLabelText(labelText, { selector: 'div' });
+
+    await userEvent.click(renderedSelect);
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Red')).toHaveAttribute('aria-label', 'Red');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Blue')).toHaveAttribute('aria-label', 'Blue');
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(getByText('Green')).toHaveAttribute('aria-label', 'Green');
+    await userEvent.keyboard('{Enter}');
+
+    await userEvent.click(renderedSelect);
+    expect(getAllByText('Green')[1]).toHaveAttribute(
+      'aria-label',
+      'Green is selected'
+    );
+  });
+
   describe('additional content', () => {
     const helpLinkLabel = 'Learn more';
 

--- a/packages/react-magma-dom/src/components/Select/Select.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.tsx
@@ -8,9 +8,10 @@ import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { useForkedRef } from '../../utils';
 import { ButtonSize, ButtonVariant } from '../Button';
+import { ClearAnnouncer } from './ClearAnnouncer';
 import { defaultComponents } from './components';
+import { ItemListAnnouncer } from './ItemListAnnouncer';
 import { ItemsList } from './ItemsList';
-import { SelectAnnouncer } from './SelectAnnouncer';
 import { SelectContainer } from './SelectContainer';
 import { SelectTriggerButton } from './SelectTriggerButton';
 import { SelectText } from './shared';
@@ -59,6 +60,7 @@ export function Select<T>(props: SelectProps<T>) {
   const toggleButtonRef = React.useRef<HTMLButtonElement>();
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
+  const [clearAnnouncement, setClearAnnouncement] = React.useState('');
 
   const ref = useForkedRef(innerRef || null, toggleButtonRef);
 
@@ -198,6 +200,15 @@ export function Select<T>(props: SelectProps<T>) {
     }
 
     reset();
+
+    setClearAnnouncement(
+      i18n.select.clearAnnounce.replace(/\{labelText\}/g, labelText)
+    );
+
+    // Clear the announcement after a delay to allow for re-announcements
+    setTimeout(() => {
+      setClearAnnouncement('');
+    }, 1000);
   }
 
   const clearIndicatorAriaLabel = i18n.select.clearIndicatorAriaLabel
@@ -294,10 +305,12 @@ export function Select<T>(props: SelectProps<T>) {
           menuStyle={menuStyle}
           setFloating={refs.setFloating}
           setHighlightedIndex={setHighlightedIndex}
+          selectedItem={selectedItem ? itemToString(selectedItem) : ''}
         />
       </SelectContainer>
 
-      <SelectAnnouncer isOpen={isOpen} labelText={labelText} />
+      <ItemListAnnouncer isOpen={isOpen} labelText={labelText} />
+      {isClearable && <ClearAnnouncer clearAnnouncement={clearAnnouncement} />}
     </>
   );
 }

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -97,6 +97,7 @@ export const defaultI18n: I18nInterface = {
     clearIndicatorAriaLabel:
       'reset selection for {labelText}. {selectedItem} is selected',
     createLabel: 'Create "{inputValue}"',
+    clearAnnounce: '{labelText} has been cleared',
     multi: {
       clearIndicatorAriaLabel:
         'reset selection for {labelText}. {selectedItem} are selected',
@@ -233,10 +234,10 @@ export const defaultI18n: I18nInterface = {
   },
   multiSelect: {
     placeholder: 'Select...',
-    selectedItemButtonAriaLabel: 'reset item {selectedItem}',
+    selectedItemButtonAriaLabel: 'clear item {selectedItem}',
   },
   multiCombobox: {
-    selectedItemButtonAriaLabel: 'reset item {selectedItem}',
+    selectedItemButtonAriaLabel: 'clear item {selectedItem}',
   },
   pagination: {
     nextButtonLabel: 'Next Page',
@@ -267,6 +268,7 @@ export const defaultI18n: I18nInterface = {
     placeholder: 'Select...',
     clearIndicatorAriaLabel:
       'reset selection for {labelText}. {selectedItem} is selected',
+    clearAnnounce: '{labelText} has been cleared',
     expandedAnnounce: '{labelText} list expanded',
     collapsedAnnounce: '{labelText} list collapsed',
     multi: {

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -98,6 +98,7 @@ export interface I18nInterface {
   combobox: {
     clearIndicatorAriaLabel: string;
     createLabel: string;
+    clearAnnounce: string;
     multi: {
       clearIndicatorAriaLabel: string;
     };
@@ -252,6 +253,7 @@ export interface I18nInterface {
   select: {
     placeholder: string;
     clearIndicatorAriaLabel: string;
+    clearAnnounce: string;
     expandedAnnounce: string;
     collapsedAnnounce: string;
     multi: {

--- a/tests/playwright/tests/storybook/accordion/accordion.spec.ts
+++ b/tests/playwright/tests/storybook/accordion/accordion.spec.ts
@@ -363,7 +363,9 @@ test.describe('Accordion', () => {
     await verifyPersonalInformationContentHidden();
     await verifyShippingAddressContentHidden();
 
-    await expect(storyBookIframe.getByText('ComboBox Example')).toBeVisible();
+    await expect(
+      storyBookIframe.getByText('ComboBox Example', { exact: true })
+    ).toBeVisible();
     await expect(
       storyBookIframe.getByRole('button', { name: 'Basic Dropdown' })
     ).toBeVisible();

--- a/website/react-magma-docs/src/pages/api/select.mdx
+++ b/website/react-magma-docs/src/pages/api/select.mdx
@@ -1184,27 +1184,60 @@ However, these can be overridden by providing custom components to the `componen
 ```tsx
 import React from 'react';
 
-import { Select } from 'react-magma-dom';
+import { Announce, VisuallyHidden, Select } from 'react-magma-dom';
 
 export function Example() {
+  const [selectedItem, setSelectedItem] = React.useState({
+    label: 'Green',
+    value: 'green',
+  });
+  const [announcement, setAnnouncement] = React.useState('');
+  const [isCleared, setIsCleared] = React.useState(false);
+  const clearedText = 'All selected items have been cleared';
+
+  function handleOnChange(changes) {
+    setAnnouncement('');
+    setSelectedItem(changes.selectedItem);
+    setIsCleared(false);
+  }
+
+  function onClear(event, clearHandler) {
+    clearHandler(event);
+    setAnnouncement(clearedText);
+    setIsCleared(true);
+  }
+
   return (
-    <Select
-      id="customComponentsId"
-      labelText="Custom components"
-      items={[
-        { label: 'Red', value: 'red' },
-        { label: 'Blue', value: 'blue' },
-        { label: 'Green', value: 'green' },
-      ]}
-      initialSelectedItem={{ label: 'Green', value: 'green' }}
-      isClearable
-      components={{
-        ClearIndicator: props => <button onClick={props.onClick}>Clear</button>,
-        DropdownIndicator: () => (
-          <span style={{ border: '1px solid' }}>Dropdown</span>
-        ),
-      }}
-    />
+    <>
+      <Select
+        id="customComponentsId"
+        labelText="Custom components"
+        items={[
+          { label: 'Red', value: 'red' },
+          { label: 'Blue', value: 'blue' },
+          { label: 'Green', value: 'green' },
+        ]}
+        selectedItem={selectedItem}
+        onSelectedItemChange={handleOnChange}
+        isClearable
+        components={{
+          ClearIndicator: props => (
+            <button
+              aria-label="Clear selected value for Custom components"
+              onClick={event => onClear(event, props.onClick)}
+            >
+              Clear
+            </button>
+          ),
+          DropdownIndicator: () => (
+            <span style={{ border: '1px solid' }}>Dropdown</span>
+          ),
+        }}
+      />
+      <Announce>
+        <VisuallyHidden>{announcement}</VisuallyHidden>
+      </Announce>
+    </>
   );
 }
 ```


### PR DESCRIPTION
Closes: #2109
Closes: #2242
Closes: #2095
Closes: #2072
Closes: #2074

Cherry pick https://github.com/cengage/react-magma/pull/2265

## What I did
- Updated `aria-label` for selected item for `Select` & `Combobox` components.
- Updated doc example
- Updated `aria-label` clear button for  `MultiSelect` & `MultiCombobox` components.
- Added announcing after pressing the `clear` button for  `Select`, `Combobox`, `MultiSelect` & `MultiCombobox` components.
## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook ->  Select & Combobox -> Default -> select Red -> during navigation across this item, VO/NVDA should announce as `Red is selected`.

Go to Storybook -> Select & Combobox -> Default -> isClearable ->  select Red -> click on `Clear` button -> VO/NVDA should announce as `Example has been cleared`.

Go to Storybook -> Select & Combobox -> Multi ->  isClearable ->  select Red -> click on `Clear` button -> VO/NVDA should announce as `Example has been cleared`.

Go to Storybook -> Select & Combobox -> Multi  ->  select Red -> clear item button should have `aria-label` such as `clear item Red`

Go to Docs -> Components ->  Select-> Custom Components  ->  select Red -> VO/NVDA should announce as `All selected items have been cleared`.