### PR TITLE
fix(Combobox): Revoke navigation across disabled items.

### DIFF
--- a/.changeset/fix-Combobox-search-disabled-options.md
+++ b/.changeset/fix-Combobox-search-disabled-options.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Combobox): Prevent focusing disabled options.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -902,6 +902,35 @@ describe('Combobox', () => {
     );
   });
 
+  it('should skip disabled items when typing to filter', async () => {
+    const customItems = [
+      {
+        label: 'Red',
+        value: 'red',
+        disabled: false,
+      },
+      {
+        label: 'Blue',
+        value: 'blue',
+        disabled: true,
+      },
+      {
+        label: 'Green',
+        value: 'green',
+        disabled: false,
+      },
+    ];
+    const { getByLabelText, getByText } = render(
+      <Combobox labelText={labelText} items={customItems} />
+    );
+
+    const renderedCombobox = getByLabelText(labelText, { selector: 'input' });
+    await userEvent.type(renderedCombobox, 'Blue');
+
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'false');
+    expect(getByText('Blue')).not.toHaveFocus();
+  });
+
   describe('events', () => {
     it('onBlur', () => {
       const onBlur = jest.fn();

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -1066,6 +1066,40 @@ describe('MultiCombobox', () => {
     expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('should skip disabled items when typing to filter', async () => {
+    const customItems = [
+      {
+        label: 'Red',
+        value: 'red',
+        disabled: false,
+      },
+      {
+        label: 'Blue',
+        value: 'blue',
+        disabled: true,
+      },
+      {
+        label: 'Green',
+        value: 'green',
+        disabled: false,
+      },
+    ];
+
+    const { getByLabelText, getByText } = render(
+      <MultiCombobox isMulti labelText={labelText} items={customItems} />
+    );
+
+    const renderedCombobox = getByLabelText(labelText, {
+      selector: 'input',
+    });
+
+    await userEvent.clear(renderedCombobox);
+    await userEvent.type(renderedCombobox, 'Blue');
+
+    expect(getByText('Blue')).toHaveAttribute('aria-selected', 'false');
+    expect(getByText('Blue')).not.toHaveFocus();
+  });
+
   describe('events', () => {
     it('onBlur', () => {
       const onBlur = jest.fn();

--- a/packages/react-magma-dom/src/components/Combobox/shared.ts
+++ b/packages/react-magma-dom/src/components/Combobox/shared.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { isItemDisabled } from '../Select/utils';
+
 export function useComboboxItems(defaultItems, items) {
   const afterInitialRender = React.useRef(false);
   const allItems = React.useRef(defaultItems || items);
@@ -73,7 +75,11 @@ export function defaultOnInputValueChange(
           .filter(Boolean)
       : items.current;
 
-    setHighlightedIndex(0);
+    const firstEnabledIndex = filteredItems.findIndex(
+      item => !isItemDisabled(item)
+    );
+
+    setHighlightedIndex(firstEnabledIndex);
     setDisplayItems(filteredItems);
   }
 


### PR DESCRIPTION
Closes: #2056
Cherry-pick https://github.com/cengage/react-magma/pull/2302

## What I did
- Revoked navigation across disabled items

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Storybook -> Combobox -> Default -> type `Blue` -> the item should not be focused
Storybook -> Combobox -> Multi -> type `Green` -> the item should not be focused