### PR TITLE
fix(Search, Input): add `role="img"` for the `SearchIcon` and fix `Form` docs issues (#2301)

### DIFF
--- a/.changeset/fix-Search-and-Form-issues.md
+++ b/.changeset/fix-Search-and-Form-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Search, Input): add `role="img"` for the `SearchIcon` and fix `Form` docs issues.

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -771,6 +771,7 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             />
             {icon && !onIconClick && (
               <IconWrapper
+                role="img"
                 aria-label={iconAriaLabel}
                 iconPosition={iconPosition}
                 inputSize={inputSize ?? InputSize.medium}

--- a/packages/react-magma-dom/src/components/Search/Search.test.js
+++ b/packages/react-magma-dom/src/components/Search/Search.test.js
@@ -192,4 +192,27 @@ describe('Search', () => {
       return expect(result).toHaveNoViolations();
     });
   });
+
+  it('should render non-interactive icon with role="img" and aria-label for predictive search', () => {
+    const { container } = render(
+      <Search onSearch={onSearchSpy} isPredictive iconAriaLabel="Search icon" />
+    );
+
+    const iconWrapper = container.querySelector('span[role="img"]');
+    expect(iconWrapper).toBeInTheDocument();
+    expect(iconWrapper).toHaveAttribute('aria-label', 'Search icon');
+
+    expect(container.querySelector('button')).not.toBeInTheDocument();
+  });
+
+  it('should render interactive icon button with aria-label for regular search', () => {
+    const { container } = render(
+      <Search onSearch={onSearchSpy} iconAriaLabel="Search button" />
+    );
+
+    const iconButton = container.querySelector(
+      'button[aria-label="Search button"]'
+    );
+    expect(iconButton).toBeInTheDocument();
+  });
 });

--- a/website/react-magma-docs/src/pages/api/form.mdx
+++ b/website/react-magma-docs/src/pages/api/form.mdx
@@ -132,6 +132,7 @@ export function Example() {
             }))
           }
           errorMessage={errors.firstName && 'First Name is required'}
+          autoComplete="given-name"
         />
         <Spacer size="12" />
         <Input
@@ -144,6 +145,7 @@ export function Example() {
             }))
           }
           errorMessage={errors.lastName && 'Last Name is required'}
+          autoComplete="family-name"
         />
         <Spacer size="12" />
         <Input
@@ -156,6 +158,7 @@ export function Example() {
             }))
           }
           errorMessage={errors.email && 'Email is required'}
+          autoComplete="email"
         />
         <Spacer size="24" />
       </>
@@ -203,9 +206,9 @@ export function Example() {
           }
         >
           <>
-            <Input labelText="Name" />
+            <Input labelText="Name" autoComplete="given-name" />
             <Spacer size="12" />
-            <Input labelText="Email" />
+            <Input labelText="Email" autoComplete="email" />
             <Spacer size="24" />
           </>
         </Form>


### PR DESCRIPTION
Closes: #2105
Cherry-pick #2301

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Add `role="img"` for the `SearchIcon` and fix `Form` docs issues

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
1. Open docs -> Form -> Check that all Inputs have `autocomplete`.
2. Open docs/storybook -> Search -> Check that icons have `role="img"` (especially with Predictive Search) -> Check axe in devTools -> Check how they announced with NVDA/VO