### PR TITLE
fix(Dropdown): Fix update state during filtering.

### DIFF
--- a/.changeset/fix-CharacterCounter-error-message.md
+++ b/.changeset/fix-CharacterCounter-error-message.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(CharacterCounter & Input & TextArea): Update announcement for error message.

--- a/.changeset/fix-Dropdown-sorting-issue.md
+++ b/.changeset/fix-Dropdown-sorting-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Fix state update when filtering or reordering.

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -998,3 +998,94 @@ export const Performance = {
 
   args: { ...Default.args },
 };
+
+const CustomDropdown = ({
+  onClick,
+  isFirst,
+  isLast,
+  moveUp,
+  moveDown,
+  args,
+}: {
+  onClick: VoidFunction;
+  isFirst: boolean;
+  isLast: boolean;
+  moveUp: VoidFunction;
+  moveDown: VoidFunction;
+  args: any;
+}) => {
+  return (
+    <Dropdown {...args}>
+      <DropdownButton>open</DropdownButton>
+      <DropdownContent>
+        <DropdownMenuItem disabled={isLast} onClick={moveDown}>
+          move down
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onClick}>nothing</DropdownMenuItem>
+        <DropdownMenuItem onClick={onClick}>nothing</DropdownMenuItem>
+        <DropdownMenuItem disabled={isFirst} onClick={moveUp}>
+          move up
+        </DropdownMenuItem>
+      </DropdownContent>
+    </Dropdown>
+  );
+};
+
+export const DropdownExpandableMenuWithSorting = {
+  render: args => {
+    const [templates, setTemplates] = React.useState([
+      { id: 1, title: 'test1', content: 'Some content 1 ' },
+      { id: 2, title: 'test2', content: 'Some content 2 ' },
+      { id: 3, title: 'test3', content: 'Some content 3 ' },
+    ]);
+
+    const moveDown = (id: number) => {
+      setTemplates(prev => {
+        const index = prev.findIndex(t => t.id === id);
+
+        if (index === prev.length - 1) return prev;
+
+        const newArr = [...prev];
+        const [item] = newArr.splice(index, 1);
+
+        newArr.splice(index + 1, 0, item);
+
+        return newArr;
+      });
+    };
+
+    const moveUp = (id: number) => {
+      setTemplates(prev => {
+        const index = prev.findIndex(t => t.id === id);
+
+        if (index === 0) return prev;
+
+        const newArr = [...prev];
+        const [item] = newArr.splice(index, 1);
+
+        newArr.splice(index - 1, 0, item);
+
+        return newArr;
+      });
+    };
+
+    return (
+      <div>
+        {templates.map((el, idx) => (
+          <div key={el.id}>
+            <span>{el.content}</span>
+            <CustomDropdown
+              args={args}
+              isLast={idx === templates.length - 1}
+              isFirst={idx === 0}
+              onClick={() => {}}
+              moveDown={() => moveDown(el.id)}
+              moveUp={() => moveUp(el.id)}
+            />
+            <Spacer size={16} />
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownExpandableMenuListItem.tsx
@@ -52,7 +52,7 @@ export const DropdownExpandableMenuListItem = React.forwardRef<
   React.useEffect(() => {
     if (!expandableMenuItemContext.disabled)
       context.registerDropdownMenuItem(context.itemRefArray, ownRef);
-  }, []);
+  }, [expandableMenuItemContext.disabled]);
 
   return (
     <StyledDropdownMenuItem

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownMenuItem.tsx
@@ -178,7 +178,7 @@ export const DropdownMenuItem = React.forwardRef<
   React.useEffect(() => {
     if (!disabled)
       context.registerDropdownMenuItem(context.itemRefArray, ownRef);
-  }, []);
+  }, [disabled]);
 
   return (
     <StyledItem

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -188,9 +188,12 @@ export const FormFieldContainer = React.forwardRef<
   const isInverse = useIsInverse(isInverseProp);
 
   const countProps = maxCount || maxLength;
-
-  const descriptionId =
-    errorMessage || helperMessage || countProps ? `${fieldId}__desc` : null;
+  const counterDescriptionId =
+    typeof countProps === 'number' && hasCharacterCounter
+      ? `${fieldId}__counter`
+      : null;
+  const messageDescriptionId =
+    errorMessage || helperMessage ? `${fieldId}__message` : null;
 
   return (
     <InverseContext.Provider value={{ isInverse }}>
@@ -234,7 +237,7 @@ export const FormFieldContainer = React.forwardRef<
           {typeof countProps === 'number' && hasCharacterCounter && (
             <CharacterCounter
               hasCharacterCounter={hasCharacterCounter}
-              id={descriptionId}
+              id={counterDescriptionId}
               inputLength={inputLength}
               isInverse={isInverse}
               maxCount={maxCount}
@@ -245,11 +248,8 @@ export const FormFieldContainer = React.forwardRef<
 
           {(errorMessage || helperMessage) && (
             <InputMessage
-              aria-describedby={
-                errorMessage ? `${errorMessage}` : `${helperMessage}`
-              }
               hasError={!!errorMessage}
-              id={descriptionId}
+              id={messageDescriptionId}
               isInverse={isInverse}
               style={messageStyle}
             >

--- a/packages/react-magma-dom/src/components/Input/index.tsx
+++ b/packages/react-magma-dom/src/components/Input/index.tsx
@@ -108,12 +108,16 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
     const id = useGenerateId(defaultId);
 
-    const descriptionId =
-      errorMessage || helperMessage || maxCount || maxLength
-        ? `${id}__desc`
-        : null;
-
     const maxCharacters = typeof maxCount === 'number' ? maxCount : maxLength;
+    const counterDescriptionId =
+      typeof maxCharacters === 'number' && hasCharacterCounter
+        ? `${id}__counter`
+        : null;
+    const messageDescriptionId =
+      errorMessage || helperMessage ? `${id}__message` : null;
+    const descriptionId =
+      [counterDescriptionId, messageDescriptionId].filter(Boolean).join(' ') ||
+      null;
 
     const maxLengthNum =
       !hasCharacterCounter && maxLength ? maxLength : undefined;

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -76,11 +76,18 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const theme = React.useContext(ThemeContext);
 
     const id = useGenerateId(defaultId);
-    const descriptionId =
-      errorMessage || helperMessage || maxCount || maxLength
-        ? `${id}__desc`
-        : null;
+
     const maxCharacters = typeof maxCount === 'number' ? maxCount : maxLength;
+
+    const counterDescriptionId =
+      typeof maxCharacters === 'number' && hasCharacterCounter
+        ? `${id}__counter`
+        : null;
+    const messageDescriptionId =
+      errorMessage || helperMessage ? `${id}__message` : null;
+    const descriptionId =
+      [counterDescriptionId, messageDescriptionId].filter(Boolean).join(' ') ||
+      null;
 
     const maxLengthNum =
       !hasCharacterCounter && maxLength ? maxLength : undefined;

--- a/website/react-magma-docs/src/pages/api/character-counter.mdx
+++ b/website/react-magma-docs/src/pages/api/character-counter.mdx
@@ -40,7 +40,11 @@ import { Input } from 'react-magma-dom';
 
 export function Example() {
   return (
-    <Input maxCount={4} value="hi" labelText="Inital Value Character Counter" />
+    <Input
+      maxCount={4}
+      value="hi"
+      labelText="Initial Value Character Counter"
+    />
   );
 }
 ```


### PR DESCRIPTION
Closes: #2293
Cherry-pick: https://github.com/cengage/react-magma/pull/2294

## What I did
- Fixed updating state during filtering.

## Screenshots


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Dropdown -> DropdownExpandableMenuWithSorting -> Open `Some content 1` -> click on `move down` -> `move up` should be not disabled ->  click on `move down` -> `move down` should be  disabled -> try vice versa. 
