### PR TITLE
fix(MultiSelect & MultiCombobox): Update aria label text.

### DIFF
--- a/.changeset/fix-MultiCombobox-announce-values.md
+++ b/.changeset/fix-MultiCombobox-announce-values.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(MultiCombobox & MultiSelect): Add announcing current values with label.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -942,7 +942,7 @@ describe('Combobox', () => {
   });
 
   it('should have updated aria-label for selected item', async () => {
-    const { getByLabelText, getByText, getAllByText } = render(
+    const { getByLabelText, getByText } = render(
       <Combobox labelText={labelText} items={items} />
     );
 

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -587,6 +587,34 @@ describe('MultiCombobox', () => {
     });
   });
 
+  it('should have aria-label with selected items', async () => {
+    const { getByText } = render(
+      <MultiCombobox
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red', 'Blue']}
+      />
+    );
+
+    const label = getByText(labelText);
+
+    expect(label).toHaveAttribute(
+      'aria-label',
+      'Label Multi-select Selected: Red, Blue'
+    );
+  });
+
+  it('should have aria-label without selected items', async () => {
+    const { getByText } = render(
+      <MultiCombobox isMulti labelText={labelText} items={items} />
+    );
+
+    const label = getByText(labelText);
+
+    expect(label).toHaveAttribute('aria-label', 'Label Multi-select');
+  });
+
   describe('isTypeahead', () => {
     describe('when isTypeahead is true,', () => {
       it('should be able to select an item that is not in the items list', async () => {

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -323,6 +323,19 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
     .replace(/\{labelText\}/g, labelText)
     .replace(/\{selectedItem\}/g, itemsArrayToString(selectedItems));
 
+  const multiComboboxAriaLabel =
+    selectedItems.length > 0
+      ? i18n.combobox.multi.ariaLabelWithSelectedItems
+          .replace(/\{labelText\}/g, labelText)
+          .replace(
+            /\{selectedItems\}/g,
+            selectedItems.map(item => itemToString(item)).join(', ')
+          )
+      : i18n.combobox.multi.ariaLabelWithoutSelectedItems.replace(
+          /\{labelText\}/g,
+          labelText
+        );
+
   function defaultHandleClearIndicatorClick(event: React.SyntheticEvent) {
     event.stopPropagation();
 
@@ -425,6 +438,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
 
   return (
     <SelectContainer
+      ariaLabel={multiComboboxAriaLabel}
       descriptionId={ariaDescribedBy}
       errorMessage={errorMessage}
       getLabelProps={getLabelProps}
@@ -483,6 +497,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
         )}
       </ComboboxInput>
       <ItemsList
+        aria-multiselectable="true"
         customComponents={customComponents}
         floatingElementStyles={floatingElementStyles}
         getItemProps={getItemProps}

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -75,6 +75,7 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
     setFloating,
     setHighlightedIndex,
     selectedItem,
+    ...rest
   } = props;
 
   const theme = React.useContext(ThemeContext);
@@ -134,6 +135,7 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
           role="listbox"
           onMouseLeave={() => {}}
           {...getMenuProps()}
+          {...rest}
         >
           {isOpen && hasItems ? (
             items.map((item, index) => {

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
@@ -680,6 +680,34 @@ describe('MultiSelect', () => {
     expect(getByText('Green')).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('should have aria-label with selected items', async () => {
+    const { getByText } = render(
+      <MultiSelect
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red', 'Blue']}
+      />
+    );
+
+    const label = getByText(labelText);
+
+    expect(label).toHaveAttribute(
+      'aria-label',
+      'Label Multi-select Selected: Red, Blue'
+    );
+  });
+
+  it('should have aria-label without selected items', async () => {
+    const { getByText } = render(
+      <MultiSelect isMulti labelText={labelText} items={items} />
+    );
+
+    const label = getByText(labelText);
+
+    expect(label).toHaveAttribute('aria-label', 'Label Multi-select');
+  });
+
   describe('events', () => {
     it('onBlur', async () => {
       const onBlur = jest.fn();

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -273,6 +273,19 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
     .replace(/\{labelText\}/g, labelText)
     .replace(/\{selectedItem\}/g, itemsArrayToString(selectedItems));
 
+  const multiSelectAriaLabel =
+    selectedItems.length > 0
+      ? i18n.select.multi.ariaLabelWithSelectedItems
+          .replace(/\{labelText\}/g, labelText)
+          .replace(
+            /\{selectedItems\}/g,
+            selectedItems.map(item => itemToString(item)).join(', ')
+          )
+      : i18n.select.multi.ariaLabelWithoutSelectedItems.replace(
+          /\{labelText\}/g,
+          labelText
+        );
+
   function defaultHandleClearIndicatorClick(event: React.SyntheticEvent) {
     event.stopPropagation();
 
@@ -309,7 +322,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
     <>
       <SelectContainer
         additionalContent={additionalContent}
-        ariaLabel={ariaLabel}
+        ariaLabel={ariaLabel ?? multiSelectAriaLabel}
         descriptionId={ariaDescribedBy}
         errorMessage={errorMessage}
         getLabelProps={getLabelProps}
@@ -394,6 +407,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
           />
         )}
         <ItemsList
+          aria-multiselectable="true"
           customComponents={customComponents}
           floatingElementStyles={floatingElementStyles}
           getItemProps={getItemProps}

--- a/packages/react-magma-dom/src/components/Select/Select.stories.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.stories.tsx
@@ -78,7 +78,6 @@ export const Default = {
     isLabelVisuallyHidden: false,
     isMulti: false,
     labelPosition: LabelPosition.top,
-    ariaLabel: 'Another select text',
   },
 };
 
@@ -106,7 +105,6 @@ export const Multi = {
   args: {
     ...Default.args,
     disabled: false,
-    ariaLabel: 'Multi select example',
   },
 };
 

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -101,6 +101,9 @@ export const defaultI18n: I18nInterface = {
     multi: {
       clearIndicatorAriaLabel:
         'reset selection for {labelText}. {selectedItem} are selected',
+      ariaLabelWithSelectedItems:
+        '{labelText} Multi-select Selected: {selectedItems}',
+      ariaLabelWithoutSelectedItems: '{labelText} Multi-select',
     },
     loading: 'Loading...',
   },
@@ -274,6 +277,9 @@ export const defaultI18n: I18nInterface = {
     multi: {
       clearIndicatorAriaLabel:
         'reset selection for {labelText}. {selectedItem} are selected',
+      ariaLabelWithSelectedItems:
+        '{labelText} Multi-select Selected: {selectedItems}',
+      ariaLabelWithoutSelectedItems: '{labelText} Multi-select',
     },
   },
   simplePagination: {

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -101,6 +101,8 @@ export interface I18nInterface {
     clearAnnounce: string;
     multi: {
       clearIndicatorAriaLabel: string;
+      ariaLabelWithSelectedItems: string;
+      ariaLabelWithoutSelectedItems: string;
     };
     loading: string;
   };
@@ -258,6 +260,8 @@ export interface I18nInterface {
     collapsedAnnounce: string;
     multi: {
       clearIndicatorAriaLabel: string;
+      ariaLabelWithSelectedItems: string;
+      ariaLabelWithoutSelectedItems: string;
     };
   };
   simplePagination: {

--- a/website/react-magma-docs/src/pages/api/aibutton.mdx
+++ b/website/react-magma-docs/src/pages/api/aibutton.mdx
@@ -53,11 +53,19 @@ import { SettingsIcon } from 'react-magma-icons';
 export function Example() {
   return (
     <ButtonGroup>
-      <AIButton leadingIcon={<SettingsIcon />}>Leading custom icon</AIButton>
-      <AIButton leadingIcon={false} trailingIcon={<SettingsIcon />}>
+      <AIButton aria-label="Leading custom icon" leadingIcon={<SettingsIcon />}>
+        Leading custom icon
+      </AIButton>
+      <AIButton
+        aria-label="Trailing custom icon"
+        leadingIcon={false}
+        trailingIcon={<SettingsIcon />}
+      >
         Trailing custom icon
       </AIButton>
-      <AIButton trailingIcon={<SettingsIcon />}>Both Icons</AIButton>
+      <AIButton aria-label="Both Icons" trailingIcon={<SettingsIcon />}>
+        Both Icons
+      </AIButton>
     </ButtonGroup>
   );
 }


### PR DESCRIPTION
Closes: #2075
Closes: #2244 

## What I did
- Updated `aria-label` for `MultiSelect` and `MultiCombobox.`
- Added minor fix for AiButton Sandbox example.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Combobox -> Multi Combobox-> Turn on NVDA/VO -> Should be announced like `Multi combobox. Selected: Red, Blue, Green. Edit combo…”` 

Go to Docs -> Components -> Select -> Multi Select-> Turn on NVDA/VO -> Should be announced like `Multi combobox. Selected: Red, Blue, Green. Edit combo…”`

Go to Docs -> Components -> AiButton -> Leading and Trailing Icons -> Sandbox example
