### PR TITLE
fix(Combobox): Fix issue when focused item wasnt scrolled into view (#2291)

### DIFF
--- a/.changeset/fix-Combobox-zoom-200%-issue.md
+++ b/.changeset/fix-Combobox-zoom-200%-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Combobox): Fix issue when focused item wasn't scrolled into view.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { magma } from '../../theme/magma';
@@ -1173,9 +1173,9 @@ describe('Combobox', () => {
         selector: 'input',
       });
 
-      await userEvent.click(renderedCombobox);
+      userEvent.click(renderedCombobox);
 
-      await userEvent.keyboard('{ArrowDown}');
+      userEvent.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(mockScrollIntoView).toHaveBeenCalledWith({
@@ -1184,7 +1184,7 @@ describe('Combobox', () => {
         });
       });
 
-      await userEvent.keyboard('{ArrowDown}');
+      userEvent.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(mockScrollIntoView).toHaveBeenCalledTimes(2);
@@ -1202,14 +1202,14 @@ describe('Combobox', () => {
         selector: 'input',
       });
 
-      await userEvent.click(renderedCombobox);
-      await userEvent.keyboard('{ArrowDown}');
+      userEvent.click(renderedCombobox);
+      userEvent.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(getByText('Red')).toHaveAttribute('data-highlighted', 'true');
       });
 
-      await userEvent.keyboard('{ArrowDown}');
+      userEvent.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(getByText('Red')).toHaveAttribute('data-highlighted', 'false');

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -1159,4 +1159,62 @@ describe('Combobox', () => {
       });
     });
   });
+
+  describe('Accessibility - scrollIntoView', () => {
+    it('should call scrollIntoView on focused item when navigating with keyboard', async () => {
+      const mockScrollIntoView = jest.fn();
+      Element.prototype.scrollIntoView = mockScrollIntoView;
+
+      const { getByLabelText } = render(
+        <Combobox labelText={labelText} items={items} />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, {
+        selector: 'input',
+      });
+
+      await userEvent.click(renderedCombobox);
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(mockScrollIntoView).toHaveBeenCalledWith({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(mockScrollIntoView).toHaveBeenCalledTimes(2);
+      });
+
+      mockScrollIntoView.mockRestore();
+    });
+
+    it('should add data-highlighted attribute to focused item', async () => {
+      const { getByLabelText, getByText } = render(
+        <Combobox labelText={labelText} items={items} />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, {
+        selector: 'input',
+      });
+
+      await userEvent.click(renderedCombobox);
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(getByText('Red')).toHaveAttribute('data-highlighted', 'true');
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(getByText('Red')).toHaveAttribute('data-highlighted', 'false');
+        expect(getByText('Blue')).toHaveAttribute('data-highlighted', 'true');
+      });
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
@@ -67,6 +67,7 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
   const [clearAnnouncement, setClearAnnouncement] = React.useState('');
+  const clearAnnouncementTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
 
   function isCreatedItem(item) {
     return (
@@ -166,6 +167,15 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
 
   const [allItems, displayItems, setDisplayItems, updateItemsRef] =
     useComboboxItems(defaultItems, items);
+
+  // Cleanup timeout on unmount
+  React.useEffect(() => {
+    return () => {
+      if (clearAnnouncementTimeoutRef.current) {
+        clearTimeout(clearAnnouncementTimeoutRef.current);
+      }
+    };
+  }, []);
 
   function getValidItem(itemToCheck: T, key: string): object {
     // When using Typeahead, don't validate the items
@@ -267,7 +277,10 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
     );
 
     // Clear the announcement after a delay to allow for re-announcements
-    setTimeout(() => {
+    if (clearAnnouncementTimeoutRef.current) {
+      clearTimeout(clearAnnouncementTimeoutRef.current);
+    }
+    clearAnnouncementTimeoutRef.current = setTimeout(() => {
       setClearAnnouncement('');
     }, 1000);
   }

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { act, fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { magma } from '../../theme/magma';
@@ -1341,9 +1341,9 @@ describe('MultiCombobox', () => {
         selector: 'input',
       });
 
-      await userEvent.click(renderedCombobox);
+      userEvent.click(renderedCombobox);
 
-      await userEvent.keyboard('{ArrowDown}');
+      userEvent.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(mockScrollIntoView).toHaveBeenCalledWith({
@@ -1352,7 +1352,7 @@ describe('MultiCombobox', () => {
         });
       });
 
-      await userEvent.keyboard('{ArrowDown}');
+      userEvent.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(mockScrollIntoView).toHaveBeenCalledTimes(2);
@@ -1370,14 +1370,14 @@ describe('MultiCombobox', () => {
         selector: 'input',
       });
 
-      await userEvent.click(renderedCombobox);
-      await userEvent.keyboard('{ArrowDown}');
+      userEvent.click(renderedCombobox);
+      userEvent.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(getByText('Red')).toHaveAttribute('data-highlighted', 'true');
       });
 
-      await userEvent.keyboard('{ArrowDown}');
+      userEvent.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(getByText('Red')).toHaveAttribute('data-highlighted', 'false');

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -1327,4 +1327,62 @@ describe('MultiCombobox', () => {
       expect(queryByText('Modal Content')).not.toBeInTheDocument();
     });
   });
+
+  describe('Accessibility - scrollIntoView', () => {
+    it('should call scrollIntoView on focused item when navigating with keyboard', async () => {
+      const mockScrollIntoView = jest.fn();
+      Element.prototype.scrollIntoView = mockScrollIntoView;
+
+      const { getByLabelText } = render(
+        <MultiCombobox isMulti labelText={labelText} items={items} />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, {
+        selector: 'input',
+      });
+
+      await userEvent.click(renderedCombobox);
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(mockScrollIntoView).toHaveBeenCalledWith({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(mockScrollIntoView).toHaveBeenCalledTimes(2);
+      });
+
+      mockScrollIntoView.mockRestore();
+    });
+
+    it('should add data-highlighted attribute to focused item', async () => {
+      const { getByLabelText, getByText } = render(
+        <MultiCombobox isMulti labelText={labelText} items={items} />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, {
+        selector: 'input',
+      });
+
+      await userEvent.click(renderedCombobox);
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(getByText('Red')).toHaveAttribute('data-highlighted', 'true');
+      });
+
+      await userEvent.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(getByText('Red')).toHaveAttribute('data-highlighted', 'false');
+        expect(getByText('Blue')).toHaveAttribute('data-highlighted', 'true');
+      });
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -68,9 +68,19 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
   const [clearAnnouncement, setClearAnnouncement] = React.useState('');
+  const clearAnnouncementTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
 
   const [allItems, displayItems, setDisplayItems, updateItemsRef] =
     useComboboxItems(defaultItems, items);
+
+  // Cleanup timeout on unmount
+  React.useEffect(() => {
+    return () => {
+      if (clearAnnouncementTimeoutRef.current) {
+        clearTimeout(clearAnnouncementTimeoutRef.current);
+      }
+    };
+  }, []);
 
   function checkSelectedItemValidity(itemToCheck) {
     // When using Typeahead, don't validate the items
@@ -336,7 +346,10 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
     );
 
     // Clear the announcement after a delay to allow for re-announcements
-    setTimeout(() => {
+    if (clearAnnouncementTimeoutRef.current) {
+      clearTimeout(clearAnnouncementTimeoutRef.current);
+    }
+    clearAnnouncementTimeoutRef.current = setTimeout(() => {
       setClearAnnouncement('');
     }, 1000);
   }

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -80,6 +80,29 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
 
+  // Scroll highlighted item into view for accessibility
+  React.useEffect(() => {
+    if (isOpen && highlightedIndex !== undefined && highlightedIndex >= 0) {
+      const animationFrame = requestAnimationFrame(() => {
+        const highlightedElement = document.querySelector(
+          '[data-highlighted="true"]'
+        );
+
+        if (
+          highlightedElement &&
+          typeof highlightedElement.scrollIntoView === 'function'
+        ) {
+          highlightedElement.scrollIntoView({
+            behavior: 'smooth',
+            block: 'nearest',
+          });
+        }
+      });
+
+      return () => cancelAnimationFrame(animationFrame);
+    }
+  }, [highlightedIndex, isOpen]);
+
   const hasItems = items && items.length > 0;
 
   const heightString = convertStyleValueToString(maxHeight);

--- a/packages/react-magma-dom/src/components/Select/components.tsx
+++ b/packages/react-magma-dom/src/components/Select/components.tsx
@@ -58,6 +58,7 @@ export function DefaultItem<T>({
       ref={itemRef}
       isDisabled={isDisabled}
       aria-disabled={isDisabled}
+      data-highlighted={props.isFocused}
     >
       {itemString}
     </StyledItem>


### PR DESCRIPTION
Closes: #2247
Cherry-pick #2291

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Added useEffect with logic that scrolls the page to the element when it is focused

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook/Docs -> Combobox/Select -> Zoom 200% -> Navigate thgrough elements -> Check that the focused element is into view (page is scrolled to it)