### PR TITLE
fix(DatePicker): accessibility fixes for WCAG 2.2 AA compliance

### DIFF
--- a/.changeset/a11y-datepicker-wcag-fixes.md
+++ b/.changeset/a11y-datepicker-wcag-fixes.md
@@ -1,0 +1,22 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DatePicker): accessibility fixes for WCAG 2.2 AA compliance
+
+- A11Y-5197: Fix ESC key behavior to prevent closing parent modal
+  - Add native DOM event listener in capture phase to intercept ESC before Modal's listener
+  - Use stopImmediatePropagation() to prevent event from reaching Modal
+  - Implement ESC closes innermost element first (keyboard shortcuts → calendar → modal stays open)
+- A11Y-5198: Improve screen reader tooltip announcement for keyboard shortcut button
+  - Restructure tooltip to wrap button properly
+  - Update aria-label to "Keyboard instructions for calendar widget"
+- A11Y-5199: Complete ARIA grid pattern for calendar
+  - Add role="grid" to calendar table element
+  - Add role="gridcell" to all date cells and empty cells
+  - Add scope="col" to tableDaysHeaders
+- A11Y-5200: Implement focus trap in keyboard instructions modal
+  - Auto-focus "Back to Calendar" button when keyboard shortcuts open
+  - Tab key cycles within modal instead of escaping to parent
+  - Uses useFocusLock hook for proper focus management
+- A11Y-5201: Ensure focus returns to calendar after closing keyboard shortcuts

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
@@ -154,7 +154,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
     } ${sameDateAsChosenDate ? i18n.datePicker.selectedDayAriaLabel : ''}`;
 
     return (
-      <CalendarDayCell onFocus={onCalendarDayFocus} theme={theme}>
+      <CalendarDayCell role="gridcell" onFocus={onCalendarDayFocus} theme={theme}>
         <CalendarDayInner
           aria-disabled={disabled}
           aria-label={ariaLabel}
@@ -175,6 +175,6 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
       </CalendarDayCell>
     );
   } else {
-    return <EmptyCell />;
+    return <EmptyCell role="gridcell" />;
   }
 };

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
@@ -56,7 +56,7 @@ describe('Calendar Month', () => {
       userEvent.tab();
       expect(getByText(/18/i)).toHaveFocus();
       userEvent.tab();
-      expect(getByLabelText(/help/i)).toHaveFocus();
+      expect(getByLabelText(/keyboard instructions for calendar widget/i)).toHaveFocus();
       userEvent.tab();
       expect(getByLabelText(/close calendar/i)).toHaveFocus();
       userEvent.tab();
@@ -129,7 +129,7 @@ describe('Calendar Month', () => {
       expect(getByLabelText(/close calendar/i)).toHaveFocus();
 
       userEvent.tab({ shift: true });
-      expect(getByLabelText(/help/i)).toHaveFocus();
+      expect(getByLabelText(/keyboard instructions for calendar widget/i)).toHaveFocus();
 
       userEvent.tab({ shift: true });
       expect(getByText(/18/i)).toHaveFocus();
@@ -165,7 +165,7 @@ describe('Calendar Month', () => {
       </CalendarContext.Provider>
     );
 
-    fireEvent.click(getByLabelText('Calendar Widget Help'));
+    fireEvent.click(getByLabelText('Keyboard instructions for calendar widget'));
 
     expect(showHelperInformation).toHaveBeenCalled();
   });
@@ -213,7 +213,7 @@ describe('Calendar Month', () => {
       </CalendarContext.Provider>
     );
 
-    getByLabelText('Calendar Widget Help').focus();
+    getByLabelText('Keyboard instructions for calendar widget').focus();
 
     expect(setDateFocused).toHaveBeenCalledWith(false);
   });

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -123,7 +123,12 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
   const startOfWeek = days.indexOf(i18n.datePicker.startOfWeek);
   const sortedDays = days.slice(startOfWeek).concat(days.slice(0, startOfWeek));
   const tableDaysHeaders = sortedDays.map((day, index) => (
-    <Th key={index} theme={theme}>
+    <Th
+      key={index}
+      scope="col"
+      aria-label={i18n.days.long[day]}
+      theme={theme}
+    >
       {i18n.days.min[day]}
     </Th>
   ));
@@ -151,13 +156,15 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
             <CalendarHeader ref={headingRef} focusHeader={focusHeader} />
 
             <Table
-              role="presentation"
+              role="grid"
               onBlur={onCalendarTableBlur}
               onFocus={onCalendarTableFocus}
               theme={theme}
             >
-              <tbody>
+              <thead>
                 <tr>{tableDaysHeaders}</tr>
+              </thead>
+              <tbody>
                 {context
                   .buildCalendarMonth(context.focusedDate)
                   .map((week, i) => (
@@ -174,22 +181,21 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
                   ))}
               </tbody>
             </Table>
-            <Tooltip
-              content={'Keyboard instructions'}
-              tooltipStyle={{ position: 'fixed' }}
-            >
-              <HelperButton theme={theme}>
+            <HelperButton theme={theme} onFocus={turnOffDateFocused}>
+              <Tooltip
+                content={'Keyboard instructions'}
+                tooltipStyle={{ position: 'fixed' }}
+              >
                 <IconButton
                   aria-label={i18n.datePicker.helpModal.helpButtonAriaLabel}
                   icon={<KeyboardIcon />}
                   onClick={context.showHelperInformation}
                   size={ButtonSize.small}
-                  onFocus={turnOffDateFocused}
                   type={ButtonType.button}
                   variant={ButtonVariant.link}
                 />
-              </HelperButton>
-            </Tooltip>
+              </Tooltip>
+            </HelperButton>
 
             <CloseButton theme={theme}>
               <IconButton

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.tsx
@@ -9,6 +9,7 @@ import { TypographyVisualStyle } from '../Typography';
 
 import { I18nContext } from '../../i18n';
 import { ThemeContext } from '../../theme/ThemeContext';
+import { useFocusLock } from '../../hooks/useFocusLock';
 
 interface HelperInformationProps {
   isOpen?: boolean;
@@ -78,11 +79,20 @@ export const HelperInformation: React.FunctionComponent<
 > = (props: HelperInformationProps) => {
   const i18n = React.useContext(I18nContext);
   const theme = React.useContext(ThemeContext);
+  const backButtonRef = React.useRef<HTMLButtonElement>();
+  const focusTrapRef = useFocusLock(props.isOpen, backButtonRef);
+
+  React.useEffect(() => {
+    if (props.isOpen && backButtonRef.current) {
+      backButtonRef.current.focus();
+    }
+  }, [props.isOpen]);
 
   return (
-    <StyledPopup>
+    <StyledPopup ref={focusTrapRef}>
       <StyledNavContainer>
         <IconButton
+          ref={backButtonRef}
           icon={<ArrowBackIcon />}
           size={ButtonSize.small}
           style={{ top: '4px', left: '-12px' }}

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -153,6 +153,32 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
     const ref = useForkedRef(forwardedRef, inputRef);
 
     React.useEffect(() => {
+      if (calendarOpened) {
+        const handleNativeEscape = (event: KeyboardEvent) => {
+          if (event.key === 'Escape') {
+            event.stopImmediatePropagation();
+            event.preventDefault();
+
+            if (helperInformationShown) {
+              hideHelperInformation();
+            } else {
+              setCalendarOpened(false);
+              if (iconRef.current) {
+                iconRef.current.focus();
+              }
+            }
+          }
+        };
+
+        document.addEventListener('keydown', handleNativeEscape, true);
+
+        return () => {
+          document.removeEventListener('keydown', handleNativeEscape, true);
+        };
+      }
+    }, [calendarOpened, helperInformationShown]);
+
+    React.useEffect(() => {
       if (!calendarOpened) {
         setDateFocused(false);
       }
@@ -304,6 +330,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
     function handleInputKeyDown(event: React.KeyboardEvent) {
       if (event.key === 'Escape') {
         event.preventDefault();
+        event.stopPropagation();
         setCalendarOpened(false);
         inputRef.current.focus();
       }
@@ -324,8 +351,15 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
         }
       } else {
         if (event.key === 'Escape') {
-          setCalendarOpened(false);
-          iconRef.current.focus();
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (helperInformationShown) {
+            hideHelperInformation();
+          } else {
+            setCalendarOpened(false);
+            iconRef.current.focus();
+          }
         }
 
         if (event.key === '?') {

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -103,7 +103,7 @@ export const defaultI18n: I18nInterface = {
     todayAriaLabel: '(Today)',
     helpModal: {
       header: 'Keyboard Shortcuts',
-      helpButtonAriaLabel: 'Calendar Widget Help',
+      helpButtonAriaLabel: 'Keyboard instructions for calendar widget',
       enter: {
         ariaLabel: 'Enter key',
         explanation: 'Select the date in focus.',


### PR DESCRIPTION
Closes: #

## What I did
- A11Y-5197: Fix ESC key behavior to prevent closing parent modal
  - Add native DOM event listener in capture phase to intercept ESC before Modal's listener
  - Use stopImmediatePropagation() to prevent event from reaching Modal
  - Implement ESC closes innermost element first (keyboard shortcuts → calendar → modal stays open)
- A11Y-5198: Improve screen reader tooltip announcement for keyboard shortcut button
  - Restructure tooltip to wrap button properly
  - Update aria-label to "Keyboard instructions for calendar widget"
- A11Y-5199: Complete ARIA grid pattern for calendar
  - Add role="grid" to calendar table element
  - Add role="gridcell" to all date cells and empty cells
  - Add scope="col" to tableDaysHeaders
- A11Y-5200: Implement focus trap in keyboard instructions modal
  - Auto-focus "Back to Calendar" button when keyboard shortcuts open
  - Tab key cycles within modal instead of escaping to parent
  - Uses useFocusLock hook for proper focus management
- A11Y-5201: Ensure focus returns to calendar after closing keyboard shortcuts


## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
### Test Case 1: ESC Key Behavior (A11Y-5197)

**Test in Modal story (available in Modal component stories):**

1. Go to **Modal** → **Multiple Modals** story (or any story with DatePicker in Modal)
2. Open the modal containing DatePicker
3. Click the calendar icon to open the date picker
4. **Expected:** Calendar opens
5. Press **ESC** key once
6. **Expected:** 
   -  Calendar closes
   -  Modal stays open
   -  Focus returns to calendar icon
7. **FAIL if:** Modal also closes (this was the bug)

**Test with Keyboard Instructions:**

1. Open DatePicker calendar
2. Click the keyboard icon (bottom-left of calendar) to open keyboard shortcuts
3. Press **ESC** key once
4. **Expected:** 
   - Keyboard shortcuts modal closes
   - Calendar stays open
   - Focus returns to the element that opened shortcuts
5. Press **ESC** key again
6. **Expected:** 
   - Calendar closes
   - Focus returns to calendar icon

### Test Case 2: Screen Reader Announcement (A11Y-5198)

**With VoiceOver (Mac):**

1. Enable VoiceOver: `Cmd + F5`
2. Open DatePicker calendar
3. Navigate to the keyboard icon (bottom-left)
4. **Expected announcement:** "Keyboard instructions for calendar widget, button"
5. **PASS if:** Screen reader announces descriptive label
6. **FAIL if:** Only announces "button" or icon name without context

**With NVDA (Windows) or JAWS:**
- Similar test - ensure button announces its purpose clearly

### Test Case 3: ARIA Grid Semantics (A11Y-5199)

**With Browser DevTools:**

1. Open DatePicker calendar
2. Open browser DevTools (F12)
3. Inspect the calendar table element
4. **Expected:** `<table role="grid">`
5. Inspect any date cell (e.g., "15")
6. **Expected:** `<td role="gridcell">`
7. Inspect an empty cell (dates outside current month)
8. **Expected:** `<td role="gridcell" />`
9. **PASS if:** All table cells have `role="gridcell"`

**With Screen Reader:**

1. Enable VoiceOver/NVDA
2. Navigate to calendar with `Tab` key
3. Use arrow keys to navigate dates
4. **Expected:** Screen reader announces "row X of Y, column Z of 7" or similar grid navigation cues
5. **PASS if:** Screen reader recognizes it as a grid structure

### Test Case 4: Focus Trap in Keyboard Instructions (A11Y-5200)

1. Open DatePicker calendar
2. Click keyboard icon to open keyboard shortcuts modal
3. **Expected:** "Back to Calendar" button is auto-focused
4. Press **Tab** key repeatedly
5. **Expected path:**
   - Back to Calendar button
   - Close button
   - (cycles back to) Back to Calendar button
6. **PASS if:** Tab key stays within the modal
7. **FAIL if:** Tab key escapes to calendar or parent modal

**Alternative test:**

1. Use `Shift + Tab` to cycle backwards
2. **Expected:** Focus cycles in reverse order within modal only

### Test Case 5: Focus Return (A11Y-5201)

1. Open DatePicker calendar
2. Navigate to a specific date (e.g., "15") using arrow keys
3. Press **?** key or click keyboard icon to open shortcuts
4. **Expected:** Keyboard shortcuts modal opens
5. Click "Back to Calendar" or press **ESC**
6. **Expected:** 
   - Keyboard shortcuts closes
   - Focus returns to date "15" (where you were before)
7. **PASS if:** Focus restoration works correctly

### Test Case 6: No Regressions

**Test existing functionality still works:**

1. Select a date by clicking → **Expected:** Date selected, calendar closes
2. Navigate with arrow keys → **Expected:** Dates navigate correctly
3. Type date in input field → **Expected:** Validates and updates calendar
4. Use Home/End/PageUp/PageDown keys → **Expected:** Navigate weeks/months
5. Clear button (if enabled) → **Expected:** Clears selected date

### Test Case 7: Browser Compatibility

**Test in multiple browsers:**
- Chrome/Edge (Chromium)
- Firefox
- Safari

**For each browser, verify:**
- ESC key behavior works
- Focus trap works
- ARIA grid is recognized (check with screen reader)
