### PR TITLE
fix(Tabs & NavTabs): Update focus behavior and aria-labels.

### DIFF
--- a/.changeset/fix-Tab-update-focus-behavior-arir-labels.md
+++ b/.changeset/fix-Tab-update-focus-behavior-arir-labels.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tab & NavTab): Add focus on the back and next buttons. Add announce tab content. Update aria-labels.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
@@ -277,7 +277,7 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
     reset();
 
     setClearAnnouncement(
-      i18n.combobox.clearAnnounce.replace(/\{labelText\}/g, labelText)
+      i18n.combobox.clearAnnounce?.replace(/\{labelText\}/g, labelText)
     );
 
     // Clear the announcement after a delay to allow for re-announcements
@@ -290,8 +290,8 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
   }
 
   const clearIndicatorAriaLabel = i18n.combobox.clearIndicatorAriaLabel
-    .replace(/\{labelText\}/g, labelText)
-    .replace(/\{selectedItem\}/g, itemToString(selectedItem));
+    ?.replace(/\{labelText\}/g, labelText)
+    ?.replace(/\{selectedItem\}/g, itemToString(selectedItem));
 
   function handleOnKeyDown(event: React.KeyboardEvent) {
     const count = document.querySelectorAll('[aria-modal="true"]').length;

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -326,22 +326,22 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
 
   const clearIndicatori18n =
     selectedItems.length > 1
-      ? i18n.combobox.multi.clearIndicatorAriaLabel
-      : i18n.combobox.clearIndicatorAriaLabel;
+      ? i18n.combobox.multi?.clearIndicatorAriaLabel
+      : i18n.combobox?.clearIndicatorAriaLabel;
 
   const clearIndicatorAriaLabel = clearIndicatori18n
-    .replace(/\{labelText\}/g, labelText)
-    .replace(/\{selectedItem\}/g, itemsArrayToString(selectedItems));
+    ?.replace(/\{labelText\}/g, labelText)
+    ?.replace(/\{selectedItem\}/g, itemsArrayToString(selectedItems));
 
   const multiComboboxAriaLabel =
     selectedItems.length > 0
       ? i18n.combobox.multi?.ariaLabelWithSelectedItems
-          .replace(/\{labelText\}/g, labelText)
-          .replace(
+          ?.replace(/\{labelText\}/g, labelText)
+          ?.replace(
             /\{selectedItems\}/g,
             selectedItems.map(item => itemToString(item)).join(', ')
           )
-      : i18n.combobox.multi?.ariaLabelWithoutSelectedItems.replace(
+      : i18n.combobox.multi?.ariaLabelWithoutSelectedItems?.replace(
           /\{labelText\}/g,
           labelText
         );
@@ -360,7 +360,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
     reset();
 
     setClearAnnouncement(
-      i18n.select.clearAnnounce.replace(/\{labelText\}/g, labelText)
+      i18n.select?.clearAnnounce?.replace(/\{labelText\}/g, labelText)
     );
 
     // Clear the announcement after a delay to allow for re-announcements
@@ -378,7 +378,7 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
         {selectedItems.map((multiSelectedItem, index) => {
           return (
             <SelectedItemButton
-              aria-label={i18n.multiCombobox.selectedItemButtonAriaLabel.replace(
+              aria-label={i18n.multiCombobox.selectedItemButtonAriaLabel?.replace(
                 /\{selectedItem\}/g,
                 itemToString(multiSelectedItem)
               )}

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -335,13 +335,13 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
 
   const multiComboboxAriaLabel =
     selectedItems.length > 0
-      ? i18n.combobox.multi.ariaLabelWithSelectedItems
+      ? i18n.combobox.multi?.ariaLabelWithSelectedItems
           .replace(/\{labelText\}/g, labelText)
           .replace(
             /\{selectedItems\}/g,
             selectedItems.map(item => itemToString(item)).join(', ')
           )
-      : i18n.combobox.multi.ariaLabelWithoutSelectedItems.replace(
+      : i18n.combobox.multi?.ariaLabelWithoutSelectedItems.replace(
           /\{labelText\}/g,
           labelText
         );

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
@@ -12,12 +12,15 @@ import {
   TabsContainerContext,
 } from '../Tabs';
 import { NavTabProps, NavTab } from './NavTab';
+import { I18nContext } from '../../i18n';
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { getNormalizedScrollLeft, Omit } from '../../utils';
+import { Announce } from '../Announce';
 import { TabsOrientation, TabsTextTransform } from '../Tabs/shared';
 import { ButtonNext, ButtonPrev } from '../Tabs/TabsScrollButtons';
 import { useTabsMeta } from '../Tabs/utils';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 export interface NavTabsProps extends Omit<TabsProps, 'onChange'> {
   'aria-label'?: string;
@@ -82,6 +85,8 @@ export const NavTabs = React.forwardRef<
 
   const navTabChildren = React.Children.toArray(children);
   const childrenWrapperRef = React.useRef<HTMLUListElement>();
+  const [scrollAnnouncement, setScrollAnnouncement] = React.useState('');
+  const i18n = React.useContext(I18nContext);
 
   const hasChildFocus = navTabChildren.some(child => {
     if (React.isValidElement(child)) {
@@ -172,7 +177,27 @@ export const NavTabs = React.forwardRef<
     scroll(nextScrollStart);
   };
 
+  const handlePrevScrollWithAnnouncement = () => {
+    handleStartScrollClick();
+    setScrollAnnouncement(i18n.tabs.scrolledBackAnnounce);
+    setTimeout(() => setScrollAnnouncement(''), 100);
+  };
+
+  const handleNextScrollWithAnnouncement = () => {
+    handleEndScrollClick();
+    setScrollAnnouncement(i18n.tabs.scrolledForwardAnnounce);
+    setTimeout(() => setScrollAnnouncement(''), 100);
+  };
+
   React.useEffect(scrollInitialActiveIndexIntoView, []);
+
+  React.useEffect(() => {
+    if (!displayScroll.start) {
+      nextButtonRef.current?.focus();
+    } else if (!displayScroll.end) {
+      prevButtonRef.current?.focus();
+    }
+  }, [displayScroll.start, displayScroll.end]);
 
   return (
     <StyledContainer
@@ -190,7 +215,7 @@ export const NavTabs = React.forwardRef<
         backgroundColor={background}
         buttonVisible={displayScroll.start}
         isInverse={isInverse}
-        onClick={handleStartScrollClick}
+        onClick={handlePrevScrollWithAnnouncement}
         orientation={orientation || TabsOrientation.horizontal}
         ref={prevButtonRef}
         theme={theme}
@@ -225,11 +250,14 @@ export const NavTabs = React.forwardRef<
         backgroundColor={background}
         buttonVisible={displayScroll.end}
         isInverse={isInverse}
-        onClick={handleEndScrollClick}
+        onClick={handleNextScrollWithAnnouncement}
         orientation={orientation || TabsOrientation.horizontal}
         ref={nextButtonRef}
         theme={theme}
       />
+      <VisuallyHidden>
+        <Announce>{scrollAnnouncement}</Announce>
+      </VisuallyHidden>
     </StyledContainer>
   );
 });

--- a/packages/react-magma-dom/src/components/Tabs/Tab.test.js
+++ b/packages/react-magma-dom/src/components/Tabs/Tab.test.js
@@ -1,9 +1,11 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { CheckIcon } from 'react-magma-icons';
 
 import { Tab } from './Tab';
+import { TabPanel } from './TabPanel';
+import { TabPanelsContainer } from './TabPanelsContainer';
 import { TabsContainer } from './TabsContainer';
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
@@ -276,20 +278,50 @@ it('should show fire a custom onClick event', () => {
 });
 
 describe('Test for accessibility', () => {
-  it('Does not violate accessibility standards', () => {
+  it('Does not violate accessibility standards', async () => {
+    jest.useFakeTimers();
     const testId = 'test-id';
     const { container } = render(
       <TabsContainer>
         <Tabs>
           <Tab testId={testId}>Tab Text</Tab>
         </Tabs>
+        <TabPanelsContainer>
+          <TabPanel>Tab Content</TabPanel>
+        </TabPanelsContainer>
       </TabsContainer>
     );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    jest.useRealTimers();
 
     return axe(container.innerHTML, {
       rules: { listitem: { enabled: false } },
     }).then(result => {
       return expect(result).toHaveNoViolations();
     });
+  });
+
+  it('should have all necessary accessibility attributes', () => {
+    const testId = 'test-id';
+    const { getAllByTestId } = render(
+      <TabsContainer>
+        <Tabs>
+          <Tab testId={testId}>Tab Text</Tab>
+        </Tabs>
+        <TabPanelsContainer>
+          <TabPanel>Tab Content</TabPanel>
+        </TabPanelsContainer>
+      </TabsContainer>
+    );
+
+    expect(getAllByTestId(testId)[0]).toHaveAttribute('role', 'tab');
+    expect(getAllByTestId(testId)[0]).toHaveAttribute(
+      'aria-controls',
+      'tabpanel-0'
+    );
+    expect(getAllByTestId(testId)[0]).toHaveAttribute('id', 'tab-0');
   });
 });

--- a/packages/react-magma-dom/src/components/Tabs/Tab.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/Tab.tsx
@@ -300,6 +300,9 @@ export const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
           : TabsIconPosition.top;
     }
 
+    const tabId = `tab-${index}`;
+    const panelId = `tabpanel-${index}`;
+
     if (unstyled) {
       const child = React.Children.only(children) as React.ReactElement;
 
@@ -332,8 +335,10 @@ export const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
         >
           {React.cloneElement(child, {
             ...clonedElProps,
+            'aria-controls': panelId,
             'aria-selected': isActive,
             disabled,
+            id: tabId,
             onClick: e => handleClick(index, e),
             ref,
             role: 'tab',
@@ -357,10 +362,12 @@ export const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
       >
         <StyledTab
           {...rest}
+          aria-controls={panelId}
           aria-selected={isActive}
           data-testid={testId}
           disabled={disabled}
           iconPosition={tabIconPosition}
+          id={tabId}
           isActive={isActive}
           isInverse={isInverse}
           isFullWidth={isFullWidth}

--- a/packages/react-magma-dom/src/components/Tabs/TabPanel.test.js
+++ b/packages/react-magma-dom/src/components/Tabs/TabPanel.test.js
@@ -6,7 +6,6 @@ import { TabPanel } from './TabPanel';
 import { TabPanelsContainer } from './TabPanelsContainer';
 import { TabsContainerContext } from './TabsContainer';
 import { axe } from '../../../axe-helper';
-import { magma } from '../../theme/magma';
 
 describe('TabPanel', () => {
   it('should correctly apply the testId', () => {
@@ -82,5 +81,24 @@ describe('Test for accessibility', () => {
     return axe(container.innerHTML).then(result => {
       return expect(result).toHaveNoViolations();
     });
+  });
+
+  it('should have all necessary accessibility attributes', () => {
+    const testId = 'test-id';
+
+    const { getAllByTestId } = render(
+      <TabsContainerContext.Provider value={{ activeTabIndex: 0 }}>
+        <TabPanelsContainer>
+          <TabPanel testId={testId}>Tab Panel Text</TabPanel>
+        </TabPanelsContainer>
+      </TabsContainerContext.Provider>
+    );
+
+    expect(getAllByTestId(testId)[0]).toHaveAttribute('role', 'tabpanel');
+    expect(getAllByTestId(testId)[0]).toHaveAttribute(
+      'aria-labelledby',
+      'tab-0'
+    );
+    expect(getAllByTestId(testId)[0]).toHaveAttribute('id', 'tabpanel-0');
   });
 });

--- a/packages/react-magma-dom/src/components/Tabs/TabPanel.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/TabPanel.tsx
@@ -42,10 +42,16 @@ export const TabPanel = React.forwardRef<HTMLDivElement, TabPanelProps>(
     const { activeTabIndex } = React.useContext(TabsContainerContext);
     const activeTab = activeTabIndex === index;
 
+    const panelId = `tabpanel-${index}`;
+    const tabId = `tab-${index}`;
+
     return activeTab ? (
       <StyledTabPanel
         ref={ref}
         data-testid={testId}
+        id={panelId}
+        role="tabpanel"
+        aria-labelledby={tabId}
         isInverse={isInverse}
         theme={theme}
         {...other}

--- a/packages/react-magma-dom/src/components/Tabs/Tabs.test.js
+++ b/packages/react-magma-dom/src/components/Tabs/Tabs.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 
 import { Tab } from './Tab';
 import { TabPanel } from './TabPanel';
@@ -828,7 +828,8 @@ describe('Tabs', () => {
 });
 
 describe('Test for accessibility', () => {
-  it('Does not violate accessibility standards', () => {
+  it('Does not violate accessibility standards', async () => {
+    jest.useFakeTimers();
     const { container } = render(
       <TabsContainer activeIndex={0}>
         <Tabs testId={'dd'} orientation="horizontal">
@@ -845,10 +846,14 @@ describe('Test for accessibility', () => {
       </TabsContainer>
     );
 
-    return axe(container.innerHTML, {
-      rules: { listitem: { enabled: false } },
-    }).then(result => {
-      return expect(result).toHaveNoViolations();
+    act(() => {
+      jest.runAllTimers();
     });
+    jest.useRealTimers();
+
+    const result = await axe(container.innerHTML, {
+      rules: { listitem: { enabled: false } },
+    });
+    expect(result).toHaveNoViolations();
   });
 });

--- a/packages/react-magma-dom/src/components/Tabs/Tabs.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/Tabs.tsx
@@ -12,6 +12,8 @@ import { I18nContext } from '../../i18n';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { omit, Omit, getNormalizedScrollLeft } from '../../utils';
+import { Announce } from '../Announce';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 export enum TabsAlignment {
   center = 'center',
@@ -220,6 +222,8 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
     const [buttonRefArray, registerTabButton] = useDescendants();
 
     const childrenWrapperRef = React.useRef<HTMLUListElement>();
+    const [scrollAnnouncement, setScrollAnnouncement] = React.useState('');
+    const [panelAnnouncement, setPanelAnnouncement] = React.useState('');
 
     function getTabsMeta() {
       const tabsNode = tabsWrapperRef.current;
@@ -313,6 +317,29 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
 
     React.useEffect(scrollInitialActiveIndexIntoView, []);
 
+    React.useEffect(() => {
+      if (!displayScroll.start) {
+        nextButtonRef.current?.focus();
+      } else if (!displayScroll.end) {
+        prevButtonRef.current?.focus();
+      }
+    }, [displayScroll.start, displayScroll.end]);
+
+    // Announce panel content when active tab changes (including initial mount)
+    React.useEffect(() => {
+      setTimeout(() => {
+        const panelId = `tabpanel-${activeTabIndex}`;
+        const panelElement = document.getElementById(panelId);
+
+        if (panelElement) {
+          const panelText = panelElement.textContent || '';
+
+          setPanelAnnouncement(panelText.trim());
+          setTimeout(() => setPanelAnnouncement(''), 100);
+        }
+      }, 100);
+    }, [activeTabIndex]);
+
     function changeHandler(
       newActiveIndex: number,
       event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -328,9 +355,11 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
 
       onChange && typeof onChange === 'function' && onChange(newActiveIndex);
 
-      newActiveIndex === activeTabIndex
-        ? scrollSelectedIntoView()
-        : setActiveTabIndex(newActiveIndex);
+      if (newActiveIndex === activeTabIndex) {
+        scrollSelectedIntoView();
+      } else {
+        setActiveTabIndex(newActiveIndex);
+      }
     }
 
     function tabIsEnabled(tabIndex) {
@@ -431,6 +460,18 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
         : i18n.tabs.horizontalTabsInstructions
     }`;
 
+    const handlePrevScrollWithAnnouncement = () => {
+      handleStartScrollClick();
+      setScrollAnnouncement(i18n.tabs.scrolledBackAnnounce);
+      setTimeout(() => setScrollAnnouncement(''), 100);
+    };
+
+    const handleNextScrollWithAnnouncement = () => {
+      handleEndScrollClick();
+      setScrollAnnouncement(i18n.tabs.scrolledForwardAnnounce);
+      setTimeout(() => setScrollAnnouncement(''), 100);
+    };
+
     const other = omit(['aria-label'], rest);
 
     return (
@@ -447,7 +488,7 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
           backgroundColor={background}
           buttonVisible={displayScroll.start}
           isInverse={isInverse}
-          onClick={handleStartScrollClick}
+          onClick={handlePrevScrollWithAnnouncement}
           orientation={orientation || TabsOrientation.horizontal}
           ref={prevButtonRef}
           theme={theme}
@@ -488,11 +529,17 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
           backgroundColor={background}
           buttonVisible={displayScroll.end}
           isInverse={isInverse}
-          onClick={handleEndScrollClick}
+          onClick={handleNextScrollWithAnnouncement}
           orientation={orientation || TabsOrientation.horizontal}
           ref={nextButtonRef}
           theme={theme}
         />
+        <VisuallyHidden>
+          <Announce>{scrollAnnouncement}</Announce>
+        </VisuallyHidden>
+        <VisuallyHidden>
+          <Announce>{panelAnnouncement}</Announce>
+        </VisuallyHidden>
       </StyledContainer>
     );
   }

--- a/packages/react-magma-dom/src/components/Tabs/TabsContainer.test.js
+++ b/packages/react-magma-dom/src/components/Tabs/TabsContainer.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
 import { Tab } from './Tab';
 import { TabPanel } from './TabPanel';
@@ -82,7 +82,8 @@ it('should render with inverse styles', () => {
 });
 
 describe('Test for accessibility', () => {
-  it('Does not violate accessibility standards', () => {
+  it('Does not violate accessibility standards', async () => {
+    jest.useFakeTimers();
     const { container } = render(
       <TabsContainer activeIndex={0}>
         <Tabs>
@@ -99,10 +100,15 @@ describe('Test for accessibility', () => {
       </TabsContainer>
     );
 
-    return axe(container.innerHTML, {
-      rules: { listitem: { enabled: false } },
-    }).then(result => {
-      return expect(result).toHaveNoViolations();
+    act(() => {
+      jest.runAllTimers();
     });
+    jest.useRealTimers();
+
+    const result = await axe(container.innerHTML, {
+      rules: { listitem: { enabled: false } },
+    });
+
+    expect(result).toHaveNoViolations();
   });
 });

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -324,6 +324,8 @@ export const defaultI18n: I18nInterface = {
       'use the down and up arrow keys to activate other tabs',
     nextButtonLabel: 'Scroll tabs forward',
     previousButtonLabel: 'Scroll tabs back',
+    scrolledBackAnnounce: 'Scrolled tabs backward',
+    scrolledForwardAnnounce: 'Scrolled tabs forward',
   },
   tag: {
     deleteAriaLabel: 'Delete {labelText} tag',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -303,6 +303,8 @@ export interface I18nInterface {
     verticalTabsInstructions: string;
     previousButtonLabel: string;
     nextButtonLabel: string;
+    scrolledBackAnnounce: string;
+    scrolledForwardAnnounce: string;
   };
   tag: {
     deleteAriaLabel: string;

--- a/website/react-magma-docs/src/pages/api/button.mdx
+++ b/website/react-magma-docs/src/pages/api/button.mdx
@@ -316,13 +316,13 @@ import {
   ButtonGroup,
   Input,
   Spacer,
-  VisuallyHidden
+  VisuallyHidden,
 } from 'react-magma-dom';
 
 export function Example() {
-  const inputRef = React.useRef<HTMLInputElement>();
   const clearedText = 'Inputs have been reset to default values.';
   const [announcement, setAnnouncement] = React.useState('');
+  const [inputValue, setInputValue] = React.useState('');
 
   function onFormSubmit(event: React.FormEventHandler) {
     event.preventDefault();
@@ -331,7 +331,7 @@ export function Example() {
 
   function onFormReset(event: React.FormEventHandler) {
     event.preventDefault();
-    inputRef.current.value = '';
+    setInputValue('');
     setAnnouncement('');
     setTimeout(() => {
       setAnnouncement(clearedText);
@@ -340,7 +340,11 @@ export function Example() {
 
   return (
     <form onSubmit={onFormSubmit} onReset={onFormReset}>
-      <Input ref={inputRef} labelText="Form Field" value="" />
+      <Input
+        labelText="Form Field"
+        value={inputValue}
+        onChange={e => setInputValue(e.target.value)}
+      />
       <Spacer size="12" />
       <ButtonGroup>
         <Button type={ButtonType.submit}>Submit</Button>


### PR DESCRIPTION
Closes: #2072
Closes: #2094

- Updated focus behavior during scrolling tabs
- Updated aria-labels for `Tabs` and `Nav tabs`
- Fixed broken Combobox example
- Fixed broken Button example

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Tabs -> Scrolling -> press twice on the `Next` button -> NVDA/VO should announce `Scrolled tabs forward` -> focus should be moved to `Previous` button -> Press on the `Previous` button -> NVDA/VO should announce `Scrolled tabs back.` 

Go to Storybook -> Nav Tabs -> Scrolling -> press on the `Next` button ->  NVDA/VO should announce `Scrolled tabs forward` -> focus should be moved to `Previous` button -> NVDA/VO should announce `Scrolled tabs back.` 

Go to Storybook -> Tabs -> Icon -> Focus on First item-> NVDA/VO should announce `First item + Email ` -> Focus on Second item->  NVDA/VO should announce `First item + Android ` 

Go to Docs -> Components -> Combobox -> Internationalization -> example should be fixed
Go to Docs -> Components -> Button -> Types -> type text -> press on Reset button -> input field should be cleared

