### PR TITLE
fix(Table & Datagrid): Add announcement for the current page.

### DIFF
--- a/.changeset/fix-Table-add-page-announcing.md
+++ b/.changeset/fix-Table-add-page-announcing.md
@@ -1,0 +1,6 @@
+---
+
+'react-magma-dom': patch
+---
+
+fix(Table): Update current page announcing.

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -10,6 +10,7 @@ import { useIsInverse } from '../../inverse';
 import { magma, ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { XOR } from '../../utils';
+import { Announce, AnnouncePoliteness } from '../Announce';
 import { ButtonColor, ButtonVariant } from '../Button';
 import { ButtonGroup, ButtonGroupAlignment } from '../ButtonGroup';
 import { DropdownDropDirection } from '../Dropdown';
@@ -17,6 +18,7 @@ import { IconButton } from '../IconButton';
 import { Label } from '../Label';
 import { NativeSelect } from '../NativeSelect';
 import { usePagination } from '../Pagination/usePagination';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 export interface BaseTablePaginationProps
   extends React.HTMLAttributes<HTMLDivElement> {
@@ -283,6 +285,10 @@ export const TablePagination = React.forwardRef<
 
   const previousButton = pageButtons[0];
   const nextButton = pageButtons[pageButtons.length - 1];
+  const currentPageLabel = i18n.table.pagination.currentPageLabel.replace(
+    '{number}',
+    page
+  );
 
   return (
     <StyledContainer
@@ -307,12 +313,14 @@ export const TablePagination = React.forwardRef<
         isInverse={isInverse}
         theme={theme}
         testId="page-count"
-        aria-live="polite"
+        aria-live={AnnouncePoliteness.polite}
         aria-atomic="true"
       >
-        {`${displayPageStart}-${displayPageEnd} ${i18n.table.pagination.ofLabel} ${itemCount}`}
+        {`${displayPageStart}-${displayPageEnd} ${i18n.table.pagination.ofLabel} ${itemCount} `}
       </PageCount>
-
+      <Announce>
+        <VisuallyHidden>{currentPageLabel}</VisuallyHidden>
+      </Announce>
       <ButtonGroup alignment={ButtonGroupAlignment.center}>
         <IconButton
           aria-label={i18n.table.pagination.previousAriaLabel}

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -308,6 +308,7 @@ export const defaultI18n: I18nInterface = {
       nextAriaLabel: 'Next page',
       previousAriaLabel: 'Previous page',
       rowsPerPageLabel: 'Rows per page',
+      currentPageLabel: 'Page {number}, current page',
     },
     selectable: {
       sortButtonAriaLabel: 'Sort rows by {labelText}',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -289,6 +289,7 @@ export interface I18nInterface {
       nextAriaLabel: string;
       previousAriaLabel: string;
       rowsPerPageLabel: string;
+      currentPageLabel: string;
     };
     selectable: {
       sortButtonAriaLabel: string;


### PR DESCRIPTION
Closes: #2304
Closes: #2077 ([A11Y-526](https://jira.cengage.com/browse/A11Y-526))
Cherry-pick https://github.com/cengage/react-magma/pull/2331

## What I did
-  Added announcement for the current page.

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Storybook -> Table -> Controlled Pagination -> Turn on NVDA/VO -> Click on the `Next` button -> `Page 2, current page` should be announced.
