### PR TITLE
fix(Modal & CharacterCounter): Fix Safari-specific focus and renderin…

### DIFF
--- a/.changeset/chore-fix-modal-safari-focus.md
+++ b/.changeset/chore-fix-modal-safari-focus.md
@@ -2,7 +2,5 @@
 'react-magma-dom': patch
 ---
 
-fix(Modal & CharacterCounter): Fix Safari-specific issues.
-
-- Modal: Fix focus escaping the modal in Safari by handling forward Tab from the header in `useFocusLock`. Safari does not respect `aria-modal` for focus containment, and the DOM reorder from #2183 exposed a gap in the focus trap.
-- CharacterCounter: Fix visual duplication when `maxCount` is applied in Safari by removing `aria-live` from the visible element and using a single hidden live region for screen reader announcements.
+- fix(Modal): Fix focus escaping the modal in Safari.
+- fix(CharacterCounter): Fix voice over announcement duplication when `maxCount` is applied in Safari.

--- a/.changeset/chore-fix-modal-safari-focus.md
+++ b/.changeset/chore-fix-modal-safari-focus.md
@@ -1,0 +1,8 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal & CharacterCounter): Fix Safari-specific issues.
+
+- Modal: Fix focus escaping the modal in Safari by handling forward Tab from the header in `useFocusLock`. Safari does not respect `aria-modal` for focus containment, and the DOM reorder from #2183 exposed a gap in the focus trap.
+- CharacterCounter: Fix visual duplication when `maxCount` is applied in Safari by removing `aria-live` from the visible element and using a single hidden live region for screen reader announcements.

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.test.js
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.test.js
@@ -128,24 +128,46 @@ describe('CharacterCounter', () => {
   });
 
   describe('accessibility', () => {
-    it('Should have the aria-live attribute "polite" until inputLength gets to 100%', () => {
+    it('Should have aria-live "off" on the visible element to avoid duplicate announcements', () => {
       const { getByText } = render(
         <CharacterCounter inputLength={2} maxCount={4} />
       );
 
       const characterCounter = getByText('2 ' + charactersLeft).parentElement;
 
-      expect(characterCounter).toHaveAttribute('aria-live', 'polite');
+      expect(characterCounter).toHaveAttribute('aria-live', 'off');
     });
 
-    it('Should have the aria-live attribute "assertive" when inputLength exceeds 100%', () => {
-      const { getByText } = render(
+    it('Should announce with aria-live "polite" via hidden element after debounce', () => {
+      jest.useFakeTimers();
+      const { getByTestId } = render(
+        <CharacterCounter inputLength={2} maxCount={4} />
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+
+      const srMessage = getByTestId('screenReaderMessage');
+      expect(srMessage).toHaveAttribute('aria-live', 'polite');
+      expect(srMessage).toHaveTextContent('2 ' + charactersLeft);
+      jest.useRealTimers();
+    });
+
+    it('Should announce with aria-live "assertive" via hidden element when inputLength exceeds 100%', () => {
+      jest.useFakeTimers();
+      const { getByTestId } = render(
         <CharacterCounter inputLength={5} maxCount={4} />
       );
 
-      const characterCounter = getByText('1 ' + characterOver).parentElement;
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
 
-      expect(characterCounter).toHaveAttribute('aria-live', 'assertive');
+      const srMessage = getByTestId('screenReaderMessage');
+      expect(srMessage).toHaveAttribute('aria-live', 'assertive');
+      expect(srMessage).toHaveTextContent('1 ' + characterOver);
+      jest.useRealTimers();
     });
   });
 

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
@@ -168,15 +168,15 @@ export const CharacterCounter = React.forwardRef<
         >
           {characterTitle}
         </StyledInputMessage>
-        {screenReaderMessage && (
-          <HiddenLabelText
-            aria-live={getAriaLiveState()}
-            data-testid="screenReaderMessage"
-          >
-            {screenReaderMessage}
-          </HiddenLabelText>
-        )}
       </div>
+      {screenReaderMessage && (
+        <HiddenLabelText
+          aria-live={getAriaLiveState()}
+          data-testid="screenReaderMessage"
+        >
+          {screenReaderMessage}
+        </HiddenLabelText>
+      )}
     </>
   );
 });

--- a/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
+++ b/packages/react-magma-dom/src/components/CharacterCounter/CharacterCounter.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import styled from '@emotion/styled';
 
-import useDeviceDetect from '../../hooks/useDeviceDetect';
 import { I18nContext } from '../../i18n';
 import { magma } from '../../theme/magma';
 import { debounce } from '../../utils';
@@ -155,13 +154,11 @@ export const CharacterCounter = React.forwardRef<
     };
   }, [inputLength, debouncedSetScreenReaderMessage, characterTitle]);
 
-  const { isMacOS } = useDeviceDetect();
-
   return (
     <>
       <div ref={ref} data-testid={testId} {...rest} id={id}>
         <StyledInputMessage
-          aria-live={getAriaLiveState()}
+          aria-live="off"
           hasCharacterCounter={hasCharacterCounter}
           hasError={isOverMaxCount}
           isInverse={isInverse}
@@ -171,9 +168,9 @@ export const CharacterCounter = React.forwardRef<
         >
           {characterTitle}
         </StyledInputMessage>
-        {isMacOS && screenReaderMessage && (
+        {screenReaderMessage && (
           <HiddenLabelText
-            aria-live="assertive"
+            aria-live={getAriaLiveState()}
             data-testid="screenReaderMessage"
           >
             {screenReaderMessage}

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -1232,6 +1232,45 @@ describe('Modal', () => {
     });
   });
 
+  describe('nested modals', () => {
+    it('should keep focus trapped in the top-most modal and not get stuck', () => {
+      const onCloseOuter = jest.fn();
+      const onCloseInner = jest.fn();
+
+      const { getAllByTestId, getByTestId, getByText } = render(
+        <>
+          <Modal header="Outer Modal" isOpen onClose={onCloseOuter}>
+            <button data-testid="outerBtn">Outer Button</button>
+          </Modal>
+          <Modal header="Inner Modal" isOpen onClose={onCloseInner}>
+            <button data-testid="innerBtn1">Yes</button>
+            <button data-testid="innerBtn2">No</button>
+          </Modal>
+        </>
+      );
+
+      // Inner modal heading should have focus
+      expect(getByText('Inner Modal')).toHaveFocus();
+
+      // The inner modal's close button is the second one rendered
+      const innerCloseBtn = getAllByTestId('modal-closebtn')[1];
+
+      // Tab should cycle through inner modal items: Close → Yes → No → Close
+      userEvent.tab();
+      expect(innerCloseBtn).toHaveFocus();
+
+      userEvent.tab();
+      expect(getByTestId('innerBtn1')).toHaveFocus();
+
+      userEvent.tab();
+      expect(getByTestId('innerBtn2')).toHaveFocus();
+
+      // Tab should wrap back to close button, not get stuck
+      userEvent.tab();
+      expect(innerCloseBtn).toHaveFocus();
+    });
+  });
+
   describe('i18n', () => {
     it('should use the close aria-label', () => {
       const closeAriaLabel = 'test aria label';

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -85,6 +85,13 @@ export function useFocusLock(
           return;
         }
 
+        // If focused on header then focus on first item when tab is pressed
+        if (!shiftKey && document.activeElement === header?.current) {
+          event.preventDefault();
+          firstItem.focus();
+          return;
+        }
+
         // If focused on last item then focus on first item when tab is pressed
         if (!shiftKey && document.activeElement === lastItem) {
           event.preventDefault();

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -24,7 +24,8 @@ export function useFocusLock(
         element instanceof HTMLElement &&
         style.display !== 'none' &&
         style.visibility !== 'hidden' &&
-        !element.hasAttribute('disabled')
+        !element.hasAttribute('disabled') &&
+        element.tabIndex !== -1
       );
     });
   };
@@ -69,7 +70,18 @@ export function useFocusLock(
       } = focusableItems.current;
 
       if (active && key === 'Tab') {
-        // If no focusable items are
+        // Only handle Tab if focus is inside this focus lock's root.
+        // This prevents nested modals from interfering with each other.
+        const activeEl = document.activeElement as HTMLElement;
+        if (
+          rootNode.current &&
+          !rootNode.current.contains(activeEl) &&
+          activeEl !== header?.current
+        ) {
+          return;
+        }
+
+        // If no focusable items, prevent tabbing entirely
         if (length === 0) {
           event.preventDefault();
           return;
@@ -78,36 +90,40 @@ export function useFocusLock(
         // If only one item then prevent tabbing when locked
         if (length === 1) {
           event.preventDefault();
-          if (firstItem !== document.activeElement) {
+          if (firstItem !== activeEl) {
             firstItem.focus();
           }
-
           return;
         }
 
-        // If focused on header then focus on first item when tab is pressed
-        if (!shiftKey && document.activeElement === header?.current) {
-          event.preventDefault();
-          firstItem.focus();
+        // Explicitly manage all Tab navigation so focus never escapes
+        // the trap (Safari does not respect aria-modal for containment)
+        event.preventDefault();
+
+        const currentIndex = focusableItems.current.indexOf(activeEl);
+
+        if (currentIndex === -1) {
+          // Focus is on an untracked element (e.g. the header)
+          if (shiftKey) {
+            lastItem.focus();
+          } else {
+            firstItem.focus();
+          }
           return;
         }
 
-        // If focused on last item then focus on first item when tab is pressed
-        if (!shiftKey && document.activeElement === lastItem) {
-          event.preventDefault();
-          firstItem.focus();
-          return;
-        }
-
-        // If focused on first item then focus on last item when shift + tab is pressed
-        if (
-          shiftKey &&
-          (document.activeElement === firstItem ||
-            document.activeElement === header?.current)
-        ) {
-          event.preventDefault();
-          lastItem.focus();
-          return;
+        if (shiftKey) {
+          if (currentIndex === 0) {
+            lastItem.focus();
+          } else {
+            focusableItems.current[currentIndex - 1].focus();
+          }
+        } else {
+          if (currentIndex === length - 1) {
+            firstItem.focus();
+          } else {
+            focusableItems.current[currentIndex + 1].focus();
+          }
         }
       }
     };


### PR DESCRIPTION
Closes: #2345 

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
### 1 Modal focus escaping in Safari

  Safari does not respect aria-modal="true" for focus containment (unlike Chrome/Firefox). PR #2183 (4005029) reordered the close button before the body content in DOM order. The old useFocusLock only intercepted Tab at the edges (wrap on last item, wrap on first item with Shift+Tab)
  and relied on native browser behavior for all intermediate items. Chrome handled this via aria-modal, but Safari let focus escape after the close button.

  Fix: Rewrote the Tab handler in useFocusLock.ts to explicitly manage all Tab navigation with event.preventDefault() + indexOf, so native browser Tab behavior is never invoked. Also added a rootNode.contains() guard so nested modals don't interfere with each other's focus traps.
  Added a unit test for the nested modal regression.

### 2 Character counter read twice by VoiceOver

  PR #1731 (70b8ba0) added a hidden aria-live region (HiddenLabelText) for screen reader announcements inside the same container that aria-describedby points to. After the 3-second debounce, that container held both the visible text and the hidden text with identical content.
  VoiceOver reads all text inside an aria-describedby target, so it announced the counter twice (e.g. "5 characters left 5 characters left").

  Fix: Moved HiddenLabelText outside the id'd container so aria-describedby only picks up the visible text. Set aria-live="off" on the visible element to prevent duplicate live region announcements. Removed the isMacOS platform check — the hidden live region now handles announcements
  consistently on all platforms.
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
  Modal focus trap (Safari only):
  1. Open any Modal story in Safari (e.g. Default Modal)
  2. Open the modal
  3. Verify focus lands on the modal heading
  4. Press Tab repeatedly — focus should cycle through modal items (close button → body content → back to close button) and never escape to elements behind the modal
  5. Press Shift+Tab — focus should cycle in reverse
  6. Verify the same behavior works in Chrome (regression check)

  CharacterCounter duplication (Safari only):
  1. Open the Input story with maxCount prop in Safari
  2. Verify the character counter text (e.g. "10 characters allowed") appears once, not duplicated
  3. Type in the input — verify the counter updates without visual duplication
  4. Exceed the maxCount — verify the error state displays correctly
  5. Verify screen reader announcements still work (VoiceOver on macOS: counter is announced after a brief debounce)