### PR TITLE
fix(MultiSelect): Improve accessibility for component. (#2344)

### DIFF
--- a/.changeset/fix-MultiSelect-update-label-annoucement.md
+++ b/.changeset/fix-MultiSelect-update-label-annoucement.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Combobox): Prevent the clear button’s label from being announced.

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -54,6 +54,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
     initialHighlightedIndex,
   } = props;
   const [clearAnnouncement, setClearAnnouncement] = React.useState('');
+  const [isItemFocused, setItemFocus] = React.useState(false);
 
   function checkSelectedItemValidity(itemToCheck: T) {
     const itemIndex = items.findIndex(
@@ -346,6 +347,7 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
 
               return (
                 <SelectedItemButton
+                  aria-hidden={!isItemFocused}
                   aria-label={i18n.multiSelect.selectedItemButtonAriaLabel.replace(
                     /\{selectedItem\}/g,
                     multiSelectedItemString
@@ -358,7 +360,14 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
                   onClick={event =>
                     handleRemoveSelectedItem(event, multiSelectedItem)
                   }
-                  onFocus={() => setActiveIndex(index)}
+                  onFocus={event => {
+                    event.stopPropagation();
+                    setActiveIndex(index);
+                    setItemFocus(true);
+                  }}
+                  onBlur={() => {
+                    setItemFocus(false);
+                  }}
                   theme={theme}
                   isInverse={isInverse}
                   disabled={disabled}

--- a/packages/react-magma-dom/src/components/Select/SelectTriggerButton.tsx
+++ b/packages/react-magma-dom/src/components/Select/SelectTriggerButton.tsx
@@ -23,6 +23,11 @@ const StyledButton = styled.div<InputBaseStylesProps & InputWrapperStylesProps>`
   padding: 0 ${props => props.theme.spaceScale.spacing03} 0
     ${props => props.theme.spaceScale.spacing02};
   text-align: left;
+
+  &:focus-within:not(:focus) {
+    outline: none;
+    box-shadow: none;
+  }
 `;
 
 const ChildrenContainer = styled.div`


### PR DESCRIPTION
Closes: #2095
Cherry-pick https://github.com/cengage/react-magma/pull/2344

## What I did
- Improved accessibility for MultiSelect
- Removed double focus for MultiSelect when the user focuses on nested items.

## Screenshots
<img width="1563" height="634" alt="Screenshot from 2026-03-17 16-13-57" src="https://github.com/user-attachments/assets/90bf353d-34d6-4234-8421-545a3210acbb" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Select -> Multi -> Turn on NVDA/VO -> Focus on the input -> `Example Multi-select Selected: Red` -> Focus on Red button -> `Clear item Red button` should be announced.
