### PR TITLE
fix(publish): Add missing repository.url to package.json for npm provenance verification for v5

### DIFF
--- a/.changeset/fix-publish-repository-url.md
+++ b/.changeset/fix-publish-repository-url.md
@@ -1,0 +1,9 @@
+---
+'react-magma-dom': patch
+'@react-magma/charts': patch
+'@react-magma/dropzone': patch
+'@react-magma/schema-renderer': patch
+'@cengage-patterns/header': patch
+---
+
+fix(publish): Add missing repository.url to package.json for npm provenance verification.

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -2,6 +2,11 @@
   "name": "@react-magma/charts",
   "version": "14.0.0-rc.3",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cengage/react-magma.git",
+    "directory": "packages/charts"
+  },
   "exports": {
     ".": {
       "import": "./dist/charts.modern.module.js",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -2,6 +2,11 @@
   "name": "@react-magma/dropzone",
   "version": "14.0.0-rc.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cengage/react-magma.git",
+    "directory": "packages/dropzone"
+  },
   "main": "dist/fileuploader.js",
   "umd:main": "dist/fileuploader.umd.js",
   "module": "dist/fileuploader.modern.module.js",


### PR DESCRIPTION
Cherry-pick e8db8f39203e51676f244033ff690334a3b3e16 commit for v5 publish