### PR TITLE
feat(charts): add new magma tooltip

### DIFF
--- a/.changeset/accessible-chart-toolbar.md
+++ b/.changeset/accessible-chart-toolbar.md
@@ -1,0 +1,13 @@
+---
+'@react-magma/charts': minor
+---
+
+feat: Add accessible chart toolbar with "Show as table", fullscreen, and "More options" buttons
+
+Adds a new `chartToolbar` prop to `CarbonChart` that renders a WCAG 2.1 compliant toolbar replacing Carbon's built-in navigation controls. When provided, Carbon's toolbar is automatically disabled and replaced with accessible Magma components featuring:
+
+- **Show as table** button with `aria-haspopup="dialog"` and `aria-expanded`, opening a focus-trapped Magma Modal with semantic headings and an accessible data table
+- **Fullscreen** button without `aria-haspopup` (fixing the previous WCAG violation)
+- **More options** dropdown using Magma's Dropdown component with proper menu semantics
+
+Also exports standalone composable components (`ChartTableButton`, `ChartFullscreenButton`, `ChartMoreOptionsButton`, `ChartTableModal`, `ChartDataTable`, `ChartToolbar`) for adopters who need granular control outside of `CarbonChart`.

--- a/.changeset/accessible-chart-toolbar.md
+++ b/.changeset/accessible-chart-toolbar.md
@@ -4,7 +4,7 @@
 
 feat: Add accessible chart toolbar with "Show as table", fullscreen, and "More options" buttons
 
-Adds a new `chartToolbar` prop to `CarbonChart` that renders a WCAG 2.1 compliant toolbar replacing Carbon's built-in navigation controls. When provided, Carbon's toolbar is automatically disabled and replaced with accessible Magma components featuring:
+Adds a new `chartToolbar` prop to `CarbonChart` that renders a WCAG 2.2 compliant toolbar replacing Carbon's built-in navigation controls. When provided, Carbon's toolbar is automatically disabled and replaced with accessible Magma components featuring:
 
 - **Show as table** button with `aria-haspopup="dialog"` and `aria-expanded`, opening a focus-trapped Magma Modal with semantic headings and an accessible data table
 - **Fullscreen** button without `aria-haspopup` (fixing the previous WCAG violation)

--- a/.changeset/accessible-chart-toolbar.md
+++ b/.changeset/accessible-chart-toolbar.md
@@ -1,5 +1,6 @@
 ---
 '@react-magma/charts': minor
+'react-magma-dom': minor
 ---
 
 feat: Add accessible chart toolbar with "Show as table", fullscreen, and "More options" buttons

--- a/.changeset/icons-version.md
+++ b/.changeset/icons-version.md
@@ -1,9 +1,9 @@
 ---
-'@react-magma/dropzone': minor
-'@react-magma/schema-renderer': minor
-'@cengage-patterns/header': minor
-'react-magma-dom': minor
-'react-magma-docs': minor
+'@react-magma/dropzone': patch
+'@react-magma/schema-renderer': patch
+'@cengage-patterns/header': patch
+'react-magma-dom': patch
+'react-magma-docs': patch
 ---
 
 Chore: update react-magma-icons version

--- a/.changeset/icons-version.md
+++ b/.changeset/icons-version.md
@@ -1,0 +1,9 @@
+---
+'@react-magma/dropzone': minor
+'@react-magma/schema-renderer': minor
+'@cengage-patterns/header': minor
+'react-magma-dom': minor
+'react-magma-docs': minor
+---
+
+Chore: update react-magma-icons version

--- a/.changeset/modal-portal-container.md
+++ b/.changeset/modal-portal-container.md
@@ -1,0 +1,7 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Modal): add `portalContainer` prop to control portal target
+
+Adds an optional `portalContainer` prop to `Modal` that lets consumers specify the DOM element the modal should be portaled into. Defaults to `document.body` (unchanged behavior).

--- a/package-lock.json
+++ b/package-lock.json
@@ -6876,20 +6876,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
-    "node_modules/@lerna/create/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@lerna/create/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -45512,9 +45498,10 @@
       "link": true
     },
     "node_modules/react-magma-icons": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.4.tgz",
-      "integrity": "sha512-0J4V6S8IisQtN3rjJM0ywzgNFnrNUvLt5EZRXe193fZiIQHiNCTZ5KFdOzj1VUL/1z1F6mrRpvGDCres/3zl/Q==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/react-magma-icons/-/react-magma-icons-3.2.5.tgz",
+      "integrity": "sha512-lKBr+qzR9a5k9ly/16/mhepQ1NvY8GVBQWASvEF2tE57u6hH6dn1piO99uJtdD8k3yLMy5+XmkGkSqUKLOWlBQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^17.0.39",
         "@types/react": ">=17.0.5",
@@ -60318,7 +60305,7 @@
     },
     "packages/charts": {
       "name": "@react-magma/charts",
-      "version": "13.0.2-next.1",
+      "version": "13.0.2",
       "license": "MIT",
       "dependencies": {
         "@carbon/charts-react": "^1.14.8",
@@ -60337,8 +60324,8 @@
         "identity-obj-proxy": "^3.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4",
+        "react-magma-dom": "^4.12.0",
+        "react-magma-icons": "^3.2.5",
         "rollup": "^4.52.4",
         "rollup-plugin-postcss": "^4.0.2"
       },
@@ -60351,8 +60338,8 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4"
+        "react-magma-dom": "^4.12.0-next.3",
+        "react-magma-icons": "^3.2.5"
       }
     },
     "packages/charts/node_modules/@rollup/plugin-commonjs": {
@@ -60511,7 +60498,7 @@
     },
     "packages/dropzone": {
       "name": "@react-magma/dropzone",
-      "version": "13.0.1-next.0",
+      "version": "12.0.2",
       "license": "MIT",
       "dependencies": {
         "polished": "^3.7.2",
@@ -60522,8 +60509,8 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4"
+        "react-magma-dom": "^4.12.0",
+        "react-magma-icons": "^3.2.5"
       },
       "engines": {
         "node": ">=22.14.0",
@@ -60534,8 +60521,8 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4"
+        "react-magma-dom": "^4.12.0-next.3",
+        "react-magma-icons": "^3.2.5"
       }
     },
     "packages/dropzone/node_modules/polished": {
@@ -60551,7 +60538,7 @@
       }
     },
     "packages/react-magma-dom": {
-      "version": "4.11.1-next.1",
+      "version": "4.12.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.13.0",
@@ -60569,7 +60556,7 @@
         "mkdirp": "^1.0.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-icons": "^3.2.4",
+        "react-magma-icons": "^3.2.5",
         "uuid": "^11.1.0"
       },
       "peerDependencies": {
@@ -60580,7 +60567,7 @@
         "framer-motion": "^4.1.11",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-icons": "^3.2.4",
+        "react-magma-icons": "^3.2.5",
         "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
@@ -60598,7 +60585,7 @@
     },
     "packages/schema-renderer": {
       "name": "@react-magma/schema-renderer",
-      "version": "13.0.1-next.0",
+      "version": "14.0.0",
       "license": "MIT",
       "devDependencies": {
         "@data-driven-forms/react-form-renderer": "^3.6.0",
@@ -60609,8 +60596,8 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-dropzone": "11.3.2",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4",
+        "react-magma-dom": "^4.12.0",
+        "react-magma-icons": "^3.2.5",
         "tsdx": "^0.14.1",
         "uuid": "^11.1.0"
       },
@@ -60626,14 +60613,14 @@
         "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4",
+        "react-magma-dom": "^4.12.0-next.3",
+        "react-magma-icons": "^3.2.5",
         "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
     "patterns/header": {
       "name": "@cengage-patterns/header",
-      "version": "14.0.1-next.0",
+      "version": "15.0.0",
       "license": "MIT",
       "devDependencies": {
         "@emotion/react": "^11.13.0",
@@ -60642,8 +60629,8 @@
         "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4",
+        "react-magma-dom": "^4.12.0",
+        "react-magma-icons": "^3.2.5",
         "uuid": "^11.1.0"
       },
       "engines": {
@@ -60658,8 +60645,8 @@
         "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4",
+        "react-magma-dom": "^4.12.0-next.3",
+        "react-magma-icons": "^3.2.5",
         "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       },
       "peerDependenciesMeta": {
@@ -60676,19 +60663,19 @@
       }
     },
     "website/react-magma-docs": {
-      "version": "5.3.1-next.5",
+      "version": "5.3.2-next.0",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "7.10.4",
-        "@cengage-patterns/header": "14.0.1-next.0",
+        "@cengage-patterns/header": "15.0.0",
         "@data-driven-forms/react-form-renderer": "^3.6.0",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/mdx": "^1.5.5",
         "@mdx-js/react": "^1.5.5",
-        "@react-magma/charts": "^13.0.2-next.1",
-        "@react-magma/dropzone": "13.0.1-next.0",
-        "@react-magma/schema-renderer": "^13.0.1-next.0",
+        "@react-magma/charts": "13.0.2",
+        "@react-magma/dropzone": "12.0.2",
+        "@react-magma/schema-renderer": "^14.0.0",
         "buble": "0.19.4",
         "buffer": "^6.0.3",
         "core-js": "^3.1.4",
@@ -60718,8 +60705,8 @@
         "react-focus-lock": "^2.9.2",
         "react-helmet": "5.2.0",
         "react-live": "^2.2.1",
-        "react-magma-dom": "^4.11.1-next.0",
-        "react-magma-icons": "^3.2.4",
+        "react-magma-dom": "^4.12.0",
+        "react-magma-icons": "^3.2.5",
         "react-spring": "6.1.9",
         "semver": "^7.3.4",
         "url-loader": "^1.1.2",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -48,7 +48,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4",
+    "react-magma-icons": "^3.2.5",
     "rollup": "^4.52.4",
     "rollup-plugin-postcss": "^4.0.2"
   },
@@ -58,7 +58,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4"
+    "react-magma-icons": "^3.2.5"
   },
   "engines": {
     "node": ">=22.14.0",

--- a/packages/charts/src/components/CarbonChart/CarbonChart.test.js
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.test.js
@@ -1,12 +1,6 @@
 import React from 'react';
 
-import {
-  act,
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-} from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import { ThemeContext, magma, DropdownMenuItem } from 'react-magma-dom';
 
 import { CarbonChart, CarbonChartType } from '.';

--- a/packages/charts/src/components/CarbonChart/CarbonChart.test.js
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.test.js
@@ -1,7 +1,13 @@
 import React from 'react';
 
-import { act, render } from '@testing-library/react';
-import { ThemeContext, magma } from 'react-magma-dom';
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { ThemeContext, magma, DropdownMenuItem } from 'react-magma-dom';
 
 import { CarbonChart, CarbonChartType } from '.';
 
@@ -752,6 +758,147 @@ describe('CarbonChart', () => {
       jest.runAllTimers();
 
       expect(document.activeElement).toBe(closeButton);
+    });
+  });
+
+  describe('chartToolbar prop', () => {
+    const toolbarProps = {
+      dataSet,
+      options: chartOptions,
+      type: CarbonChartType.bar,
+      chartToolbar: {},
+    };
+
+    it('should render the show-as-table button with aria-haspopup="dialog"', () => {
+      render(<CarbonChart {...toolbarProps} />);
+
+      const button = screen.getByRole('button', {
+        name: chartOptions.title,
+      });
+      expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+      expect(button).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should render the fullscreen button without aria-haspopup', () => {
+      render(<CarbonChart {...toolbarProps} />);
+
+      const button = screen.getByRole('button', {
+        name: `View ${chartOptions.title} full screen`,
+      });
+      expect(button).not.toHaveAttribute('aria-haspopup');
+    });
+
+    it('should open the table modal when show-as-table button is clicked', () => {
+      render(<CarbonChart {...toolbarProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: chartOptions.title }));
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: `Tabular representation ${chartOptions.title}`,
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'Group' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'Value' })
+      ).toBeInTheDocument();
+    });
+
+    it('should render chart data in the table modal', () => {
+      render(<CarbonChart {...toolbarProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: chartOptions.title }));
+
+      expect(screen.getByRole('cell', { name: 'Qty' })).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: '65000' })).toBeInTheDocument();
+    });
+
+    it('should set aria-expanded to true when modal is open', () => {
+      render(<CarbonChart {...toolbarProps} />);
+
+      const tableButton = screen.getByRole('button', {
+        name: chartOptions.title,
+      });
+      fireEvent.click(tableButton);
+
+      expect(tableButton).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should not render the table button when showAsTable is false', () => {
+      render(
+        <CarbonChart {...toolbarProps} chartToolbar={{ showAsTable: false }} />
+      );
+
+      expect(
+        screen.queryByRole('button', { name: chartOptions.title })
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not render the fullscreen button when fullscreen is false', () => {
+      render(
+        <CarbonChart {...toolbarProps} chartToolbar={{ fullscreen: false }} />
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /full screen/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('should always render the more options dropdown with built-in download items', () => {
+      render(<CarbonChart {...toolbarProps} />);
+
+      const moreBtn = screen.getByRole('button', { name: 'More options' });
+      expect(moreBtn).toBeInTheDocument();
+
+      fireEvent.click(moreBtn);
+      expect(screen.getByText('Download as CSV')).toBeVisible();
+      expect(screen.getByText('Download as PNG')).toBeVisible();
+      expect(screen.getByText('Download as JPG')).toBeVisible();
+    });
+
+    it('should render additional moreOptions items below built-in downloads', () => {
+      render(
+        <CarbonChart
+          {...toolbarProps}
+          chartToolbar={{
+            moreOptions: <DropdownMenuItem>Custom Action</DropdownMenuItem>,
+          }}
+        />
+      );
+
+      const moreBtn = screen.getByRole('button', { name: 'More options' });
+      fireEvent.click(moreBtn);
+      expect(screen.getByText('Download as CSV')).toBeVisible();
+      expect(screen.getByText('Download as PNG')).toBeVisible();
+      expect(screen.getByText('Download as JPG')).toBeVisible();
+      expect(screen.getByText('Custom Action')).toBeVisible();
+    });
+
+    it('should support custom table columns', () => {
+      render(
+        <CarbonChart
+          {...toolbarProps}
+          chartToolbar={{
+            tableColumns: [
+              { header: 'Category', key: 'group' },
+              { header: 'Count', key: 'value' },
+            ],
+          }}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: chartOptions.title }));
+
+      expect(
+        screen.getByRole('columnheader', { name: 'Category' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('columnheader', { name: 'Count' })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -47,6 +47,7 @@ import {
   ChartTableModal,
 } from '../ChartTable';
 import type { ChartDataTableColumn } from '../ChartTable';
+import { useChartToolbarI18n } from '../ChartTable/chartToolbarI18n';
 
 export enum CarbonChartType {
   area = 'area',
@@ -83,13 +84,13 @@ export interface ChartToolbarConfig {
   fullscreen?: boolean;
   /**
    * Additional menu items rendered inside a "More options" dropdown,
-   * below the built-in "Download as CSV" and "Download as PNG" items.
+   * below the built-in "Download as CSV", "Download as PNG", and "Download as JPG" items.
    * Pass DropdownMenuItem elements.
    */
   moreOptions?: React.ReactNode;
   /**
    * Custom column definitions for the table modal.
-   * Defaults to [{ header: 'Group', key: 'group' }, { header: 'Value', key: 'value' }].
+   * If omitted, columns are auto-derived from the dataset object keys.
    */
   tableColumns?: ChartDataTableColumn[];
   /**
@@ -664,10 +665,10 @@ const ChartTitle = styled.h2<{
       : props.theme.colors.neutral700} !important;
 `;
 
-const ToolbarActions = styled.div`
+const ToolbarActions = styled.div<{ theme: ThemeInterface }>`
   align-items: center;
   display: flex;
-  gap: 4px;
+  gap: ${props => props.theme.spaceScale.spacing02};
 
   > * button,
   > button {
@@ -679,25 +680,39 @@ const ToolbarActions = styled.div`
   }
 
   [role='tooltip'] {
-    padding: 4px 8px;
+    padding: ${props => props.theme.spaceScale.spacing03}
+      ${props => props.theme.spaceScale.spacing04};
+    text-align: center;
     white-space: nowrap;
+  }
+
+  [role='menu'] {
+    padding: ${props => props.theme.spaceScale.spacing03} 0;
   }
 
   [role='menuitem'],
   [data-testid='dropdownMenuItem'] {
-    padding: 8px 16px;
+    padding: ${props => props.theme.spaceScale.spacing03}
+      ${props => props.theme.spaceScale.spacing05};
   }
 `;
+
+function sanitizeCsvValue(value: string): string {
+  if (/^[=+\-@\t\r]/.test(value)) {
+    return `'${value}`;
+  }
+  return value;
+}
 
 function downloadCsv(dataSet: Array<Record<string, unknown>>, title: string) {
   if (!dataSet.length) return;
   const keys = Object.keys(dataSet[0]);
-  const header = keys.join(',');
+  const header = keys.map(k => sanitizeCsvValue(k)).join(',');
   const rows = dataSet.map(row =>
     keys
       .map(k => {
         const v = row[k];
-        const s = String(v ?? '');
+        const s = sanitizeCsvValue(String(v ?? ''));
         return s.includes(',') || s.includes('"') || s.includes('\n')
           ? `"${s.replace(/"/g, '""')}"`
           : s;
@@ -908,8 +923,10 @@ function CarbonChartToolbar({
   title,
   wrapperRef,
 }: InternalToolbarProps) {
+  const t = useChartToolbarI18n();
   const showTable = config.showAsTable !== false;
   const showFullscreen = config.fullscreen !== false;
+  const resolvedTitle = title || 'Chart';
 
   const handleDownloadCsv = React.useCallback(() => {
     downloadCsv(dataSet, title);
@@ -926,13 +943,13 @@ function CarbonChartToolbar({
   const moreOptionsContent = (
     <>
       <DropdownMenuItem onClick={handleDownloadCsv}>
-        Download as CSV
+        {t.downloadAsCsv}
       </DropdownMenuItem>
       <DropdownMenuItem onClick={handleDownloadPng}>
-        Download as PNG
+        {t.downloadAsPng}
       </DropdownMenuItem>
       <DropdownMenuItem onClick={handleDownloadJpg}>
-        Download as JPG
+        {t.downloadAsJpg}
       </DropdownMenuItem>
       {config.moreOptions && (
         <>
@@ -950,12 +967,12 @@ function CarbonChartToolbar({
       theme={theme}
     >
       <ChartTitle isInverse={isInverse} theme={theme}>
-        {title}
+        {resolvedTitle}
       </ChartTitle>
-      <ToolbarActions>
+      <ToolbarActions theme={theme}>
         {showTable && (
           <ChartTableButton
-            ariaLabel={title}
+            ariaLabel={resolvedTitle}
             icon={<TableChartIcon size={20} />}
             isInverse={isInverse}
             isTableOpen={isTableOpen}
@@ -964,7 +981,7 @@ function CarbonChartToolbar({
         )}
         {showFullscreen && (
           <ChartFullscreenButton
-            ariaLabel={`${isFullscreen ? 'Exit' : 'View'} ${title} full screen`}
+            ariaLabel={`${isFullscreen ? 'Exit' : 'View'} ${resolvedTitle} full screen`}
             icon={<FullscreenIcon size={20} />}
             exitIcon={<FullscreenExitIcon size={20} />}
             isInverse={isInverse}
@@ -1061,9 +1078,13 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
     const toggleFullscreen = React.useCallback(() => {
       if (!document.fullscreenElement && internalRef.current) {
-        internalRef.current.requestFullscreen();
+        internalRef.current.requestFullscreen().catch(() => {
+          // Fullscreen request may be denied by the browser or user agent
+        });
       } else if (document.fullscreenElement) {
-        document.exitFullscreen();
+        document.exitFullscreen().catch(() => {
+          // Exit fullscreen may fail if already exited
+        });
       }
     }, []);
 

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -138,6 +138,25 @@ const ChartContentWrapper = styled.div`
   position: relative;
 `;
 
+const FullscreenRoot = styled.div<{
+  isInverse?: boolean;
+  theme: ThemeInterface;
+}>`
+  height: 100%;
+  width: 100%;
+
+  &:fullscreen,
+  &:-webkit-full-screen {
+    background: ${props =>
+      props.isInverse
+        ? props.theme.colors.primary700
+        : props.theme.colors.neutral100};
+    .cds--chart-holder {
+      height: 100vh !important;
+    }
+  }
+`;
+
 const CarbonChartWrapper = styled.div<{
   isInverse?: boolean;
   groupsLength: number;
@@ -1172,35 +1191,37 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
     const showTable = chartToolbar?.showAsTable !== false;
 
     return (
-      <CarbonChartWrapper
-        data-testid={testId}
-        ref={mergedRef}
-        isInverse={isInverse}
-        theme={theme}
-        className={`carbon-chart-wrapper${chartToolbar ? ' has-magma-toolbar' : ''}`}
-        groupsLength={groupsLength < 6 ? groupsLength : 14}
-        {...rest}
-      >
-        <ChartContentWrapper>
-          {chartToolbar && (
-            <CarbonChartToolbar
-              config={chartToolbar}
-              dataSet={dataSet as Array<Record<string, unknown>>}
-              isInverse={isInverse}
-              isTableOpen={isTableOpen}
-              isFullscreen={isFullscreen}
-              onOpenTable={openTableModal}
-              onToggleFullscreen={toggleFullscreen}
-              theme={theme}
-              title={chartTitle}
-              wrapperRef={internalRef}
-            />
-          )}
-          <ChartType data={dataSet} options={newOptions} />
-        </ChartContentWrapper>
+      <FullscreenRoot ref={mergedRef} isInverse={isInverse} theme={theme}>
+        <CarbonChartWrapper
+          data-testid={testId}
+          isInverse={isInverse}
+          theme={theme}
+          className={`carbon-chart-wrapper${chartToolbar ? ' has-magma-toolbar' : ''}`}
+          groupsLength={groupsLength < 6 ? groupsLength : 14}
+          {...rest}
+        >
+          <ChartContentWrapper>
+            {chartToolbar && (
+              <CarbonChartToolbar
+                config={chartToolbar}
+                dataSet={dataSet as Array<Record<string, unknown>>}
+                isInverse={isInverse}
+                isTableOpen={isTableOpen}
+                isFullscreen={isFullscreen}
+                onOpenTable={openTableModal}
+                onToggleFullscreen={toggleFullscreen}
+                theme={theme}
+                title={chartTitle}
+                wrapperRef={internalRef}
+              />
+            )}
+            <ChartType data={dataSet} options={newOptions} />
+          </ChartContentWrapper>
+        </CarbonChartWrapper>
         {chartToolbar && showTable && (
           <ChartTableModal
             columns={chartToolbar.tableColumns}
+            portalContainer={isFullscreen ? internalRef.current : undefined}
             dataSet={dataSet as Array<Record<string, React.ReactNode>>}
             headerLabel={chartToolbar.tableHeaderLabel}
             headerLevel={chartToolbar.tableHeaderLevel}
@@ -1211,7 +1232,7 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
             title={chartTitle}
           />
         )}
-      </CarbonChartWrapper>
+      </FullscreenRoot>
     );
   }
 );

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -717,7 +717,8 @@ const ToolbarActions = styled.div<{ theme: ThemeInterface }>`
 `;
 
 function sanitizeCsvValue(value: string): string {
-  if (/^[=+\-@\t\r]/.test(value)) {
+  const trimmed = value.trimStart();
+  if (/^[=+\-@\t\r]/.test(trimmed)) {
     return `'${value}`;
   }
   return value;
@@ -945,7 +946,7 @@ function CarbonChartToolbar({
   const t = useChartToolbarI18n();
   const showTable = config.showAsTable !== false;
   const showFullscreen = config.fullscreen !== false;
-  const resolvedTitle = title || 'Chart';
+  const resolvedTitle = title || t.defaultTitle;
 
   const handleDownloadCsv = React.useCallback(() => {
     downloadCsv(dataSet, title);
@@ -1033,6 +1034,7 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
     } = props;
     const theme = React.useContext(ThemeContext);
     const isInverse = useIsInverse(isInverseProp);
+    const toolbarI18n = useChartToolbarI18n();
     const internalRef = React.useRef<HTMLDivElement | null>(null);
 
     const [isTableOpen, setIsTableOpen] = React.useState(false);
@@ -1107,7 +1109,8 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       }
     }, []);
 
-    const chartTitle: string = (options as any).title || '';
+    const chartTitle: string =
+      (options as any).title || toolbarI18n.defaultTitle;
 
     const handleModalDownloadCsv = React.useCallback(() => {
       downloadCsv(dataSet as Array<Record<string, unknown>>, chartTitle);

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -35,7 +35,7 @@ import {
   FullscreenExitIcon,
   FullscreenIcon,
   MoreVertIcon,
-  TableChartIcon,
+  TableIcon,
 } from 'react-magma-icons';
 
 import { useCarbonModalFocusManagement } from '../../hooks/useCarbonModalFocusManagement';
@@ -973,7 +973,7 @@ function CarbonChartToolbar({
         {showTable && (
           <ChartTableButton
             ariaLabel={resolvedTitle}
-            icon={<TableChartIcon size={20} />}
+            icon={<TableIcon size={20} />}
             isInverse={isInverse}
             isTableOpen={isTableOpen}
             onClick={onOpenTable}

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import * as React from 'react';
 
 import {
@@ -23,10 +24,29 @@ import {
 } from '@carbon/charts-react';
 import styled from '@emotion/styled';
 import { transparentize } from 'polished';
-import { ThemeInterface, ThemeContext, useIsInverse } from 'react-magma-dom';
+import {
+  DropdownDivider,
+  DropdownMenuItem,
+  ThemeInterface,
+  ThemeContext,
+  useIsInverse,
+} from 'react-magma-dom';
+import {
+  FullscreenExitIcon,
+  FullscreenIcon,
+  MoreVertIcon,
+  TableChartIcon,
+} from 'react-magma-icons';
 
 import { useCarbonModalFocusManagement } from '../../hooks/useCarbonModalFocusManagement';
 import './carbon-charts.css';
+import {
+  ChartFullscreenButton,
+  ChartMoreOptionsButton,
+  ChartTableButton,
+  ChartTableModal,
+} from '../ChartTable';
+import type { ChartDataTableColumn } from '../ChartTable';
 
 export enum CarbonChartType {
   area = 'area',
@@ -49,6 +69,41 @@ export enum CarbonChartType {
   combo = 'combo',
 }
 
+export interface ChartToolbarConfig {
+  /**
+   * When true, renders a "Show as table" button that opens a Magma Modal
+   * with the chart data in an accessible table.
+   * @default true
+   */
+  showAsTable?: boolean;
+  /**
+   * When true, renders a fullscreen toggle button.
+   * @default true
+   */
+  fullscreen?: boolean;
+  /**
+   * Additional menu items rendered inside a "More options" dropdown,
+   * below the built-in "Download as CSV" and "Download as PNG" items.
+   * Pass DropdownMenuItem elements.
+   */
+  moreOptions?: React.ReactNode;
+  /**
+   * Custom column definitions for the table modal.
+   * Defaults to [{ header: 'Group', key: 'group' }, { header: 'Value', key: 'value' }].
+   */
+  tableColumns?: ChartDataTableColumn[];
+  /**
+   * First line of the modal heading.
+   * @default "Tabular representation"
+   */
+  tableHeaderLabel?: string;
+  /**
+   * Heading level for the modal header.
+   * @default 2
+   */
+  tableHeaderLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+}
+
 export interface CarbonChartProps extends React.HTMLAttributes<HTMLDivElement> {
   dataSet: Array<Object>;
   isInverse?: boolean;
@@ -69,13 +124,36 @@ export interface CarbonChartProps extends React.HTMLAttributes<HTMLDivElement> {
    * Text for the aria-label attribute for main SVG container, if provided
    */
   ariaLabel?: string;
+  /**
+   * When provided, renders an accessible Magma toolbar above the chart with
+   * "Show as table", fullscreen, and "More options" buttons. Carbon's built-in
+   * toolbar is automatically disabled.
+   */
+  chartToolbar?: ChartToolbarConfig;
 }
+
+const ChartContentWrapper = styled.div`
+  height: 100%;
+  position: relative;
+`;
 
 const CarbonChartWrapper = styled.div<{
   isInverse?: boolean;
   groupsLength: number;
   theme: ThemeInterface;
 }>`
+  &:fullscreen,
+  &:-webkit-full-screen {
+    background: ${props =>
+      props.isInverse
+        ? props.theme.colors.primary700
+        : props.theme.colors.neutral100};
+
+    .cds--chart-holder {
+      height: 100vh !important;
+    }
+  }
+
   .cds--data-table thead tr th {
     background: ${props =>
       props.isInverse ? props.theme.colors.primary700 : ''} !important;
@@ -131,9 +209,9 @@ const CarbonChartWrapper = styled.div<{
     }
   }
 
-  p,
-  div,
-  text,
+  .chart-holder p,
+  .chart-holder div,
+  .chart-holder text,
   .cds--cc--axes g.axis .axis-title,
   .cds--cc--title p.title,
   .cds--cc--axes g.axis g.tick text {
@@ -488,6 +566,10 @@ const CarbonChartWrapper = styled.div<{
     }
   }
 
+  &.has-magma-toolbar .cds--cc--title p.title {
+    visibility: hidden;
+  }
+
   svg:not(:root) {
     overflow: visible;
   }
@@ -535,6 +617,372 @@ interface ColorsObject {
   [key: string]: string;
 }
 
+const ToolbarWrapper = styled.div<{
+  isFullscreen?: boolean;
+  isInverse?: boolean;
+  theme: ThemeInterface;
+}>`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  left: ${props => (props.isFullscreen ? '2em' : '0')};
+  position: absolute;
+  right: ${props => (props.isFullscreen ? '2em' : '0')};
+  top: ${props => (props.isFullscreen ? '2em' : '0')};
+  z-index: 2;
+
+  button {
+    color: ${props =>
+      props.isInverse
+        ? props.theme.colors.neutral100
+        : props.theme.colors.primary500};
+
+    &:focus {
+      outline: 2px solid
+        ${props =>
+          props.isInverse
+            ? props.theme.colors.focusInverse
+            : props.theme.colors.focus};
+      outline-offset: 0;
+    }
+  }
+`;
+
+const ChartTitle = styled.h2<{
+  isInverse?: boolean;
+  theme: ThemeInterface;
+}>`
+  font-family: ${props => props.theme.bodyFont} !important;
+  font-size: 16px !important;
+  font-weight: 700 !important;
+  letter-spacing: normal !important;
+  line-height: 1.25 !important;
+  margin: 0 !important;
+  color: ${props =>
+    props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral700} !important;
+`;
+
+const ToolbarActions = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 4px;
+
+  > * button,
+  > button {
+    height: 2rem;
+    min-height: 2rem;
+    min-width: 2rem;
+    padding: 4px;
+    width: 2rem;
+  }
+
+  [role='tooltip'] {
+    padding: 4px 8px;
+    white-space: nowrap;
+  }
+
+  [role='menuitem'],
+  [data-testid='dropdownMenuItem'] {
+    padding: 8px 16px;
+  }
+`;
+
+function downloadCsv(dataSet: Array<Record<string, unknown>>, title: string) {
+  if (!dataSet.length) return;
+  const keys = Object.keys(dataSet[0]);
+  const header = keys.join(',');
+  const rows = dataSet.map(row =>
+    keys
+      .map(k => {
+        const v = row[k];
+        const s = String(v ?? '');
+        return s.includes(',') || s.includes('"') || s.includes('\n')
+          ? `"${s.replace(/"/g, '""')}"`
+          : s;
+      })
+      .join(',')
+  );
+  const csv = [header, ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${title || 'chart-data'}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function inlineStyles(source: Element, target: Element) {
+  const computed = window.getComputedStyle(source);
+  if (target instanceof HTMLElement || target instanceof SVGElement) {
+    target.setAttribute(
+      'style',
+      Array.from(computed)
+        .map(prop => `${prop}:${computed.getPropertyValue(prop)}`)
+        .join(';')
+    );
+  }
+  for (let i = 0; i < source.children.length; i++) {
+    if (target.children[i]) {
+      inlineStyles(source.children[i], target.children[i]);
+    }
+  }
+}
+
+interface LegendItem {
+  label: string;
+  color: string;
+}
+
+function readLegendItems(wrapper: HTMLElement): LegendItem[] {
+  const items: LegendItem[] = [];
+  wrapper.querySelectorAll('.legend-item').forEach(item => {
+    const checkbox = item.querySelector<HTMLElement>('.checkbox');
+    const label = item.querySelector('p');
+    if (checkbox && label) {
+      items.push({
+        color: checkbox.style.background || checkbox.style.backgroundColor,
+        label: label.textContent || '',
+      });
+    }
+  });
+  return items;
+}
+
+function drawLegend(
+  ctx: CanvasRenderingContext2D,
+  items: LegendItem[],
+  startY: number,
+  canvasWidth: number,
+  scale: number
+) {
+  const fontSize = 13 * scale;
+  const swatchSize = 12 * scale;
+  const gap = 8 * scale;
+  const itemGap = 16 * scale;
+  const paddingX = 16 * scale;
+
+  ctx.font = `${fontSize}px sans-serif`;
+  ctx.textBaseline = 'middle';
+
+  let x = paddingX;
+  let y = startY;
+
+  for (const item of items) {
+    const textWidth = ctx.measureText(item.label).width;
+    const itemWidth = swatchSize + gap + textWidth + itemGap;
+
+    if (x + itemWidth > canvasWidth - paddingX && x > paddingX) {
+      x = paddingX;
+      y += fontSize + gap;
+    }
+
+    ctx.fillStyle = item.color;
+    ctx.fillRect(x, y - swatchSize / 2, swatchSize, swatchSize);
+
+    ctx.fillStyle = '#161616';
+    ctx.fillText(item.label, x + swatchSize + gap, y);
+
+    x += itemWidth;
+  }
+
+  return y + fontSize + gap;
+}
+
+function downloadImage(
+  wrapperRef: React.RefObject<HTMLDivElement | null>,
+  title: string,
+  format: 'png' | 'jpg'
+) {
+  const wrapper = wrapperRef.current;
+  if (!wrapper) return;
+  const svg = wrapper.querySelector('svg.layout-svg-wrapper');
+  if (!svg) return;
+
+  const svgRect = svg.getBoundingClientRect();
+  const legendItems = readLegendItems(wrapper);
+  const scale = 2;
+
+  // Measure legend height
+  const tempCanvas = document.createElement('canvas');
+  const tempCtx = tempCanvas.getContext('2d');
+  const fontSize = 13 * scale;
+  const swatchSize = 12 * scale;
+  const gap = 8 * scale;
+  const itemGap = 16 * scale;
+  const paddingX = 16 * scale;
+  const canvasWidth = svgRect.width * scale;
+
+  let legendHeight = 0;
+  if (legendItems.length > 0 && tempCtx) {
+    tempCtx.font = `${fontSize}px sans-serif`;
+    let x = paddingX;
+    let rows = 1;
+    for (const item of legendItems) {
+      const textWidth = tempCtx.measureText(item.label).width;
+      const itemWidth = swatchSize + gap + textWidth + itemGap;
+      if (x + itemWidth > canvasWidth - paddingX && x > paddingX) {
+        x = paddingX;
+        rows++;
+      }
+      x += itemWidth;
+    }
+    legendHeight = rows * (fontSize + gap) + gap * 2;
+  }
+
+  const width = svgRect.width * scale;
+  const height = svgRect.height * scale + legendHeight;
+
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute('width', String(svgRect.width));
+  clone.setAttribute('height', String(svgRect.height));
+  clone.setAttribute('viewBox', `0 0 ${svgRect.width} ${svgRect.height}`);
+  clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+
+  inlineStyles(svg, clone);
+
+  const serializer = new XMLSerializer();
+  const svgString = serializer.serializeToString(clone);
+  const svgBlob = new Blob([svgString], {
+    type: 'image/svg+xml;charset=utf-8',
+  });
+  const url = URL.createObjectURL(svgBlob);
+
+  const mimeType = format === 'jpg' ? 'image/jpeg' : 'image/png';
+  const ext = format === 'jpg' ? 'jpg' : 'png';
+
+  const img = new Image();
+  img.onload = () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, svgRect.width * scale, svgRect.height * scale);
+    URL.revokeObjectURL(url);
+
+    if (legendItems.length > 0) {
+      drawLegend(ctx, legendItems, svgRect.height * scale + gap, width, scale);
+    }
+
+    canvas.toBlob(blob => {
+      if (!blob) return;
+      const imgUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = imgUrl;
+      a.download = `${title || 'chart'}.${ext}`;
+      a.click();
+      URL.revokeObjectURL(imgUrl);
+    }, mimeType);
+  };
+  img.src = url;
+}
+
+interface InternalToolbarProps {
+  config: ChartToolbarConfig;
+  dataSet: Array<Record<string, unknown>>;
+  isInverse: boolean;
+  isTableOpen: boolean;
+  isFullscreen: boolean;
+  onOpenTable: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onToggleFullscreen: () => void;
+  theme: ThemeInterface;
+  title: string;
+  wrapperRef: React.RefObject<HTMLDivElement | null>;
+}
+
+function CarbonChartToolbar({
+  config,
+  dataSet,
+  isInverse,
+  isTableOpen,
+  isFullscreen,
+  onOpenTable,
+  onToggleFullscreen,
+  theme,
+  title,
+  wrapperRef,
+}: InternalToolbarProps) {
+  const showTable = config.showAsTable !== false;
+  const showFullscreen = config.fullscreen !== false;
+
+  const handleDownloadCsv = React.useCallback(() => {
+    downloadCsv(dataSet, title);
+  }, [dataSet, title]);
+
+  const handleDownloadPng = React.useCallback(() => {
+    downloadImage(wrapperRef, title, 'png');
+  }, [wrapperRef, title]);
+
+  const handleDownloadJpg = React.useCallback(() => {
+    downloadImage(wrapperRef, title, 'jpg');
+  }, [wrapperRef, title]);
+
+  const moreOptionsContent = (
+    <>
+      <DropdownMenuItem onClick={handleDownloadCsv}>
+        Download as CSV
+      </DropdownMenuItem>
+      <DropdownMenuItem onClick={handleDownloadPng}>
+        Download as PNG
+      </DropdownMenuItem>
+      <DropdownMenuItem onClick={handleDownloadJpg}>
+        Download as JPG
+      </DropdownMenuItem>
+      {config.moreOptions && (
+        <>
+          <DropdownDivider />
+          {config.moreOptions}
+        </>
+      )}
+    </>
+  );
+
+  return (
+    <ToolbarWrapper
+      isFullscreen={isFullscreen}
+      isInverse={isInverse}
+      theme={theme}
+    >
+      <ChartTitle isInverse={isInverse} theme={theme}>
+        {title}
+      </ChartTitle>
+      <ToolbarActions>
+        {showTable && (
+          <ChartTableButton
+            ariaLabel={title}
+            icon={<TableChartIcon size={20} />}
+            isInverse={isInverse}
+            isTableOpen={isTableOpen}
+            onClick={onOpenTable}
+          />
+        )}
+        {showFullscreen && (
+          <ChartFullscreenButton
+            ariaLabel={`${isFullscreen ? 'Exit' : 'View'} ${title} full screen`}
+            icon={<FullscreenIcon size={20} />}
+            exitIcon={<FullscreenExitIcon size={20} />}
+            isInverse={isInverse}
+            isFullscreen={isFullscreen}
+            onClick={onToggleFullscreen}
+          />
+        )}
+        <ChartMoreOptionsButton
+          icon={<MoreVertIcon size={20} />}
+          isInverse={isInverse}
+        >
+          {moreOptionsContent}
+        </ChartMoreOptionsButton>
+      </ToolbarActions>
+    </ToolbarWrapper>
+  );
+}
+
 export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
   (props, ref) => {
     const {
@@ -544,11 +992,16 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       dataSet,
       options,
       ariaLabel,
+      chartToolbar,
       ...rest
     } = props;
     const theme = React.useContext(ThemeContext);
     const isInverse = useIsInverse(isInverseProp);
     const internalRef = React.useRef<HTMLDivElement | null>(null);
+
+    const [isTableOpen, setIsTableOpen] = React.useState(false);
+    const [isFullscreen, setIsFullscreen] = React.useState(false);
+    const lastTableTriggerRef = React.useRef<HTMLButtonElement | null>(null);
 
     const mergedRef = React.useCallback(
       (node: HTMLDivElement | null) => {
@@ -561,6 +1014,64 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       },
       [ref]
     );
+
+    const fullscreenEnabled = chartToolbar
+      ? chartToolbar.fullscreen !== false
+      : false;
+
+    const savedHeightRef = React.useRef<string>('');
+
+    React.useEffect(() => {
+      if (!fullscreenEnabled) return;
+
+      const onFullscreenChange = () => {
+        const isFs = !!document.fullscreenElement;
+        setIsFullscreen(isFs);
+
+        const chartHolder =
+          internalRef.current?.querySelector<HTMLElement>('.cds--chart-holder');
+        if (chartHolder) {
+          if (isFs) {
+            savedHeightRef.current = chartHolder.style.height;
+            chartHolder.style.height = '100vh';
+          } else {
+            chartHolder.style.height = savedHeightRef.current;
+          }
+        }
+      };
+      document.addEventListener('fullscreenchange', onFullscreenChange);
+      return () =>
+        document.removeEventListener('fullscreenchange', onFullscreenChange);
+    }, [fullscreenEnabled]);
+
+    const openTableModal = React.useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        lastTableTriggerRef.current = event.currentTarget;
+        setIsTableOpen(true);
+      },
+      []
+    );
+
+    const closeTableModal = React.useCallback(() => {
+      setIsTableOpen(false);
+      setTimeout(() => {
+        lastTableTriggerRef.current?.focus();
+      }, 0);
+    }, []);
+
+    const toggleFullscreen = React.useCallback(() => {
+      if (!document.fullscreenElement && internalRef.current) {
+        internalRef.current.requestFullscreen();
+      } else if (document.fullscreenElement) {
+        document.exitFullscreen();
+      }
+    }, []);
+
+    const chartTitle: string = (options as any).title || '';
+
+    const handleModalDownloadCsv = React.useCallback(() => {
+      downloadCsv(dataSet as Array<Record<string, unknown>>, chartTitle);
+    }, [dataSet, chartTitle]);
 
     useCarbonModalFocusManagement(internalRef);
     const allCharts = {
@@ -621,6 +1132,7 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
           type: 'none',
         },
       },
+      ...(chartToolbar ? { toolbar: { enabled: false } } : {}),
     };
 
     const ChartType = allCharts[type] as any;
@@ -636,17 +1148,48 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
     const groupsLength = Object.keys(buildColors()).length;
 
+    const showTable = chartToolbar?.showAsTable !== false;
+
     return (
       <CarbonChartWrapper
         data-testid={testId}
         ref={mergedRef}
         isInverse={isInverse}
         theme={theme}
-        className="carbon-chart-wrapper"
+        className={`carbon-chart-wrapper${chartToolbar ? ' has-magma-toolbar' : ''}`}
         groupsLength={groupsLength < 6 ? groupsLength : 14}
         {...rest}
       >
-        <ChartType data={dataSet} options={newOptions} />
+        <ChartContentWrapper>
+          {chartToolbar && (
+            <CarbonChartToolbar
+              config={chartToolbar}
+              dataSet={dataSet as Array<Record<string, unknown>>}
+              isInverse={isInverse}
+              isTableOpen={isTableOpen}
+              isFullscreen={isFullscreen}
+              onOpenTable={openTableModal}
+              onToggleFullscreen={toggleFullscreen}
+              theme={theme}
+              title={chartTitle}
+              wrapperRef={internalRef}
+            />
+          )}
+          <ChartType data={dataSet} options={newOptions} />
+        </ChartContentWrapper>
+        {chartToolbar && showTable && (
+          <ChartTableModal
+            columns={chartToolbar.tableColumns}
+            dataSet={dataSet as Array<Record<string, React.ReactNode>>}
+            headerLabel={chartToolbar.tableHeaderLabel}
+            headerLevel={chartToolbar.tableHeaderLevel}
+            isInverse={isInverse}
+            isOpen={isTableOpen}
+            onClose={closeTableModal}
+            onDownloadCsv={handleModalDownloadCsv}
+            title={chartTitle}
+          />
+        )}
       </CarbonChartWrapper>
     );
   }

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -686,7 +686,7 @@ const ToolbarActions = styled.div<{ theme: ThemeInterface }>`
     white-space: nowrap;
   }
 
-  [role='menu'] {
+  [data-testid='dropdownContent'] {
     padding: ${props => props.theme.spaceScale.spacing03} 0;
   }
 

--- a/packages/charts/src/components/ChartTable/ChartDataTable.tsx
+++ b/packages/charts/src/components/ChartTable/ChartDataTable.tsx
@@ -17,7 +17,7 @@ export interface ChartDataTableColumn {
 }
 
 export interface ChartDataTableProps {
-  /** Column definitions (header + key). If omitted, columns are auto-derived from the dataset object keys. */
+  /** Column definitions (header + key). If omitted, columns are auto-derived from the dataset object keys with the first character capitalized (e.g. "group" → "Group"). */
   columns?: ChartDataTableColumn[];
   /** Array of data objects. Each object should have keys matching the column `key` values. */
   dataSet: Array<Record<string, React.ReactNode>>;

--- a/packages/charts/src/components/ChartTable/ChartDataTable.tsx
+++ b/packages/charts/src/components/ChartTable/ChartDataTable.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+} from 'react-magma-dom';
+
+export interface ChartDataTableColumn {
+  /** Header text for this column */
+  header: string;
+  /** Key to read from each row object */
+  key: string;
+}
+
+export interface ChartDataTableProps {
+  /** Column definitions (header + key). Defaults to Group / Value if omitted. */
+  columns?: ChartDataTableColumn[];
+  /** Array of data objects. Each object should have keys matching the column `key` values. */
+  dataSet: Array<Record<string, React.ReactNode>>;
+  /**
+   * If true, the table uses inverse (dark) styling.
+   * @default false
+   */
+  isInverse?: boolean;
+}
+
+function deriveColumns(
+  dataSet: Array<Record<string, React.ReactNode>>
+): ChartDataTableColumn[] {
+  if (!dataSet.length) return [];
+  return Object.keys(dataSet[0]).map(key => ({
+    header: key.charAt(0).toUpperCase() + key.slice(1),
+    key,
+  }));
+}
+
+export function ChartDataTable({
+  columns,
+  dataSet,
+  isInverse,
+}: ChartDataTableProps) {
+  const resolvedColumns = columns || deriveColumns(dataSet);
+  return (
+    <Table isInverse={isInverse}>
+      <TableHead>
+        <TableRow>
+          {resolvedColumns.map(col => (
+            <TableHeaderCell key={col.key}>{col.header}</TableHeaderCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {dataSet.map((row, index) => (
+          <TableRow key={index}>
+            {resolvedColumns.map(col => (
+              <TableCell key={col.key}>{row[col.key]}</TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/packages/charts/src/components/ChartTable/ChartDataTable.tsx
+++ b/packages/charts/src/components/ChartTable/ChartDataTable.tsx
@@ -17,7 +17,7 @@ export interface ChartDataTableColumn {
 }
 
 export interface ChartDataTableProps {
-  /** Column definitions (header + key). Defaults to Group / Value if omitted. */
+  /** Column definitions (header + key). If omitted, columns are auto-derived from the dataset object keys. */
   columns?: ChartDataTableColumn[];
   /** Array of data objects. Each object should have keys matching the column `key` values. */
   dataSet: Array<Record<string, React.ReactNode>>;
@@ -54,13 +54,18 @@ export function ChartDataTable({
         </TableRow>
       </TableHead>
       <TableBody>
-        {dataSet.map((row, index) => (
-          <TableRow key={index}>
-            {resolvedColumns.map(col => (
-              <TableCell key={col.key}>{row[col.key]}</TableCell>
-            ))}
-          </TableRow>
-        ))}
+        {dataSet.map((row, index) => {
+          const rowKey = resolvedColumns
+            .map(col => String(row[col.key] ?? ''))
+            .join('-');
+          return (
+            <TableRow key={`${rowKey}-${index}`}>
+              {resolvedColumns.map(col => (
+                <TableCell key={col.key}>{row[col.key]}</TableCell>
+              ))}
+            </TableRow>
+          );
+        })}
       </TableBody>
     </Table>
   );

--- a/packages/charts/src/components/ChartTable/ChartFullscreenButton.tsx
+++ b/packages/charts/src/components/ChartTable/ChartFullscreenButton.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import { ButtonVariant, IconButton, Tooltip } from 'react-magma-dom';
+
+export interface ChartFullscreenButtonProps {
+  /** Accessible label for the button, e.g. "View Overall Performance in full screen" */
+  ariaLabel: string;
+  /** Icon rendered when not in fullscreen mode */
+  icon: React.ReactElement;
+  /** Icon rendered when in fullscreen mode. Falls back to `icon` if omitted. */
+  exitIcon?: React.ReactElement;
+  /**
+   * If true, the button uses inverse (dark) styling.
+   * @default false
+   */
+  isInverse?: boolean;
+  /** Whether the chart is currently in fullscreen mode */
+  isFullscreen: boolean;
+  /** Click handler – should toggle fullscreen */
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Optional ref forwarded to the underlying IconButton */
+  buttonRef?: React.Ref<HTMLButtonElement>;
+  /**
+   * Tooltip text shown on hover.
+   * @default "Make full screen" / "Exit full screen" based on state
+   */
+  tooltipContent?: string;
+}
+
+export function ChartFullscreenButton({
+  ariaLabel,
+  buttonRef,
+  exitIcon,
+  icon,
+  isInverse,
+  isFullscreen,
+  onClick,
+  tooltipContent,
+}: ChartFullscreenButtonProps) {
+  const resolvedTooltip =
+    tooltipContent ?? (isFullscreen ? 'Exit full screen' : 'Make full screen');
+  const resolvedIcon = isFullscreen && exitIcon ? exitIcon : icon;
+
+  return (
+    <Tooltip content={resolvedTooltip} isInverse={isInverse}>
+      <IconButton
+        aria-label={ariaLabel}
+        icon={resolvedIcon}
+        isInverse={isInverse}
+        onClick={onClick}
+        ref={buttonRef}
+        variant={ButtonVariant.link}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/charts/src/components/ChartTable/ChartFullscreenButton.tsx
+++ b/packages/charts/src/components/ChartTable/ChartFullscreenButton.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { ButtonVariant, IconButton, Tooltip } from 'react-magma-dom';
 
+import { useChartToolbarI18n } from './chartToolbarI18n';
+
 export interface ChartFullscreenButtonProps {
   /** Accessible label for the button, e.g. "View Overall Performance in full screen" */
   ariaLabel: string;
@@ -22,7 +24,7 @@ export interface ChartFullscreenButtonProps {
   buttonRef?: React.Ref<HTMLButtonElement>;
   /**
    * Tooltip text shown on hover.
-   * @default "Make full screen" / "Exit full screen" based on state
+   * @default "Make full screen" / "Exit full screen" based on state (i18n overridable)
    */
   tooltipContent?: string;
 }
@@ -37,8 +39,9 @@ export function ChartFullscreenButton({
   onClick,
   tooltipContent,
 }: ChartFullscreenButtonProps) {
+  const t = useChartToolbarI18n();
   const resolvedTooltip =
-    tooltipContent ?? (isFullscreen ? 'Exit full screen' : 'Make full screen');
+    tooltipContent ?? (isFullscreen ? t.exitFullScreen : t.makeFullScreen);
   const resolvedIcon = isFullscreen && exitIcon ? exitIcon : icon;
 
   return (

--- a/packages/charts/src/components/ChartTable/ChartMoreOptionsButton.tsx
+++ b/packages/charts/src/components/ChartTable/ChartMoreOptionsButton.tsx
@@ -7,10 +7,12 @@ import {
   DropdownContent,
 } from 'react-magma-dom';
 
+import { useChartToolbarI18n } from './chartToolbarI18n';
+
 export interface ChartMoreOptionsButtonProps {
   /**
    * Accessible label for the trigger button.
-   * @default "More options"
+   * @default "More options" (i18n overridable)
    */
   ariaLabel?: string;
   /** Menu items rendered inside the dropdown (DropdownMenuItem, DropdownDivider, etc.) */
@@ -25,15 +27,17 @@ export interface ChartMoreOptionsButtonProps {
 }
 
 export function ChartMoreOptionsButton({
-  ariaLabel = 'More options',
+  ariaLabel,
   children,
   icon,
   isInverse,
 }: ChartMoreOptionsButtonProps) {
+  const t = useChartToolbarI18n();
+  const resolvedAriaLabel = ariaLabel ?? t.moreOptionsAriaLabel;
   return (
     <Dropdown isInverse={isInverse}>
       <DropdownButton
-        aria-label={ariaLabel}
+        aria-label={resolvedAriaLabel}
         icon={icon}
         variant={ButtonVariant.link}
       />

--- a/packages/charts/src/components/ChartTable/ChartMoreOptionsButton.tsx
+++ b/packages/charts/src/components/ChartTable/ChartMoreOptionsButton.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import {
+  ButtonVariant,
+  Dropdown,
+  DropdownButton,
+  DropdownContent,
+} from 'react-magma-dom';
+
+export interface ChartMoreOptionsButtonProps {
+  /**
+   * Accessible label for the trigger button.
+   * @default "More options"
+   */
+  ariaLabel?: string;
+  /** Menu items rendered inside the dropdown (DropdownMenuItem, DropdownDivider, etc.) */
+  children: React.ReactNode;
+  /** Icon element rendered inside the trigger button */
+  icon: React.ReactElement;
+  /**
+   * If true, the dropdown uses inverse (dark) styling.
+   * @default false
+   */
+  isInverse?: boolean;
+}
+
+export function ChartMoreOptionsButton({
+  ariaLabel = 'More options',
+  children,
+  icon,
+  isInverse,
+}: ChartMoreOptionsButtonProps) {
+  return (
+    <Dropdown isInverse={isInverse}>
+      <DropdownButton
+        aria-label={ariaLabel}
+        icon={icon}
+        variant={ButtonVariant.link}
+      />
+      <DropdownContent>{children}</DropdownContent>
+    </Dropdown>
+  );
+}

--- a/packages/charts/src/components/ChartTable/ChartTable.stories.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTable.stories.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+
+import { StoryFn, Meta } from '@storybook/react/types-6-0';
+import { Card } from 'react-magma-dom';
+
+import { CarbonChart, CarbonChartProps, CarbonChartType } from '../CarbonChart';
+
+export default {
+  component: CarbonChart,
+  title: 'CarbonChart/ChartToolbar',
+  argTypes: {
+    isInverse: {
+      control: { type: 'boolean' },
+    },
+  },
+} as Meta;
+
+// ---------------------------------------------------------------------------
+// Shared data
+// ---------------------------------------------------------------------------
+
+const donutDataSet = [
+  { group: 'Not attempted', value: 5 },
+  { group: 'Poor performance (Score less than 33%)', value: 15 },
+  { group: 'High performance (Score greater than 66%)', value: 50 },
+  { group: 'Average performance (Score between 33% and 66%)', value: 30 },
+];
+
+const barDataSet = [
+  { group: 'Chapter 1', value: 85 },
+  { group: 'Chapter 2', value: 72 },
+  { group: 'Chapter 3', value: 91 },
+  { group: 'Chapter 4', value: 64 },
+];
+
+// ---------------------------------------------------------------------------
+// Full toolbar – Donut chart (all buttons via chartToolbar prop)
+// ---------------------------------------------------------------------------
+
+/**
+ * Full toolbar with Show as Table, Full Screen, and More Options buttons,
+ * driven entirely by the `chartToolbar` prop on CarbonChart.
+ *
+ * Carbon's built-in toolbar is automatically disabled when `chartToolbar`
+ * is provided. The Magma toolbar renders accessible replacements with
+ * proper ARIA attributes, focus management, and heading semantics.
+ */
+const FullToolbarTemplate: StoryFn<CarbonChartProps> = args => (
+  <Card isInverse={args.isInverse} style={{ padding: '12px' }}>
+    <CarbonChart {...args} />
+  </Card>
+);
+
+export const DonutWithToolbar = {
+  render: FullToolbarTemplate,
+  args: {
+    isInverse: false,
+    type: CarbonChartType.donut,
+    dataSet: donutDataSet,
+    options: {
+      title: 'Overall Activity Performance',
+      resizable: true,
+      height: '400px',
+      donut: {
+        center: { label: 'Questions' },
+      },
+      legend: {
+        truncation: { type: 'none' },
+      },
+    },
+    chartToolbar: {},
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Bar chart with custom table columns
+// ---------------------------------------------------------------------------
+
+export const BarWithToolbar = {
+  render: FullToolbarTemplate,
+  args: {
+    isInverse: false,
+    type: CarbonChartType.bar,
+    dataSet: barDataSet,
+    options: {
+      title: 'Chapter Performance',
+      axes: {
+        left: { mapsTo: 'value' },
+        bottom: { mapsTo: 'group', scaleType: 'labels' },
+      },
+      height: '400px',
+    },
+    chartToolbar: {
+      tableColumns: [
+        { header: 'Chapter', key: 'group' },
+        { header: 'Score (%)', key: 'value' },
+      ],
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Inverse theme
+// ---------------------------------------------------------------------------
+
+export const InverseTheme = {
+  render: FullToolbarTemplate,
+  args: {
+    isInverse: true,
+    type: CarbonChartType.donut,
+    dataSet: donutDataSet,
+    options: {
+      title: 'Inverse Theme Demo',
+      resizable: true,
+      height: '400px',
+      donut: {
+        center: { label: 'Questions' },
+      },
+      legend: {
+        truncation: { type: 'none' },
+      },
+    },
+    chartToolbar: {},
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Table only (no fullscreen or more options)
+// ---------------------------------------------------------------------------
+
+export const TableOnly = {
+  render: FullToolbarTemplate,
+  args: {
+    isInverse: false,
+    type: CarbonChartType.donut,
+    dataSet: donutDataSet,
+    options: {
+      title: 'Table Only (No Fullscreen)',
+      resizable: true,
+      height: '400px',
+      donut: {
+        center: { label: 'Questions' },
+      },
+      legend: {
+        truncation: { type: 'none' },
+      },
+    },
+    chartToolbar: {
+      fullscreen: false,
+    },
+  },
+};

--- a/packages/charts/src/components/ChartTable/ChartTable.test.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTable.test.tsx
@@ -1,0 +1,444 @@
+import React from 'react';
+
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { DropdownMenuItem } from 'react-magma-dom';
+import {
+  FullscreenExitIcon,
+  FullscreenIcon,
+  MoreVertIcon,
+  TableChartIcon,
+} from 'react-magma-icons';
+
+import { ChartDataTable } from './ChartDataTable';
+import { ChartFullscreenButton } from './ChartFullscreenButton';
+import { ChartMoreOptionsButton } from './ChartMoreOptionsButton';
+import { ChartTableButton } from './ChartTableButton';
+import { ChartTableModal } from './ChartTableModal';
+import { ChartToolbar } from './ChartToolbar';
+
+const dataSet = [
+  { group: 'High performance', value: 50 },
+  { group: 'Average performance', value: 30 },
+  { group: 'Poor performance', value: 15 },
+  { group: 'Not attempted', value: 5 },
+];
+
+// ---------------------------------------------------------------------------
+// ChartDataTable
+// ---------------------------------------------------------------------------
+describe('ChartDataTable', () => {
+  it('derives column headers from dataset keys when no columns prop is given', () => {
+    render(<ChartDataTable dataSet={dataSet} />);
+
+    expect(
+      screen.getByRole('columnheader', { name: 'Group' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Value' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders all data rows', () => {
+    render(<ChartDataTable dataSet={dataSet} />);
+
+    expect(
+      screen.getByRole('cell', { name: 'High performance' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '50' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', { name: 'Not attempted' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '5' })).toBeInTheDocument();
+  });
+
+  it('accepts custom column definitions', () => {
+    const columns = [
+      { header: 'Category', key: 'group' },
+      { header: 'Count', key: 'value' },
+    ];
+    render(<ChartDataTable columns={columns} dataSet={dataSet} />);
+
+    expect(
+      screen.getByRole('columnheader', { name: 'Category' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Count' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders with isInverse without error', () => {
+    render(<ChartDataTable dataSet={dataSet} isInverse />);
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChartTableModal
+// ---------------------------------------------------------------------------
+describe('ChartTableModal', () => {
+  it('renders a dialog with semantic heading when open', () => {
+    render(
+      <ChartTableModal
+        dataSet={dataSet}
+        isOpen
+        onClose={jest.fn()}
+        title="Overall Performance"
+      />
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'Tabular representation Overall Performance',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('respects custom headerLevel', () => {
+    render(
+      <ChartTableModal
+        dataSet={dataSet}
+        headerLevel={1}
+        isOpen
+        onClose={jest.fn()}
+        title="Test"
+      />
+    );
+
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('respects custom headerLabel', () => {
+    render(
+      <ChartTableModal
+        dataSet={dataSet}
+        headerLabel="Data table"
+        isOpen
+        onClose={jest.fn()}
+        title="My Chart"
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Data table My Chart' })
+    ).toBeInTheDocument();
+  });
+
+  it('does not render dialog when closed', () => {
+    render(
+      <ChartTableModal
+        dataSet={dataSet}
+        isOpen={false}
+        onClose={jest.fn()}
+        title="Test"
+      />
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the data table inside the modal', () => {
+    render(
+      <ChartTableModal
+        dataSet={dataSet}
+        isOpen
+        onClose={jest.fn()}
+        title="Test"
+      />
+    );
+
+    expect(
+      screen.getByRole('columnheader', { name: 'Group' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', { name: 'High performance' })
+    ).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is activated', async () => {
+    jest.useFakeTimers();
+    const onClose = jest.fn();
+    render(
+      <ChartTableModal
+        dataSet={dataSet}
+        isOpen
+        onClose={onClose}
+        title="Test"
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('modal-closebtn'));
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('renders with isInverse without error', () => {
+    render(
+      <ChartTableModal
+        dataSet={dataSet}
+        isInverse
+        isOpen
+        onClose={jest.fn()}
+        title="Inverse Modal"
+      />
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChartTableButton
+// ---------------------------------------------------------------------------
+describe('ChartTableButton', () => {
+  const icon = <TableChartIcon />;
+
+  it('renders with aria-haspopup="dialog"', () => {
+    render(
+      <ChartTableButton
+        ariaLabel="Overall Performance"
+        icon={icon}
+        isTableOpen={false}
+        onClick={jest.fn()}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Overall Performance' });
+    expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+
+  it('sets aria-expanded to false when modal is closed', () => {
+    render(
+      <ChartTableButton
+        ariaLabel="Overall Performance"
+        icon={icon}
+        isTableOpen={false}
+        onClick={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Overall Performance' })
+    ).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('sets aria-expanded to true when modal is open', () => {
+    render(
+      <ChartTableButton
+        ariaLabel="Overall Performance"
+        icon={icon}
+        isTableOpen
+        onClick={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Overall Performance' })
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('calls onClick when activated', () => {
+    const onClick = jest.fn();
+    render(
+      <ChartTableButton
+        ariaLabel="Overall Performance"
+        icon={icon}
+        isTableOpen={false}
+        onClick={onClick}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Overall Performance' })
+    );
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders with custom tooltip content on hover', async () => {
+    render(
+      <ChartTableButton
+        ariaLabel="Overall Performance"
+        icon={icon}
+        isTableOpen={false}
+        onClick={jest.fn()}
+        tooltipContent="View data as table"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: 'Overall Performance' });
+    fireEvent.mouseEnter(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('View data as table')).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChartFullscreenButton
+// ---------------------------------------------------------------------------
+describe('ChartFullscreenButton', () => {
+  it('does NOT have aria-haspopup', () => {
+    render(
+      <ChartFullscreenButton
+        ariaLabel="View chart in full screen"
+        icon={<FullscreenIcon />}
+        isFullscreen={false}
+        onClick={jest.fn()}
+      />
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'View chart in full screen',
+    });
+    expect(button).not.toHaveAttribute('aria-haspopup');
+  });
+
+  it('calls onClick when activated', () => {
+    const onClick = jest.fn();
+    render(
+      <ChartFullscreenButton
+        ariaLabel="View chart in full screen"
+        icon={<FullscreenIcon />}
+        isFullscreen={false}
+        onClick={onClick}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'View chart in full screen' })
+    );
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Make full screen" tooltip by default', async () => {
+    render(
+      <ChartFullscreenButton
+        ariaLabel="Fullscreen"
+        icon={<FullscreenIcon />}
+        isFullscreen={false}
+        onClick={jest.fn()}
+      />
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Fullscreen' }));
+    await waitFor(() => {
+      expect(screen.getByText('Make full screen')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Exit full screen" tooltip when in fullscreen', async () => {
+    render(
+      <ChartFullscreenButton
+        ariaLabel="Fullscreen"
+        icon={<FullscreenIcon />}
+        exitIcon={<FullscreenExitIcon />}
+        isFullscreen
+        onClick={jest.fn()}
+      />
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Fullscreen' }));
+    await waitFor(() => {
+      expect(screen.getByText('Exit full screen')).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChartMoreOptionsButton
+// ---------------------------------------------------------------------------
+describe('ChartMoreOptionsButton', () => {
+  it('renders with default "More options" label', () => {
+    render(
+      <ChartMoreOptionsButton icon={<MoreVertIcon />}>
+        <DropdownMenuItem>Download</DropdownMenuItem>
+      </ChartMoreOptionsButton>
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'More options' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders with custom aria-label', () => {
+    render(
+      <ChartMoreOptionsButton ariaLabel="Chart actions" icon={<MoreVertIcon />}>
+        <DropdownMenuItem>Download</DropdownMenuItem>
+      </ChartMoreOptionsButton>
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Chart actions' })
+    ).toBeInTheDocument();
+  });
+
+  it('opens dropdown menu on click', () => {
+    render(
+      <ChartMoreOptionsButton icon={<MoreVertIcon />}>
+        <DropdownMenuItem>Download as CSV</DropdownMenuItem>
+      </ChartMoreOptionsButton>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }));
+    expect(screen.getByText('Download as CSV')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChartToolbar
+// ---------------------------------------------------------------------------
+describe('ChartToolbar', () => {
+  it('renders the title as a heading', () => {
+    render(
+      <ChartToolbar title="Overall Performance">
+        <button>Action</button>
+      </ChartToolbar>
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Overall Performance' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders children action buttons', () => {
+    render(
+      <ChartToolbar title="Test">
+        <button>Show as table</button>
+        <button>Full screen</button>
+      </ChartToolbar>
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Show as table' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Full screen' })
+    ).toBeInTheDocument();
+  });
+
+  it('respects custom heading level', () => {
+    render(
+      <ChartToolbar title="Test" headingLevel={2}>
+        <button>Action</button>
+      </ChartToolbar>
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Test' })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/charts/src/components/ChartTable/ChartTableButton.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTableButton.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { ButtonVariant, IconButton, Tooltip } from 'react-magma-dom';
+
+export interface ChartTableButtonProps {
+  /** Accessible label for the button – should describe the chart, e.g. "Overall Performance" */
+  ariaLabel: string;
+  /** Icon element rendered inside the button */
+  icon: React.ReactElement;
+  /**
+   * If true, the button uses inverse (dark) styling.
+   * @default false
+   */
+  isInverse?: boolean;
+  /** Whether the associated modal is currently open */
+  isTableOpen: boolean;
+  /** Click handler – should open the modal */
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Optional ref forwarded to the underlying IconButton */
+  buttonRef?: React.Ref<HTMLButtonElement>;
+  /**
+   * Tooltip text shown on hover.
+   * @default "Show as table"
+   */
+  tooltipContent?: string;
+}
+
+export function ChartTableButton({
+  ariaLabel,
+  buttonRef,
+  icon,
+  isInverse,
+  isTableOpen,
+  onClick,
+  tooltipContent = 'Show as table',
+}: ChartTableButtonProps) {
+  return (
+    <Tooltip content={tooltipContent} isInverse={isInverse}>
+      <IconButton
+        aria-expanded={isTableOpen}
+        aria-haspopup="dialog"
+        aria-label={ariaLabel}
+        icon={icon}
+        isInverse={isInverse}
+        onClick={onClick}
+        ref={buttonRef}
+        variant={ButtonVariant.link}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/charts/src/components/ChartTable/ChartTableButton.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTableButton.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { ButtonVariant, IconButton, Tooltip } from 'react-magma-dom';
 
+import { useChartToolbarI18n } from './chartToolbarI18n';
+
 export interface ChartTableButtonProps {
   /** Accessible label for the button – should describe the chart, e.g. "Overall Performance" */
   ariaLabel: string;
@@ -20,7 +22,7 @@ export interface ChartTableButtonProps {
   buttonRef?: React.Ref<HTMLButtonElement>;
   /**
    * Tooltip text shown on hover.
-   * @default "Show as table"
+   * @default "Show as table" (i18n overridable)
    */
   tooltipContent?: string;
 }
@@ -32,10 +34,12 @@ export function ChartTableButton({
   isInverse,
   isTableOpen,
   onClick,
-  tooltipContent = 'Show as table',
+  tooltipContent,
 }: ChartTableButtonProps) {
+  const t = useChartToolbarI18n();
+  const resolvedTooltip = tooltipContent ?? t.showAsTableTooltip;
   return (
-    <Tooltip content={tooltipContent} isInverse={isInverse}>
+    <Tooltip content={resolvedTooltip} isInverse={isInverse}>
       <IconButton
         aria-expanded={isTableOpen}
         aria-haspopup="dialog"

--- a/packages/charts/src/components/ChartTable/ChartTableModal.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTableModal.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
 import styled from '@emotion/styled';
-import { Button, Modal, ModalSize } from 'react-magma-dom';
+import { Button, Modal, ModalSize, ThemeContext } from 'react-magma-dom';
 
 import { ChartDataTable, ChartDataTableColumn } from './ChartDataTable';
+import { useChartToolbarI18n } from './chartToolbarI18n';
 
 export interface ChartTableModalProps {
   /** The chart's data passed to ChartDataTable */
@@ -30,39 +31,45 @@ export interface ChartTableModalProps {
   headerLevel?: 1 | 2 | 3 | 4 | 5 | 6;
   /**
    * First line of the modal heading.
-   * @default "Tabular representation"
+   * @default "Tabular representation" (i18n overridable)
    */
   headerLabel?: string;
-  /** Magma Modal size */
+  /**
+   * Magma Modal size.
+   * @default ModalSize.large
+   */
   size?: ModalSize;
 }
 
-const ModalFooter = styled.div`
+const ModalFooter = styled.div<{ theme: any }>`
   display: flex;
   justify-content: flex-end;
-  padding-top: 16px;
+  padding-top: ${props => props.theme.spaceScale.spacing05};
 `;
 
 export function ChartTableModal({
   columns,
   dataSet,
-  headerLabel = 'Tabular representation',
+  headerLabel,
   headerLevel = 2,
   isInverse,
   isOpen,
   onClose,
   onDownloadCsv,
-  size,
+  size = ModalSize.large,
   title,
 }: ChartTableModalProps) {
+  const t = useChartToolbarI18n();
+  const theme = React.useContext(ThemeContext);
+  const resolvedHeaderLabel = headerLabel ?? t.tabularRepresentationLabel;
   const header = React.useMemo(
     () => (
       <span>
-        <span style={{ display: 'block' }}>{headerLabel}</span>
+        <span style={{ display: 'block' }}>{resolvedHeaderLabel}</span>
         <span style={{ display: 'block' }}>{title}</span>
       </span>
     ),
-    [headerLabel, title]
+    [resolvedHeaderLabel, title]
   );
 
   return (
@@ -80,9 +87,9 @@ export function ChartTableModal({
         isInverse={isInverse}
       />
       {onDownloadCsv && (
-        <ModalFooter>
+        <ModalFooter theme={theme}>
           <Button isInverse={isInverse} onClick={onDownloadCsv}>
-            Download as CSV
+            {t.downloadAsCsv}
           </Button>
         </ModalFooter>
       )}

--- a/packages/charts/src/components/ChartTable/ChartTableModal.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTableModal.tsx
@@ -12,6 +12,12 @@ export interface ChartTableModalProps {
   /** Column definitions forwarded to ChartDataTable */
   columns?: ChartDataTableColumn[];
   /**
+   * DOM element to portal the modal into. Defaults to `document.body`.
+   * When the chart is in fullscreen, pass the fullscreen element so the
+   * modal renders inside it and is visible to the browser.
+   */
+  portalContainer?: HTMLElement | null;
+  /**
    * If true, the modal uses inverse (dark) styling.
    * @default false
    */
@@ -55,12 +61,23 @@ const HeaderLabel = styled.span`
   line-height: 20px;
 `;
 
+const containerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+const contentStyle: React.CSSProperties = {
+  width: '100%',
+  margin: 0,
+};
+
 const HeaderTitle = styled.span`
   display: block;
 `;
 
 export function ChartTableModal({
   columns,
+  portalContainer,
   dataSet,
   headerLabel,
   headerLevel = 2,
@@ -86,12 +103,15 @@ export function ChartTableModal({
 
   return (
     <Modal
+      portalContainer={portalContainer}
+      containerStyle={portalContainer ? containerStyle : undefined}
       header={header}
       headerLevel={headerLevel}
       isInverse={isInverse}
       isOpen={isOpen}
       onClose={onClose}
       size={size}
+      style={portalContainer ? contentStyle : undefined}
     >
       <ChartDataTable
         columns={columns}

--- a/packages/charts/src/components/ChartTable/ChartTableModal.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTableModal.tsx
@@ -47,6 +47,18 @@ const ModalFooter = styled.div<{ theme: any }>`
   padding-top: ${props => props.theme.spaceScale.spacing05};
 `;
 
+const HeaderLabel = styled.span`
+  display: block;
+  font-size: 14px;
+  font-weight: normal;
+  color: #707070;
+  line-height: 20px;
+`;
+
+const HeaderTitle = styled.span`
+  display: block;
+`;
+
 export function ChartTableModal({
   columns,
   dataSet,
@@ -65,8 +77,8 @@ export function ChartTableModal({
   const header = React.useMemo(
     () => (
       <span>
-        <span style={{ display: 'block' }}>{resolvedHeaderLabel}</span>
-        <span style={{ display: 'block' }}>{title}</span>
+        <HeaderLabel>{resolvedHeaderLabel}</HeaderLabel>
+        <HeaderTitle>{title}</HeaderTitle>
       </span>
     ),
     [resolvedHeaderLabel, title]

--- a/packages/charts/src/components/ChartTable/ChartTableModal.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTableModal.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+
+import styled from '@emotion/styled';
+import { Button, Modal, ModalSize } from 'react-magma-dom';
+
+import { ChartDataTable, ChartDataTableColumn } from './ChartDataTable';
+
+export interface ChartTableModalProps {
+  /** The chart's data passed to ChartDataTable */
+  dataSet: Array<Record<string, React.ReactNode>>;
+  /** Column definitions forwarded to ChartDataTable */
+  columns?: ChartDataTableColumn[];
+  /**
+   * If true, the modal uses inverse (dark) styling.
+   * @default false
+   */
+  isInverse?: boolean;
+  /** Whether the modal is open */
+  isOpen: boolean;
+  /** Called when the modal requests to close */
+  onClose: () => void;
+  /** Called when the "Download as CSV" footer button is clicked */
+  onDownloadCsv?: () => void;
+  /** Chart title – displayed as a second line in the modal heading */
+  title: string;
+  /**
+   * Heading level for the modal header (1–6).
+   * @default 2
+   */
+  headerLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  /**
+   * First line of the modal heading.
+   * @default "Tabular representation"
+   */
+  headerLabel?: string;
+  /** Magma Modal size */
+  size?: ModalSize;
+}
+
+const ModalFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 16px;
+`;
+
+export function ChartTableModal({
+  columns,
+  dataSet,
+  headerLabel = 'Tabular representation',
+  headerLevel = 2,
+  isInverse,
+  isOpen,
+  onClose,
+  onDownloadCsv,
+  size,
+  title,
+}: ChartTableModalProps) {
+  const header = React.useMemo(
+    () => (
+      <span>
+        <span style={{ display: 'block' }}>{headerLabel}</span>
+        <span style={{ display: 'block' }}>{title}</span>
+      </span>
+    ),
+    [headerLabel, title]
+  );
+
+  return (
+    <Modal
+      header={header}
+      headerLevel={headerLevel}
+      isInverse={isInverse}
+      isOpen={isOpen}
+      onClose={onClose}
+      size={size}
+    >
+      <ChartDataTable
+        columns={columns}
+        dataSet={dataSet}
+        isInverse={isInverse}
+      />
+      {onDownloadCsv && (
+        <ModalFooter>
+          <Button isInverse={isInverse} onClick={onDownloadCsv}>
+            Download as CSV
+          </Button>
+        </ModalFooter>
+      )}
+    </Modal>
+  );
+}

--- a/packages/charts/src/components/ChartTable/ChartTableModal.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTableModal.tsx
@@ -53,12 +53,15 @@ const ModalFooter = styled.div<{ theme: any }>`
   padding-top: ${props => props.theme.spaceScale.spacing05};
 `;
 
-const HeaderLabel = styled.span`
+const HeaderLabel = styled.span<{ isInverse?: boolean; theme: any }>`
   display: block;
-  font-size: 14px;
+  font-size: ${props => props.theme.typeScale.size02.fontSize};
   font-weight: normal;
-  color: #707070;
-  line-height: 20px;
+  color: ${props =>
+    props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral500};
+  line-height: ${props => props.theme.typeScale.size02.lineHeight};
 `;
 
 const containerStyle: React.CSSProperties = {
@@ -94,11 +97,13 @@ export function ChartTableModal({
   const header = React.useMemo(
     () => (
       <span>
-        <HeaderLabel>{resolvedHeaderLabel}</HeaderLabel>
+        <HeaderLabel isInverse={isInverse} theme={theme}>
+          {resolvedHeaderLabel}
+        </HeaderLabel>
         <HeaderTitle>{title}</HeaderTitle>
       </span>
     ),
-    [resolvedHeaderLabel, title]
+    [resolvedHeaderLabel, title, isInverse, theme]
   );
 
   return (

--- a/packages/charts/src/components/ChartTable/ChartToolbar.tsx
+++ b/packages/charts/src/components/ChartTable/ChartToolbar.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import styled from '@emotion/styled';
+import { Heading, TypographyVisualStyle } from 'react-magma-dom';
+
+export interface ChartToolbarProps {
+  /** Toolbar action buttons (ChartTableButton, ChartFullscreenButton, ChartMoreOptionsButton, etc.) */
+  children: React.ReactNode;
+  /**
+   * Heading level for the chart title.
+   * @default 3
+   */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  /**
+   * Visual style for the heading.
+   * @default TypographyVisualStyle.headingSmall
+   */
+  headingVisualStyle?: TypographyVisualStyle;
+  /** Chart title text */
+  title: string;
+}
+
+const ToolbarWrapper = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ActionsWrapper = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 4px;
+`;
+
+export function ChartToolbar({
+  children,
+  headingLevel = 3,
+  headingVisualStyle = TypographyVisualStyle.headingSmall,
+  title,
+}: ChartToolbarProps) {
+  return (
+    <ToolbarWrapper>
+      <Heading level={headingLevel} noMargins visualStyle={headingVisualStyle}>
+        {title}
+      </Heading>
+      <ActionsWrapper>{children}</ActionsWrapper>
+    </ToolbarWrapper>
+  );
+}

--- a/packages/charts/src/components/ChartTable/ChartToolbar.tsx
+++ b/packages/charts/src/components/ChartTable/ChartToolbar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import styled from '@emotion/styled';
-import { Heading, TypographyVisualStyle } from 'react-magma-dom';
+import { Heading, ThemeContext, TypographyVisualStyle } from 'react-magma-dom';
 
 export interface ChartToolbarProps {
   /** Toolbar action buttons (ChartTableButton, ChartFullscreenButton, ChartMoreOptionsButton, etc.) */
@@ -26,10 +26,10 @@ const ToolbarWrapper = styled.div`
   justify-content: space-between;
 `;
 
-const ActionsWrapper = styled.div`
+const ActionsWrapper = styled.div<{ theme: any }>`
   align-items: center;
   display: flex;
-  gap: 4px;
+  gap: ${props => props.theme.spaceScale.spacing02};
 `;
 
 export function ChartToolbar({
@@ -38,12 +38,13 @@ export function ChartToolbar({
   headingVisualStyle = TypographyVisualStyle.headingSmall,
   title,
 }: ChartToolbarProps) {
+  const theme = React.useContext(ThemeContext);
   return (
     <ToolbarWrapper>
       <Heading level={headingLevel} noMargins visualStyle={headingVisualStyle}>
         {title}
       </Heading>
-      <ActionsWrapper>{children}</ActionsWrapper>
+      <ActionsWrapper theme={theme}>{children}</ActionsWrapper>
     </ToolbarWrapper>
   );
 }

--- a/packages/charts/src/components/ChartTable/chartToolbarI18n.ts
+++ b/packages/charts/src/components/ChartTable/chartToolbarI18n.ts
@@ -1,0 +1,52 @@
+import * as React from 'react';
+
+import { I18nContext } from 'react-magma-dom';
+
+export interface ChartToolbarI18n {
+  downloadAsCsv: string;
+  downloadAsJpg: string;
+  downloadAsPng: string;
+  exitFullScreen: string;
+  makeFullScreen: string;
+  moreOptionsAriaLabel: string;
+  showAsTableTooltip: string;
+  tabularRepresentationLabel: string;
+}
+
+const defaults: ChartToolbarI18n = {
+  downloadAsCsv: 'Download as CSV',
+  downloadAsJpg: 'Download as JPG',
+  downloadAsPng: 'Download as PNG',
+  exitFullScreen: 'Exit full screen',
+  makeFullScreen: 'Make full screen',
+  moreOptionsAriaLabel: 'More options',
+  showAsTableTooltip: 'Show as table',
+  tabularRepresentationLabel: 'Tabular representation',
+};
+
+/**
+ * Reads chart toolbar i18n strings from the I18nContext if available,
+ * falling back to English defaults.
+ */
+export function useChartToolbarI18n(): ChartToolbarI18n {
+  const i18n = React.useContext(I18nContext);
+  const toolbar = (i18n.charts as any)?.toolbar as
+    | Partial<ChartToolbarI18n>
+    | undefined;
+
+  if (!toolbar) return defaults;
+
+  return {
+    downloadAsCsv: toolbar.downloadAsCsv ?? defaults.downloadAsCsv,
+    downloadAsJpg: toolbar.downloadAsJpg ?? defaults.downloadAsJpg,
+    downloadAsPng: toolbar.downloadAsPng ?? defaults.downloadAsPng,
+    exitFullScreen: toolbar.exitFullScreen ?? defaults.exitFullScreen,
+    makeFullScreen: toolbar.makeFullScreen ?? defaults.makeFullScreen,
+    moreOptionsAriaLabel:
+      toolbar.moreOptionsAriaLabel ?? defaults.moreOptionsAriaLabel,
+    showAsTableTooltip:
+      toolbar.showAsTableTooltip ?? defaults.showAsTableTooltip,
+    tabularRepresentationLabel:
+      toolbar.tabularRepresentationLabel ?? defaults.tabularRepresentationLabel,
+  };
+}

--- a/packages/charts/src/components/ChartTable/chartToolbarI18n.ts
+++ b/packages/charts/src/components/ChartTable/chartToolbarI18n.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { I18nContext } from 'react-magma-dom';
 
 export interface ChartToolbarI18n {
+  defaultTitle: string;
   downloadAsCsv: string;
   downloadAsJpg: string;
   downloadAsPng: string;
@@ -14,6 +15,7 @@ export interface ChartToolbarI18n {
 }
 
 const defaults: ChartToolbarI18n = {
+  defaultTitle: 'Chart',
   downloadAsCsv: 'Download as CSV',
   downloadAsJpg: 'Download as JPG',
   downloadAsPng: 'Download as PNG',
@@ -28,15 +30,16 @@ const defaults: ChartToolbarI18n = {
  * Reads chart toolbar i18n strings from the I18nContext if available,
  * falling back to English defaults.
  */
+// eslint-disable-next-line complexity
 export function useChartToolbarI18n(): ChartToolbarI18n {
   const i18n = React.useContext(I18nContext);
-  const toolbar = (i18n.charts as any)?.toolbar as
-    | Partial<ChartToolbarI18n>
-    | undefined;
+  const toolbar = (i18n.charts as { toolbar?: Partial<ChartToolbarI18n> })
+    ?.toolbar;
 
   if (!toolbar) return defaults;
 
   return {
+    defaultTitle: toolbar.defaultTitle ?? defaults.defaultTitle,
     downloadAsCsv: toolbar.downloadAsCsv ?? defaults.downloadAsCsv,
     downloadAsJpg: toolbar.downloadAsJpg ?? defaults.downloadAsJpg,
     downloadAsPng: toolbar.downloadAsPng ?? defaults.downloadAsPng,

--- a/packages/charts/src/components/ChartTable/index.ts
+++ b/packages/charts/src/components/ChartTable/index.ts
@@ -18,3 +18,6 @@ export type { ChartTableModalProps } from './ChartTableModal';
 
 export { ChartToolbar } from './ChartToolbar';
 export type { ChartToolbarProps } from './ChartToolbar';
+
+export { useChartToolbarI18n } from './chartToolbarI18n';
+export type { ChartToolbarI18n } from './chartToolbarI18n';

--- a/packages/charts/src/components/ChartTable/index.ts
+++ b/packages/charts/src/components/ChartTable/index.ts
@@ -1,0 +1,20 @@
+export { ChartDataTable } from './ChartDataTable';
+export type {
+  ChartDataTableProps,
+  ChartDataTableColumn,
+} from './ChartDataTable';
+
+export { ChartFullscreenButton } from './ChartFullscreenButton';
+export type { ChartFullscreenButtonProps } from './ChartFullscreenButton';
+
+export { ChartMoreOptionsButton } from './ChartMoreOptionsButton';
+export type { ChartMoreOptionsButtonProps } from './ChartMoreOptionsButton';
+
+export { ChartTableButton } from './ChartTableButton';
+export type { ChartTableButtonProps } from './ChartTableButton';
+
+export { ChartTableModal } from './ChartTableModal';
+export type { ChartTableModalProps } from './ChartTableModal';
+
+export { ChartToolbar } from './ChartToolbar';
+export type { ChartToolbarProps } from './ChartToolbar';

--- a/packages/charts/src/components/LineChart/DataTable.tsx
+++ b/packages/charts/src/components/LineChart/DataTable.tsx
@@ -15,7 +15,7 @@ export interface DataTableProps {
   data?: any;
 }
 
-export const DataTable = props => {
+export const DataTable = (props: DataTableProps) => {
   const { data } = props;
 
   return (
@@ -32,8 +32,8 @@ export const DataTable = props => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {data.map((dataset, i) => (
-            <TableRow key={i}>
+          {data.map((dataset: any, i: number) => (
+            <TableRow key={dataset.label ?? `row-${i}`}>
               <TableHeaderCell
                 scope={TableHeaderCellScope.row}
                 style={{

--- a/packages/charts/src/components/LineChart/LineChart.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.tsx
@@ -653,7 +653,7 @@ export function LineChart<T>(props: LineChartProps<T>) {
               color={theme.iterableColors[i]}
               dataIndex={i}
               isHidden={hiddenData.includes(i)}
-              key={i}
+              key={name}
               name={name}
               onClick={handleLegendClick}
               onKeyDown={i === 0 ? handleFirstLegendButtonKeydown : undefined}

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components/LineChart';
 export * from './components/CarbonChart';
+export * from './components/ChartTable';

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -33,15 +33,15 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4"
+    "react-magma-icons": "^3.2.5"
   },
   "peerDependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4"
+    "react-magma-dom": "^4.12.0-next.3",
+    "react-magma-icons": "^3.2.5"
   },
   "engines": {
     "node": ">=22.14.0",

--- a/packages/react-magma-dom/package.json
+++ b/packages/react-magma-dom/package.json
@@ -47,7 +47,7 @@
     "mkdirp": "^1.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-magma-icons": "^3.2.4",
+    "react-magma-icons": "^3.2.5",
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
@@ -58,7 +58,7 @@
     "framer-motion": "^4.1.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-magma-icons": "^3.2.4",
+    "react-magma-icons": "^3.2.5",
     "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   }
 }

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -727,3 +727,77 @@ export const Inverse = () => {
     </>
   );
 };
+
+export const WithPortalContainer = {
+  render: (
+    args: React.JSX.IntrinsicAttributes &
+      ModalProps &
+      React.RefAttributes<HTMLDivElement>
+  ) => {
+    const [showModal, setShowModal] = React.useState(false);
+    const buttonRef = React.useRef<HTMLButtonElement>(null);
+    const mainRef = React.useRef<HTMLDivElement>(null);
+    const [isFullscreen, setIsFullscreen] = React.useState(false);
+
+    React.useEffect(() => {
+      const onChange = () =>
+        setIsFullscreen(document.fullscreenElement === mainRef.current);
+      document.addEventListener('fullscreenchange', onChange);
+      return () => document.removeEventListener('fullscreenchange', onChange);
+    }, []);
+
+    const toggleFullscreen = () => {
+      if (document.fullscreenElement) {
+        document.exitFullscreen();
+      } else {
+        mainRef.current?.requestFullscreen();
+      }
+    };
+
+    return (
+      <div
+        ref={mainRef}
+        role="main"
+        style={{
+          padding: '24px',
+          background: '#f4f4f4',
+          minHeight: '200px',
+        }}
+      >
+        <ButtonGroup>
+          <Button ref={buttonRef} onClick={() => setShowModal(true)}>
+            Show Modal
+            <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+          </Button>
+          <Button onClick={toggleFullscreen}>
+            {isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
+          </Button>
+        </ButtonGroup>
+        <Modal
+          {...args}
+          header="Portaled Modal"
+          portalContainer={mainRef.current}
+          isOpen={showModal}
+          onClose={() => {
+            setShowModal(false);
+            buttonRef.current?.focus();
+          }}
+        >
+          <Paragraph noTopMargin>
+            This modal is rendered inside the main container rather than
+            <code> document.body</code>, so it remains visible when the
+            container is in fullscreen mode.
+          </Paragraph>
+          <ButtonGroup alignment={ButtonGroupAlignment.right}>
+            <Button
+              color={ButtonColor.secondary}
+              onClick={() => setShowModal(false)}
+            >
+              Close
+            </Button>
+          </ButtonGroup>
+        </Modal>
+      </div>
+    );
+  },
+};

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -221,6 +221,97 @@ describe('Modal', () => {
     expect(queryByTestId('modal-closebtn')).not.toBeInTheDocument();
   });
 
+  describe('portalContainer prop', () => {
+    let host;
+
+    afterEach(() => {
+      if (host && host.parentNode) {
+        host.parentNode.removeChild(host);
+      }
+      host = null;
+    });
+
+    it('portals into document.body by default', () => {
+      const { getByTestId } = render(
+        <Modal isOpen testId="default-portal" header="Hello">
+          Modal Content
+        </Modal>
+      );
+
+      const modal = getByTestId('default-portal');
+      expect(modal.parentElement.parentElement).toBe(document.body);
+    });
+
+    it('portals into the provided container and not into document.body', () => {
+      host = document.createElement('div');
+      document.body.appendChild(host);
+
+      const { getByTestId, getByText } = render(
+        <Modal
+          isOpen
+          testId="custom-portal"
+          header="Hello"
+          portalContainer={host}
+        >
+          Modal Content
+        </Modal>
+      );
+
+      const modal = getByTestId('custom-portal');
+      expect(host.contains(modal)).toBe(true);
+      expect(getByText('Modal Content')).toBeInTheDocument();
+      // Sanity: the modal tree is inside host, not a direct child of body.
+      expect(modal.parentElement.parentElement).not.toBe(document.body);
+    });
+
+    it('remains fully interactive when portaled into a custom container', async () => {
+      jest.useFakeTimers();
+      host = document.createElement('div');
+      document.body.appendChild(host);
+
+      const onClose = jest.fn();
+      const { getByTestId } = render(
+        <Modal
+          isOpen
+          testId="interactive-portal"
+          header="Hello"
+          onClose={onClose}
+          portalContainer={host}
+        >
+          Modal Content
+        </Modal>
+      );
+
+      // Close button lives inside the portaled tree and still fires onClose.
+      const closeBtn = getByTestId('modal-closebtn');
+      expect(host.contains(closeBtn)).toBe(true);
+
+      fireEvent.click(closeBtn);
+      await act(async () => {
+        jest.runAllTimers();
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
+    });
+
+    it('falls back to document.body when portalContainer is null', () => {
+      const { getByTestId } = render(
+        <Modal
+          isOpen
+          testId="null-portal"
+          header="Hello"
+          portalContainer={null}
+        >
+          Modal Content
+        </Modal>
+      );
+
+      const modal = getByTestId('null-portal');
+      expect(modal.parentElement.parentElement).toBe(document.body);
+    });
+  });
+
   describe('Closing', () => {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -85,6 +85,13 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   unmountOnExit?: boolean;
   /**
+   * DOM element to portal the modal into. Defaults to `document.body`.
+   * Useful when the modal must render inside a specific subtree, such as
+   * when the parent element has been put into the browser's fullscreen mode
+   * (only DOM within the fullscreen element is rendered by the browser).
+   */
+  portalContainer?: HTMLElement | null;
+  /**
    * @internal
    */
   containerTransition?: Omit<TransitionProps, 'isOpen'>;
@@ -238,6 +245,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       children,
       closeAriaLabel,
       closeButtonSize,
+      portalContainer,
       containerStyle,
       containerTransition,
       isBackgroundClickDisabled,
@@ -469,7 +477,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
               />
             )}
           </div>,
-          document.getElementsByTagName('body')[0]
+          portalContainer ?? document.getElementsByTagName('body')[0]
         )
       : null;
   }

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -94,6 +94,17 @@ export interface I18nInterface {
       keyboardInstructionsTooltip: string;
       legendButtonAriaLabel: string;
     };
+    toolbar?: {
+      defaultTitle?: string;
+      downloadAsCsv?: string;
+      downloadAsJpg?: string;
+      downloadAsPng?: string;
+      exitFullScreen?: string;
+      makeFullScreen?: string;
+      moreOptionsAriaLabel?: string;
+      showAsTableTooltip?: string;
+      tabularRepresentationLabel?: string;
+    };
   };
   combobox: {
     clearIndicatorAriaLabel: string;

--- a/packages/schema-renderer/package.json
+++ b/packages/schema-renderer/package.json
@@ -30,7 +30,7 @@
     "react-dom": "^17.0.2",
     "react-dropzone": "11.3.2",
     "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4",
+    "react-magma-icons": "^3.2.5",
     "tsdx": "^0.14.1",
     "uuid": "^11.1.0"
   },
@@ -43,7 +43,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4",
+    "react-magma-icons": "^3.2.5",
     "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "engines": {

--- a/patterns/header/package.json
+++ b/patterns/header/package.json
@@ -28,7 +28,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4",
+    "react-magma-icons": "^3.2.5",
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
@@ -40,7 +40,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4",
+    "react-magma-icons": "^3.2.5",
     "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "peerDependenciesMeta": {

--- a/website/react-magma-docs/package.json
+++ b/website/react-magma-docs/package.json
@@ -66,7 +66,7 @@
     "react-helmet": "5.2.0",
     "react-live": "^2.2.1",
     "react-magma-dom": "^4.12.2-next.0",
-    "react-magma-icons": "^3.2.4",
+    "react-magma-icons": "^3.2.5",
     "react-spring": "6.1.9",
     "semver": "^7.3.4",
     "url-loader": "^1.1.2",

--- a/website/react-magma-docs/src/components/PageContent/index.js
+++ b/website/react-magma-docs/src/components/PageContent/index.js
@@ -226,13 +226,13 @@ export const PageContent = ({ children, componentName, type }) => {
         const designPatternsLink = designPatternDocs?.node.fields.slug;
         const dataVisualizationLink = dataVisualization?.node.fields.slug;
 
-        const hasDocs = !!(
+        const hasNavTabs = !!(
           apiDocs ||
           designDocs ||
           patternsDocs ||
-          designPatternDocs ||
-          dataVisualization
+          designPatternDocs
         );
+        const hasDocs = !!(hasNavTabs || dataVisualization);
 
         const apiNavTabToLink = patternsDocs
           ? patternsLink
@@ -283,30 +283,32 @@ export const PageContent = ({ children, componentName, type }) => {
             {hasDocs ? (
               <>
                 <StyledTabsContainer isInverse={isInverse}>
-                  <TabsWrapper>
-                    <StyledTabs aria-label="">
-                      {apiDocs || patternsDocs ? (
-                        <NavTab
-                          component={
-                            <Link to={apiNavTabToLink}>Implementation</Link>
-                          }
-                          isActive={type === NAV_TABS.API}
-                        />
-                      ) : (
-                        <></>
-                      )}
-                      {designDocs || designPatternDocs ? (
-                        <NavTab
-                          component={
-                            <Link to={designNavTabToLink}>Design</Link>
-                          }
-                          isActive={type === NAV_TABS.DESIGN}
-                        />
-                      ) : (
-                        <></>
-                      )}
-                    </StyledTabs>
-                  </TabsWrapper>
+                  {hasNavTabs && (
+                    <TabsWrapper>
+                      <StyledTabs aria-label="">
+                        {apiDocs || patternsDocs ? (
+                          <NavTab
+                            component={
+                              <Link to={apiNavTabToLink}>Implementation</Link>
+                            }
+                            isActive={type === NAV_TABS.API}
+                          />
+                        ) : (
+                          <></>
+                        )}
+                        {designDocs || designPatternDocs ? (
+                          <NavTab
+                            component={
+                              <Link to={designNavTabToLink}>Design</Link>
+                            }
+                            isActive={type === NAV_TABS.DESIGN}
+                          />
+                        ) : (
+                          <></>
+                        )}
+                      </StyledTabs>
+                    </TabsWrapper>
+                  )}
 
                   <StyledTabPanelsContainer>
                     <StyledTabPanel>

--- a/website/react-magma-docs/src/pages/data-visualization/chart-toolbar.mdx
+++ b/website/react-magma-docs/src/pages/data-visualization/chart-toolbar.mdx
@@ -276,11 +276,11 @@ The chart title is read from `options.title` (the standard Carbon Charts title o
     },
     tableHeaderLevel: {
       type: {
-        name: 'enum',
-        options: ['1', '2', '3', '4', '5', '6'],
+        name: '1 | 2 | 3 | 4 | 5 | 6',
       },
       required: false,
-      description: 'Heading level for the modal header.',
+      description:
+        'Number to indicate which level heading will render (e.g. h1, h2 etc.)',
       defaultValue: '2',
     },
   }}

--- a/website/react-magma-docs/src/pages/data-visualization/chart-toolbar.mdx
+++ b/website/react-magma-docs/src/pages/data-visualization/chart-toolbar.mdx
@@ -1,0 +1,322 @@
+---
+pageTitle: Accessible Chart Toolbar
+title: Accessible Chart Toolbar
+order: 4
+---
+
+import { LeadParagraph } from '../../components/LeadParagraph';
+
+<PageContent componentName="accessible_chart_toolbar" type="data_visualization">
+
+<LeadParagraph>
+  The chart toolbar provides an accessible alternative to Carbon's built-in
+  navigation controls, addressing WCAG 2.2 compliance issues with focus
+  management, ARIA attributes, screen reader announcements, and semantic
+  headings.
+</LeadParagraph>
+
+## Overview
+
+Carbon Charts includes built-in toolbar buttons (Show as Table, Fullscreen, More Options) that have several accessibility violations:
+
+- `aria-haspopup="true"` used incorrectly (should be `"dialog"` for the table button, absent for fullscreen)
+- Focus does not move into the modal when "Show as Table" is activated
+- The table dialog lacks a semantic heading
+- Chart title uses `<p role="heading">` instead of a proper `<h2>` tag
+- Screen readers announce button labels redundantly
+- "Show as table" label is not descriptive enough
+
+The `chartToolbar` prop on `CarbonChart` replaces Carbon's toolbar with accessible Magma components. When provided, Carbon's built-in toolbar is **automatically disabled** and the chart title is replaced with a semantic `<h2>` element.
+
+## Basic Usage
+
+Pass a `chartToolbar` object to `CarbonChart`. The title is read from `options.title`. This renders the accessible toolbar with "Show as table", "Fullscreen", and "More options" buttons. The "More options" dropdown includes built-in "Download as CSV", "Download as PNG", and "Download as JPG" items.
+
+```tsx
+import React from 'react';
+
+import { CarbonChart, CarbonChartType } from '@react-magma/charts';
+import { Card } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card style={{ padding: '12px' }}>
+      <CarbonChart
+        type={CarbonChartType.donut}
+        dataSet={[
+          { group: 'High performance', value: 50 },
+          { group: 'Average performance', value: 30 },
+          { group: 'Poor performance', value: 15 },
+          { group: 'Not attempted', value: 5 },
+        ]}
+        options={{
+          title: 'Overall Activity Performance',
+          resizable: true,
+          height: '400px',
+          donut: {
+            center: { label: 'Questions' },
+          },
+          legend: {
+            truncation: { type: 'none' },
+          },
+        }}
+        chartToolbar={{}}
+      />
+    </Card>
+  );
+}
+```
+
+## Additional More Options Items
+
+Pass additional `DropdownMenuItem` elements to `moreOptions` to append custom actions below the built-in download items.
+
+```tsx
+import React from 'react';
+
+import { CarbonChart, CarbonChartType } from '@react-magma/charts';
+import { Card, DropdownMenuItem } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card style={{ padding: '12px' }}>
+      <CarbonChart
+        type={CarbonChartType.donut}
+        dataSet={[
+          { group: 'High performance', value: 50 },
+          { group: 'Average performance', value: 30 },
+          { group: 'Poor performance', value: 15 },
+          { group: 'Not attempted', value: 5 },
+        ]}
+        options={{
+          title: 'Overall Activity Performance',
+          resizable: true,
+          height: '400px',
+          donut: {
+            center: { label: 'Questions' },
+          },
+          legend: {
+            truncation: { type: 'none' },
+          },
+        }}
+        chartToolbar={{
+          moreOptions: (
+            <>
+              <DropdownMenuItem onClick={() => alert('Print')}>
+                Print chart
+              </DropdownMenuItem>
+            </>
+          ),
+        }}
+      />
+    </Card>
+  );
+}
+```
+
+## Custom Table Columns
+
+By default, the table modal auto-derives columns from the dataset keys (e.g. `{ group, value }` becomes "Group" and "Value" columns). Override with `tableColumns` for custom headers.
+
+```tsx
+import React from 'react';
+
+import { CarbonChart, CarbonChartType } from '@react-magma/charts';
+import { Card } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card style={{ padding: '12px' }}>
+      <CarbonChart
+        type={CarbonChartType.bar}
+        dataSet={[
+          { group: 'Chapter 1', value: 85 },
+          { group: 'Chapter 2', value: 72 },
+          { group: 'Chapter 3', value: 91 },
+          { group: 'Chapter 4', value: 64 },
+        ]}
+        options={{
+          title: 'Chapter Performance',
+          axes: {
+            left: { mapsTo: 'value' },
+            bottom: { mapsTo: 'group', scaleType: 'labels' },
+          },
+          height: '400px',
+        }}
+        chartToolbar={{
+          tableColumns: [
+            { header: 'Chapter', key: 'group' },
+            { header: 'Score (%)', key: 'value' },
+          ],
+        }}
+      />
+    </Card>
+  );
+}
+```
+
+## Selective Button Visibility
+
+Disable individual toolbar buttons by setting `showAsTable` or `fullscreen` to `false`.
+
+```tsx
+import React from 'react';
+
+import { CarbonChart, CarbonChartType } from '@react-magma/charts';
+import { Card } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card style={{ padding: '12px' }}>
+      <CarbonChart
+        type={CarbonChartType.donut}
+        dataSet={[
+          { group: 'High performance', value: 50 },
+          { group: 'Average performance', value: 30 },
+          { group: 'Poor performance', value: 15 },
+          { group: 'Not attempted', value: 5 },
+        ]}
+        options={{
+          title: 'Table Only (No Fullscreen)',
+          resizable: true,
+          height: '400px',
+          donut: {
+            center: { label: 'Questions' },
+          },
+          legend: {
+            truncation: { type: 'none' },
+          },
+        }}
+        chartToolbar={{
+          fullscreen: false,
+        }}
+      />
+    </Card>
+  );
+}
+```
+
+## Inverse Theme
+
+The toolbar respects the `isInverse` prop on `CarbonChart`, applying inverse styling to all toolbar buttons, the modal, and the data table.
+
+```tsx
+import React from 'react';
+
+import { CarbonChart, CarbonChartType } from '@react-magma/charts';
+import { Card } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <Card isInverse style={{ padding: '12px' }}>
+      <CarbonChart
+        isInverse
+        type={CarbonChartType.donut}
+        dataSet={[
+          { group: 'High performance', value: 50 },
+          { group: 'Average performance', value: 30 },
+          { group: 'Poor performance', value: 15 },
+          { group: 'Not attempted', value: 5 },
+        ]}
+        options={{
+          title: 'Inverse Theme Demo',
+          resizable: true,
+          height: '400px',
+          donut: {
+            center: { label: 'Questions' },
+          },
+          legend: {
+            truncation: { type: 'none' },
+          },
+        }}
+        chartToolbar={{}}
+      />
+    </Card>
+  );
+}
+```
+
+## ChartToolbarConfig Props
+
+The chart title is read from `options.title` (the standard Carbon Charts title option) and rendered as a semantic `<h2>` element, replacing Carbon's inaccessible `<p role="heading">`.
+
+<SimplePropsTable
+  propertyValues={{
+    showAsTable: {
+      type: { name: 'boolean' },
+      required: false,
+      description: 'Renders the "Show as table" button and modal.',
+      defaultValue: 'true',
+    },
+    fullscreen: {
+      type: { name: 'boolean' },
+      required: false,
+      description: 'Renders the fullscreen toggle button.',
+      defaultValue: 'true',
+    },
+    moreOptions: {
+      type: { name: 'ReactNode' },
+      required: false,
+      description:
+        'Additional DropdownMenuItem elements appended below the built-in CSV/PNG/JPG download items.',
+      defaultValue: 'undefined',
+    },
+    tableColumns: {
+      type: { name: 'ChartDataTableColumn[]' },
+      required: false,
+      description:
+        'Column definitions for the data table. If omitted, columns are auto-derived from the dataset object keys.',
+      defaultValue: 'undefined',
+    },
+    tableHeaderLabel: {
+      type: { name: 'string' },
+      required: false,
+      description: 'First line of the modal heading.',
+      defaultValue: "'Tabular representation'",
+    },
+    tableHeaderLevel: {
+      type: {
+        name: 'enum',
+        options: ['1', '2', '3', '4', '5', '6'],
+      },
+      required: false,
+      description: 'Heading level for the modal header.',
+      defaultValue: '2',
+    },
+  }}
+/>
+
+## Standalone Components
+
+For adopters who need more granular control outside of `CarbonChart`, the following components are also exported from `@react-magma/charts`:
+
+- `ChartTableButton` — Accessible "Show as table" trigger with `aria-haspopup="dialog"`
+- `ChartFullscreenButton` — Fullscreen toggle (no `aria-haspopup`)
+- `ChartMoreOptionsButton` — Dropdown wrapper with `MoreVertIcon`
+- `ChartTableModal` — Focus-trapped modal with semantic heading, data table, and "Download as CSV" button
+- `ChartDataTable` — Renders chart data in a Magma `Table` with auto-derived columns
+- `ChartToolbar` — Flex layout wrapper with heading and action slot
+
+## Accessibility
+
+The toolbar addresses the following WCAG 2.2 guidelines:
+
+- **1.3.1 Info and Relationships (Level A)** — Chart title uses a semantic `<h2>` instead of `<p role="heading">`. Modal has a semantic heading. Table uses `<th>` elements.
+- **2.4.3 Focus Order (Level A)** — Focus moves into the modal when it opens, and returns to the trigger button when it closes.
+- **2.4.6 Headings and Labels (Level AA)** — "Show as table" button uses the chart title as its accessible label. Button labels are descriptive and unique.
+- **4.1.2 Name, Role, Value (Level A)** — Correct `aria-haspopup="dialog"` on the table button. No `aria-haspopup` on the fullscreen button. `aria-expanded` reflects modal state.
+
+### Issues Resolved
+
+| Issue                                                                 | Status |
+| --------------------------------------------------------------------- | ------ |
+| Focus does not move to close button when table dialog opens           | Fixed  |
+| Incorrect `aria-haspopup` on "Show as Table" and "Fullscreen" buttons | Fixed  |
+| Chart title uses `<p role="heading">` instead of `<h2>`               | Fixed  |
+| "Show as table" label is not descriptive enough                       | Fixed  |
+| Table dialog missing a semantic heading                               | Fixed  |
+| Table heading not semantic (`<div>` instead of `<th>`)                | Fixed  |
+| Screen reader announces extra content on button focus                 | Fixed  |
+| Screen reader silent after activating "Show as table"                 | Fixed  |
+
+</PageContent>


### PR DESCRIPTION
Closes: https://github.com/cengage/react-magma/issues/2323 , https://github.com/cengage/react-magma/issues/1803                                                                                                                                                                                                                                                                                   
                                         
  ## What I did                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                   
  ### New feature (Charts): Adds an accessible `chartToolbar` prop to `CarbonChart` that replaces Carbon's inaccessible toolbar with Magma components.                                                                                                                                                         
                                                            
  Fixes: incorrect `aria-haspopup`, missing focus management, non-semantic chart title (`<p>` to `<h2>`), missing modal heading, non-descriptive button labels, and silent screen reader on table open.                                                                                            
                                                            
  Includes: show as table with CSV download, fullscreen toggle, more options dropdown with CSV/PNG/JPG export, auto-derived table columns, and inverse theme support.

### New feature (Modal): add `portalContainer` prop to control portal target

Adds an optional `portalContainer` prop to `Modal` that lets consumers specify the DOM element the modal should be portaled into. Defaults to `document.body` (unchanged behavior).                                                                                                                              
                                                            
  ## Checklist                                                                                                                                                                                                                                                                                     
  - [x] changeset has been added                            
  - [x] Pull request is assigned, labels have been added and ticket is linked                                                                                                                                                                                                                      
  - [x] Pull request description is descriptive and testing steps are listed
  - [x] Corresponding changes to the documentation have been made
  - [x] New and existing unit tests pass locally with the proposed changes
  - [x] Tests that prove the fix is effective or that the feature works have been added                                                                                                                                                                                                            
   
  ## How to test                                                                                                                                                                                                                                                                                   
                                                            
  1. Add `chartToolbar={{}}` with `options={{ title: 'My Chart' }}` to any `CarbonChart`                                                                                                                                                                                                           
  2. Click table button - verify modal opens with focus, semantic heading, `<th>` headers, and CSV download
  3. Click fullscreen - verify chart fills viewport and restores correctly on exit                                                                                                                                                                                                                 
  4. Click more options - verify CSV/PNG/JPG downloads work                                                                                                                                                                                                                                        
  5. Test `showAsTable: false` and `fullscreen: false`                                                                                                                                                                                                                                             
  6. Test with `isInverse`                                                                                                                                                                                                                                                                         
  7. Keyboard: Tab through buttons, Enter/Space to activate, Esc to close                                                                                                                                                                                                                          
  8. Visit `/data-visualization/accessible-chart-toolbar` on doc site  