### PR TITLE
fix(IconButton & Form & Accordion & NavTabs & Modal): Fix doc examples.

### DIFF
--- a/.changeset/fix-Combobox-docs-issues.md
+++ b/.changeset/fix-Combobox-docs-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Docs): Fix docs issues on the `Combobox` page.

--- a/.changeset/fix-Form-docs-issues.md
+++ b/.changeset/fix-Form-docs-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(Docs): Fix docs issues on the `Form` page.

--- a/.changeset/fix-IconButton-Modal-Form-doc-examples.md
+++ b/.changeset/fix-IconButton-Modal-Form-doc-examples.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(IconButton & Modal & Form & Accordion & Nav Tabs): Fix doc examples to enhance accessibility.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -12,6 +12,7 @@
     "react-magma-landing": "1.1.8"
   },
   "changesets": [
+    "fix-Combobox-docs-issues",
     "fix-Form-docs-issues",
     "tall-worms-add"
   ]

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -12,6 +12,7 @@
     "react-magma-landing": "1.1.8"
   },
   "changesets": [
+    "fix-Form-docs-issues",
     "tall-worms-add"
   ]
 }

--- a/packages/react-magma-dom/src/components/NavTabs/NavTab.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTab.tsx
@@ -200,6 +200,7 @@ export const NavTab = React.forwardRef<any, NavTabProps>(
         isFullWidth={isFullWidth}
         isInverse={isInverse}
         orientation={orientation}
+        role="presentation"
         theme={theme}
       >
         {component ? (
@@ -239,6 +240,7 @@ export const NavTab = React.forwardRef<any, NavTabProps>(
             textTransform={textTransform}
             theme={theme}
             tabIndex={0}
+            role="tab"
           >
             {icon && (
               <StyledIcon

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
@@ -225,6 +225,7 @@ export const NavTabs = React.forwardRef<
           alignment={alignment ? alignment : TabsAlignment.left}
           orientation={orientation}
           ref={childrenWrapperRef}
+          role="tablist"
         >
           <NavTabsContext.Provider
             value={{

--- a/website/react-magma-docs/CHANGELOG.md
+++ b/website/react-magma-docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.3.2-next.1
+
+### Patch Changes
+
+- 80b7a7b44: fix(Docs): Fix docs issues on the `Form` page.
+
 ## 5.3.2-next.0
 
 ### Patch Changes

--- a/website/react-magma-docs/CHANGELOG.md
+++ b/website/react-magma-docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 5.3.2-next.2
+
+### Patch Changes
+
+- 40a9c8bd6: fix(Docs): Fix docs issues on the `Combobox` page.
+
 ## 5.3.2-next.1
 
 ### Patch Changes

--- a/website/react-magma-docs/package.json
+++ b/website/react-magma-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-magma-docs",
-  "version": "5.3.2-next.1",
+  "version": "5.3.2-next.2",
   "private": true,
   "description": "React Magma docs",
   "keywords": [

--- a/website/react-magma-docs/package.json
+++ b/website/react-magma-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-magma-docs",
-  "version": "5.3.2-next.0",
+  "version": "5.3.2-next.1",
   "private": true,
   "description": "React Magma docs",
   "keywords": [

--- a/website/react-magma-docs/src/pages/api/accordion.mdx
+++ b/website/react-magma-docs/src/pages/api/accordion.mdx
@@ -117,12 +117,14 @@ import {
   AccordionItem,
   AccordionButton,
   AccordionPanel,
+  Announce,
   Button,
   ButtonSize,
   ButtonVariant,
   ButtonGroup,
   Spacer,
   useDeviceDetect,
+  VisuallyHidden,
 } from 'react-magma-dom';
 
 export function Example() {
@@ -175,6 +177,11 @@ export function Example() {
           <AccordionPanel>Content for section two lorem ipsum</AccordionPanel>
         </AccordionItem>
       </Accordion>
+      <VisuallyHidden>
+        <Announce>
+          {isAllExpanded ? 'All sections expanded' : 'All sections collapsed'}
+        </Announce>
+      </VisuallyHidden>
     </>
   );
 }

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -1342,9 +1342,19 @@ export function Example() {
       onInputValueChange={handleInputValueChange}
       components={{
         ClearIndicator: props => (
-          <button onClick={props.onClick as any}>Clear</button>
+          <button onClick={props.onClick} aria-label="Clear selection">
+            Clear
+          </button>
         ),
-        DropdownIndicator: () => <span>▼</span>,
+        DropdownIndicator: React.forwardRef((props, ref) => (
+          <button
+            ref={ref}
+            onClick={props.onClick}
+            aria-label="Expand dropdown"
+          >
+            Dropdown
+          </button>
+        )),
         LoadingIndicator: props => <>Loading</>,
       }}
     />

--- a/website/react-magma-docs/src/pages/api/form.mdx
+++ b/website/react-magma-docs/src/pages/api/form.mdx
@@ -25,6 +25,8 @@ import {
   Form,
   Input,
   Spacer,
+  Announce,
+  VisuallyHidden,
 } from 'react-magma-dom';
 
 export function Example() {
@@ -93,34 +95,28 @@ export function Example() {
       lastName: false,
       email: false,
     });
+
+    setAnnouncement('');
+
+    setTimeout(() => {
+      setAnnouncement(
+        'Changes discarded. Form inputs have been reset to default.'
+      );
+    }, 10);
   };
 
   const errorMessage = React.useMemo(() => {
-    let message = '';
+    const errorCount = Object.values(errors).filter(Boolean).length;
 
-    if (Object.values(errors).some(error => error)) {
-      message += 'Please fix the following errors:\n';
+    if (!errorCount) {
+      return '';
     }
 
-    for (const error in errors) {
-      if (errors[error]) {
-        switch (error) {
-          case 'firstName':
-            message += '· First Name is required\n';
-            break;
-          case 'lastName':
-            message += '· Last Name is required\n';
-            break;
-          case 'email':
-            message += '· Email is required\n';
-            break;
-          default:
-            return;
-        }
-      }
+    if (errorCount === 1) {
+      return 'There is 1 error in the form. Please review the field below.';
     }
 
-    return message;
+    return `There are ${errorCount} errors in the form. Please review the fields below.`;
   }, [errors]);
 
   return (
@@ -181,6 +177,9 @@ export function Example() {
           ref={emailRef}
         />
         <Spacer size="24" />
+        <Announce>
+          <VisuallyHidden>{announcement}</VisuallyHidden>
+        </Announce>
       </>
     </Form>
   );

--- a/website/react-magma-docs/src/pages/api/form.mdx
+++ b/website/react-magma-docs/src/pages/api/form.mdx
@@ -28,6 +28,11 @@ import {
 } from 'react-magma-dom';
 
 export function Example() {
+  const [announcement, setAnnouncement] = React.useState('');
+  const firstNameRef = React.useRef<any>();
+  const lastNameRef = React.useRef<any>();
+  const emailRef = React.useRef<any>();
+
   const [state, setState] = React.useState({
     firstName: '',
     lastName: '',
@@ -52,16 +57,28 @@ export function Example() {
     event.preventDefault();
     resetErrors();
 
-    if (!state.firstName) {
-      setErrors(prevErrors => ({ ...prevErrors, firstName: true }));
+    const errors = {
+      firstName: !state.firstName,
+      lastName: !state.lastName,
+      email: !state.email,
+    };
+
+    setErrors(errors);
+
+    if (errors.firstName) {
+      firstNameRef.current?.focus();
+
+      return;
     }
 
-    if (!state.lastName) {
-      setErrors(prevErrors => ({ ...prevErrors, lastName: true }));
+    if (errors.lastName) {
+      lastNameRef.current?.focus();
+
+      return;
     }
 
-    if (!state.email) {
-      setErrors(prevErrors => ({ ...prevErrors, email: true }));
+    if (errors.email) {
+      emailRef.current?.focus();
     }
   };
 
@@ -133,6 +150,7 @@ export function Example() {
           }
           errorMessage={errors.firstName && 'First Name is required'}
           autoComplete="given-name"
+          ref={firstNameRef}
         />
         <Spacer size="12" />
         <Input
@@ -146,6 +164,7 @@ export function Example() {
           }
           errorMessage={errors.lastName && 'Last Name is required'}
           autoComplete="family-name"
+          ref={lastNameRef}
         />
         <Spacer size="12" />
         <Input
@@ -159,6 +178,7 @@ export function Example() {
           }
           errorMessage={errors.email && 'Email is required'}
           autoComplete="email"
+          ref={emailRef}
         />
         <Spacer size="24" />
       </>

--- a/website/react-magma-docs/src/pages/api/icon-button.mdx
+++ b/website/react-magma-docs/src/pages/api/icon-button.mdx
@@ -161,7 +161,7 @@ export function Example() {
         <IconButton
           icon={<CheckIcon />}
           variant={ButtonVariant.link}
-          aria-label="Check"
+          aria-label="Submit"
         >
           Submit
         </IconButton>

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -32,13 +32,7 @@ This can be done by supplementing the button label or link text with "(opens mod
 ```tsx
 import React from 'react';
 
-import {
-  Button,
-  Hyperlink,
-  Modal,
-  Paragraph,
-  VisuallyHidden,
-} from 'react-magma-dom';
+import { Button, Hyperlink, Modal, Paragraph } from 'react-magma-dom';
 
 export function Example() {
   const [showModal, setShowModal] = React.useState(false);
@@ -70,7 +64,6 @@ export function Example() {
         ref={buttonRef}
       >
         Modal
-        <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
       </Button>
     </>
   );
@@ -90,7 +83,6 @@ import {
   Modal,
   ModalSize,
   Paragraph,
-  VisuallyHidden,
   ButtonGroup,
 } from 'react-magma-dom';
 
@@ -138,7 +130,6 @@ export function Example() {
           ref={smallButtonRef}
         >
           Small Modal
-          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>
         <Button
           aria-haspopup="dialog"
@@ -147,7 +138,6 @@ export function Example() {
           ref={largeButtonRef}
         >
           Large Modal
-          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>
       </ButtonGroup>
     </>
@@ -183,7 +173,6 @@ import {
   magma,
   ModalSize,
   Paragraph,
-  VisuallyHidden,
   ButtonGroup,
   ButtonGroupAlignment,
 } from 'react-magma-dom';
@@ -316,7 +305,6 @@ export function Example() {
           ref={buttonRef}
         >
           Modal with no header
-          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>
         <Button
           aria-haspopup="dialog"
@@ -324,7 +312,6 @@ export function Example() {
           ref={headerButtonRef}
         >
           Modal with header
-          <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>
         <Button
           aria-haspopup="dialog"
@@ -388,7 +375,7 @@ If you would like to add a custom close button to the `Modal` be sure not to use
 ```tsx
 import React from 'react';
 
-import { Button, Modal, Paragraph, VisuallyHidden } from 'react-magma-dom';
+import { Button, Modal, Paragraph } from 'react-magma-dom';
 
 export function Example() {
   const [showModal, setShowModal] = React.useState(false);
@@ -426,7 +413,7 @@ export function Example() {
         onClick={() => setShowModal(true)}
         ref={buttonRef}
       >
-        Modal <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
+        Modal
       </Button>
     </>
   );
@@ -440,13 +427,7 @@ Although we don't recommend using nested modals, the ability for one nested moda
 ```tsx
 import React from 'react';
 
-import {
-  Button,
-  Modal,
-  ModalSize,
-  Paragraph,
-  VisuallyHidden,
-} from 'react-magma-dom';
+import { Button, Modal, ModalSize, Paragraph } from 'react-magma-dom';
 
 export function Example() {
   const [showModal, setShowModal] = React.useState(false);
@@ -487,7 +468,6 @@ export function Example() {
         ref={buttonRef}
       >
         Modal
-        <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
       </Button>
       <Modal
         size={ModalSize.small}
@@ -609,7 +589,6 @@ import {
   Hyperlink,
   Modal,
   Paragraph,
-  VisuallyHidden,
   Card,
   CardBody,
 } from 'react-magma-dom';
@@ -659,7 +638,6 @@ export function Example() {
             isInverse
           >
             Inverse Modal
-            <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
           </Button>
         </CardBody>
       </Card>

--- a/website/react-magma-docs/src/pages/api/nav-tabs.mdx
+++ b/website/react-magma-docs/src/pages/api/nav-tabs.mdx
@@ -211,9 +211,7 @@ This sets the CSS `text-transform` property.
   have its own accessible name. You can provide this by using `aria-labelledby`,
   ensuring that every `NavTabs` instance has a unique label.
 </Alert>
-
-```tsx
-import React from 'react';
+```tsx import React from 'react';
 
 import { NavTabs, NavTab, TabsTextTransform } from 'react-magma-dom';
 
@@ -221,8 +219,8 @@ export function Example() {
   return (
     <>
       <NavTabs
+        aria-label="Uppercase Nav Tabs region"
         textTransform={TabsTextTransform.uppercase}
-        aria-labelledby="Uppercase Nav Tabs region"
       >
         <NavTab isActive to="javascript:void(0)">
           First uppercase
@@ -233,8 +231,8 @@ export function Example() {
       <br />
       <br />
       <NavTabs
+        aria-label="Lowercase Nav Tabs region"
         textTransform={TabsTextTransform.none}
-        aria-labelledby="Lowercase Nav Tabs region"
       >
         <NavTab isActive to="javascript:void(0)">
           First lowercase
@@ -463,8 +461,7 @@ export function Example() {
   return (
     <>
       <NavTabs
-        aria-label="Icon Position Left Nav Tabs"
-        aria-labelledby="Icon Position Left Nav Tabs"
+        aria-label="Icon Position Left Nav Tabs region"
         iconPosition={TabsIconPosition.left}
       >
         <NavTab icon={<EmailIcon />} isActive to="javascript:void(0)">
@@ -483,8 +480,7 @@ export function Example() {
       <br />
 
       <NavTabs
-        aria-label="Icon Position Right Nav Tabs"
-        aria-labelledby="Icon Position Right Nav Tabs"
+        aria-label="Icon Position Right Nav Tabs region"
         iconPosition={TabsIconPosition.right}
       >
         <NavTab icon={<EmailIcon />} isActive to="javascript:void(0)">


### PR DESCRIPTION
Closes: #2001
Closes: #2082 
Closes: #2021
Closes: #2038
Closes: #2097

Cherry-pick:  https://github.com/cengage/react-magma/pull/2372

## What I did
- Fixed accessibility issues for doc examples: IconButton & Form & Accordion & NavTabs & Modal
- Updated documentation

## Screenshots
#2021

<img width="1581" height="842" alt="Screenshot from 2026-03-25 10-21-00" src="https://github.com/user-attachments/assets/d82de712-68db-4134-a40c-edd956a7e95b" />
<img width="1581" height="842" alt="Screenshot from 2026-03-25 10-21-36" src="https://github.com/user-attachments/assets/26b6539a-65c5-4591-bf03-db913fccc135" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
**Form**
Go to Docs -> Components -> Form ->  Basic Usage -> click on submit -> focus goes to the firstname field

**NavTabs**
Go to Docs -> Components -> NavTabs -> Text Transform -> Turn on NVDA/VO ->  focus on the first navtabs -> `Uppercase Nav Tabs region` should be announced ->  focus on the second `NavTabs` -> `Lowercase Nav Tabs region` should be announced 
Go to Docs -> Components -> NavTabs -> Icon Position -> Turn on NVDA/VO ->  focus on the first navtabs -> `Icon Position Left Nav Tabs region` should be announced ->  focus on the second `NavTabs` -> `Icon Position Right Nav Tabs region` should be announced 

**Modal** 
Go to Docs -> Components -> Modal -> verify all examples don't have this code `<VisuallyHidden>(opens modal dialog)</VisuallyHidden>` which is reduntant for accessibility

**IconButton**
Go to Docs -> Components -> IconButton -> Basic Usage -> Turn on NVDA/VO -> Verify screen reader announces `Submit` button as a submit

**Accordion**
Go to Docs -> Components -> Accordion -> Controlled Accordion -> Turn on NVDA/VO -> Click on `Expand All` -> `All sections expanded`  should be announced  -> Click on `Collapse All` -> `All sections collapsed`  should be announced  -> 