### PR TITLE
V4/fix(MultiCombobox & MultiSelect): Fix issue with clearable `MultiCombobox` and `MultiSelect` (#2366)

### DIFF
--- a/.changeset/fix-MultiCombobox-announce-a11y.md
+++ b/.changeset/fix-MultiCombobox-announce-a11y.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(MultiCombobox & MultiSelect): Fix issue with clearable `MultiCombobox` and `MultiSelect`

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.test.js
@@ -1356,6 +1356,56 @@ describe('MultiCombobox', () => {
     });
   });
 
+  it('should announce the removal of a selected item', () => {
+    const { getByText } = render(
+      <MultiCombobox
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red']}
+        isClearable
+      />
+    );
+
+    userEvent.click(getByText('Red', { selector: 'button' }));
+
+    expect(getByText('Red has been removed')).toBeInTheDocument();
+  });
+
+  it('should announce clearing multiple selected items', () => {
+    const { getByLabelText, getByText } = render(
+      <MultiCombobox
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red', 'Blue']}
+        isClearable
+      />
+    );
+
+    userEvent.click(getByLabelText(/reset selection/i));
+
+    expect(
+      getByText('Label has been cleared. Red, Blue were removed')
+    ).toBeInTheDocument();
+  });
+
+  it('should announce clearing single selected item', () => {
+    const { getByLabelText, getByText } = render(
+      <MultiCombobox
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red']}
+        isClearable
+      />
+    );
+
+    userEvent.click(getByLabelText(/reset selection/i));
+
+    expect(getByText('Label has been cleared')).toBeInTheDocument();
+  });
+
   describe('Accessibility - scrollIntoView', () => {
     it('should call scrollIntoView on focused item when navigating with keyboard', async () => {
       const mockScrollIntoView = jest.fn();

--- a/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/MultiCombobox.tsx
@@ -104,6 +104,8 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
     reset,
   } = useMultipleSelection({
     ...props,
+    // Disable downshift's built-in a11y removal message to use custom clearAnnounce
+    getA11yRemovalMessage: () => '',
     ...(props.initialSelectedItems && {
       initialSelectedItems: props.initialSelectedItems.filter(
         checkSelectedItemValidity
@@ -289,6 +291,23 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
   function handleRemoveSelectedItem(event: React.SyntheticEvent, selectedItem) {
     event.stopPropagation();
 
+    // Announce the removal of the specific item
+    const itemName = itemToString(selectedItem);
+    const removeMessage = i18n.combobox.multi?.removeItemAnnounce?.replace(
+      /\{selectedItem\}/g,
+      itemName
+    );
+
+    setClearAnnouncement(removeMessage || '');
+
+    // Clear the announcement after a delay
+    if (clearAnnouncementTimeoutRef.current) {
+      clearTimeout(clearAnnouncementTimeoutRef.current);
+    }
+    clearAnnouncementTimeoutRef.current = setTimeout(() => {
+      setClearAnnouncement('');
+    }, 1000);
+
     onRemoveSelectedItem && typeof onRemoveSelectedItem === 'function'
       ? onRemoveSelectedItem(selectedItem)
       : removeSelectedItem(selectedItem);
@@ -354,9 +373,15 @@ export function MultiCombobox<T>(props: MultiComboboxProps<T>) {
 
     reset();
 
-    setClearAnnouncement(
-      i18n.select?.clearAnnounce?.replace(/\{labelText\}/g, labelText)
-    );
+    const selectedItemsText = itemsArrayToString(selectedItems);
+    const clearMessage =
+      selectedItems.length > 1
+        ? i18n.combobox.multi?.clearAnnounce
+            ?.replace(/\{labelText\}/g, labelText)
+            ?.replace(/\{selectedItems\}/g, selectedItemsText)
+        : i18n.combobox.clearAnnounce?.replace(/\{labelText\}/g, labelText);
+
+    setClearAnnouncement(clearMessage || '');
 
     // Clear the announcement after a delay to allow for re-announcements
     if (clearAnnouncementTimeoutRef.current) {

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
@@ -278,6 +278,56 @@ describe('MultiSelect', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should announce the removal of a selected item', () => {
+    const { getByText } = render(
+      <MultiSelect
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red']}
+        isClearable
+      />
+    );
+
+    userEvent.click(getByText('Red', { selector: 'button' }));
+
+    expect(getByText('Red has been removed')).toBeInTheDocument();
+  });
+
+  it('should announce clearing multiple selected items', () => {
+    const { getByLabelText, getByText } = render(
+      <MultiSelect
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red', 'Blue']}
+        isClearable
+      />
+    );
+
+    userEvent.click(getByLabelText(/reset selection/i));
+
+    expect(
+      getByText('Label has been cleared. Red, Blue were removed')
+    ).toBeInTheDocument();
+  });
+
+  it('should announce clearing single selected item', () => {
+    const { getByLabelText, getByText } = render(
+      <MultiSelect
+        isMulti
+        labelText={labelText}
+        items={items}
+        initialSelectedItems={['Red']}
+        isClearable
+      />
+    );
+
+    userEvent.click(getByLabelText(/reset selection/i));
+
+    expect(getByText('Label has been cleared')).toBeInTheDocument();
+  });
+
   it('should allow for the removal of selected items with the keyboard', () => {
     const selectedItems = ['Red', 'Blue', 'Green'];
     const { getByLabelText, getByText, queryByText } = render(

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -53,8 +53,21 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
     isClearable,
     initialHighlightedIndex,
   } = props;
+
+  const theme = React.useContext(ThemeContext);
+  const i18n = React.useContext(I18nContext);
   const [clearAnnouncement, setClearAnnouncement] = React.useState('');
   const [isItemFocused, setItemFocus] = React.useState(false);
+  const clearAnnouncementTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+
+  // Cleanup timeout on unmount
+  React.useEffect(() => {
+    return () => {
+      if (clearAnnouncementTimeoutRef.current) {
+        clearTimeout(clearAnnouncementTimeoutRef.current);
+      }
+    };
+  }, []);
 
   function checkSelectedItemValidity(itemToCheck: T) {
     const itemIndex = items.findIndex(
@@ -114,6 +127,8 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
     reset,
   } = useMultipleSelection<T>({
     ...props,
+    // Disable downshift's built-in a11y removal message to use custom clearAnnounce
+    getA11yRemovalMessage: () => '',
     ...(props.initialSelectedItems && {
       initialSelectedItems: props.initialSelectedItems.filter(
         checkSelectedItemValidity
@@ -204,13 +219,27 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
   function handleRemoveSelectedItem(event: React.SyntheticEvent, selectedItem) {
     event.stopPropagation();
 
+    // Announce the removal of the specific item
+    const itemName = itemToString(selectedItem);
+    const removeMessage = i18n.select.multi?.removeItemAnnounce?.replace(
+      /\{selectedItem\}/g,
+      itemName
+    );
+
+    setClearAnnouncement(removeMessage || '');
+
+    // Clear the announcement after a delay
+    if (clearAnnouncementTimeoutRef.current) {
+      clearTimeout(clearAnnouncementTimeoutRef.current);
+    }
+    clearAnnouncementTimeoutRef.current = setTimeout(() => {
+      setClearAnnouncement('');
+    }, 1000);
+
     onRemoveSelectedItem && typeof onRemoveSelectedItem === 'function'
       ? onRemoveSelectedItem(selectedItem)
       : removeSelectedItem(selectedItem);
   }
-
-  const theme = React.useContext(ThemeContext);
-  const i18n = React.useContext(I18nContext);
 
   const toggleButtonRef = React.useRef<HTMLButtonElement>();
   const forkedtoggleButtonRef = useForkedRef(innerRef || null, toggleButtonRef);
@@ -292,12 +321,21 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
 
     reset();
 
-    setClearAnnouncement(
-      i18n.select.clearAnnounce.replace(/\{labelText\}/g, labelText)
-    );
+    const selectedItemsText = itemsArrayToString(selectedItems);
+    const clearMessage =
+      selectedItems.length > 1
+        ? i18n.select.multi?.clearAnnounce
+            ?.replace(/\{labelText\}/g, labelText)
+            ?.replace(/\{selectedItems\}/g, selectedItemsText)
+        : i18n.select.clearAnnounce?.replace(/\{labelText\}/g, labelText);
+
+    setClearAnnouncement(clearMessage || '');
 
     // Clear the announcement after a delay to allow for re-announcements
-    setTimeout(() => {
+    if (clearAnnouncementTimeoutRef.current) {
+      clearTimeout(clearAnnouncementTimeoutRef.current);
+    }
+    clearAnnouncementTimeoutRef.current = setTimeout(() => {
       setClearAnnouncement('');
     }, 1000);
   }

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -101,6 +101,9 @@ export const defaultI18n: I18nInterface = {
     multi: {
       clearIndicatorAriaLabel:
         'reset selection for {labelText}. {selectedItem} are selected',
+      clearAnnounce:
+        '{labelText} has been cleared. {selectedItems} were removed',
+      removeItemAnnounce: '{selectedItem} has been removed',
       ariaLabelWithSelectedItems:
         '{labelText} Multi-select Selected: {selectedItems}',
       ariaLabelWithoutSelectedItems: '{labelText} Multi-select',
@@ -283,6 +286,9 @@ export const defaultI18n: I18nInterface = {
     multi: {
       clearIndicatorAriaLabel:
         'reset selection for {labelText}. {selectedItem} are selected',
+      clearAnnounce:
+        '{labelText} has been cleared. {selectedItems} were removed',
+      removeItemAnnounce: '{selectedItem} has been removed',
       ariaLabelWithSelectedItems:
         '{labelText} Multi-select Selected: {selectedItems}',
       ariaLabelWithoutSelectedItems: '{labelText} Multi-select',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -101,6 +101,8 @@ export interface I18nInterface {
     clearAnnounce: string;
     multi: {
       clearIndicatorAriaLabel: string;
+      clearAnnounce: string;
+      removeItemAnnounce: string;
       ariaLabelWithSelectedItems: string;
       ariaLabelWithoutSelectedItems: string;
     };
@@ -266,6 +268,8 @@ export interface I18nInterface {
     collapsedAnnounce: string;
     multi: {
       clearIndicatorAriaLabel: string;
+      clearAnnounce: string;
+      removeItemAnnounce: string;
       ariaLabelWithSelectedItems: string;
       ariaLabelWithoutSelectedItems: string;
     };

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -1388,6 +1388,9 @@ export function Example() {
             'click to reset selection for {labelText}. {selectedItem} is currently selected',
           createLabel: 'Custom Create "{inputValue}"',
           multi: {
+            clearAnnounce:
+              '{labelText} has been cleared. Items {selectedItems} were removed',
+            removeItemAnnounce: '{selectedItem} was removed',
             clearIndicatorAriaLabel: 'clear all',
           },
           loading: 'Loading items',

--- a/website/react-magma-docs/src/pages/api/select.mdx
+++ b/website/react-magma-docs/src/pages/api/select.mdx
@@ -813,6 +813,11 @@ export function Example() {
           placeholder: 'Custom Select Placeholder...',
           clearIndicatorAriaLabel:
             'Click to reset selection for {labelText}. {selectedItem} is currently selected',
+          multi: {
+            clearAnnounce:
+              '{labelText} has been cleared. {selectedItems} were removed',
+            removeItemAnnounce: '{selectedItem} has been removed',
+          },
         },
         multiSelect: {
           ...defaultI18n.multiSelect,


### PR DESCRIPTION
Closes: #2076
Cherry-pick #2366

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix issue with clearable `MultiCombobox` and `MultiSelect`

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook/Docs -> MultiCombobox/MultiSelect -> `isClearable` is on -> Turn on NVDA/VO -> Select item -> Remove it -> Screenreader should announce that MultiCombobox/MultiSelect has been cleared and item was removed -> Select a few items -> Click `x` icon -> Screenreader should announce what items were removed.