### PR TITLE
chore: Update useFocusLock behavior.

### DIFF
--- a/.changeset/fix-focus-lock-issue.md
+++ b/.changeset/fix-focus-lock-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+chore: Fix focuslock issue for DatePicker component.

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -19,14 +19,29 @@ export function useFocusLock(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), video'
       ) || []
     ).filter((element): element is HTMLElement => {
+      if (!(element instanceof HTMLElement)) {
+        return false;
+      }
       const style = window.getComputedStyle(element);
-      return (
-        element instanceof HTMLElement &&
-        style.display !== 'none' &&
-        style.visibility !== 'hidden' &&
-        !element.hasAttribute('disabled') &&
-        element.tabIndex !== -1
-      );
+      if (
+        style.display === 'none' ||
+        style.visibility === 'hidden' ||
+        element.hasAttribute('disabled') ||
+        element.tabIndex === -1
+      ) {
+        return false;
+      }
+      // CSS `display` is not inherited, so children of a `display:none` parent
+      // still report their own display value. Walk up the ancestor chain to
+      // exclude elements hidden by a collapsed ancestor (e.g. a closed calendar).
+      let ancestor: HTMLElement | null = element.parentElement;
+      while (ancestor && ancestor !== rootNode.current) {
+        if (window.getComputedStyle(ancestor).display === 'none') {
+          return false;
+        }
+        ancestor = ancestor.parentElement;
+      }
+      return true;
     });
   };
 
@@ -63,13 +78,21 @@ export function useFocusLock(
       if (!focusableItems.current) return;
 
       const { key, shiftKey } = event;
-      const {
-        length,
-        0: firstItem,
-        [length - 1]: lastItem,
-      } = focusableItems.current;
 
       if (active && key === 'Tab') {
+        // Refresh the list on every Tab so CSS-toggled visibility changes
+        // (e.g. a DatePicker calendar opening/closing via display:none) are
+        // always reflected — the MutationObserver only fires on childList
+        // mutations and cannot detect styled-component class/style updates.
+        updateFocusableItems();
+
+        // Destructure after the refresh so values reflect the current DOM state.
+        const {
+          length,
+          0: firstItem,
+          [focusableItems.current.length - 1]: lastItem,
+        } = focusableItems.current;
+
         // Only handle Tab if focus is inside this focus lock's root.
         // This prevents nested modals from interfering with each other.
         const activeEl = document.activeElement as HTMLElement;

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -19,29 +19,13 @@ export function useFocusLock(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), video'
       ) || []
     ).filter((element): element is HTMLElement => {
-      if (!(element instanceof HTMLElement)) {
-        return false;
-      }
       const style = window.getComputedStyle(element);
-      if (
-        style.display === 'none' ||
-        style.visibility === 'hidden' ||
-        element.hasAttribute('disabled') ||
-        element.tabIndex === -1
-      ) {
-        return false;
-      }
-      // CSS `display` is not inherited, so children of a `display:none` parent
-      // still report their own display value. Walk up the ancestor chain to
-      // exclude elements hidden by a collapsed ancestor (e.g. a closed calendar).
-      let ancestor: HTMLElement | null = element.parentElement;
-      while (ancestor && ancestor !== rootNode.current) {
-        if (window.getComputedStyle(ancestor).display === 'none') {
-          return false;
-        }
-        ancestor = ancestor.parentElement;
-      }
-      return true;
+      return (
+        element instanceof HTMLElement &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        !element.hasAttribute('disabled')
+      );
     });
   };
 
@@ -78,33 +62,14 @@ export function useFocusLock(
       if (!focusableItems.current) return;
 
       const { key, shiftKey } = event;
+      const {
+        length,
+        0: firstItem,
+        [length - 1]: lastItem,
+      } = focusableItems.current;
 
       if (active && key === 'Tab') {
-        // Refresh the list on every Tab so CSS-toggled visibility changes
-        // (e.g. a DatePicker calendar opening/closing via display:none) are
-        // always reflected — the MutationObserver only fires on childList
-        // mutations and cannot detect styled-component class/style updates.
-        updateFocusableItems();
-
-        // Destructure after the refresh so values reflect the current DOM state.
-        const {
-          length,
-          0: firstItem,
-          [focusableItems.current.length - 1]: lastItem,
-        } = focusableItems.current;
-
-        // Only handle Tab if focus is inside this focus lock's root.
-        // This prevents nested modals from interfering with each other.
-        const activeEl = document.activeElement as HTMLElement;
-        if (
-          rootNode.current &&
-          !rootNode.current.contains(activeEl) &&
-          activeEl !== header?.current
-        ) {
-          return;
-        }
-
-        // If no focusable items, prevent tabbing entirely
+        // If no focusable items are
         if (length === 0) {
           event.preventDefault();
           return;
@@ -113,40 +78,29 @@ export function useFocusLock(
         // If only one item then prevent tabbing when locked
         if (length === 1) {
           event.preventDefault();
-          if (firstItem !== activeEl) {
+          if (firstItem !== document.activeElement) {
             firstItem.focus();
           }
+
           return;
         }
 
-        // Explicitly manage all Tab navigation so focus never escapes
-        // the trap (Safari does not respect aria-modal for containment)
-        event.preventDefault();
-
-        const currentIndex = focusableItems.current.indexOf(activeEl);
-
-        if (currentIndex === -1) {
-          // Focus is on an untracked element (e.g. the header)
-          if (shiftKey) {
-            lastItem.focus();
-          } else {
-            firstItem.focus();
-          }
+        // If focused on last item then focus on first item when tab is pressed
+        if (!shiftKey && document.activeElement === lastItem) {
+          event.preventDefault();
+          firstItem.focus();
           return;
         }
 
-        if (shiftKey) {
-          if (currentIndex === 0) {
-            lastItem.focus();
-          } else {
-            focusableItems.current[currentIndex - 1].focus();
-          }
-        } else {
-          if (currentIndex === length - 1) {
-            firstItem.focus();
-          } else {
-            focusableItems.current[currentIndex + 1].focus();
-          }
+        // If focused on first item then focus on last item when shift + tab is pressed
+        if (
+          shiftKey &&
+          (document.activeElement === firstItem ||
+            document.activeElement === header?.current)
+        ) {
+          event.preventDefault();
+          lastItem.focus();
+          return;
         }
       }
     };

--- a/website/react-magma-docs/src/pages/api/modal.mdx
+++ b/website/react-magma-docs/src/pages/api/modal.mdx
@@ -20,9 +20,6 @@ properly manages focus; moving to the modal content, and keeping it there until 
 The modal will _only_ render if the `isOpen` prop is set to true. For that reason, it is redundant to show the modal using the following anti-pattern: `{flag && <Modal isOpen={flag} />`. Instead,
 simply use `<Modal isOpen={flag} />`
 
-Although not required, it is helpful to inform users (especially screen reader users) when a button or link will trigger a modal dialog.
-This can be done by supplementing the button label or link text with "(opens modal dialog)" using the <Link to="/api/visually-hidden/">VisuallyHidden</Link> component.
-
 <Alert variant="warning">
   The modal trigger button must have the{' '}
   <inlineCode>aria-haspopup="dialog"</inlineCode> attribute for accessibility


### PR DESCRIPTION
Closes: #2368 
Closes: 2001

## What I did
- Reverted [this](https://github.com/cengage/react-magma/pull/2346/changes#diff-2baa1040d2e95f9fc6fb15bb3f1bae8d5c3770d612d3374eddc9f28da0bba727) changes to fix focus behavior
- Minor documentation update

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Modal -> Modal in Modal -> Open Modal -> navigate across interactive elements via tabbing -> All elements should have been focused. (after focusing `DatePicker` component)