### PR TITLE
fix(Datagrid & Table): Update the table header aria-label.

### DIFF
--- a/.changeset/fix-Datagrid-accessibility-issue.md
+++ b/.changeset/fix-Datagrid-accessibility-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Datagrid): Add announce initial sort order.

--- a/packages/react-magma-dom/src/components/Table/Table.stories.tsx
+++ b/packages/react-magma-dom/src/components/Table/Table.stories.tsx
@@ -746,6 +746,7 @@ export const Sortable = {
                   onSort={() => {
                     requestSort('name');
                   }}
+                  header="Name"
                   isSortable
                   sortDirection={
                     sortConfig.key === 'name'
@@ -766,6 +767,7 @@ export const Sortable = {
                       ? sortConfig.direction
                       : TableSortDirection.none
                   }
+                  header="Price"
                 >
                   Price
                 </TableHeaderCell>
@@ -780,6 +782,7 @@ export const Sortable = {
                       ? sortConfig.direction
                       : TableSortDirection.none
                   }
+                  header="In Stock"
                 >
                   In Stock
                 </TableHeaderCell>

--- a/packages/react-magma-dom/src/components/Table/TableHeaderCell.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableHeaderCell.tsx
@@ -11,7 +11,7 @@ import {
   TableSortDirection,
 } from './Table';
 import { baseTableCellStyle, buildCellPaddingStyle } from './TableCell';
-import { getAriaSort, getTableSortIcon } from './utils';
+import { getAriaSort, getAriaSortLabel, getTableSortIcon } from './utils';
 import { I18nContext } from '../..';
 import { ThemeContext } from '../../theme/ThemeContext';
 
@@ -207,8 +207,11 @@ export const TableHeaderCell = React.forwardRef<
 
   const widthString = typeof width === 'number' ? `${width}px` : width;
 
+  const sortDirectionLabel =
+    getAriaSortLabel(sortDirection) || i18n.table.selectable.sortDirectionNone;
   const sortRowsAriaLabel = isSortable
-    ? i18n.table.selectable.sortButtonAriaLabel.replace('{labelText}', header)
+    ? i18n.table.selectable.sortButtonAriaLabel.replace('{labelText}', header) +
+      `, ${sortDirectionLabel}`
     : undefined;
 
   return (

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -324,6 +324,7 @@ export const defaultI18n: I18nInterface = {
     selectable: {
       sortButtonAriaLabel: 'Sort rows by {labelText}',
       sortButtonAriaLabelBySelected: 'Sort rows by selected',
+      sortDirectionNone: 'not sorted',
       selectAllRowsAriaLabel: 'Select all rows',
       selectRowAriaLabel: 'Select row',
       deselectAllRowsAriaLabel: 'Deselect all rows',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -304,6 +304,7 @@ export interface I18nInterface {
     selectable: {
       sortButtonAriaLabel: string;
       sortButtonAriaLabelBySelected: string;
+      sortDirectionNone: string;
       selectAllRowsAriaLabel: string;
       selectRowAriaLabel: string;
       deselectAllRowsAriaLabel: string;

--- a/website/react-magma-docs/src/pages/api/table.mdx
+++ b/website/react-magma-docs/src/pages/api/table.mdx
@@ -392,6 +392,14 @@ The `sortDirection` prop indicates the direction by which the column is sorted, 
 
 These props do not handle the actual sorting of the table, just the visual appearance.
 
+<Alert variant="warning">
+  To improve accessibility, when using the <inlineCode>isSortable</inlineCode>{' '}
+  prop, it is recommended to also include the <inlineCode>header</inlineCode>{' '}
+  prop with a string value that indicates the name of the column. This will be
+  used in the <inlineCode>aria-label</inlineCode> for the sort button to provide
+  more context for screen reader users.
+</Alert>
+
 ```tsx
 import React from 'react';
 
@@ -471,6 +479,7 @@ export function Example() {
                   ? sortConfig.direction
                   : TableSortDirection.none
               }
+              header="Name"
             >
               Name
             </TableHeaderCell>
@@ -485,6 +494,7 @@ export function Example() {
                   ? sortConfig.direction
                   : TableSortDirection.none
               }
+              header="Price"
             >
               Price
             </TableHeaderCell>
@@ -499,6 +509,7 @@ export function Example() {
                   ? sortConfig.direction
                   : TableSortDirection.none
               }
+              header="In Stock"
             >
               In Stock
             </TableHeaderCell>


### PR DESCRIPTION
Closes: #2079
Closes: #2395

## What I did
- Updated the table header aria-label.
- Updated `Table` docs.

## Screenshots
**Datagrid**
[Screencast from 31.03.26 13:40:39.webm](https://github.com/user-attachments/assets/ca190ec4-47d1-467e-9033-1f40ab4e05fd)
[Screencast from 31.03.26 13:38:16.webm](https://github.com/user-attachments/assets/8a9fc2db-cc3c-4ef2-8d5f-0bace5a3162f)

Table
[Screencast from 31.03.26 13:52:41.webm](https://github.com/user-attachments/assets/23e6d185-4c51-46e9-8ca8-29f9638d8ffe)


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Table -> Sortable -> Turn on NVDA/VO 
-> focus on `Name` column -> column should be announced as `Sort rows by Name, not sorted button.` 
-> focus on `In stock` column -> column should be announced as `Sort rows by in stock, ascending button.` 
-> sort column ->  column should be announced as `Sort rows by in stock, descending button.`

Go to Storybook -> Datagrid -> Selectable and Sortable -> Turn on NVDA/VO 
-> focus on `Price` column -> column should be announced as `Sort rows by Price, not sorted button` 
-> focus on `Stock` column -> column should be announced as `Sort rows by Stock, not sorted button` 
-> sort column ->  column should be announced as `Sort rows by Stock, ascending button` 
-> focus on `Price` column -> column should be announced as `Sort rows by Price, not sorted button` 
->  Focus on `Stock` column -> column should be announced as `Sort rows by Stock, ascending button` 
