### PR TITLE
Fix tab controls for datepicker when NVDA opened

### DIFF
--- a/.changeset/a11y-datepicker-nvda-controls-fix.md
+++ b/.changeset/a11y-datepicker-nvda-controls-fix.md
@@ -1,0 +1,12 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DatePicker): accessibility fixes for WCAG 2.2 AA compliance
+
+- WAPLAT-45616: Fix Date and Time Picker (NVDA screen reader blocks the focus for keyboard navigation for the dates in the calendar table)
+  - Adjusted ARIA roles in the calendar day cell to improve compatibility with NVDA screen reader.
+  - Changed the td role to presentation and moved the gridcell role to the interactive element (button).
+  - This prevents NVDA from switching to browse mode when navigating dates with arrow keys and allows keyboard navigation to work correctly with the screen reader.
+
+

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
@@ -154,7 +154,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
     } ${sameDateAsChosenDate ? i18n.datePicker.selectedDayAriaLabel : ''}`;
 
     return (
-      <CalendarDayCell role="gridcell" onFocus={onCalendarDayFocus} theme={theme}>
+      <CalendarDayCell role="presentation" onFocus={onCalendarDayFocus} theme={theme}>
         <CalendarDayInner
           aria-disabled={disabled}
           aria-label={ariaLabel}
@@ -163,6 +163,7 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
           isFocused={dayFocusable && sameDateAsFocusedDate}
           onClick={onDayClick}
           ref={dayRef}
+          role="gridcell"
           tabIndex={sameDateAsFocusedDate ? 0 : -1}
           type="button"
           theme={theme}


### PR DESCRIPTION
Closes: #

## What I did

Bug fix (accessibility).

Adjusted ARIA roles in the calendar day cell to improve compatibility with NVDA screen reader.
Changed the td role to presentation and moved the gridcell role to the interactive element (button).

This prevents NVDA from switching to browse mode when navigating dates with arrow keys and allows keyboard navigation to work correctly with the screen reader.

## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Open DatePicker in Storybook
- Launch NVDA screen reader
- Open Calendar
- Verify that keyboard navigation works well in calendar
