### PR TITLE
fix(DateFieldInput): Add invalid year error message

### DIFF
--- a/.changeset/fix-DateFieldInput-error-message.md
+++ b/.changeset/fix-DateFieldInput-error-message.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Date Field Input): Add error message when the user enters an invalid date.

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -33,7 +33,7 @@ import { IconButton } from '../../IconButton';
 import { IconButtonContainer } from '../../InputBase';
 import { Divider, StyledNumInput } from '../../TimePicker';
 import { VisuallyHidden } from '../../VisuallyHidden';
-import { MAX_YEAR, MIN_YEAR } from '../utils';
+import { MAX_YEAR, MIN_YEAR, isYearOutOfRange } from '../utils';
 
 export interface DateFieldInputProps
   extends Omit<FormFieldContainerBaseProps, 'inputSize' | 'fieldId'> {
@@ -230,54 +230,42 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   };
 
   React.useEffect(() => {
-    let isMounted = true;
-
-    // Preventing calling handleDateChange and onClearDate on initial mount when fields are empty
     if (!didMountRef.current) {
       didMountRef.current = true;
-
       return;
     }
 
     const allFieldsEmpty = !month && !day && !year;
 
-    if (allFieldsEmpty && isMounted) {
+    if (allFieldsEmpty) {
       handleDateChange?.(null, null);
       onClearDate?.();
       setIsInvalidYear(false);
-
       return;
     }
 
-    const yearValue = Number(year);
-    const isValidYear =
-      !isEmpty(year) && yearValue >= MIN_YEAR && yearValue <= MAX_YEAR;
     const hasAllFields = month && day && year;
 
-    // Prevents showing the error message when user is still filling out the fields
     if (!hasAllFields) {
       setIsInvalidYear(false);
       return;
     }
 
-    if (!isValidYear) {
-      setIsInvalidYear(true);
+    const yearValue = Number(year);
+
+    if (isYearOutOfRange(yearValue)) {
       return;
     }
+
+    setIsInvalidYear(false);
 
     const newDate = hasMonthLongFormat
       ? new Date(`${month} ${day}, ${year}`)
       : new Date(yearValue, Number(month) - 1, Number(day));
 
-    setIsInvalidYear(false);
-
-    if (!isNaN(newDate.getTime()) && isMounted) {
+    if (!isNaN(newDate.getTime())) {
       handleDateChange?.(newDate, null);
     }
-
-    return () => {
-      isMounted = false;
-    };
   }, [month, day, year, hasMonthLongFormat]);
 
   React.useEffect(() => {
@@ -352,6 +340,14 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   };
 
   const handleOnBlur = (e: React.FocusEvent) => {
+    const isLeavingGroup = !e.currentTarget.contains(e.relatedTarget as Node);
+
+    if (isLeavingGroup && month && day && year) {
+      if (isYearOutOfRange(Number(year))) {
+        setIsInvalidYear(true);
+      }
+    }
+
     onInputBlur?.(e);
     setIsFocused(false);
   };

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -11,7 +11,6 @@ import {
   IsClearableContainer,
 } from './StyledDateFieldInput';
 import { InputDateFields, useDateField } from './useDateField';
-import { VisuallyHidden } from '../../..';
 import { I18nContext } from '../../../i18n';
 import { useIsInverse } from '../../../inverse';
 import { ThemeContext } from '../../../theme/ThemeContext';
@@ -33,6 +32,7 @@ import {
 import { IconButton } from '../../IconButton';
 import { IconButtonContainer } from '../../InputBase';
 import { Divider, StyledNumInput } from '../../TimePicker';
+import { VisuallyHidden } from '../../VisuallyHidden';
 import { MAX_YEAR, MIN_YEAR } from '../utils';
 
 export interface DateFieldInputProps
@@ -124,16 +124,21 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
     return isEmpty(month) ? 3.25 : 2;
   };
 
+  const invalidYearErrorMessage = i18n.datePicker.invalidYearError
+    .replace('{minYear}', MIN_YEAR.toString())
+    .replace('{maxYear}', MAX_YEAR.toString());
+
+  const ariaDescribedBy =
+    invalidYearErrorMessage || errorMessage || helperMessage
+      ? `${id}${descriptionSuffix}`
+      : undefined;
+
   const renderInput = (key: string) => {
     switch (key) {
       case InputDateFields.Day:
         return (
           <StyledNumInput
-            aria-describedby={
-              errorMessage || helperMessage
-                ? `${id}${descriptionSuffix}`
-                : undefined
-            }
+            aria-describedby={ariaDescribedBy}
             aria-label={datePicker.day}
             data-testid="day-input"
             id={dayId}
@@ -156,11 +161,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       case InputDateFields.Month:
         return (
           <StyledNumInput
-            aria-describedby={
-              errorMessage || helperMessage
-                ? `${id}${descriptionSuffix}`
-                : undefined
-            }
+            aria-describedby={ariaDescribedBy}
             aria-label={datePicker.month}
             data-testid="month-input"
             id={monthId}
@@ -189,11 +190,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       case InputDateFields.Year:
         return (
           <StyledNumInput
-            aria-describedby={
-              errorMessage || helperMessage
-                ? `${id}${descriptionSuffix}`
-                : undefined
-            }
+            aria-describedby={ariaDescribedBy}
             aria-label={datePicker.year}
             data-testid="year-input"
             id={yearId}
@@ -231,10 +228,6 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
     // Focus the first available field in fieldOrder
     firstFieldRef?.focus();
   };
-
-  const invalidYearErrorMessage = i18n.datePicker.invalidYearError
-    .replace('{minYear}', MIN_YEAR.toString())
-    .replace('{maxYear}', MAX_YEAR.toString());
 
   React.useEffect(() => {
     let isMounted = true;

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -11,6 +11,7 @@ import {
   IsClearableContainer,
 } from './StyledDateFieldInput';
 import { InputDateFields, useDateField } from './useDateField';
+import { VisuallyHidden } from '../../..';
 import { I18nContext } from '../../../i18n';
 import { useIsInverse } from '../../../inverse';
 import { ThemeContext } from '../../../theme/ThemeContext';
@@ -104,6 +105,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   const didMountRef = React.useRef(false);
   const firstFieldRef = fieldRefs[fieldOrder[0]]?.current;
   const [isFocused, setIsFocused] = React.useState(false);
+  const [isInvalidYear, setIsInvalidYear] = React.useState(false);
 
   const dayId = `${id}__day`;
   const monthId = `${id}__month`;
@@ -230,6 +232,10 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
     firstFieldRef?.focus();
   };
 
+  const invalidYearErrorMessage = i18n.datePicker.invalidYearError
+    .replace('{minYear}', MIN_YEAR.toString())
+    .replace('{maxYear}', MAX_YEAR.toString());
+
   React.useEffect(() => {
     let isMounted = true;
 
@@ -240,26 +246,37 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       return;
     }
 
-    const allFieldsEmpty = isEmpty(day) && isEmpty(month) && isEmpty(year);
+    const allFieldsEmpty = !month && !day && !year;
 
     if (allFieldsEmpty && isMounted) {
       handleDateChange?.(null, null);
       onClearDate?.();
+      setIsInvalidYear(false);
 
       return;
     }
 
-    const isCompletedDate =
-      month &&
-      day &&
-      year &&
-      Number(year) >= MIN_YEAR &&
-      Number(year) <= MAX_YEAR;
+    const yearValue = Number(year);
+    const isValidYear =
+      !isEmpty(year) && yearValue >= MIN_YEAR && yearValue <= MAX_YEAR;
+    const hasAllFields = month && day && year;
 
-    if (!isCompletedDate) return;
+    // Prevents showing the error message when user is still filling out the fields
+    if (!hasAllFields) {
+      setIsInvalidYear(false);
+      return;
+    }
+
+    if (!isValidYear) {
+      setIsInvalidYear(true);
+      return;
+    }
+
     const newDate = hasMonthLongFormat
       ? new Date(`${month} ${day}, ${year}`)
-      : new Date(Number(year), Number(month) - 1, Number(day));
+      : new Date(yearValue, Number(month) - 1, Number(day));
+
+    setIsInvalidYear(false);
 
     if (!isNaN(newDate.getTime()) && isMounted) {
       handleDateChange?.(newDate, null);
@@ -349,7 +366,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   return (
     <FormFieldContainer
       containerStyle={containerStyle}
-      errorMessage={errorMessage}
+      errorMessage={isInvalidYear ? invalidYearErrorMessage : errorMessage}
       fieldId={id}
       helperMessage={helperMessage}
       isInverse={isInverse}
@@ -405,6 +422,9 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
             />
           </IconButtonContainer>
         </IconWrapper>
+        <VisuallyHidden>
+          <input id={id} aria-hidden="true" tabIndex={-1} />
+        </VisuallyHidden>
       </DateFieldInputContainer>
     </FormFieldContainer>
   );

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -1574,6 +1574,51 @@ describe('Date Picker', () => {
       expect(yearInput).toHaveValue('2026');
     });
 
+    it('should render error message when user enters an invalid year', () => {
+      const { getByTestId, getByText } = render(
+        <DatePicker isDateFieldInput />
+      );
+
+      const monthInput = getByTestId('month-input');
+      const dayInput = getByTestId('day-input');
+      const yearInput = getByTestId('year-input');
+
+      userEvent.type(monthInput, '1');
+      userEvent.type(dayInput, '15');
+      userEvent.type(yearInput, '1800');
+
+      expect(monthInput).toHaveDisplayValue('01');
+      expect(dayInput).toHaveDisplayValue('15');
+      expect(yearInput).toHaveDisplayValue('1800');
+      expect(
+        getByText('Invalid date. Please enter a year between 1900 and 2099.')
+      ).toBeInTheDocument();
+    });
+
+    it('should render invalid year error message after showing custom error message', () => {
+      const customErrorMessage = 'Please, enter a date';
+      const { getByTestId, getByText } = render(
+        <DatePicker isDateFieldInput errorMessage={customErrorMessage} />
+      );
+
+      const monthInput = getByTestId('month-input');
+      const dayInput = getByTestId('day-input');
+      const yearInput = getByTestId('year-input');
+
+      expect(getByText(customErrorMessage)).toBeInTheDocument();
+
+      userEvent.type(monthInput, '10');
+      userEvent.type(dayInput, '22');
+      userEvent.type(yearInput, '1861');
+
+      expect(monthInput).toHaveDisplayValue('10');
+      expect(dayInput).toHaveDisplayValue('22');
+      expect(yearInput).toHaveDisplayValue('1861');
+      expect(
+        getByText('Invalid date. Please enter a year between 1900 and 2099.')
+      ).toBeInTheDocument();
+    });
+
     describe('Focus behavior', () => {
       it('should handle input focus behavior via tabbing', () => {
         const { getByTestId } = render(<DatePicker isDateFieldInput />);

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -1574,8 +1574,8 @@ describe('Date Picker', () => {
       expect(yearInput).toHaveValue('2026');
     });
 
-    it('should render error message when user enters an invalid year', () => {
-      const { getByTestId, getByText } = render(
+    it('should render error message when user enters an invalid year and on blur', () => {
+      const { getByTestId, getByText, queryByText } = render(
         <DatePicker isDateFieldInput />
       );
 
@@ -1591,13 +1591,19 @@ describe('Date Picker', () => {
       expect(dayInput).toHaveDisplayValue('15');
       expect(yearInput).toHaveDisplayValue('1800');
       expect(
+        queryByText('Invalid date. Please enter a year between 1900 and 2099.')
+      ).not.toBeInTheDocument();
+
+      userEvent.tab();
+
+      expect(
         getByText('Invalid date. Please enter a year between 1900 and 2099.')
       ).toBeInTheDocument();
     });
 
     it('should render invalid year error message after showing custom error message', () => {
       const customErrorMessage = 'Please, enter a date';
-      const { getByTestId, getByText } = render(
+      const { getByTestId, getByText, queryByText } = render(
         <DatePicker isDateFieldInput errorMessage={customErrorMessage} />
       );
 
@@ -1614,6 +1620,13 @@ describe('Date Picker', () => {
       expect(monthInput).toHaveDisplayValue('10');
       expect(dayInput).toHaveDisplayValue('22');
       expect(yearInput).toHaveDisplayValue('1861');
+
+      expect(
+        queryByText('Invalid date. Please enter a year between 1900 and 2099.')
+      ).not.toBeInTheDocument();
+
+      userEvent.tab();
+
       expect(
         getByText('Invalid date. Please enter a year between 1900 and 2099.')
       ).toBeInTheDocument();

--- a/packages/react-magma-dom/src/components/DatePicker/utils.ts
+++ b/packages/react-magma-dom/src/components/DatePicker/utils.ts
@@ -174,3 +174,7 @@ export function setYearForDate(prevDate, numberYear: number) {
 export const MAX_YEAR = 2099;
 
 export const MIN_YEAR = 1900;
+
+export const isYearOutOfRange = (year: number) => {
+  return year < MIN_YEAR || year > MAX_YEAR;
+};

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -130,6 +130,8 @@ export const defaultI18n: I18nInterface = {
     day: 'Day',
     month: 'Month',
     year: 'Year',
+    invalidYearError:
+      'Invalid date. Please enter a year between {minYear} and {maxYear}.',
     helpModal: {
       header: 'Keyboard Shortcuts',
       helpButtonAriaLabel: 'Keyboard instructions for calendar widget',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -134,6 +134,7 @@ export interface I18nInterface {
     day: string;
     month: string;
     year: string;
+    invalidYearError: string;
 
     helpModal: {
       header: string;


### PR DESCRIPTION
Closes: #2407

## What I did
- Added an error message to inform users about invalid date

## Screenshots

<img width="1906" height="406" alt="Screenshot from 2026-04-07 12-33-16" src="https://github.com/user-attachments/assets/a6714335-9eda-4811-b351-b82e64442d42" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Date Picker -> Date Field Input -> type 11/11/1800 -> press tab -> the error invalid year message should be visible -> type a year between 1900 and 2099 -> the error message should be gone.

Go to Storybook -> Default -> `isDateDieldInpit=true` -> error message = "Custom error message" -> type 11/11/1800 -> press tab ->  the error invalid year message should be visible -> type a year between 1900 and 2099 ->the error invalid year message should be gone + "Custom error message" should be visible.

