### PR TITLE
fix(DateFieldInput & TimePicker): Update aria attributes. Add Form examples. Refactor code.

### DIFF
--- a/.changeset/fix-DatePicker-accessibility-issues.md
+++ b/.changeset/fix-DatePicker-accessibility-issues.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Date Picker & Time Picker & Native Select): Update aria attributes.

--- a/packages/react-magma-dom/src/components/Checkbox/index.tsx
+++ b/packages/react-magma-dom/src/components/Checkbox/index.tsx
@@ -7,7 +7,12 @@ import { CheckBoxIcon, CheckBoxOutlineBlankIcon } from 'react-magma-icons';
 import { useIsInverse } from '../../inverse';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { omit, reactNodeToString, useGenerateId } from '../../utils';
+import {
+  descriptionSuffix,
+  omit,
+  reactNodeToString,
+  useGenerateId,
+} from '../../utils';
 import { HiddenStyles } from '../../utils/UtilityStyles';
 import { FormGroupContext } from '../FormGroup';
 import { InputMessage } from '../Input/InputMessage';
@@ -211,7 +216,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     } = props;
     const other = omit(['defaultChecked'], rest);
 
-    const descriptionId = errorMessage && `${id}__desc`;
+    const descriptionId = errorMessage && `${id}${descriptionSuffix}`;
     const groupDescriptionId = context.descriptionId;
 
     const describedBy =

--- a/packages/react-magma-dom/src/components/Combobox/index.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/index.tsx
@@ -16,7 +16,7 @@ import {
 import { InternalCombobox } from './Combobox';
 import { MultiCombobox } from './MultiCombobox';
 import { useIsInverse } from '../../inverse';
-import { Omit, useGenerateId, XOR } from '../../utils';
+import { descriptionSuffix, Omit, useGenerateId, XOR } from '../../utils';
 import { LabelPosition } from '../Label';
 
 export interface ComboboxProps<T extends SelectOptions>
@@ -169,7 +169,8 @@ export function Combobox<T>(props: XORComboboxProps<T>) {
   const hasError = !!errorMessage;
 
   const id = useGenerateId(defaultId);
-  const descriptionId = errorMessage || helperMessage ? `${id}__desc` : null;
+  const descriptionId =
+    errorMessage || helperMessage ? `${id}${descriptionSuffix}` : null;
 
   const isInverse = useIsInverse(props.isInverse);
 

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -14,7 +14,11 @@ import { InputDateFields, useDateField } from './useDateField';
 import { I18nContext } from '../../../i18n';
 import { useIsInverse } from '../../../inverse';
 import { ThemeContext } from '../../../theme/ThemeContext';
-import { handleNumericBeforeInput } from '../../../utils';
+import {
+  descriptionSuffix,
+  handleNumericBeforeInput,
+  labelSuffix,
+} from '../../../utils';
 import {
   ButtonShape,
   ButtonSize,
@@ -40,7 +44,6 @@ export interface DateFieldInputProps
   setReference?: (node: ReferenceType) => void;
   iconRef?: React.RefObject<HTMLButtonElement>;
   isClearable?: boolean;
-  iconAriaLabel?: string;
   inputRef?: React.RefObject<HTMLDivElement>;
   inputValue: Date | string;
   handleDateChange?: (day: Date, event) => void;
@@ -77,7 +80,6 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   } = props;
 
   const {
-    allMonthNames,
     month,
     day,
     year,
@@ -92,7 +94,6 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
     setYearValue,
     handleFieldKeyDown,
     formatWithLeadingZero,
-    getIndexMonth,
   } = useDateField({
     dateFormat,
   });
@@ -126,11 +127,12 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       case InputDateFields.Day:
         return (
           <StyledNumInput
+            aria-describedby={
+              errorMessage || helperMessage
+                ? `${id}${descriptionSuffix}`
+                : undefined
+            }
             aria-label={datePicker.day}
-            aria-valuemin={1}
-            aria-valuemax={31}
-            aria-valuenow={Number(day)}
-            aria-valuetext={day}
             data-testid="day-input"
             id={dayId}
             isInverse={isInverse}
@@ -152,17 +154,12 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       case InputDateFields.Month:
         return (
           <StyledNumInput
+            aria-describedby={
+              errorMessage || helperMessage
+                ? `${id}${descriptionSuffix}`
+                : undefined
+            }
             aria-label={datePicker.month}
-            aria-valuemax={12}
-            aria-valuemin={1}
-            aria-valuenow={
-              hasMonthLongFormat
-                ? getIndexMonth(month)[0] + 1
-                : Number(month) - 1
-            }
-            aria-valuetext={
-              hasMonthLongFormat ? month : allMonthNames[Number(month) - 1]
-            }
             data-testid="month-input"
             id={monthId}
             isInverse={isInverse}
@@ -190,11 +187,12 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       case InputDateFields.Year:
         return (
           <StyledNumInput
+            aria-describedby={
+              errorMessage || helperMessage
+                ? `${id}${descriptionSuffix}`
+                : undefined
+            }
             aria-label={datePicker.year}
-            aria-valuemin={MIN_YEAR}
-            aria-valuemax={MAX_YEAR}
-            aria-valuenow={Number(year)}
-            aria-valuetext={year}
             data-testid="year-input"
             id={yearId}
             isInverse={isInverse}
@@ -370,6 +368,8 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
           onClick={focusInputContainer}
           onFocus={handleOnFocus}
           onBlur={handleOnBlur}
+          role="group"
+          aria-labelledby={`${id}${labelSuffix}`}
         >
           {renderDateFields()}
         </InputsContainer>
@@ -391,7 +391,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
         <IconWrapper theme={theme}>
           <IconButtonContainer theme={theme} isClickable>
             <IconButton
-              aria-label={props.iconAriaLabel}
+              aria-label={i18n.datePicker.calendarIconAriaLabel}
               data-testid="toggle-calendar-button"
               icon={<EventIcon />}
               size={ButtonSize.small}

--- a/packages/react-magma-dom/src/components/Form/Form.stories.tsx
+++ b/packages/react-magma-dom/src/components/Form/Form.stories.tsx
@@ -3,30 +3,32 @@ import React from 'react';
 import { StoryFn, Meta } from '@storybook/react-webpack5';
 import { SettingsIcon } from 'react-magma-icons';
 
-import { Button, ButtonColor, ButtonType } from '../Button';
-import { ButtonGroup, ButtonGroupAlignment } from '../ButtonGroup';
-import { Checkbox } from '../Checkbox';
-import { Combobox } from '../Combobox';
-import { DatePicker } from '../DatePicker';
 import {
+  Checkbox,
+  Combobox,
   Dropdown,
   DropdownButton,
   DropdownContent,
   DropdownMenuItem,
-} from '../Dropdown';
-import { FormGroup } from '../FormGroup';
-import { IconButton } from '../IconButton';
-import { Input } from '../Input';
-import { Paragraph } from '../Paragraph';
+  FormGroup,
+  IconButton,
+  Input,
+  Modal,
+  Paragraph,
+  Radio,
+  RadioGroup,
+  Search,
+  Select,
+  Spacer,
+  Textarea,
+  TimePicker,
+  Toggle,
+  Tooltip,
+} from '../..';
+import { Button, ButtonColor, ButtonType } from '../Button';
+import { ButtonGroup, ButtonGroupAlignment } from '../ButtonGroup';
+import { DatePicker } from '../DatePicker';
 import { PasswordInput } from '../PasswordInput';
-import { Radio } from '../Radio';
-import { RadioGroup } from '../RadioGroup';
-import { Search } from '../Search';
-import { Select } from '../Select';
-import { Textarea } from '../Textarea';
-import { TimePicker } from '../TimePicker';
-import { Toggle } from '../Toggle';
-import { Tooltip } from '../Tooltip';
 
 import { Form, FormProps } from '.';
 
@@ -127,3 +129,134 @@ export const Expanded = {
     style: { padding: '4px 16px 16px' },
   },
 };
+
+export function PasswordInputForm() {
+  const passwordRef = React.useRef<HTMLInputElement>(null);
+  const [password, setPassword] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const validate = () => {
+    if (!password) {
+      setError('Please enter a password!');
+
+      return true;
+    }
+    setError('');
+
+    return false;
+  };
+
+  const onSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const hasError = validate();
+
+    if (hasError && passwordRef.current) {
+      passwordRef.current.focus();
+    }
+  };
+
+  const cancel = () => {
+    setPassword('');
+    setError('');
+  };
+
+  return (
+    <Form
+      onSubmit={onSubmit}
+      header="Password Input Form"
+      description="Enter your password below."
+      actions={
+        <ButtonGroup>
+          <Button color={ButtonColor.secondary} onClick={cancel}>
+            Cancel
+          </Button>
+          <Button type={ButtonType.submit}>Submit</Button>
+        </ButtonGroup>
+      }
+    >
+      <PasswordInput
+        labelText="Password *"
+        value={password}
+        onChange={e => {
+          setPassword(e.target.value);
+          setError('');
+        }}
+        errorMessage={error}
+        autoComplete="current-password"
+        ref={passwordRef}
+      />
+      <Spacer size="12" />
+    </Form>
+  );
+}
+
+export function DatePickerForm() {
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const [birthday, setBirthday] = React.useState<Date | undefined>(undefined);
+  const [error, setError] = React.useState('');
+
+  const focusDateInput = () => {
+    const input = wrapperRef.current?.querySelector('input');
+
+    input?.focus();
+  };
+
+  const validate = () => {
+    if (!birthday) {
+      setError('Please select a date!');
+
+      return true;
+    }
+    setError('');
+
+    return false;
+  };
+
+  const onSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const hasError = validate();
+
+    if (hasError) {
+      setTimeout(() => {
+        focusDateInput();
+      }, 0);
+    }
+  };
+
+  const cancel = () => {
+    setBirthday(undefined);
+    setError('');
+  };
+
+  return (
+    <Modal isOpen>
+      <Form
+        onSubmit={onSubmit}
+        header="DatePicker Form"
+        description="Select your birthday below."
+        actions={
+          <ButtonGroup>
+            <Button color={ButtonColor.secondary} onClick={cancel}>
+              Cancel
+            </Button>
+            <Button type={ButtonType.submit}>Submit</Button>
+          </ButtonGroup>
+        }
+      >
+        <div ref={wrapperRef}>
+          <DatePicker
+            isDateFieldInput
+            labelText="Birthday *"
+            value={birthday}
+            onDateChange={date => {
+              setBirthday(date);
+              setError('');
+            }}
+            errorMessage={error}
+          />
+        </div>
+        <Spacer size="12" />
+      </Form>
+    </Modal>
+  );
+}

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.test.js
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.test.js
@@ -115,6 +115,30 @@ describe('FormFieldContainer', () => {
     expect(getByText(labelText)).toHaveStyle('flex-basis: 20%');
   });
 
+  it('Should render the label with an id based on fieldId', () => {
+    const { getByText } = render(
+      <FormFieldContainer fieldId="my-field" labelText={labelText}>
+        {TEXT}
+      </FormFieldContainer>
+    );
+
+    const label = getByText(labelText);
+    expect(label).toHaveAttribute('id', 'my-field__label');
+  });
+
+  it('Should render the error message with an id based on fieldId', () => {
+    const errorMsg = 'Test error';
+    const { container } = render(
+      <FormFieldContainer fieldId="my-field" errorMessage={errorMsg}>
+        {TEXT}
+      </FormFieldContainer>
+    );
+
+    const messageEl = document.getElementById('my-field__desc');
+    expect(messageEl).toBeInTheDocument();
+    expect(messageEl).toHaveTextContent(errorMsg);
+  });
+
   it('Does not violate accessibility standards', () => {
     const { container } = render(
       <FormFieldContainer>{TEXT}</FormFieldContainer>

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import { InverseContext, useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
+import { descriptionSuffix, labelSuffix } from '../../utils';
 import { CharacterCounter } from '../CharacterCounter';
 import { InputMessage } from '../Input/InputMessage';
 import { InputIconPosition, InputSize } from '../InputBase';
@@ -194,7 +195,7 @@ export const FormFieldContainer = React.forwardRef<
       ? `${fieldId}__counter`
       : null;
   const messageDescriptionId =
-    errorMessage || helperMessage ? `${fieldId}__message` : null;
+    errorMessage || helperMessage ? `${fieldId}${descriptionSuffix}` : null;
 
   return (
     <InverseContext.Provider value={{ isInverse }}>
@@ -214,6 +215,7 @@ export const FormFieldContainer = React.forwardRef<
             <Label
               actionable={actionable}
               htmlFor={fieldId}
+              id={`${fieldId}${labelSuffix}`}
               iconPosition={iconPosition}
               labelPosition={labelPosition}
               size={inputSize}

--- a/packages/react-magma-dom/src/components/FormGroup/index.tsx
+++ b/packages/react-magma-dom/src/components/FormGroup/index.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { omit, useGenerateId } from '../../utils';
+import { descriptionSuffix, omit, useGenerateId } from '../../utils';
 import { HiddenStyles } from '../../utils/UtilityStyles';
 import { InputMessage } from '../Input/InputMessage';
 import { Label } from '../Label';
@@ -81,7 +81,8 @@ export const FormGroup = React.forwardRef<HTMLDivElement, FormGroupProps>(
     } = props;
     const other = omit(['id'], rest);
 
-    const descriptionId = errorMessage || helperMessage ? `${id}__desc` : null;
+    const descriptionId =
+      errorMessage || helperMessage ? `${id}${descriptionSuffix}` : null;
     const theme = React.useContext(ThemeContext);
     const isInverse = useIsInverse(props.isInverse);
 

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/index.tsx
@@ -9,7 +9,7 @@ import {
 import { I18nContext } from '../../i18n';
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { Omit, useGenerateId } from '../../utils';
+import { descriptionSuffix, Omit, useGenerateId } from '../../utils';
 import { Announce } from '../Announce';
 import {
   CheckboxProps,
@@ -140,7 +140,7 @@ export const IndeterminateCheckbox = React.forwardRef<
           )
         : '';
 
-  const descriptionId = errorMessage ? `${id}__desc` : null;
+  const descriptionId = errorMessage ? `${id}${descriptionSuffix}` : null;
   const groupDescriptionId = context.descriptionId;
 
   const describedBy =

--- a/packages/react-magma-dom/src/components/Input/index.tsx
+++ b/packages/react-magma-dom/src/components/Input/index.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import { useIsInverse } from '../../inverse';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { omit, useGenerateId } from '../../utils';
+import { descriptionSuffix, omit, useGenerateId } from '../../utils';
 import {
   FormFieldContainer,
   FormFieldContainerBaseProps,
@@ -116,7 +116,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         ? `${id}__counter`
         : null;
     const messageDescriptionId =
-      errorMessage || helperMessage ? `${id}__message` : null;
+      errorMessage || helperMessage ? `${id}${descriptionSuffix}` : null;
     const descriptionId =
       [counterDescriptionId, messageDescriptionId].filter(Boolean).join(' ') ||
       null;

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
@@ -101,6 +101,49 @@ describe('NativeSelect', () => {
     expect(getByText(errorMessage)).toBeInTheDocument();
   });
 
+  it('should set aria-invalid on the select when in error state', () => {
+    const { getByTestId } = render(
+      <NativeSelect errorMessage="Error" testId={testId}>
+        <option>Red</option>
+      </NativeSelect>
+    );
+
+    expect(getByTestId(testId)).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('should not set aria-invalid when there is no error', () => {
+    const { getByTestId } = render(
+      <NativeSelect testId={testId}>
+        <option>Red</option>
+      </NativeSelect>
+    );
+
+    expect(getByTestId(testId)).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('should set aria-describedby referencing the error message element', () => {
+    const { getByTestId } = render(
+      <NativeSelect errorMessage="Error" testId={testId} id="my-select">
+        <option>Red</option>
+      </NativeSelect>
+    );
+
+    const select = getByTestId(testId);
+    expect(select).toHaveAttribute('aria-describedby', 'my-select__desc');
+    expect(document.getElementById('my-select__desc')).toBeInTheDocument();
+  });
+
+  it('should set aria-describedby referencing the helper message element', () => {
+    const { getByTestId } = render(
+      <NativeSelect helperMessage="Help text" testId={testId} id="my-select">
+        <option>Red</option>
+      </NativeSelect>
+    );
+
+    const select = getByTestId(testId);
+    expect(select).toHaveAttribute('aria-describedby', 'my-select__desc');
+  });
+
   it('should render an inverse error state', () => {
     const errorMessage = 'This is an error';
     const { getByTestId, getByText } = render(
@@ -152,7 +195,7 @@ describe('NativeSelect', () => {
       alert('Help link clicked!');
     };
 
-    it('Should accept additional content to the right of the native select label', () => {
+    it('should accept additional content to the right of the native select label', () => {
       const { getByTestId } = render(
         <NativeSelect
           testId={testId}
@@ -175,7 +218,7 @@ describe('NativeSelect', () => {
       expect(getByTestId('Icon Button')).toBeInTheDocument();
     });
 
-    it(`Should display additional content inline with the native select label when labelPosition is set to 'left'`, () => {
+    it(`should display additional content inline with the native select label when labelPosition is set to 'left'`, () => {
       const { getByTestId } = render(
         <NativeSelect
           labelPosition="left"
@@ -201,7 +244,7 @@ describe('NativeSelect', () => {
       );
     });
 
-    it(`Should display an additional wrapper with additionalContent'`, () => {
+    it(`should display an additional wrapper with additionalContent'`, () => {
       const { queryByTestId } = render(
         <NativeSelect
           labelPosition="left"
@@ -226,13 +269,53 @@ describe('NativeSelect', () => {
       ).toBeInTheDocument();
     });
 
-    it(`Shouldn't display an additional wrapper without additionalContent'`, () => {
+    it(`shouldn't display an additional wrapper without additionalContent'`, () => {
       const { queryByTestId } = render(
         <NativeSelect labelPosition="left" testId={testId} />
       );
       expect(
         queryByTestId(`${testId}-additional-content-wrapper`)
       ).not.toBeInTheDocument();
+    });
+
+    it('should set aria-labelledby when additionalContent and labelText are present', () => {
+      const { getByTestId } = render(
+        <NativeSelect
+          testId={testId}
+          id="my-select"
+          labelText="Select color"
+          additionalContent={
+            <Tooltip content="Learn more">
+              <IconButton
+                aria-label="Learn more"
+                icon={<HelpIcon />}
+                onClick={() => {}}
+                type={ButtonType.button}
+                size={ButtonSize.small}
+                variant={ButtonVariant.link}
+              />
+            </Tooltip>
+          }
+        >
+          <option>Red</option>
+        </NativeSelect>
+      );
+
+      const select = getByTestId(testId);
+      expect(select).toHaveAttribute('aria-labelledby', 'my-select__label');
+      expect(document.getElementById('my-select__label')).toHaveTextContent(
+        'Select color'
+      );
+    });
+
+    it('should not set aria-labelledby when there is no additionalContent', () => {
+      const { getByTestId } = render(
+        <NativeSelect testId={testId} labelText="Select color">
+          <option>Red</option>
+        </NativeSelect>
+      );
+
+      expect(getByTestId(testId)).not.toHaveAttribute('aria-labelledby');
     });
   });
 });

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.tsx
@@ -7,7 +7,7 @@ import { transparentize } from 'polished';
 import { useIsInverse } from '../../inverse';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { useGenerateId } from '../../utils';
+import { descriptionSuffix, labelSuffix, useGenerateId } from '../../utils';
 import {
   FormFieldContainer,
   FormFieldContainerBaseProps,
@@ -175,7 +175,6 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
           return;
       }
 
-      e.preventDefault();
       select.selectedIndex = index;
       select.dispatchEvent(new Event('change', { bubbles: true }));
     };
@@ -206,7 +205,13 @@ export const NativeSelect = React.forwardRef<HTMLDivElement, NativeSelectProps>(
           <StyledNativeSelect
             data-testid={testId}
             aria-describedby={
-              errorMessage || helperMessage ? `${id}__desc` : undefined
+              errorMessage || helperMessage
+                ? `${id}${descriptionSuffix}`
+                : undefined
+            }
+            aria-invalid={!!errorMessage || undefined}
+            aria-labelledby={
+              additionalContent && labelText ? `${id}${labelSuffix}` : undefined
             }
             hasError={!!errorMessage}
             disabled={disabled}

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { I18nContext } from '../../i18n';
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { useGenerateId } from '../../utils';
+import { descriptionSuffix, useGenerateId } from '../../utils';
 import { Announce } from '../Announce';
 import { Button, ButtonVariant, ButtonType, ButtonSize } from '../Button';
 import {
@@ -117,7 +117,8 @@ export const PasswordInput = React.forwardRef<
     ? showPasswordButtonText
     : i18n.password.shown.buttonText;
 
-  const descriptionId = errorMessage || helperMessage ? `${id}__desc` : null;
+  const descriptionId =
+    errorMessage || helperMessage ? `${id}${descriptionSuffix}` : null;
   const theme = React.useContext(ThemeContext);
 
   const isInverse = useIsInverse(props.isInverse);

--- a/packages/react-magma-dom/src/components/ProgressBar/index.tsx
+++ b/packages/react-magma-dom/src/components/ProgressBar/index.tsx
@@ -6,7 +6,11 @@ import { transparentize } from 'polished';
 
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { convertStyleValueToString, useGenerateId } from '../../utils';
+import {
+  convertStyleValueToString,
+  labelSuffix,
+  useGenerateId,
+} from '../../utils';
 import { VisuallyHidden } from '../VisuallyHidden';
 
 export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -174,7 +178,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
     } = props;
 
     const id = useGenerateId(defaultId);
-    const labelId = `${id}__label`;
+    const labelId = `${id}${labelSuffix}`;
 
     const percentageValue = percentage ? percentage : 0;
 

--- a/packages/react-magma-dom/src/components/RadioGroup/index.tsx
+++ b/packages/react-magma-dom/src/components/RadioGroup/index.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { omit, useGenerateId } from '../../utils';
+import { descriptionSuffix, omit, useGenerateId } from '../../utils';
 import { HiddenStyles } from '../../utils/UtilityStyles';
 import { InputMessage } from '../Input/InputMessage';
 import { Label } from '../Label';
@@ -132,7 +132,8 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
     } = props;
     const other = omit(['onBlur', 'onChange', 'onFocus', 'id'], rest);
 
-    const descriptionId = errorMessage || helperMessage ? `${id}__desc` : null;
+    const descriptionId =
+      errorMessage || helperMessage ? `${id}${descriptionSuffix}` : null;
 
     const theme = React.useContext(ThemeContext);
 

--- a/packages/react-magma-dom/src/components/Select/index.tsx
+++ b/packages/react-magma-dom/src/components/Select/index.tsx
@@ -7,12 +7,12 @@ import {
   UseSelectProps,
 } from 'downshift';
 
-import { useIsInverse } from '../../inverse';
-import { Omit, useGenerateId, XOR } from '../../utils';
-import { LabelPosition } from '../Label';
 import { SelectComponents } from './components';
 import { MultiSelect } from './MultiSelect';
 import { Select as InternalSelect } from './Select';
+import { useIsInverse } from '../../inverse';
+import { descriptionSuffix, Omit, useGenerateId, XOR } from '../../utils';
+import { LabelPosition } from '../Label';
 
 export type SelectOptions =
   | string
@@ -242,7 +242,8 @@ export function Select<T>(props: XORSelectProps<T>) {
 
   const id = useGenerateId(defaultId);
 
-  const descriptionId = errorMessage || helperMessage ? `${id}__desc` : null;
+  const descriptionId =
+    errorMessage || helperMessage ? `${id}${descriptionSuffix}` : null;
 
   const isInverse = useIsInverse(props.isInverse);
 

--- a/packages/react-magma-dom/src/components/Textarea/index.tsx
+++ b/packages/react-magma-dom/src/components/Textarea/index.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import { useIsInverse } from '../../inverse';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { useGenerateId, Omit } from '../../utils';
+import { useGenerateId, Omit, descriptionSuffix } from '../../utils';
 import {
   FormFieldContainer,
   FormFieldContainerBaseProps,
@@ -84,7 +84,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         ? `${id}__counter`
         : null;
     const messageDescriptionId =
-      errorMessage || helperMessage ? `${id}__message` : null;
+      errorMessage || helperMessage ? `${id}${descriptionSuffix}` : null;
     const descriptionId =
       [counterDescriptionId, messageDescriptionId].filter(Boolean).join(' ') ||
       null;

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
@@ -570,12 +570,11 @@ describe('TimePicker', () => {
 
     it('should use the i18n context defaults', () => {
       const { getByLabelText } = render(<TimePicker labelText="label" />);
-
       expect(
-        getByLabelText(`label, ${defaultI18n.timePicker.hoursAriaLabel}`)
+        getByLabelText(defaultI18n.timePicker.hoursAriaLabel)
       ).toBeInTheDocument();
       expect(
-        getByLabelText(`label, ${defaultI18n.timePicker.minutesAriaLabel}`)
+        getByLabelText(defaultI18n.timePicker.minutesAriaLabel)
       ).toBeInTheDocument();
     });
   });

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.tsx
@@ -12,7 +12,7 @@ import { useTimePicker, UseTimePickerProps } from './useTimePicker';
 import { I18nContext } from '../../i18n';
 import { useIsInverse } from '../../inverse';
 import { ThemeInterface } from '../../theme/magma';
-import { handleNumericBeforeInput } from '../../utils';
+import { handleNumericBeforeInput, labelSuffix } from '../../utils';
 import { FormFieldContainer } from '../FormFieldContainer';
 import { inputWrapperStyles } from '../InputBase';
 import { VisuallyHidden } from '../VisuallyHidden';
@@ -182,14 +182,12 @@ export const TimePicker = React.forwardRef<HTMLInputElement, TimePickerProps>(
       handleAmPmKeyDown,
     } = useTimePicker(props);
 
-    const hoursLabel = `${labelText}, ${i18n.timePicker.hoursAriaLabel}`;
-    const minutesLabel = `${labelText}, ${i18n.timePicker.minutesAriaLabel}`;
-    const amPmLabel = `${labelText}, ${
+    const hoursLabel = i18n.timePicker.hoursAriaLabel;
+    const minutesLabel = i18n.timePicker.minutesAriaLabel;
+    const amPmLabel =
       amPm === am
         ? i18n.timePicker.amButtonAriaLabel
-        : i18n.timePicker.pmButtonAriaLabel
-    }`;
-
+        : i18n.timePicker.pmButtonAriaLabel;
     const hasTime = !isEmpty(hour) || !isEmpty(minute);
 
     return (
@@ -210,6 +208,8 @@ export const TimePicker = React.forwardRef<HTMLInputElement, TimePickerProps>(
             hasError={!!errorMessage}
             theme={theme}
             style={inputStyle}
+            role="group"
+            aria-labelledby={`${id}${labelSuffix}`}
           >
             <ScheduleIcon
               color={

--- a/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
+++ b/packages/react-magma-dom/src/components/TimePicker/useTimePicker.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { enUS } from 'date-fns/locale';
 
 import { I18nContext } from '../../i18n';
-import { useGenerateId, Omit } from '../../utils';
+import { useGenerateId, Omit, descriptionSuffix } from '../../utils';
 import { FormFieldContainerBaseProps } from '../FormFieldContainer';
 
 export interface UseTimePickerProps
@@ -65,7 +65,8 @@ export function useTimePicker(props: UseTimePickerProps) {
 
   const hourId = `${id}__hour`;
   const minuteId = `${id}__minute`;
-  const descriptionId = errorMessage || helperMessage ? `${id}__desc` : null;
+  const descriptionId =
+    errorMessage || helperMessage ? `${id}${descriptionSuffix}` : null;
 
   function updateTime(newTime: string) {
     setTime(newTime);

--- a/packages/react-magma-dom/src/components/Toggle/index.tsx
+++ b/packages/react-magma-dom/src/components/Toggle/index.tsx
@@ -8,7 +8,7 @@ import { CheckIcon } from 'react-magma-icons';
 import { useIsInverse } from '../../inverse';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { useGenerateId } from '../../utils';
+import { descriptionSuffix, useGenerateId } from '../../utils';
 import { HiddenStyles } from '../../utils/UtilityStyles';
 import { FormGroupContext } from '../FormGroup';
 import { InputMessage } from '../Input/InputMessage';
@@ -294,7 +294,7 @@ export const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>(
     const theme = React.useContext(ThemeContext);
     const context = React.useContext(FormGroupContext);
 
-    const descriptionId = errorMessage ? `${id}__desc` : null;
+    const descriptionId = errorMessage ? `${id}${descriptionSuffix}` : null;
     const groupDescriptionId = context.descriptionId;
 
     const describedBy =

--- a/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
-import { useGenerateId } from '../../utils';
+import { descriptionSuffix, useGenerateId } from '../../utils';
 import { ButtonColor, ButtonSize } from '../Button';
 import { ButtonGroup, ButtonGroupProps } from '../ButtonGroup';
 import { ToggleButton, ToggleButtonProps } from '../ToggleButton/ToggleButton';
@@ -161,7 +161,7 @@ export const ToggleButtonGroup = React.forwardRef<
   const id = useGenerateId(defaultId);
   const descriptionId = props.descriptionId
     ? props.descriptionId
-    : `${id}__desc`;
+    : `${id}${descriptionSuffix}`;
 
   return (
     <ButtonGroup

--- a/packages/react-magma-dom/src/utils/index.ts
+++ b/packages/react-magma-dom/src/utils/index.ts
@@ -401,3 +401,6 @@ export function hasActiveElementsInside(ref) {
     }).length > 0
   );
 }
+
+export const descriptionSuffix = '__desc';
+export const labelSuffix = '__label';


### PR DESCRIPTION
Closes: #2406
Cherry-pick: https://github.com/cengage/react-magma/pull/2421

## What I did
- Updated `descriptionId` for `DateFieldInput`, `TimePicker`, `NativeSelect` components.
- Updated `aria-label` for `DateFieldInput`, `TimePicker`.
- Add announcing `error message` for  `DateFieldInput`, `TimePicker`, and `PasswordInput` in the `Form`
- Fixed `Axe` issues.
- Refactored code.

<img width="1858" height="972" alt="Screenshot from 2026-04-02 10-59-40" src="https://github.com/user-attachments/assets/dc93b0c5-1842-4ea8-b08c-ca40d43bf4f7" />

<img width="1858" height="948" alt="Screenshot from 2026-04-02 10-59-54" src="https://github.com/user-attachments/assets/4651d75a-d97a-4f48-a0ef-3a47e8c990cb" />

<img width="1639" height="957" alt="Screenshot from 2026-04-06 11-53-32" src="https://github.com/user-attachments/assets/1c195ab6-cc57-473c-af7b-332bcf626835" />

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Form -> Password Input Form -> Press on submit -> Error message should be announced
Go to Storybook -> Form -> Date Picker Form -> Press on submit -> Error message should be announced

Go to Storybook -> Combobox & Input & NativeSelect & Progress Bar &  Password Input -> Default-> NVDA and Vo should work as before

Go to Docs -> Components -> Date Picker -> scan the page via `AXE tool` -> NO issues related to **DatePicker** and **DateFieldInput**

Go to Storybook -> TimePicker -> Default ->Focus on the `Hour` -> NVDA & VO should announce `Time Due` as a group + `Hour` -> focus on the `Minutes` ->  NVDA & VO should announce `Minutes` -> label shoud be announced only once when user focuses on the input

Go to Storybook -> DatePicker  ->  Default -> `isDateFiledInput=true` -> Focus on the `Month` -> NVDA & VO should announce `Date as a group` + `Month` -> focus on the `days` ->  NVDA & VO should announce `Day` -> label shoud be announced only once when user focuses on the input