### PR TITLE
fix(DateFieldInput): Add invalid year error message.

### DIFF
--- a/.changeset/fix-DateFieldInput-error-message.md
+++ b/.changeset/fix-DateFieldInput-error-message.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Date Field Input): Add error message when the user enters an invalid date.

--- a/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DateField/DateFieldInput.tsx
@@ -32,7 +32,8 @@ import {
 import { IconButton } from '../../IconButton';
 import { IconButtonContainer } from '../../InputBase';
 import { Divider, StyledNumInput } from '../../TimePicker';
-import { MAX_YEAR, MIN_YEAR } from '../utils';
+import { VisuallyHidden } from '../../VisuallyHidden';
+import { MAX_YEAR, MIN_YEAR, isYearOutOfRange } from '../utils';
 
 export interface DateFieldInputProps
   extends Omit<FormFieldContainerBaseProps, 'inputSize' | 'fieldId'> {
@@ -104,6 +105,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   const didMountRef = React.useRef(false);
   const firstFieldRef = fieldRefs[fieldOrder[0]]?.current;
   const [isFocused, setIsFocused] = React.useState(false);
+  const [isInvalidYear, setIsInvalidYear] = React.useState(false);
 
   const dayId = `${id}__day`;
   const monthId = `${id}__month`;
@@ -122,16 +124,21 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
     return isEmpty(month) ? 3.25 : 2;
   };
 
+  const invalidYearErrorMessage = i18n.datePicker.invalidYearError
+    .replace('{minYear}', MIN_YEAR.toString())
+    .replace('{maxYear}', MAX_YEAR.toString());
+
+  const ariaDescribedBy =
+    invalidYearErrorMessage || errorMessage || helperMessage
+      ? `${id}${descriptionSuffix}`
+      : undefined;
+
   const renderInput = (key: string) => {
     switch (key) {
       case InputDateFields.Day:
         return (
           <StyledNumInput
-            aria-describedby={
-              errorMessage || helperMessage
-                ? `${id}${descriptionSuffix}`
-                : undefined
-            }
+            aria-describedby={ariaDescribedBy}
             aria-label={datePicker.day}
             data-testid="day-input"
             id={dayId}
@@ -154,11 +161,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       case InputDateFields.Month:
         return (
           <StyledNumInput
-            aria-describedby={
-              errorMessage || helperMessage
-                ? `${id}${descriptionSuffix}`
-                : undefined
-            }
+            aria-describedby={ariaDescribedBy}
             aria-label={datePicker.month}
             data-testid="month-input"
             id={monthId}
@@ -187,11 +190,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
       case InputDateFields.Year:
         return (
           <StyledNumInput
-            aria-describedby={
-              errorMessage || helperMessage
-                ? `${id}${descriptionSuffix}`
-                : undefined
-            }
+            aria-describedby={ariaDescribedBy}
             aria-label={datePicker.year}
             data-testid="year-input"
             id={yearId}
@@ -231,43 +230,42 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   };
 
   React.useEffect(() => {
-    let isMounted = true;
-
-    // Preventing calling handleDateChange and onClearDate on initial mount when fields are empty
     if (!didMountRef.current) {
       didMountRef.current = true;
-
       return;
     }
 
-    const allFieldsEmpty = isEmpty(day) && isEmpty(month) && isEmpty(year);
+    const allFieldsEmpty = !month && !day && !year;
 
-    if (allFieldsEmpty && isMounted) {
+    if (allFieldsEmpty) {
       handleDateChange?.(null, null);
       onClearDate?.();
-
+      setIsInvalidYear(false);
       return;
     }
 
-    const isCompletedDate =
-      month &&
-      day &&
-      year &&
-      Number(year) >= MIN_YEAR &&
-      Number(year) <= MAX_YEAR;
+    const hasAllFields = month && day && year;
 
-    if (!isCompletedDate) return;
-    const newDate = hasMonthLongFormat
-      ? new Date(`${month} ${day}, ${year}`)
-      : new Date(Number(year), Number(month) - 1, Number(day));
-
-    if (!isNaN(newDate.getTime()) && isMounted) {
-      handleDateChange?.(newDate, null);
+    if (!hasAllFields) {
+      setIsInvalidYear(false);
+      return;
     }
 
-    return () => {
-      isMounted = false;
-    };
+    const yearValue = Number(year);
+
+    if (isYearOutOfRange(yearValue)) {
+      return;
+    }
+
+    setIsInvalidYear(false);
+
+    const newDate = hasMonthLongFormat
+      ? new Date(`${month} ${day}, ${year}`)
+      : new Date(yearValue, Number(month) - 1, Number(day));
+
+    if (!isNaN(newDate.getTime())) {
+      handleDateChange?.(newDate, null);
+    }
   }, [month, day, year, hasMonthLongFormat]);
 
   React.useEffect(() => {
@@ -342,6 +340,14 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   };
 
   const handleOnBlur = (e: React.FocusEvent) => {
+    const isLeavingGroup = !e.currentTarget.contains(e.relatedTarget as Node);
+
+    if (isLeavingGroup && month && day && year) {
+      if (isYearOutOfRange(Number(year))) {
+        setIsInvalidYear(true);
+      }
+    }
+
     onInputBlur?.(e);
     setIsFocused(false);
   };
@@ -349,7 +355,7 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
   return (
     <FormFieldContainer
       containerStyle={containerStyle}
-      errorMessage={errorMessage}
+      errorMessage={isInvalidYear ? invalidYearErrorMessage : errorMessage}
       fieldId={id}
       helperMessage={helperMessage}
       isInverse={isInverse}
@@ -405,6 +411,9 @@ export const DateFieldInput: React.FunctionComponent<DateFieldInputProps> = (
             />
           </IconButtonContainer>
         </IconWrapper>
+        <VisuallyHidden>
+          <input id={id} aria-hidden="true" tabIndex={-1} />
+        </VisuallyHidden>
       </DateFieldInputContainer>
     </FormFieldContainer>
   );

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -1606,6 +1606,64 @@ describe('Date Picker', () => {
       expect(yearInput).toHaveValue('2026');
     });
 
+    it('should render error message when user enters an invalid year and on blur', () => {
+      const { getByTestId, getByText, queryByText } = render(
+        <DatePicker isDateFieldInput />
+      );
+
+      const monthInput = getByTestId('month-input');
+      const dayInput = getByTestId('day-input');
+      const yearInput = getByTestId('year-input');
+
+      userEvent.type(monthInput, '1');
+      userEvent.type(dayInput, '15');
+      userEvent.type(yearInput, '1800');
+
+      expect(monthInput).toHaveDisplayValue('01');
+      expect(dayInput).toHaveDisplayValue('15');
+      expect(yearInput).toHaveDisplayValue('1800');
+      expect(
+        queryByText('Invalid date. Please enter a year between 1900 and 2099.')
+      ).not.toBeInTheDocument();
+
+      userEvent.tab();
+
+      expect(
+        getByText('Invalid date. Please enter a year between 1900 and 2099.')
+      ).toBeInTheDocument();
+    });
+
+    it('should render invalid year error message after showing custom error message', () => {
+      const customErrorMessage = 'Please, enter a date';
+      const { getByTestId, getByText, queryByText } = render(
+        <DatePicker isDateFieldInput errorMessage={customErrorMessage} />
+      );
+
+      const monthInput = getByTestId('month-input');
+      const dayInput = getByTestId('day-input');
+      const yearInput = getByTestId('year-input');
+
+      expect(getByText(customErrorMessage)).toBeInTheDocument();
+
+      userEvent.type(monthInput, '10');
+      userEvent.type(dayInput, '22');
+      userEvent.type(yearInput, '1861');
+
+      expect(monthInput).toHaveDisplayValue('10');
+      expect(dayInput).toHaveDisplayValue('22');
+      expect(yearInput).toHaveDisplayValue('1861');
+
+      expect(
+        queryByText('Invalid date. Please enter a year between 1900 and 2099.')
+      ).not.toBeInTheDocument();
+
+      userEvent.tab();
+
+      expect(
+        getByText('Invalid date. Please enter a year between 1900 and 2099.')
+      ).toBeInTheDocument();
+    });
+
     describe('Focus behavior', () => {
       it('should handle input focus behavior via tabbing', async () => {
         const user = userEvent.setup();

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -1606,7 +1606,8 @@ describe('Date Picker', () => {
       expect(yearInput).toHaveValue('2026');
     });
 
-    it('should render error message when user enters an invalid year and on blur', () => {
+    it('should render error message when user enters an invalid year and on blur', async () => {
+      const user = userEvent.setup();
       const { getByTestId, getByText, queryByText } = render(
         <DatePicker isDateFieldInput />
       );
@@ -1615,9 +1616,9 @@ describe('Date Picker', () => {
       const dayInput = getByTestId('day-input');
       const yearInput = getByTestId('year-input');
 
-      userEvent.type(monthInput, '1');
-      userEvent.type(dayInput, '15');
-      userEvent.type(yearInput, '1800');
+      await user.type(monthInput, '1');
+      await user.type(dayInput, '15');
+      await user.type(yearInput, '1800');
 
       expect(monthInput).toHaveDisplayValue('01');
       expect(dayInput).toHaveDisplayValue('15');
@@ -1626,14 +1627,15 @@ describe('Date Picker', () => {
         queryByText('Invalid date. Please enter a year between 1900 and 2099.')
       ).not.toBeInTheDocument();
 
-      userEvent.tab();
+      await user.tab();
 
       expect(
         getByText('Invalid date. Please enter a year between 1900 and 2099.')
       ).toBeInTheDocument();
     });
 
-    it('should render invalid year error message after showing custom error message', () => {
+    it('should render invalid year error message after showing custom error message', async () => {
+      const user = userEvent.setup();
       const customErrorMessage = 'Please, enter a date';
       const { getByTestId, getByText, queryByText } = render(
         <DatePicker isDateFieldInput errorMessage={customErrorMessage} />
@@ -1645,9 +1647,9 @@ describe('Date Picker', () => {
 
       expect(getByText(customErrorMessage)).toBeInTheDocument();
 
-      userEvent.type(monthInput, '10');
-      userEvent.type(dayInput, '22');
-      userEvent.type(yearInput, '1861');
+      await user.type(monthInput, '10');
+      await user.type(dayInput, '22');
+      await user.type(yearInput, '1861');
 
       expect(monthInput).toHaveDisplayValue('10');
       expect(dayInput).toHaveDisplayValue('22');
@@ -1657,7 +1659,7 @@ describe('Date Picker', () => {
         queryByText('Invalid date. Please enter a year between 1900 and 2099.')
       ).not.toBeInTheDocument();
 
-      userEvent.tab();
+      await user.tab();
 
       expect(
         getByText('Invalid date. Please enter a year between 1900 and 2099.')

--- a/packages/react-magma-dom/src/components/DatePicker/utils.ts
+++ b/packages/react-magma-dom/src/components/DatePicker/utils.ts
@@ -184,3 +184,7 @@ export function setYearForDate(prevDate, numberYear: number) {
 export const MAX_YEAR = 2099;
 
 export const MIN_YEAR = 1900;
+
+export const isYearOutOfRange = (year: number) => {
+  return year < MIN_YEAR || year > MAX_YEAR;
+};

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -130,6 +130,8 @@ export const defaultI18n: I18nInterface = {
     day: 'Day',
     month: 'Month',
     year: 'Year',
+    invalidYearError:
+      'Invalid date. Please enter a year between {minYear} and {maxYear}.',
     helpModal: {
       header: 'Keyboard Shortcuts',
       helpButtonAriaLabel: 'Keyboard instructions for calendar widget',

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -134,6 +134,7 @@ export interface I18nInterface {
     day: string;
     month: string;
     year: string;
+    invalidYearError: string;
 
     helpModal: {
       header: string;


### PR DESCRIPTION
Closes: #2407
Cherry-pick: https://github.com/cengage/react-magma/pull/2425

## What I did
- Added an error message to inform users about an invalid date

## Screenshots

<img width="1906" height="406" alt="Screenshot from 2026-04-07 12-33-16" src="https://github.com/user-attachments/assets/a6714335-9eda-4811-b351-b82e64442d42" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Date Picker -> Date Field Input -> type 11/11/1800 -> press tab -> the error invalid year message should be visible -> type a year between 1900 and 2099 -> the error message should be gone.

Go to Storybook -> Default -> `isDateDieldInpit=true` -> error message = "Custom error message" -> type 11/11/1800 -> press tab ->  the error invalid year message should be visible -> type a year between 1900 and 2099 ->the error invalid year message should be gone + "Custom error message" should be visible.

