### PR TITLE
fix(Modal): Fix bug when `Modal` doesnt close after pressing `Esc`

### DIFF
--- a/.changeset/fix-Modal-esc-handler.md
+++ b/.changeset/fix-Modal-esc-handler.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Modal): Fix bug when `Modal` doesn't close after pressing `Esc`

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { Meta } from '@storybook/react';
-
 import {
   Modal,
   ModalProps,
@@ -763,7 +761,7 @@ export const EscWithForeignAriaModal = () => {
         <br />
         2. Press <code>Esc</code>
         <br />
-        3. Clarify that modal closes and no errors are thrown in the console
+        3. Verify that the modal closes
       </Paragraph>
 
       <Paragraph>

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Meta } from '@storybook/react-webpack5';
+import { Meta } from '@storybook/react';
 
 import {
   Modal,
@@ -724,6 +724,63 @@ export const Inverse = () => {
           <VisuallyHidden>(opens modal dialog)</VisuallyHidden>
         </Button>
       </Container>
+    </>
+  );
+};
+
+export const EscWithForeignAriaModal = () => {
+  const [showModal, setShowModal] = React.useState(true);
+  const [foreignModalMounted, setForeignModalMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    const foreignModal = document.createElement('div');
+
+    foreignModal.setAttribute('aria-modal', 'true');
+    foreignModal.setAttribute('role', 'dialog');
+    foreignModal.setAttribute('id', 'fake-optanon-modal');
+    foreignModal.style.display = 'none';
+    foreignModal.textContent = 'Hidden foreign modal';
+
+    document.body.appendChild(foreignModal);
+    setForeignModalMounted(true);
+
+    return () => {
+      foreignModal.remove();
+    };
+  }, []);
+
+  return (
+    <>
+      <Paragraph>
+        This story mounts the modal open from the first render and injects a
+        second hidden <code>aria-modal="true"</code> element into the DOM.
+      </Paragraph>
+
+      <Paragraph>
+        Expected repro steps:
+        <br />
+        1. Open this story
+        <br />
+        2. Click inside the modal once if needed
+        <br />
+        3. Press <code>Esc</code>
+      </Paragraph>
+
+      <Paragraph>
+        Foreign modal mounted: {foreignModalMounted ? 'yes' : 'no'}
+      </Paragraph>
+
+      <Modal
+        header="Repro modal"
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+      >
+        <Paragraph noTopMargin>
+          Press Esc. If the bug is in our modal, this should hit the broken path
+          when another aria-modal exists in the DOM.
+        </Paragraph>
+        <Button onClick={() => setShowModal(false)}>Close</Button>
+      </Modal>
     </>
   );
 };

--- a/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.stories.tsx
@@ -761,9 +761,9 @@ export const EscWithForeignAriaModal = () => {
         <br />
         1. Open this story
         <br />
-        2. Click inside the modal once if needed
+        2. Press <code>Esc</code>
         <br />
-        3. Press <code>Esc</code>
+        3. Clarify that modal closes and no errors are thrown in the console
       </Paragraph>
 
       <Paragraph>

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -363,6 +363,28 @@ describe('Modal', () => {
       expect(onCloseSpy).toHaveBeenCalled();
     });
 
+    it('should close on Escape when modal starts open and a foreign aria-modal exists in the DOM', async () => {
+      const onCloseSpy = jest.fn();
+
+      const foreignModal = document.createElement('div');
+      foreignModal.setAttribute('aria-modal', 'true');
+      foreignModal.setAttribute('role', 'dialog');
+      foreignModal.style.display = 'none';
+      document.body.appendChild(foreignModal);
+
+      render(
+        <Modal header="Hello" isOpen onClose={onCloseSpy}>
+          Modal Content
+        </Modal>
+      );
+
+      await userEvent.keyboard('{Escape}');
+
+      expect(onCloseSpy).toHaveBeenCalled();
+
+      foreignModal.remove();
+    });
+
     it('should not force close when pressing the escape button if isModalClosingControlledManually is true', async () => {
       const onCloseSpy = jest.fn();
 

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -314,8 +314,11 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     }, [isModalOpen]);
 
     function handleModalClick(event: React.SyntheticEvent) {
+      const contentEl = document.getElementById(contentId);
+
       if (
-        !document.getElementById(contentId).contains(event.target as Node) &&
+        contentEl &&
+        !contentEl.contains(event.target as Node) &&
         event.target === currentTarget
       ) {
         handleClose(event);
@@ -341,12 +344,12 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         ).length;
 
         if (modalCount <= 1 && modalsInDom !== 1) {
-          if (
-            document.getElementById(id).contains(event.target as HTMLDivElement)
-          ) {
+          const modalEl = document.getElementById(id);
+
+          if (modalEl && modalEl.contains(event.target as HTMLDivElement)) {
             handleClose(event);
           } else {
-            headingRef.current.focus();
+            headingRef.current?.focus();
           }
         } else {
           handleClose(event);

--- a/packages/react-magma-dom/src/components/Modal/Modal.tsx
+++ b/packages/react-magma-dom/src/components/Modal/Modal.tsx
@@ -311,7 +311,7 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
           false
         );
       };
-    }, [isModalOpen]);
+    }, [isModalOpen, isEscKeyDownDisabled]);
 
     function handleModalClick(event: React.SyntheticEvent) {
       const contentEl = document.getElementById(contentId);

--- a/packages/react-magma-dom/src/utils/index.ts
+++ b/packages/react-magma-dom/src/utils/index.ts
@@ -10,7 +10,9 @@ export function useGenerateId(newId?: string) {
   const [id, updateId] = React.useState<string>(() => generateId(newId));
 
   React.useEffect(() => {
-    newId && updateId(generateId(newId));
+    if (newId) {
+      updateId(generateId(newId));
+    }
   }, [newId]);
 
   return id;

--- a/packages/react-magma-dom/src/utils/index.ts
+++ b/packages/react-magma-dom/src/utils/index.ts
@@ -7,11 +7,7 @@ export function generateId(id?: string) {
 }
 
 export function useGenerateId(newId?: string) {
-  const [id, updateId] = React.useState<string>(newId);
-
-  React.useEffect(() => {
-    updateId(generateId(newId));
-  }, []);
+  const [id, updateId] = React.useState<string>(() => generateId(newId));
 
   React.useEffect(() => {
     newId && updateId(generateId(newId));


### PR DESCRIPTION
Closes: #2404

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix bug when `Modal` doesn't close after pressing `Esc`

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
1. Open Storybook -> Modal -> Esc With Foreign Aria Modal
2. Test that everything else works as before.
3. Tested on MT side.