### PR TITLE
fix(Combobox & Select): clear floating ref on close for controlled up…

### DIFF
--- a/.changeset/combobox-select-fix-floating-ref-stale.md
+++ b/.changeset/combobox-select-fix-floating-ref-stale.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Combobox & Select): Clear floating element ref when the dropdown closes so controlled `selectedItem` and `items` updates re-render correctly.

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
@@ -1293,3 +1293,58 @@ export const FullPageExample = {
 
   parameters: { controls: { exclude: ['labelPosition'] } },
 };
+
+export const ControlledSelectedItem = {
+  render: () => {
+    const items = [
+      { label: 'Red', value: 'red' },
+      { label: 'Blue', value: 'blue' },
+      { label: 'Green', value: 'green' },
+    ];
+    const [selectedItem, setSelectedItem] = React.useState<
+      { label: string; value: string } | undefined
+    >(undefined);
+
+    return (
+      <Combobox
+        id="controlledSelectedItemId"
+        labelText="Controlled selectedItem"
+        items={items}
+        selectedItem={selectedItem}
+        onSelectedItemChange={changes => setSelectedItem(changes.selectedItem)}
+      />
+    );
+  },
+};
+
+export const ControlledItems = {
+  render: () => {
+    const defaultItems = [
+      { label: 'Red', value: 'red' },
+      { label: 'Blue', value: 'blue' },
+      { label: 'Green', value: 'green' },
+    ];
+    const [items, updateItems] = React.useState(defaultItems);
+
+    function newItemTransform(item: { value: string }) {
+      return {
+        label: item.value,
+        value: item.value.toLowerCase(),
+      };
+    }
+
+    function onItemCreated(item: { label: string; value: string }) {
+      updateItems(prev => [...prev, item]);
+    }
+
+    return (
+      <Combobox
+        id="controlledItemsId"
+        labelText="Controlled items"
+        items={items}
+        newItemTransform={newItemTransform}
+        onItemCreated={onItemCreated}
+      />
+    );
+  },
+};

--- a/packages/react-magma-dom/src/components/Select/ItemsList.tsx
+++ b/packages/react-magma-dom/src/components/Select/ItemsList.tsx
@@ -81,6 +81,15 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
 
+  const setFloatingRef = React.useCallback(
+    (node: Element | null) => {
+      if (setFloating) {
+        setFloating(isOpen ? node : null);
+      }
+    },
+    [isOpen, setFloating]
+  );
+
   // Scroll highlighted item into view for accessibility
   React.useEffect(() => {
     if (isOpen && highlightedIndex !== undefined && highlightedIndex >= 0) {
@@ -140,10 +149,7 @@ export function ItemsList<T>(props: ItemsListProps<T>) {
   }
 
   return (
-    <div
-      ref={el => isOpen && setFloating && setFloating(el)}
-      style={{ ...floatingElementStyles, zIndex: '2' }}
-    >
+    <div ref={setFloatingRef} style={{ ...floatingElementStyles, zIndex: '2' }}>
       <StyledCard
         hasDropShadow
         isInverse={isInverse}


### PR DESCRIPTION
Closes: #2254

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
  Bug fix (non-breaking).

  Fixed a stale floating-element ref in ItemsList (shared by Select and Combobox). The previous ref callback only called setFloating when isOpen was truthy, so when the dropdown closed the floating reference was never cleared. This caused controlled consumers (e.g. controlled selectedItem / items on
  Combobox) to hold onto a detached node and miss re-renders.

  - ItemsList.tsx: replaced the inline ref={el => isOpen && setFloating && setFloating(el)} with a stable useCallback that passes node when open and null when closed, so the floating ref is always in sync with isOpen.
  - Combobox.stories.tsx: added ControlledSelectedItem and ControlledItems stories to cover the controlled cases that surfaced the bug.
## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
  1. Open Combobox → Controlled Selected Item:
    - Select an option, close the menu, then reopen and pick another — the controlled selectedItem should update on every selection.                                                                                                                                                                            
  2. Open Combobox → Controlled Items:                                                                                                                                                                                                                                                                          
    - Type a new value and press Enter to create an item; close and reopen — the new item should appear in the list.                                                                                                                                                                                            
  3. Repeat with Select (single and multi) to confirm no regressions when opening/closing the dropdown repeatedly.   