### PR TITLE
fix(Badge): Add outline offset on clickable components. (#2435)

### DIFF
--- a/.changeset/fix-Badge-focus-outline.md
+++ b/.changeset/fix-Badge-focus-outline.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Badge): Add focus outline offset.

--- a/packages/react-magma-dom/src/components/Badge/Badge.test.js
+++ b/packages/react-magma-dom/src/components/Badge/Badge.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
-import { darken, lighten } from 'polished';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
@@ -42,6 +41,42 @@ describe('Badge', () => {
     expect(getByText(TEXT)).toHaveStyleRule(
       'line-height',
       magma.typeScale.size02.lineHeight
+    );
+  });
+
+  it('should have styles when badge is clickable', () => {
+    const { getByText } = render(
+      <Badge color="primary" onClick={() => {}}>
+        {TEXT}
+      </Badge>
+    );
+
+    expect(getByText(TEXT)).toHaveStyleRule('cursor', 'pointer');
+
+    expect(getByText(TEXT)).toHaveStyleRule(
+      'outline',
+      `2px solid ${magma.colors.focus}`,
+      { target: ':focus' }
+    );
+
+    expect(getByText(TEXT)).toHaveStyleRule(
+      'outline-offset',
+      `${magma.spaceScale.spacing01}`,
+      { target: ':focus' }
+    );
+  });
+
+  it('should have styles when badge is clickable and isInverse', () => {
+    const { getByText } = render(
+      <Badge color="primary" onClick={() => {}} isInverse>
+        {TEXT}
+      </Badge>
+    );
+
+    expect(getByText(TEXT)).toHaveStyleRule(
+      'outline',
+      `2px solid ${magma.colors.focusInverse}`,
+      { target: ':focus' }
     );
   });
 

--- a/packages/react-magma-dom/src/components/Badge/index.tsx
+++ b/packages/react-magma-dom/src/components/Badge/index.tsx
@@ -162,6 +162,7 @@ const StyledButton = styled.button<BadgeProps>`
         props.isInverse
           ? props.theme.colors.focusInverse
           : props.theme.colors.focus};
+    outline-offset: ${props => props.theme.spaceScale.spacing01};
   }
 `;
 

--- a/website/react-magma-docs/src/pages/api/alert.mdx
+++ b/website/react-magma-docs/src/pages/api/alert.mdx
@@ -20,14 +20,14 @@ See the <Link to="/api/toast/">Toasts documentation</Link> for more information.
 ```tsx
 import React from 'react';
 
-import { Alert } from 'react-magma-dom';
+import { Alert, Hyperlink } from 'react-magma-dom';
 
 export function Example() {
   return (
     <>
       <Alert isDismissible>I'm an Alert</Alert>
       <Alert>
-        I'm an Alert with <a href="#">linked text</a>
+        I'm an Alert with <Hyperlink to="#">linked text</Hyperlink>
       </Alert>
     </>
   );
@@ -42,7 +42,7 @@ This prop determines the icon and color scheme used to style the Alert.
 ```tsx
 import React from 'react';
 
-import { Alert, AlertVariant } from 'react-magma-dom';
+import { Alert, AlertVariant, Hyperlink } from 'react-magma-dom';
 
 export function Example() {
   return (
@@ -51,7 +51,7 @@ export function Example() {
       <Alert variant={AlertVariant.info}>Info Alert</Alert>
       <Alert variant={AlertVariant.success}>Success Alert</Alert>
       <Alert variant={AlertVariant.warning}>
-        Warning Alert with <a href="#">linked text</a>
+        Warning Alert with <Hyperlink to="#">linked text</Hyperlink>
       </Alert>
       <Alert variant={AlertVariant.danger}>
         Danger Alert
@@ -155,7 +155,7 @@ export function Example() {
 ```tsx
 import React from 'react';
 
-import { Alert, AlertVariant, Container } from 'react-magma-dom';
+import { Alert, AlertVariant, Container, Hyperlink } from 'react-magma-dom';
 
 export function Example() {
   return (
@@ -167,7 +167,10 @@ export function Example() {
         Inverse Success Alert
       </Alert>
       <Alert variant={AlertVariant.warning} isInverse>
-        Inverse Warning Alert with <a href="#">linked text</a>
+        Inverse Warning Alert with{' '}
+        <Hyperlink to="#" isInverse>
+          linked text
+        </Hyperlink>
       </Alert>
       <Alert variant={AlertVariant.danger} isInverse>
         Inverse Danger Alert


### PR DESCRIPTION
Closes: #2089
Cherry-pick: https://github.com/cengage/react-magma/pull/2435

## What I did
- Updated doc example for `Alert` component
- Added outline for clickable `Badge`.

## Screenshots


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Docs -> Components -> Alert -> All examples with links don't have any color ratio violation
Go to Docs -> Components -> Badge-> Event Handling -> Press on `Click me` -> outline with 2px should be presented
