### PR TITLE
chore(deps): move runtime-only dependencies out of peerDependencies

### DIFF
--- a/.changeset/fix-package-runtime-deps.md
+++ b/.changeset/fix-package-runtime-deps.md
@@ -1,0 +1,7 @@
+---
+'react-magma-dom': patch
+'@react-magma/schema-renderer': patch
+'@cengage-patterns/header': patch
+---
+
+chore(deps): move runtime-only dependencies out of peerDependencies and into package dependencies where needed

--- a/package-lock.json
+++ b/package-lock.json
@@ -60305,7 +60305,7 @@
     },
     "packages/charts": {
       "name": "@react-magma/charts",
-      "version": "13.0.2",
+      "version": "14.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "@carbon/charts-react": "^1.14.8",
@@ -60324,7 +60324,7 @@
         "identity-obj-proxy": "^3.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.12.0",
+        "react-magma-dom": "^4.13.0-next.2",
         "react-magma-icons": "^3.2.5",
         "rollup": "^4.52.4",
         "rollup-plugin-postcss": "^4.0.2"
@@ -60338,7 +60338,7 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.12.0-next.3",
+        "react-magma-dom": "^4.13.0-next.2",
         "react-magma-icons": "^3.2.5"
       }
     },
@@ -60498,7 +60498,7 @@
     },
     "packages/dropzone": {
       "name": "@react-magma/dropzone",
-      "version": "12.0.2",
+      "version": "12.0.4-next.1",
       "license": "MIT",
       "dependencies": {
         "polished": "^3.7.2",
@@ -60509,7 +60509,7 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.12.0",
+        "react-magma-dom": "^4.13.0-next.2",
         "react-magma-icons": "^3.2.5"
       },
       "engines": {
@@ -60521,7 +60521,7 @@
         "@emotion/styled": "^11.13.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.12.0-next.3",
+        "react-magma-dom": "^4.13.0-next.2",
         "react-magma-icons": "^3.2.5"
       }
     },
@@ -60538,7 +60538,7 @@
       }
     },
     "packages/react-magma-dom": {
-      "version": "4.12.0",
+      "version": "4.13.0-next.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.13.0",
@@ -60546,29 +60546,25 @@
         "@floating-ui/react": "^0.26.28",
         "@floating-ui/react-dom": "^2.1.2",
         "csstype": "^3.0.8",
-        "polished": "^3.7.2",
-        "react-virtual": "^2.10.4"
-      },
-      "devDependencies": {
         "date-fns": "^2.16.1",
         "downshift": "^5.4.5",
         "framer-motion": "^4.1.11",
+        "polished": "^3.7.2",
+        "react-virtual": "^2.10.4",
+        "uuid": "^11.1.0"
+      },
+      "devDependencies": {
         "mkdirp": "^1.0.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-icons": "^3.2.5",
-        "uuid": "^11.1.0"
+        "react-magma-icons": "^3.2.5"
       },
       "peerDependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
-        "date-fns": "^2.12.0",
-        "downshift": "^5.4.5",
-        "framer-motion": "^4.1.11",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-icons": "^3.2.5",
-        "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+        "react-magma-icons": "^3.2.5"
       }
     },
     "packages/react-magma-dom/node_modules/polished": {
@@ -60585,21 +60581,23 @@
     },
     "packages/schema-renderer": {
       "name": "@react-magma/schema-renderer",
-      "version": "14.0.0",
+      "version": "15.0.0-next.1",
       "license": "MIT",
+      "dependencies": {
+        "date-fns": "^2.16.1",
+        "downshift": "^5.4.5",
+        "uuid": "^11.1.0"
+      },
       "devDependencies": {
         "@data-driven-forms/react-form-renderer": "^3.6.0",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
-        "date-fns": "^2.16.1",
-        "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-dropzone": "11.3.2",
-        "react-magma-dom": "^4.12.0",
+        "react-magma-dom": "^4.13.0-next.2",
         "react-magma-icons": "^3.2.5",
-        "tsdx": "^0.14.1",
-        "uuid": "^11.1.0"
+        "tsdx": "^0.14.1"
       },
       "engines": {
         "node": ">=22.14.0",
@@ -60609,29 +60607,23 @@
         "@data-driven-forms/react-form-renderer": "^3.6.0",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
-        "date-fns": "^2.12.0",
-        "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.12.0-next.3",
-        "react-magma-icons": "^3.2.5",
-        "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+        "react-magma-dom": "^4.13.0-next.2",
+        "react-magma-icons": "^3.2.5"
       }
     },
     "patterns/header": {
       "name": "@cengage-patterns/header",
-      "version": "15.0.0",
+      "version": "16.0.0-next.1",
       "license": "MIT",
       "devDependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
-        "date-fns": "^2.16.1",
-        "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.12.0",
-        "react-magma-icons": "^3.2.5",
-        "uuid": "^11.1.0"
+        "react-magma-dom": "^4.13.0-next.2",
+        "react-magma-icons": "^3.2.5"
       },
       "engines": {
         "node": ">=22.14.0",
@@ -60640,19 +60632,10 @@
       "peerDependencies": {
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
-        "@types/uuid": "^8.3.0",
-        "date-fns": "^2.12.0",
-        "downshift": "^5.4.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-magma-dom": "^4.12.0-next.3",
-        "react-magma-icons": "^3.2.5",
-        "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/uuid": {
-          "optional": true
-        }
+        "react-magma-dom": "^4.13.0-next.2",
+        "react-magma-icons": "^3.2.5"
       }
     },
     "tests/playwright": {
@@ -60663,19 +60646,19 @@
       }
     },
     "website/react-magma-docs": {
-      "version": "5.3.2-next.0",
+      "version": "5.3.3-next.3",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "7.10.4",
-        "@cengage-patterns/header": "15.0.0",
+        "@cengage-patterns/header": "16.0.0-next.1",
         "@data-driven-forms/react-form-renderer": "^3.6.0",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/mdx": "^1.5.5",
         "@mdx-js/react": "^1.5.5",
-        "@react-magma/charts": "13.0.2",
-        "@react-magma/dropzone": "12.0.2",
-        "@react-magma/schema-renderer": "^14.0.0",
+        "@react-magma/charts": "14.0.0-next.1",
+        "@react-magma/dropzone": "12.0.4-next.1",
+        "@react-magma/schema-renderer": "^15.0.0-next.1",
         "buble": "0.19.4",
         "buffer": "^6.0.3",
         "core-js": "^3.1.4",
@@ -60705,7 +60688,7 @@
         "react-focus-lock": "^2.9.2",
         "react-helmet": "5.2.0",
         "react-live": "^2.2.1",
-        "react-magma-dom": "^4.12.0",
+        "react-magma-dom": "^4.13.0-next.2",
         "react-magma-icons": "^3.2.5",
         "react-spring": "6.1.9",
         "semver": "^7.3.4",

--- a/packages/react-magma-dom/package.json
+++ b/packages/react-magma-dom/package.json
@@ -38,27 +38,23 @@
     "@floating-ui/react-dom": "^2.1.2",
     "react-virtual": "^2.10.4",
     "csstype": "^3.0.8",
-    "polished": "^3.7.2"
-  },
-  "devDependencies": {
     "date-fns": "^2.16.1",
     "downshift": "^5.4.5",
     "framer-motion": "^4.1.11",
+    "polished": "^3.7.2",
+    "uuid": "^11.1.0"
+  },
+  "devDependencies": {
     "mkdirp": "^1.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-magma-icons": "^3.2.5",
-    "uuid": "^11.1.0"
+    "react-magma-icons": "^3.2.5"
   },
   "peerDependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
-    "date-fns": "^2.12.0",
-    "downshift": "^5.4.5",
-    "framer-motion": "^4.1.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-magma-icons": "^3.2.5",
-    "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+    "react-magma-icons": "^3.2.5"
   }
 }

--- a/packages/schema-renderer/package.json
+++ b/packages/schema-renderer/package.json
@@ -19,32 +19,30 @@
     "lint": "eslint ./src",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "date-fns": "^2.16.1",
+    "downshift": "^5.4.5",
+    "uuid": "^11.1.0"
+  },
   "devDependencies": {
     "@data-driven-forms/react-form-renderer": "^3.6.0",
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
-    "date-fns": "^2.16.1",
-    "downshift": "^5.4.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-dropzone": "11.3.2",
     "react-magma-dom": "^4.13.0-next.2",
     "react-magma-icons": "^3.2.5",
-    "tsdx": "^0.14.1",
-    "uuid": "^11.1.0"
+    "tsdx": "^0.14.1"
   },
   "peerDependencies": {
     "@data-driven-forms/react-form-renderer": "^3.6.0",
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
-    "date-fns": "^2.12.0",
-    "downshift": "^5.4.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.13.0-next.2",
-    "react-magma-icons": "^3.2.5",
-    "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+    "react-magma-icons": "^3.2.5"
   },
   "engines": {
     "node": ">=22.14.0",

--- a/patterns/header/package.json
+++ b/patterns/header/package.json
@@ -23,30 +23,18 @@
   "devDependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
-    "date-fns": "^2.16.1",
-    "downshift": "^5.4.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.13.0-next.2",
-    "react-magma-icons": "^3.2.5",
-    "uuid": "^11.1.0"
+    "react-magma-icons": "^3.2.5"
   },
   "peerDependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
-    "@types/uuid": "^8.3.0",
-    "date-fns": "^2.12.0",
-    "downshift": "^5.4.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-magma-dom": "^4.13.0-next.2",
-    "react-magma-icons": "^3.2.5",
-    "uuid": "^8.3.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@types/uuid": {
-      "optional": true
-    }
+    "react-magma-icons": "^3.2.5"
   },
   "engines": {
     "node": ">=22.14.0",


### PR DESCRIPTION
Closes: #2446

## What I did
Bug fix and package maintenance update.

This change fixes package manifest issues in published libraries by moving runtime dependencies out of `peerDependencies` or `devDependencies` and into `dependencies` where appropriate. That ensures consumers receive the packages required at runtime instead of needing to install them manually or encountering missing dependency issues.

Updated packages:
- `react-magma-dom`
- `@react-magma/schema-renderer`
- `@cengage-patterns/header`

This is a non-breaking packaging fix intended to improve install/runtime reliability for consumers.

## Screenshots
N/A - no UI changes

## Checklist 
- [x] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
1. Review the updated `package.json` files for the affected packages and confirm runtime dependencies were moved into `dependencies`.
2. Verify the removed entries are no longer listed under `peerDependencies` or `devDependencies` when they are required at runtime.
3. Confirm the changeset file exists and includes the affected packages.
4. If desired, run install/build flows that consume these packages to confirm there are no missing dependency errors.

Affected areas:
- Package publishing metadata
- Consumer install/runtime dependency resolution

Edge cases to consider:
- Consumers relying on peer dependency installation behavior
- Published package manifests containing all required runtime dependencies
