### PR TITLE
V4/fix(Datagrid, Table): Fix the issue where the focus is lost when the button becomes disabled (#2445)

### DIFF
--- a/.changeset/fix-Datagrid-Table-accessibility-issue.md
+++ b/.changeset/fix-Datagrid-Table-accessibility-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Datagrid, Table): Fix the issue where the focus is lost when the button becomes disabled

--- a/packages/react-magma-dom/src/components/Table/TablePagination.test.js
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { transparentize } from 'polished';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
 
 import { TablePagination } from '.';
+import userEvent from '@testing-library/user-event';
 
 describe('Table Pagination', () => {
   it('should find element by testId', () => {
@@ -90,11 +91,44 @@ describe('Table Pagination', () => {
     );
   });
 
+  it('should move focus to the previous button when clicking next and the next page is disabled', () => {
+    const { getByTestId } = render(
+      <TablePagination itemCount={20} isInverse rowsPerPage={10} />
+    );
+    const nextBtn = getByTestId('nextBtn');
+    const previousBtn = getByTestId('previousBtn');
+
+    userEvent.click(nextBtn);
+
+    waitFor(() => {
+      expect(previousBtn).toHaveFocus();
+    });
+  });
+
+  it('should move focus to the next button when clicking previous and the previous page is disabled', () => {
+    const { getByTestId } = render(
+      <TablePagination
+        itemCount={20}
+        isInverse
+        defaultPage={2}
+        rowsPerPage={10}
+      />
+    );
+    const nextBtn = getByTestId('nextBtn');
+    const previousBtn = getByTestId('previousBtn');
+
+    userEvent.click(previousBtn);
+
+    waitFor(() => {
+      expect(nextBtn).toHaveFocus();
+    });
+  });
+
   describe('uncontrolled', () => {
     it('should change page when clicking next', () => {
       const handlePageChange = jest.fn();
 
-      const { getByTestId, getByText } = render(
+      const { getByTestId } = render(
         <TablePagination
           itemCount={20}
           isInverse
@@ -111,7 +145,7 @@ describe('Table Pagination', () => {
     it('should change page when clicking previous', () => {
       const handlePageChange = jest.fn();
 
-      const { getByTestId, getByText } = render(
+      const { getByTestId } = render(
         <TablePagination
           itemCount={20}
           defaultPage={2}
@@ -130,7 +164,7 @@ describe('Table Pagination', () => {
       const handlePageChange = jest.fn();
       const handleRowsPerPageChange = jest.fn();
 
-      const { getByTestId, getByText } = render(
+      const { getByTestId } = render(
         <TablePagination
           itemCount={20}
           isInverse
@@ -160,7 +194,7 @@ describe('Table Pagination', () => {
         page = newPage;
       };
 
-      const { getByTestId, getByText, rerender } = render(
+      const { getByTestId, rerender } = render(
         <TablePagination
           itemCount={20}
           isInverse
@@ -191,7 +225,7 @@ describe('Table Pagination', () => {
         page = newPage;
       };
 
-      const { getByTestId, getByText, rerender } = render(
+      const { getByTestId, rerender } = render(
         <TablePagination
           itemCount={20}
           isInverse

--- a/packages/react-magma-dom/src/components/Table/TablePagination.tsx
+++ b/packages/react-magma-dom/src/components/Table/TablePagination.tsx
@@ -228,6 +228,8 @@ export const TablePagination = React.forwardRef<
 
   const theme = React.useContext(ThemeContext);
   const i18n = React.useContext(I18nContext);
+  const previousButtonRef = React.useRef<HTMLButtonElement>(null);
+  const nextButtonRef = React.useRef<HTMLButtonElement>(null);
 
   const hasRowPerPageChangeFunction =
     onRowsPerPageChange && typeof onRowsPerPageChange === 'function';
@@ -285,6 +287,26 @@ export const TablePagination = React.forwardRef<
   const previousButton = pageButtons[0];
   const nextButton = pageButtons[pageButtons.length - 1];
 
+  const previousButtonClick = event => {
+    previousButton.onClick(event);
+
+    setTimeout(() => {
+      if (previousButtonRef.current?.disabled) {
+        nextButtonRef.current?.focus();
+      }
+    }, 0);
+  };
+
+  const nextButtonClick = event => {
+    nextButton.onClick(event);
+
+    setTimeout(() => {
+      if (nextButtonRef.current?.disabled) {
+        previousButtonRef.current?.focus();
+      }
+    }, 0);
+  };
+
   return (
     <StyledContainer
       {...other}
@@ -315,22 +337,24 @@ export const TablePagination = React.forwardRef<
       </PageCount>
       <ButtonGroup alignment={ButtonGroupAlignment.center}>
         <IconButton
+          ref={previousButtonRef}
           aria-label={i18n.table.pagination.previousAriaLabel}
           color={ButtonColor.secondary}
           disabled={previousButton.disabled}
           icon={<WestIcon />}
           isInverse={isInverse}
-          onClick={previousButton.onClick}
+          onClick={previousButtonClick}
           testId="previousBtn"
           variant={ButtonVariant.link}
         />
         <IconButton
+          ref={nextButtonRef}
           aria-label={i18n.table.pagination.nextAriaLabel}
           color={ButtonColor.secondary}
           disabled={nextButton.disabled}
           icon={<EastIcon />}
           isInverse={isInverse}
-          onClick={nextButton.onClick}
+          onClick={nextButtonClick}
           testId="nextBtn"
           variant={ButtonVariant.link}
         />


### PR DESCRIPTION
Closes: #2402
Cherry-pick #2445

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Fix the issue where the focus is lost when the button becomes disabled

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook/Docs -> Datagrid/Table with pagination -> Click on the `Next` button -> when it becomes disabled, focus should move to the `Previous` button -> And vice versa