### PR TITLE
feat(TreeView): create `Guide Lines` for expanded items with `hasGuideLines` prop (`false` by default)

### DIFF
--- a/.changeset/feat-TreeView-Divider.md
+++ b/.changeset/feat-TreeView-Divider.md
@@ -1,5 +1,0 @@
----
-'react-magma-dom': minor
----
-
-feat(TreeView): create `Divider` for expanded items with `hasDivider` prop (`false` by default)

--- a/.changeset/feat-TreeView-Divider.md
+++ b/.changeset/feat-TreeView-Divider.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): create `Divider` for expanded items with `hasDivider` prop (`false` by default)

--- a/.changeset/feat-TreeView-GuideLines.md
+++ b/.changeset/feat-TreeView-GuideLines.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): create `Guide Lines` for expanded items with `hasGuideLines` prop (`false` by default)

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -80,12 +80,19 @@ const StyledTreeItem = styled.li<{
     outline: none;
 
     & > *:first-child {
-      outline-offset: -2px;
-      outline: 2px solid
-        ${props =>
-          props.isInverse
-            ? props.theme.colors.focusInverse
-            : props.theme.colors.focus};
+      &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        outline: 2px solid
+          ${props =>
+            props.isInverse
+              ? props.theme.colors.focusInverse
+              : props.theme.colors.focus};
+        outline-offset: -2px;
+        pointer-events: none;
+        z-index: 2;
+      }
     }
   }
 
@@ -202,6 +209,40 @@ const StyledExpandWrapper = styled.div<{
     size !== undefined ? `${size}px` : theme.spaceScale.spacing06};
 `;
 
+const Divider = styled.div<{
+  theme?: ThemeInterface;
+  isInverse?: boolean;
+  dividerLeft: string;
+}>`
+  position: absolute;
+  top: ${props => props.theme.spaceScale.spacing08};
+  bottom: 0;
+  inset-inline-start: ${props => props.dividerLeft};
+  width: 2px;
+  background-color: ${props =>
+    props.isInverse
+      ? transparentize(0.7, props.theme.colors.neutral100)
+      : props.theme.colors.neutral300};
+  pointer-events: none;
+  z-index: 1;
+`;
+
+const VirtualizedConnector = styled.div<{
+  theme?: ThemeInterface;
+  isInverse?: boolean;
+}>`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background-color: ${props =>
+    props.isInverse
+      ? transparentize(0.7, props.theme.colors.neutral100)
+      : props.theme.colors.neutral300};
+  pointer-events: none;
+  z-index: 1;
+`;
+
 const StyledCheckboxWrapper = styled.div<{
   theme?: ThemeInterface;
   hasAdditionalContent?: boolean;
@@ -270,11 +311,14 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
     const { handleExpandedChange } = React.useContext(TreeViewExpansionContext);
     const {
       expandIconStyles,
+      hasDivider,
       hasIcons,
       isTopLevelSelectable,
       selectable,
       selectParents = true,
     } = React.useContext(TreeViewConfigContext);
+
+    console.log(hasDivider);
 
     // Pass the resolved values to useTreeItem
     const propsWithHierarchy = {
@@ -711,6 +755,40 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
                 </>
               )}
             </StyledItemWrapper>
+
+            {hasDivider &&
+              (hierarchyContext.isVirtualized
+                ? itemDepth > 0 &&
+                  Array.from({ length: itemDepth }, (_, d) => (
+                    <VirtualizedConnector
+                      key={`connector-${d}`}
+                      theme={theme}
+                      isInverse={isInverse}
+                      style={{
+                        insetInlineStart: `calc(${calculateOffset(
+                          TreeNodeType.branch,
+                          d,
+                          false,
+                          false,
+                          true
+                        )} + ${expandIconStyles?.size !== undefined ? `${expandIconStyles.size}px` : theme.spaceScale.spacing06} / 2 - 1px)`,
+                      }}
+                    />
+                  ))
+                : hasOwnTreeItems &&
+                  expanded && (
+                    <Divider
+                      theme={theme}
+                      isInverse={isInverse}
+                      dividerLeft={`calc(${calculateOffset(
+                        TreeNodeType.branch,
+                        itemDepth,
+                        false,
+                        false,
+                        false
+                      )} + ${expandIconStyles?.size !== undefined ? `${expandIconStyles.size}px` : theme.spaceScale.spacing06} / 2 - 1px) `}
+                    />
+                  ))}
 
             {React.Children.map(
               children,

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -760,6 +760,7 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
                   Array.from({ length: itemDepth }, (_, d) => (
                     <VirtualizedConnector
                       key={`connector-${d}`}
+                      data-testid={`${testId || itemId}-virtualized-connector-${d}`}
                       theme={theme}
                       isInverse={isInverse}
                       style={{
@@ -776,6 +777,7 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
                 : hasOwnTreeItems &&
                   expanded && (
                     <Divider
+                      data-testid={`${testId || itemId}-divider`}
                       theme={theme}
                       isInverse={isInverse}
                       dividerLeft={`calc(${calculateOffset(

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -209,36 +209,38 @@ const StyledExpandWrapper = styled.div<{
     size !== undefined ? `${size}px` : theme.spaceScale.spacing06};
 `;
 
-const Divider = styled.div<{
+const GuideLine = styled.div<{
   theme?: ThemeInterface;
   isInverse?: boolean;
-  dividerLeft: string;
+  guideLineLeft: string;
 }>`
   position: absolute;
   top: ${props => props.theme.spaceScale.spacing08};
   bottom: 0;
-  inset-inline-start: ${props => props.dividerLeft};
-  width: 2px;
-  background-color: ${props =>
-    props.isInverse
-      ? transparentize(0.7, props.theme.colors.neutral100)
-      : props.theme.colors.neutral300};
+  inset-inline-start: ${props => props.guideLineLeft};
+  width: 0;
+  border-inline-start: 1px solid
+    ${props =>
+      props.isInverse
+        ? transparentize(0.7, props.theme.colors.neutral100)
+        : props.theme.colors.neutral300};
   pointer-events: none;
   z-index: 1;
 `;
 
-const VirtualizedConnector = styled.div<{
+const VirtualizedGuideLine = styled.div<{
   theme?: ThemeInterface;
   isInverse?: boolean;
 }>`
   position: absolute;
   top: 0;
   bottom: 0;
-  width: 2px;
-  background-color: ${props =>
-    props.isInverse
-      ? transparentize(0.7, props.theme.colors.neutral100)
-      : props.theme.colors.neutral300};
+  width: 0;
+  border-inline-start: 1px solid
+    ${props =>
+      props.isInverse
+        ? transparentize(0.7, props.theme.colors.neutral100)
+        : props.theme.colors.neutral300};
   pointer-events: none;
   z-index: 1;
 `;
@@ -311,7 +313,7 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
     const { handleExpandedChange } = React.useContext(TreeViewExpansionContext);
     const {
       expandIconStyles,
-      hasDivider,
+      hasGuideLines,
       hasIcons,
       isTopLevelSelectable,
       selectable,
@@ -754,13 +756,13 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
               )}
             </StyledItemWrapper>
 
-            {hasDivider &&
+            {hasGuideLines &&
               (hierarchyContext.isVirtualized
                 ? itemDepth > 0 &&
                   Array.from({ length: itemDepth }, (_, d) => (
-                    <VirtualizedConnector
-                      key={`connector-${d}`}
-                      data-testid={`${testId || itemId}-virtualized-connector-${d}`}
+                    <VirtualizedGuideLine
+                      key={`guideline-${d}`}
+                      data-testid={`${testId || itemId}-virtualized-guideline-${d}`}
                       theme={theme}
                       isInverse={isInverse}
                       style={{
@@ -770,23 +772,23 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
                           false,
                           false,
                           true
-                        )} + ${expandIconStyles?.size !== undefined ? `${expandIconStyles.size}px` : theme.spaceScale.spacing06} / 2 - 1px)`,
+                        )} + ${expandIconStyles?.size !== undefined ? `${expandIconStyles.size}px` : theme.spaceScale.spacing06} / 2 - 0.5px)`,
                       }}
                     />
                   ))
                 : hasOwnTreeItems &&
                   expanded && (
-                    <Divider
-                      data-testid={`${testId || itemId}-divider`}
+                    <GuideLine
+                      data-testid={`${testId || itemId}-guideline`}
                       theme={theme}
                       isInverse={isInverse}
-                      dividerLeft={`calc(${calculateOffset(
+                      guideLineLeft={`calc(${calculateOffset(
                         TreeNodeType.branch,
                         itemDepth,
                         false,
                         false,
                         false
-                      )} + ${expandIconStyles?.size !== undefined ? `${expandIconStyles.size}px` : theme.spaceScale.spacing06} / 2 - 1px) `}
+                      )} + ${expandIconStyles?.size !== undefined ? `${expandIconStyles.size}px` : theme.spaceScale.spacing06} / 2 - 0.5px) `}
                     />
                   ))}
 

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -318,8 +318,6 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
       selectParents = true,
     } = React.useContext(TreeViewConfigContext);
 
-    console.log(hasDivider);
-
     // Pass the resolved values to useTreeItem
     const propsWithHierarchy = {
       ...props,

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -111,7 +111,7 @@ export default {
       control: 'number',
       defaultValue: 800,
     },
-    hasDivider: {
+    hasGuideLines: {
       control: 'boolean',
       defaultValue: false,
     },

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -111,6 +111,10 @@ export default {
       control: 'number',
       defaultValue: 800,
     },
+    hasDivider: {
+      control: 'boolean',
+      defaultValue: false,
+    },
   },
   args: {
     isInverse: false,
@@ -3251,7 +3255,7 @@ export const ComplexWithAdditionalContent = {
   },
 };
 
-export function TreeViewWithDifferentElements() {
+export function TreeViewWithDifferentElements(args) {
   const parrotsInDropdown = () => {
     return (
       <div style={{ width: '100%', marginTop: '12px' }}>
@@ -3325,6 +3329,7 @@ export function TreeViewWithDifferentElements() {
 
   return (
     <TreeView
+      {...args}
       selectable={TreeViewSelectable.off}
       initialExpandedItems={[
         'parrots-AdditionalContent',

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.stories.tsx
@@ -3255,7 +3255,7 @@ export const ComplexWithAdditionalContent = {
   },
 };
 
-export function TreeViewWithDifferentElements(args) {
+export function TreeViewWithDifferentElements(args: Partial<TreeViewProps>) {
   const parrotsInDropdown = () => {
     return (
       <div style={{ width: '100%', marginTop: '12px' }}>

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -5496,4 +5496,106 @@ describe('TreeView', () => {
       });
     });
   });
+
+  describe('hasDivider', () => {
+    it('should not render divider by default', () => {
+      const { container } = render(
+        <TreeView testId={testId} initialExpandedItems={['item1']}>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(
+        container.querySelector('[class*="Divider"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render divider when hasDivider is true and item is expanded', () => {
+      const { container } = render(
+        <TreeView testId={testId} hasDivider initialExpandedItems={['item1']}>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const dividers = container.querySelectorAll('[class*="Divider"]');
+
+      expect(dividers.length).toBeGreaterThan(0);
+    });
+
+    it('should not render divider when hasDivider is true but item is collapsed', () => {
+      const { container } = render(
+        <TreeView testId={testId} hasDivider>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(
+        container.querySelector('[class*="Divider"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should show divider after expanding and hide after collapsing', async () => {
+      const { container, getByTestId } = render(
+        <TreeView testId={testId} hasDivider>
+          <TreeItem label="Node 1" itemId="item1" testId="item1">
+            <TreeItem
+              label="Child 1"
+              itemId="item-child1"
+              testId="item-child1"
+            />
+          </TreeItem>
+        </TreeView>
+      );
+
+      expect(
+        container.querySelector('[class*="Divider"]')
+      ).not.toBeInTheDocument();
+
+      // Expand
+      await act(async () => {
+        await userEvent.click(getByTestId('item1-expand'));
+      });
+
+      expect(container.querySelector('[class*="Divider"]')).toBeInTheDocument();
+
+      // Collapse
+      await act(async () => {
+        await userEvent.click(getByTestId('item1-expand'));
+      });
+
+      expect(
+        container.querySelector('[class*="Divider"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not render divider on leaf nodes', () => {
+      const { container } = render(
+        <TreeView testId={testId} hasDivider>
+          <TreeItem label="Leaf" itemId="leaf" testId="leaf" />
+        </TreeView>
+      );
+
+      expect(
+        container.querySelector('[class*="Divider"]')
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -5512,7 +5512,7 @@ describe('TreeView', () => {
       );
 
       expect(
-        container.querySelector('[class*="Divider"]')
+        container.querySelector('[data-testid$="-divider"]')
       ).not.toBeInTheDocument();
     });
 
@@ -5529,9 +5529,9 @@ describe('TreeView', () => {
         </TreeView>
       );
 
-      const dividers = container.querySelectorAll('[class*="Divider"]');
-
-      expect(dividers.length).toBeGreaterThan(0);
+      expect(
+        container.querySelector('[data-testid="item1-divider"]')
+      ).toBeInTheDocument();
     });
 
     it('should not render divider when hasDivider is true but item is collapsed', () => {
@@ -5548,7 +5548,7 @@ describe('TreeView', () => {
       );
 
       expect(
-        container.querySelector('[class*="Divider"]')
+        container.querySelector('[data-testid$="-divider"]')
       ).not.toBeInTheDocument();
     });
 
@@ -5566,7 +5566,7 @@ describe('TreeView', () => {
       );
 
       expect(
-        container.querySelector('[class*="Divider"]')
+        container.querySelector('[data-testid="item1-divider"]')
       ).not.toBeInTheDocument();
 
       // Expand
@@ -5574,7 +5574,9 @@ describe('TreeView', () => {
         await userEvent.click(getByTestId('item1-expand'));
       });
 
-      expect(container.querySelector('[class*="Divider"]')).toBeInTheDocument();
+      expect(
+        container.querySelector('[data-testid="item1-divider"]')
+      ).toBeInTheDocument();
 
       // Collapse
       await act(async () => {
@@ -5582,7 +5584,7 @@ describe('TreeView', () => {
       });
 
       expect(
-        container.querySelector('[class*="Divider"]')
+        container.querySelector('[data-testid="item1-divider"]')
       ).not.toBeInTheDocument();
     });
 
@@ -5594,7 +5596,7 @@ describe('TreeView', () => {
       );
 
       expect(
-        container.querySelector('[class*="Divider"]')
+        container.querySelector('[data-testid$="-divider"]')
       ).not.toBeInTheDocument();
     });
   });

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -5497,8 +5497,8 @@ describe('TreeView', () => {
     });
   });
 
-  describe('hasDivider', () => {
-    it('should not render divider by default', () => {
+  describe('hasGuideLines', () => {
+    it('should not render guide lines by default', () => {
       const { container } = render(
         <TreeView testId={testId} initialExpandedItems={['item1']}>
           <TreeItem label="Node 1" itemId="item1" testId="item1">
@@ -5512,13 +5512,17 @@ describe('TreeView', () => {
       );
 
       expect(
-        container.querySelector('[data-testid$="-divider"]')
+        container.querySelector('[data-testid$="-guideline"]')
       ).not.toBeInTheDocument();
     });
 
-    it('should render divider when hasDivider is true and item is expanded', () => {
+    it('should render guide line when hasGuideLines is true and item is expanded', () => {
       const { container } = render(
-        <TreeView testId={testId} hasDivider initialExpandedItems={['item1']}>
+        <TreeView
+          testId={testId}
+          hasGuideLines
+          initialExpandedItems={['item1']}
+        >
           <TreeItem label="Node 1" itemId="item1" testId="item1">
             <TreeItem
               label="Child 1"
@@ -5530,13 +5534,13 @@ describe('TreeView', () => {
       );
 
       expect(
-        container.querySelector('[data-testid="item1-divider"]')
+        container.querySelector('[data-testid="item1-guideline"]')
       ).toBeInTheDocument();
     });
 
-    it('should not render divider when hasDivider is true but item is collapsed', () => {
+    it('should not render guide line when hasGuideLines is true but item is collapsed', () => {
       const { container } = render(
-        <TreeView testId={testId} hasDivider>
+        <TreeView testId={testId} hasGuideLines>
           <TreeItem label="Node 1" itemId="item1" testId="item1">
             <TreeItem
               label="Child 1"
@@ -5548,13 +5552,13 @@ describe('TreeView', () => {
       );
 
       expect(
-        container.querySelector('[data-testid$="-divider"]')
+        container.querySelector('[data-testid$="-guideline"]')
       ).not.toBeInTheDocument();
     });
 
-    it('should show divider after expanding and hide after collapsing', async () => {
+    it('should show guide line after expanding and hide after collapsing', async () => {
       const { container, getByTestId } = render(
-        <TreeView testId={testId} hasDivider>
+        <TreeView testId={testId} hasGuideLines>
           <TreeItem label="Node 1" itemId="item1" testId="item1">
             <TreeItem
               label="Child 1"
@@ -5566,7 +5570,7 @@ describe('TreeView', () => {
       );
 
       expect(
-        container.querySelector('[data-testid="item1-divider"]')
+        container.querySelector('[data-testid="item1-guideline"]')
       ).not.toBeInTheDocument();
 
       // Expand
@@ -5575,7 +5579,7 @@ describe('TreeView', () => {
       });
 
       expect(
-        container.querySelector('[data-testid="item1-divider"]')
+        container.querySelector('[data-testid="item1-guideline"]')
       ).toBeInTheDocument();
 
       // Collapse
@@ -5584,13 +5588,13 @@ describe('TreeView', () => {
       });
 
       expect(
-        container.querySelector('[data-testid="item1-divider"]')
+        container.querySelector('[data-testid="item1-guideline"]')
       ).not.toBeInTheDocument();
     });
 
-    it('should not render divider on leaf nodes', () => {
+    it('should not render guide line on leaf nodes', () => {
       const { container } = render(
-        <TreeView testId={testId} hasDivider>
+        <TreeView testId={testId} hasGuideLines>
           <TreeItem label="Leaf" itemId="leaf" testId="leaf" />
         </TreeView>
       );

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewConfigContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewConfigContext.ts
@@ -16,7 +16,7 @@ export interface TreeViewConfigContextInterface {
   isTopLevelSelectable?: boolean;
   selectParents?: boolean;
   expandIconStyles?: ExpandIconInterface;
-  hasDivider?: boolean;
+  hasGuideLines?: boolean;
   registerTreeItem: (
     itemRefArray: React.MutableRefObject<React.MutableRefObject<Element>[]>,
     itemRef: React.MutableRefObject<Element>
@@ -32,7 +32,7 @@ export const TreeViewConfigContext =
     checkChildren: true,
     isTopLevelSelectable: true,
     selectParents: true,
-    hasDivider: false,
+    hasGuideLines: false,
     registerTreeItem: (elements, element) => {},
     expandIconStyles: {
       size: magma.iconSizes.medium,

--- a/packages/react-magma-dom/src/components/TreeView/TreeViewConfigContext.ts
+++ b/packages/react-magma-dom/src/components/TreeView/TreeViewConfigContext.ts
@@ -16,6 +16,7 @@ export interface TreeViewConfigContextInterface {
   isTopLevelSelectable?: boolean;
   selectParents?: boolean;
   expandIconStyles?: ExpandIconInterface;
+  hasDivider?: boolean;
   registerTreeItem: (
     itemRefArray: React.MutableRefObject<React.MutableRefObject<Element>[]>,
     itemRef: React.MutableRefObject<Element>
@@ -31,6 +32,7 @@ export const TreeViewConfigContext =
     checkChildren: true,
     isTopLevelSelectable: true,
     selectParents: true,
+    hasDivider: false,
     registerTreeItem: (elements, element) => {},
     expandIconStyles: {
       size: magma.iconSizes.medium,

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -275,9 +275,14 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -454,9 +459,14 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -581,9 +591,14 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   outline: none;
 }
 
-.emotion-96:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-96:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-96>div:first-of-type {
@@ -965,9 +980,14 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -1144,9 +1164,14 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -1271,9 +1296,14 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   outline: none;
 }
 
-.emotion-96:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-96:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-96>div:first-of-type {
@@ -2180,9 +2210,14 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -2359,9 +2394,14 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -2486,9 +2526,14 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -2526,9 +2571,14 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -2975,9 +3025,14 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -3154,9 +3209,14 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -3281,9 +3341,14 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -3321,9 +3386,14 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -4344,9 +4414,14 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -4523,9 +4598,14 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -4650,9 +4730,14 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -4690,9 +4775,14 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -5074,9 +5164,14 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -5253,9 +5348,14 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -5380,9 +5480,14 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -5420,9 +5525,14 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -6377,9 +6487,14 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -6556,9 +6671,14 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -6683,9 +6803,14 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -6723,9 +6848,14 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -7107,9 +7237,14 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -7286,9 +7421,14 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -7413,9 +7553,14 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -7453,9 +7598,14 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -8410,9 +8560,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -8589,9 +8744,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -8716,9 +8876,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -8756,9 +8921,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -9205,9 +9375,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -9384,9 +9559,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -9511,9 +9691,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -9551,9 +9736,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -10574,9 +10764,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -10753,9 +10948,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -10880,9 +11080,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -10920,9 +11125,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -11369,9 +11579,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -11548,9 +11763,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -11675,9 +11895,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -11715,9 +11940,14 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -12738,9 +12968,14 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -12917,9 +13152,14 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -13044,9 +13284,14 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -13084,9 +13329,14 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {
@@ -13468,9 +13718,14 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   outline: none;
 }
 
-.emotion-32:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-32:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-32>div:first-of-type {
@@ -13647,9 +13902,14 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   outline: none;
 }
 
-.emotion-48:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-48:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-48>div:first-of-type {
@@ -13774,9 +14034,14 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   outline: none;
 }
 
-.emotion-64:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-64:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-64>div:first-of-type {
@@ -13814,9 +14079,14 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   outline: none;
 }
 
-.emotion-82:focus>*:first-child {
-  outline-offset: -2px;
+.emotion-82:focus>*:first-child::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   outline: 2px solid #0074B7;
+  outline-offset: -2px;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .emotion-82>div:first-of-type {

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -131,9 +131,9 @@ export interface UseTreeViewProps {
    */
   testId?: string;
   /**
-   * If true, TreeView will render a divider for expanded items with children.
+   * If true, TreeView will render guide lines for expanded items with children.
    */
-  hasDivider?: boolean;
+  hasGuideLines?: boolean;
 }
 
 interface ExpandIconStylesProps {
@@ -163,7 +163,7 @@ export function useTreeView(props: UseTreeViewProps) {
     isTopLevelSelectable = true,
     expandIconStyles,
     selectParents = true,
-    hasDivider = false,
+    hasGuideLines = false,
   } = props;
 
   const hasPreselectedItems = Boolean(preselectedItems);
@@ -636,7 +636,7 @@ export function useTreeView(props: UseTreeViewProps) {
       isTopLevelSelectable,
       selectParents,
       expandIconStyles,
-      hasDivider,
+      hasGuideLines,
       registerTreeItem,
       treeItemRefArray,
     }),
@@ -648,7 +648,7 @@ export function useTreeView(props: UseTreeViewProps) {
       isTopLevelSelectable,
       selectParents,
       expandIconStyles,
-      hasDivider,
+      hasGuideLines,
       registerTreeItem,
       treeItemRefArray,
     ]

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -130,6 +130,10 @@ export interface UseTreeViewProps {
    * @internal
    */
   testId?: string;
+  /**
+   * If true, TreeView will render a divider for items with children.
+   */
+  hasDivider?: boolean;
 }
 
 interface ExpandIconStylesProps {
@@ -159,6 +163,7 @@ export function useTreeView(props: UseTreeViewProps) {
     isTopLevelSelectable = true,
     expandIconStyles,
     selectParents = true,
+    hasDivider = false,
   } = props;
 
   const hasPreselectedItems = Boolean(preselectedItems);
@@ -631,6 +636,7 @@ export function useTreeView(props: UseTreeViewProps) {
       isTopLevelSelectable,
       selectParents,
       expandIconStyles,
+      hasDivider,
       registerTreeItem,
       treeItemRefArray,
     }),
@@ -642,6 +648,7 @@ export function useTreeView(props: UseTreeViewProps) {
       isTopLevelSelectable,
       selectParents,
       expandIconStyles,
+      hasDivider,
       registerTreeItem,
       treeItemRefArray,
     ]

--- a/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeView.ts
@@ -131,7 +131,7 @@ export interface UseTreeViewProps {
    */
   testId?: string;
   /**
-   * If true, TreeView will render a divider for items with children.
+   * If true, TreeView will render a divider for expanded items with children.
    */
   hasDivider?: boolean;
 }

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -1926,11 +1926,11 @@ export function Example() {
 }
 ```
 
-## Divider
+## Guide Lines
 
-When `hasDivider` is set to `true`, a vertical line is rendered alongside expanded parent items to visually connect them with their children. This helps users understand the hierarchy at a glance, especially in deep or complex trees.
+When `hasGuideLines` is set to `true`, a vertical line is rendered alongside expanded parent items to visually connect them with their children. This helps users understand the hierarchy at a glance, especially in deep or complex trees.
 
-By default, `hasDivider` is set to `false`.
+By default, `hasGuideLines` is set to `false`.
 
 ```tsx
 import React from 'react';
@@ -1940,10 +1940,10 @@ import { TreeView, TreeItem, TreeViewSelectable } from 'react-magma-dom';
 export function Example() {
   return (
     <TreeView
-      ariaLabel="divider-example"
+      ariaLabel="guideline-example"
       selectable={TreeViewSelectable.single}
       initialExpandedItems={['divider-Mammals', 'divider-Dogs']}
-      hasDivider
+      hasGuideLines
     >
       <TreeItem label="Mammals" itemId="divider-Mammals">
         <TreeItem label="Dogs" itemId="divider-Dogs">

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -1926,6 +1926,58 @@ export function Example() {
 }
 ```
 
+## Divider
+
+When `hasDivider` is set to `true`, a vertical line is rendered alongside expanded parent items to visually connect them with their children. This helps users understand the hierarchy at a glance, especially in deep or complex trees.
+
+By default, `hasDivider` is set to `false`.
+
+```tsx
+import React from 'react';
+
+import { TreeView, TreeItem, TreeViewSelectable } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <TreeView
+      ariaLabel="divider-example"
+      selectable={TreeViewSelectable.single}
+      initialExpandedItems={['divider-Mammals', 'divider-Dogs']}
+      hasDivider
+    >
+      <TreeItem label="Mammals" itemId="divider-Mammals">
+        <TreeItem label="Dogs" itemId="divider-Dogs">
+          <TreeItem label="German Shepherd" itemId="divider-German Shepherd" />
+          <TreeItem
+            label="Labrador Retriever"
+            itemId="divider-Labrador Retriever"
+          />
+          <TreeItem label="American Bully" itemId="divider-American Bully" />
+        </TreeItem>
+        <TreeItem label="Cats" itemId="divider-Cats">
+          <TreeItem label="Siamese" itemId="divider-Siamese" />
+          <TreeItem label="Persian" itemId="divider-Persian" />
+          <TreeItem label="Bengal" itemId="divider-Bengal" />
+        </TreeItem>
+      </TreeItem>
+      <TreeItem label="Birds" itemId="divider-Birds">
+        <TreeItem label="Parrots" itemId="divider-Parrots">
+          <TreeItem label="African Grey" itemId="divider-African Grey" />
+          <TreeItem label="Cockatiel" itemId="divider-Cockatiel" />
+          <TreeItem label="Budgerigar" itemId="divider-Budgerigar" />
+        </TreeItem>
+        <TreeItem label="Birds of Prey" itemId="divider-Birds of Prey">
+          <TreeItem label="Eagles" itemId="divider-Eagles" />
+          <TreeItem label="Hawks" itemId="divider-Hawks" />
+          <TreeItem label="Falcons" itemId="divider-Falcons" />
+        </TreeItem>
+      </TreeItem>
+      <TreeItem label="Amphibians" itemId="divider-Amphibians" />
+    </TreeView>
+  );
+}
+```
+
 ## Virtualization
 
 For large trees with many items, you can enable virtualization to improve performance by only rendering visible items. This is especially useful for trees with hundreds or thousands of items.


### PR DESCRIPTION
Closes: #2443

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Create `Guide Lines` for expanded items with `hasGuideLines` prop

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
- Open Storybook -> TreeView -> Check all examples with/without new `hasGuideLines` prop
- Open Docs -> TreeView -> Guide Lines section; -> Props, new `hasGuideLines` prop should exist