### PR TITLE
fix(Tabs): Added focusing Tab during scrolling

### DIFF
--- a/.changeset/fix-NavTabs-Tabs-update focus-management.md
+++ b/.changeset/fix-NavTabs-Tabs-update focus-management.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tabs & NavTabs): Add focus management for the first item during scrolling and navigation.

--- a/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
+++ b/packages/react-magma-dom/src/components/NavTabs/NavTabs.tsx
@@ -19,7 +19,7 @@ import { getNormalizedScrollLeft, Omit } from '../../utils';
 import { Announce } from '../Announce';
 import { TabsOrientation, TabsTextTransform } from '../Tabs/shared';
 import { ButtonNext, ButtonPrev } from '../Tabs/TabsScrollButtons';
-import { useTabsMeta } from '../Tabs/utils';
+import { useTabsMeta, useScrollTabFocus } from '../Tabs/utils';
 import { VisuallyHidden } from '../VisuallyHidden';
 
 export interface NavTabsProps extends Omit<TabsProps, 'onChange'> {
@@ -87,6 +87,7 @@ export const NavTabs = React.forwardRef<
   const childrenWrapperRef = React.useRef<HTMLUListElement>();
   const [scrollAnnouncement, setScrollAnnouncement] = React.useState('');
   const i18n = React.useContext(I18nContext);
+  const isScrollFocusRef = React.useRef(false);
 
   const hasChildFocus = navTabChildren.some(child => {
     if (React.isValidElement(child)) {
@@ -95,6 +96,10 @@ export const NavTabs = React.forwardRef<
   });
 
   const handleNavTabFocus = (event: React.FocusEvent<HTMLElement>) => {
+    if (isScrollFocusRef.current) {
+      return;
+    }
+
     const navTabElement = event.currentTarget;
 
     navTabElement.scrollIntoView({
@@ -177,27 +182,34 @@ export const NavTabs = React.forwardRef<
     scroll(nextScrollStart);
   };
 
+  const { focusFirstVisibleTab } = useScrollTabFocus(
+    tabsWrapperRef,
+    orientation
+  );
+
   const handlePrevScrollWithAnnouncement = () => {
     handleStartScrollClick();
     setScrollAnnouncement(i18n.tabs.scrolledBackAnnounce);
-    setTimeout(() => setScrollAnnouncement(''), 100);
+    setTimeout(() => {
+      setScrollAnnouncement('');
+      isScrollFocusRef.current = true;
+      focusFirstVisibleTab();
+      isScrollFocusRef.current = false;
+    }, 300);
   };
 
   const handleNextScrollWithAnnouncement = () => {
     handleEndScrollClick();
     setScrollAnnouncement(i18n.tabs.scrolledForwardAnnounce);
-    setTimeout(() => setScrollAnnouncement(''), 100);
+    setTimeout(() => {
+      setScrollAnnouncement('');
+      isScrollFocusRef.current = true;
+      focusFirstVisibleTab();
+      isScrollFocusRef.current = false;
+    }, 300);
   };
 
   React.useEffect(scrollInitialActiveIndexIntoView, []);
-
-  React.useEffect(() => {
-    if (!displayScroll.start) {
-      nextButtonRef.current?.focus();
-    } else if (!displayScroll.end) {
-      prevButtonRef.current?.focus();
-    }
-  }, [displayScroll.start, displayScroll.end]);
 
   return (
     <StyledContainer

--- a/packages/react-magma-dom/src/components/Tabs/Tabs.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/Tabs.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import { TabsOrientation, TabsTextTransform } from './shared';
 import { TabsContainerContext } from './TabsContainer';
 import { ButtonNext, ButtonPrev } from './TabsScrollButtons';
-import { useTabsMeta } from './utils';
+import { useTabsMeta, useScrollTabFocus } from './utils';
 import { useDescendants } from '../../hooks/useDescendants';
 import { I18nContext } from '../../i18n';
 import { ThemeInterface } from '../../theme/magma';
@@ -322,13 +322,10 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
 
     React.useEffect(scrollInitialActiveIndexIntoView, []);
 
-    React.useEffect(() => {
-      if (!displayScroll.start) {
-        nextButtonRef.current?.focus();
-      } else if (!displayScroll.end) {
-        prevButtonRef.current?.focus();
-      }
-    }, [displayScroll.start, displayScroll.end]);
+    const { focusFirstVisibleTab } = useScrollTabFocus(
+      tabsWrapperRef,
+      orientation
+    );
 
     // Announce panel content when active tab changes (excluding initial mount)
     React.useEffect(() => {
@@ -481,7 +478,8 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
       }
       timeoutRef.current = setTimeout(() => {
         setScrollAnnouncement('');
-      }, 100);
+        focusFirstVisibleTab();
+      }, 300);
     };
 
     const handleNextScrollWithAnnouncement = () => {
@@ -492,7 +490,8 @@ export const Tabs = React.forwardRef<HTMLDivElement, TabsProps & Orientation>(
       }
       timeoutRef.current = setTimeout(() => {
         setScrollAnnouncement('');
-      }, 100);
+        focusFirstVisibleTab();
+      }, 300);
     };
 
     const other = omit(['aria-label'], rest);

--- a/packages/react-magma-dom/src/components/Tabs/utils.ts
+++ b/packages/react-magma-dom/src/components/Tabs/utils.ts
@@ -118,6 +118,38 @@ export function useTabsMeta(theme, orientation, backgroundColor, isInverse) {
   ];
 }
 
+export function useScrollTabFocus(
+  tabsWrapperRef: React.RefObject<HTMLElement>,
+  orientation: TabsOrientation
+) {
+  const focusFirstVisibleTab = React.useCallback(() => {
+    const wrapper = tabsWrapperRef.current;
+    if (!wrapper) return;
+
+    const tabs = wrapper.querySelectorAll<HTMLElement>('[role="tab"]');
+    if (!tabs || tabs.length === 0) return;
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const isVertical = orientation === TabsOrientation.vertical;
+    const tolerance = 2;
+
+    for (const tab of Array.from(tabs)) {
+      const tabRect = tab.getBoundingClientRect();
+      const isVisible = isVertical
+        ? tabRect.top >= wrapperRect.top - tolerance &&
+          tabRect.bottom <= wrapperRect.bottom + tolerance
+        : tabRect.left >= wrapperRect.left - tolerance &&
+          tabRect.right <= wrapperRect.right + tolerance;
+      if (isVisible) {
+        tab.focus();
+        break;
+      }
+    }
+  }, [tabsWrapperRef, orientation]);
+
+  return { focusFirstVisibleTab };
+}
+
 // ScrollSpy by Dewaun Ayers:
 // https://blog.devgenius.io/diy-scrollspy-4f1c270cafaf
 


### PR DESCRIPTION
Closes: #2094 
Cherry-pick: https://github.com/cengage/react-magma/pull/2429

## What I did
- Added focusing `Tab` during scrolling

## Screenshots

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Go to Storybook -> Tabs -> Scrolling> Press on the forward button -> focus should move to the first visible `Tab` ->  Press on the forward button -> focus should move to the first visible `Tab` ->  Press on the back button -> focus should move to the first visible `Tab`.

Go to Storybook -> Nav Tabs -> Scrolling> Press on the forward button -> focus should move to the first visible `Tab` ->  Press on the forward button -> focus should move to the first visible `Tab` ->  Press on the back button -> focus should move to the first visible `Tab`.

- Go to Docs -> Tabs & Nav Tabs -> Focus fould move to the Basic Usage section

All examples should work in horizontal and vertical alignments.
