### PR TITLE
fix(Drawer): Apply drawerStyle prop to Drawer panel

### DIFF
--- a/.changeset/fix-Drawer-drawerStyle-prop-issue.md
+++ b/.changeset/fix-Drawer-drawerStyle-prop-issue.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Drawer): Apply `drawerStyle` prop to Drawer panel

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.stories.tsx
@@ -35,6 +35,11 @@ const info = {
         type: 'boolean',
       },
     },
+    drawerStyle: {
+      control: {
+        type: 'object',
+      },
+    },
   },
 };
 

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
@@ -196,5 +196,22 @@ describe('Drawer', () => {
       expect(modalContent).toHaveStyle('background: green');
       expect(modalContent).toHaveStyle('color: red');
     });
+
+    it('should merge drawerStyle and style, with drawerStyle taking precedence', () => {
+      const { getByTestId } = render(
+        <Drawer
+          isOpen
+          testId="my-drawer"
+          style={{ color: 'blue', background: 'yellow' }}
+          drawerStyle={{ color: 'red' }}
+        >
+          {TEXT}
+        </Drawer>
+      );
+
+      const modalContent = getByTestId('modal-content');
+      expect(modalContent).toHaveStyle('background: yellow');
+      expect(modalContent).toHaveStyle('color: red');
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.test.js
@@ -178,4 +178,23 @@ describe('Drawer', () => {
       expect(transition.style.transform).toContain('translate');
     });
   });
+
+  describe('drawerStyle prop', () => {
+    it('should apply styles from drawerStyle prop', () => {
+      const { getByTestId } = render(
+        <Drawer
+          isOpen
+          testId="my-drawer"
+          drawerStyle={{ color: 'red', background: 'green' }}
+        >
+          {TEXT}
+        </Drawer>
+      );
+
+      const modalContent = getByTestId('modal-content');
+
+      expect(modalContent).toHaveStyle('background: green');
+      expect(modalContent).toHaveStyle('color: red');
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
@@ -57,6 +57,7 @@ export interface DrawerProps extends Omit<ModalProps, 'size'> {
 export const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
   (props, _ref) => {
     const {
+      style,
       drawerStyle: propDrawerStyle,
       containerStyle,
       position,
@@ -86,7 +87,7 @@ export const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
         }}
         containerTransition={containerTransition}
         hasDrawerAnimation={isAnimated}
-        style={{ ...drawerStyle, ...propDrawerStyle }}
+        style={{ ...drawerStyle, ...style, ...propDrawerStyle }}
         {...rest}
       />
     );

--- a/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
+++ b/packages/react-magma-dom/src/components/Drawer/Drawer.tsx
@@ -57,7 +57,7 @@ export interface DrawerProps extends Omit<ModalProps, 'size'> {
 export const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
   (props, _ref) => {
     const {
-      style,
+      drawerStyle: propDrawerStyle,
       containerStyle,
       position,
       isAnimated = false,
@@ -86,7 +86,7 @@ export const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(
         }}
         containerTransition={containerTransition}
         hasDrawerAnimation={isAnimated}
-        style={{ ...drawerStyle, ...style }}
+        style={{ ...drawerStyle, ...propDrawerStyle }}
         {...rest}
       />
     );


### PR DESCRIPTION
Closes: #2166

## What I did

This change fixes an issue where the drawerStyle prop was not applied to the Drawer panel. 


## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

Open Storybook/Docs -> Drawer -> enable drawerStyle controls -> set a custom style (e.g. background color) -> open Drawer -> check that styles are applied to the Drawer panel

