### PR TITLE
fix(TreeView): Stop All subitems are selected from being announced on…

### DIFF
--- a/.changeset/fix-treeview-repeated-subitem-announcement.md
+++ b/.changeset/fix-treeview-repeated-subitem-announcement.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(TreeView): Stop All subitems are selected from being announced once per descendant when a parent is checked.

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.test.js
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.test.js
@@ -235,9 +235,17 @@ describe('Indeterminate Checkbox', () => {
 
   it('announces status changes triggered by direct user interaction', () => {
     const testId = 'click-id';
-    const { getByTestId, getByText } = render(
-      <IndeterminateCheckbox testId={testId} status="unchecked" />
-    );
+    function ControlledCheckbox() {
+      const [status, setStatus] = React.useState('unchecked');
+      return (
+        <IndeterminateCheckbox
+          testId={testId}
+          status={status}
+          onChange={e => setStatus(e.target.checked ? 'checked' : 'unchecked')}
+        />
+      );
+    }
+    const { getByTestId, getByText } = render(<ControlledCheckbox />);
 
     fireEvent.click(getByTestId(testId));
 

--- a/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.test.js
+++ b/packages/react-magma-dom/src/components/IndeterminateCheckbox/IndeterminateCheckbox.test.js
@@ -219,4 +219,28 @@ describe('Indeterminate Checkbox', () => {
       return expect(result).toHaveNoViolations();
     });
   });
+
+  it('does not announce status changes triggered only by prop updates (e.g. TreeView parent cascade)', () => {
+    const testId = 'cascade-id';
+    const { queryByText, rerender } = render(
+      <IndeterminateCheckbox testId={testId} status="unchecked" />
+    );
+
+    rerender(<IndeterminateCheckbox testId={testId} status="checked" />);
+    expect(queryByText('All subitems are selected')).not.toBeInTheDocument();
+
+    rerender(<IndeterminateCheckbox testId={testId} status="indeterminate" />);
+    expect(queryByText('Some subitems are selected')).not.toBeInTheDocument();
+  });
+
+  it('announces status changes triggered by direct user interaction', () => {
+    const testId = 'click-id';
+    const { getByTestId, getByText } = render(
+      <IndeterminateCheckbox testId={testId} status="unchecked" />
+    );
+
+    fireEvent.click(getByTestId(testId));
+
+    expect(getByText('All subitems are selected')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes: #2444

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
- Go to a selectable tree view and expand a parent item
- Use a screenreader (can reproduce with NVDA + VO) and listen to "All subitems are selected" getting announced only once