### PR TITLE
fix(Toast): Toast does not close on click or after timeout (#2469)

### DIFF
--- a/.changeset/fix-Toast-not-closing.md
+++ b/.changeset/fix-Toast-not-closing.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Toast): Fix: Toast not closing on click or timeout (Strict Mode issue with unmount)

--- a/packages/react-magma-dom/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-magma-dom/src/components/Toast/Toast.stories.tsx
@@ -124,3 +124,49 @@ export const TwoLine = {
     ...Default.args,
   },
 };
+
+export const Strict = {
+  render: args => {
+    const [showToast, setShowToast] = React.useState(false);
+
+    function handleClick() {
+      setShowToast(true);
+    }
+
+    function handleDismiss() {
+      setShowToast(false);
+    }
+
+    return (
+      <React.StrictMode>
+        <div
+          style={{
+            background: args.isInverse ? magma.colors.primary600 : 'none',
+          }}
+        >
+          <Button
+            size={ButtonSize.small}
+            onClick={handleClick}
+            isInverse={args.isInverse}
+          >
+            Show Toast in Strict Mode
+          </Button>
+          <Announce>
+            {showToast ? (
+              <Toast onDismiss={handleDismiss} {...args}>
+                Default Toast in Strict Mode
+              </Toast>
+            ) : null}
+          </Announce>
+        </div>
+      </React.StrictMode>
+    );
+  },
+
+  args: {
+    variant: AlertVariant.info,
+    toastDuration: 5000,
+    disableAutoDismiss: false,
+    isInverse: false,
+  },
+};

--- a/packages/react-magma-dom/src/components/Toast/Toast.test.js
+++ b/packages/react-magma-dom/src/components/Toast/Toast.test.js
@@ -239,4 +239,44 @@ describe('Toast', () => {
       magma.colors.success100
     );
   });
+
+  describe('strictMode', () => {
+    it('should auto-dismiss in StrictMode', async () => {
+      const onDismiss = jest.fn();
+
+      render(
+        <React.StrictMode>
+          <Toast onDismiss={onDismiss}>Toast Content</Toast>
+        </React.StrictMode>
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(6000);
+      });
+
+      await waitFor(() => {
+        expect(onDismiss).toHaveBeenCalled();
+      });
+    });
+
+    it('should call onDismiss if the dismiss button is clicked', async () => {
+      const onDismiss = jest.fn();
+
+      const { container } = render(
+        <React.StrictMode>
+          <Toast onDismiss={onDismiss}>Toast Content</Toast>
+        </React.StrictMode>
+      );
+
+      const button = container.querySelector('button');
+
+      fireEvent.click(button);
+
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+
+      expect(onDismiss).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Toast/index.tsx
+++ b/packages/react-magma-dom/src/components/Toast/index.tsx
@@ -193,6 +193,7 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       React.useState(0);
 
     React.useEffect(() => {
+      mountedRef.current = true;
       lastFocus.current = document.activeElement as HTMLElement;
       if (!props.disableAutoDismiss) {
         setAutoHideTimer(props.toastDuration);


### PR DESCRIPTION
Closes: #2388

## What I did
In React 18 and higher, Strict Mode, useEffect runs mount → unmount → mount again in development, which caused mountedRef.current to stay in an incorrect state. Updated logic to properly reset the flag on each mount/unmount cycle so the toast behavior works correctly and state is not retained between Strict Mode re-mounts.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Wrap the Toast component in <React.StrictMode> in Storybook -> Open Storybook/Docs -> Toast -> trigger Toast → try to close it via click and via timeout
