### PR TITLE
feat(ButtonGroup): add isList prop for semantic list rendering (#2490)

### DIFF
--- a/.changeset/feat-ButtonGroup-add-isList-prop.md
+++ b/.changeset/feat-ButtonGroup-add-isList-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(ButtonGroup): add `isList` prop for semantic list rendering.

--- a/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -119,6 +119,11 @@ export default {
         type: 'boolean',
       },
     },
+    isList: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 } as Meta;
 

--- a/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.test.js
+++ b/packages/react-magma-dom/src/components/ButtonGroup/ButtonGroup.test.js
@@ -559,4 +559,83 @@ describe('ButtonGroup', () => {
       expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
     });
   });
+
+  describe('isList', () => {
+    it('renders as a div by default (no isList)', () => {
+      const { getByTestId } = render(
+        <ButtonGroup testId={testId}>
+          <Button>1</Button>
+          <Button>2</Button>
+        </ButtonGroup>
+      );
+
+      const el = getByTestId(testId);
+      expect(el.tagName).toBe('DIV');
+      expect(el).not.toHaveAttribute('role', 'list');
+      expect(el.querySelector('li')).not.toBeInTheDocument();
+    });
+
+    it('renders as a ul with li children when isList is set', () => {
+      const { getByTestId } = render(
+        <ButtonGroup testId={testId} isList>
+          <Button>1</Button>
+          <Button>2</Button>
+        </ButtonGroup>
+      );
+
+      const el = getByTestId(testId);
+      expect(el.tagName).toBe('UL');
+      expect(el).toHaveAttribute('role', 'list');
+
+      const listItems = el.querySelectorAll(':scope > li');
+      expect(listItems).toHaveLength(2);
+    });
+
+    it('renders buttons inside li items when isList is set', () => {
+      const { getByTestId } = render(
+        <ButtonGroup testId={testId} isList>
+          <Button testId={`${testId}-1`}>1</Button>
+          <Button testId={`${testId}-2`}>2</Button>
+        </ButtonGroup>
+      );
+
+      const btn1 = getByTestId(`${testId}-1`);
+      const btn2 = getByTestId(`${testId}-2`);
+
+      expect(btn1.closest('li')).toBeInTheDocument();
+      expect(btn2.closest('li')).toBeInTheDocument();
+    });
+
+    it('does not violate accessibility standards with isList', () => {
+      const { container } = render(
+        <ButtonGroup isList>
+          <Button>1</Button>
+          <Button>2</Button>
+          <Button>3</Button>
+        </ButtonGroup>
+      );
+
+      return axe(container.innerHTML).then(result => {
+        return expect(result).toHaveNoViolations();
+      });
+    });
+
+    it('Snapshot: isList with noSpace horizontal', () => {
+      const { container } = render(
+        <ButtonGroup
+          testId={testId}
+          isList
+          noSpace
+          orientation={ButtonGroupOrientation.horizontal}
+          alignment={ButtonGroupAlignment.left}
+        >
+          <Button testId={`${testId}-1`}>1</Button>
+          <Button testId={`${testId}-2`}>2</Button>
+          <Button testId={`${testId}-3`}>3</Button>
+        </ButtonGroup>
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/react-magma-dom/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -30,7 +30,6 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
   flex: none;
 }
 
-.emotion-0>li>div div>button:nth-child(2),
 .emotion-0>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -42,11 +41,11 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
   flex: none;
 }
 
-.emotion-0>li:first-child:not(:only-child)>button {
+.emotion-0>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-0>li:last-child:not(:only-child)>button {
+.emotion-0>li:last-child:not(:only-child) {
   margin-right: 0;
 }
 
@@ -119,11 +118,4860 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
   border-right: 1px solid #FFFFFF;
 }
 
+.emotion-0>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child).emotion-0>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child).emotion-0>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+
+.emotion-0>li>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>li:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li:not(:first-child).emotion-0>li:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:not(:first-child).emotion-0>li>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>li>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:not(:first-child).emotion-0>li>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>li>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child).emotion-0>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child).emotion-0>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+    color="primary"
+    data-testid="test-id"
+    orientation="horizontal"
+    role="group"
+  >
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      data-testid="test-id-1"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        1
+      </span>
+    </button>
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      data-testid="test-id-2"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        2
+      </span>
+    </button>
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      data-testid="test-id-3"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        3
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ButtonGroup Vertical No Space Does NOT remove the border radius around the buttons 1`] = `
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-0>li>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.emotion-0>li>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+    color="primary"
+    data-testid="test-id"
+    orientation="vertical"
+    role="group"
+  >
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      data-testid="test-id-4"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        1
+      </span>
+    </button>
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      data-testid="test-id-5"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        2
+      </span>
+    </button>
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      data-testid="test-id-6"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        3
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] = `
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+
+.emotion-0>li>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-6 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  padding-right: 8px;
+}
+
+.emotion-9:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-9:not(:disabled):hover,
+.emotion-9:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-9 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  padding-left: 0;
+  padding-right: 8px;
+}
+
+.emotion-16 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-16:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-18:hover,
+.emotion-18:focus {
+  background: #F5F5F5;
+}
+
+.emotion-18:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-18:active {
+  outline-color: #0074B7;
+}
+
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+
+.emotion-0>li>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-6 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  padding-right: 8px;
+}
+
+.emotion-9:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-9:not(:disabled):hover,
+.emotion-9:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-9 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  padding-left: 0;
+  padding-right: 8px;
+}
+
+.emotion-16 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-16:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-18:hover,
+.emotion-18:focus {
+  background: #F5F5F5;
+}
+
+.emotion-18:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-18:active {
+  outline-color: #0074B7;
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+    color="primary"
+    orientation="horizontal"
+    role="group"
+  >
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        1
+      </span>
+    </button>
+    <div
+      class="emotion-6 emotion-7"
+    >
+      <div>
+        <button
+          aria-controls="2_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="emotion-8 emotion-9 emotion-3"
+          color="primary"
+          id="2"
+          shape="fill"
+          type="button"
+        >
+          <span
+            class="emotion-4 emotion-5"
+          >
+            <span
+              class="emotion-13 emotion-14"
+            >
+              Dropdown 2
+            </span>
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              role="none"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="2_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-15 emotion-16 emotion-17"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="2"
+            role="menu"
+          >
+            <div
+              class="emotion-18 emotion-19"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 2.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-6 emotion-7"
+    >
+      <div>
+        <button
+          aria-controls="3_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="emotion-8 emotion-9 emotion-3"
+          color="primary"
+          id="3"
+          shape="fill"
+          type="button"
+        >
+          <span
+            class="emotion-4 emotion-5"
+          >
+            <span
+              class="emotion-13 emotion-14"
+            >
+              Dropdown 3
+            </span>
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              role="none"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="3_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-15 emotion-16 emotion-17"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="3"
+            role="menu"
+          >
+            <div
+              class="emotion-18 emotion-19"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 3.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ButtonGroup With dropdowns Snapshot: SplitButton 1`] = `
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: stretch;
+  -ms-flex-pack: stretch;
+  -webkit-justify-content: stretch;
+  justify-content: stretch;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.emotion-0>li>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button {
+  width: calc(100% - 42px);
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>button:not([aria-label]):not([title]) {
+  width: 100%;
+}
+
+.emotion-0>li>button[aria-label]:empty,
+.emotion-0>li>button[title]:empty {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>button:has(svg):not(:has(:not(svg))) {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button {
+  width: calc(100% - 42px);
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:not([aria-label]):not([title]) {
+  width: 100%;
+}
+
+.emotion-0>button[aria-label]:empty,
+.emotion-0>button[title]:empty {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:has(svg):not(:has(:not(svg))) {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-2 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px 0 0 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-4:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-4:not(:disabled):hover,
+.emotion-4:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-4:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-4:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-4 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-6 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 0 8px 8px 0;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 40px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  line-height: 1;
+  min-width: 0;
+  padding: 0;
+}
+
+.emotion-8:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-8:not(:disabled):hover,
+.emotion-8:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-8:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-8:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-8 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-13:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-15 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-15:hover,
+.emotion-15:focus {
+  background: #F5F5F5;
+}
+
+.emotion-15:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-15:active {
+  outline-color: #0074B7;
+}
+
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: stretch;
+  -ms-flex-pack: stretch;
+  -webkit-justify-content: stretch;
+  justify-content: stretch;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.emotion-0>li>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button {
+  width: calc(100% - 42px);
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>button:not([aria-label]):not([title]) {
+  width: 100%;
+}
+
+.emotion-0>li>button[aria-label]:empty,
+.emotion-0>li>button[title]:empty {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>button:has(svg):not(:has(:not(svg))) {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button {
+  width: calc(100% - 42px);
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:not([aria-label]):not([title]) {
+  width: 100%;
+}
+
+.emotion-0>button[aria-label]:empty,
+.emotion-0>button[title]:empty {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:has(svg):not(:has(:not(svg))) {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-2 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px 0 0 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-4:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-4:not(:disabled):hover,
+.emotion-4:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-4:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-4:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-4 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-6 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 0 8px 8px 0;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: 40px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  line-height: 1;
+  min-width: 0;
+  padding: 0;
+}
+
+.emotion-8:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-8:not(:disabled):hover,
+.emotion-8:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-8:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-8:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-8 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-13:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-15 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-15:hover,
+.emotion-15:focus {
+  background: #F5F5F5;
+}
+
+.emotion-15:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-15:active {
+  outline-color: #0074B7;
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+    color="primary"
+    orientation="vertical"
+    role="group"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    >
+      <div>
+        <button
+          class="emotion-4 emotion-5"
+          color="primary"
+          id="1"
+          shape="leftCap"
+          style="border-right: 0; margin-right: 0px;"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="emotion-6 emotion-7"
+          >
+            Dropdown SplitButton 1
+          </span>
+        </button>
+        <button
+          aria-controls="1_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Toggle menu"
+          class="emotion-8 emotion-5"
+          color="primary"
+          shape="rightCap"
+          style="margin-left: 2px;"
+          type="button"
+        >
+          <span
+            class="emotion-6 emotion-7"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              role="none"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="1_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-12 emotion-13 emotion-14"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="1"
+            role="menu"
+          >
+            <div
+              class="emotion-15 emotion-16"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 2.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-2 emotion-3"
+    >
+      <div>
+        <button
+          class="emotion-4 emotion-5"
+          color="primary"
+          id="2"
+          shape="leftCap"
+          style="border-right: 0; margin-right: 0px;"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="emotion-6 emotion-7"
+          >
+            Dropdown SplitButton 2
+          </span>
+        </button>
+        <button
+          aria-controls="2_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Toggle menu"
+          class="emotion-8 emotion-5"
+          color="primary"
+          shape="rightCap"
+          style="margin-left: 2px;"
+          type="button"
+        >
+          <span
+            class="emotion-6 emotion-7"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              role="none"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="2_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-12 emotion-13 emotion-14"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="2"
+            role="menu"
+          >
+            <div
+              class="emotion-15 emotion-16"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 2.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: stretch;
+  -ms-flex-pack: stretch;
+  -webkit-justify-content: stretch;
+  justify-content: stretch;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.emotion-0>li>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button {
+  width: calc(100% - 42px);
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>button:not([aria-label]):not([title]) {
+  width: 100%;
+}
+
+.emotion-0>li>button[aria-label]:empty,
+.emotion-0>li>button[title]:empty {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>button:has(svg):not(:has(:not(svg))) {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button {
+  width: calc(100% - 42px);
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:not([aria-label]):not([title]) {
+  width: 100%;
+}
+
+.emotion-0>button[aria-label]:empty,
+.emotion-0>button[title]:empty {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:has(svg):not(:has(:not(svg))) {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-6 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  padding-right: 8px;
+}
+
+.emotion-9:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-9:not(:disabled):hover,
+.emotion-9:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-9 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  padding-left: 0;
+  padding-right: 8px;
+}
+
+.emotion-16 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-16:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-18:hover,
+.emotion-18:focus {
+  background: #F5F5F5;
+}
+
+.emotion-18:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-18:active {
+  outline-color: #0074B7;
+}
+
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: stretch;
+  -ms-flex-pack: stretch;
+  -webkit-justify-content: stretch;
+  justify-content: stretch;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.emotion-0>li>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button {
+  width: calc(100% - 42px);
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>button:not([aria-label]):not([title]) {
+  width: 100%;
+}
+
+.emotion-0>li>button[aria-label]:empty,
+.emotion-0>li>button[title]:empty {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>button:has(svg):not(:has(:not(svg))) {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>div {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button {
+  width: calc(100% - 42px);
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-0>button {
+  margin: 0 0 8px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:not([aria-label]):not([title]) {
+  width: 100%;
+}
+
+.emotion-0>button[aria-label]:empty,
+.emotion-0>button[title]:empty {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:has(svg):not(:has(:not(svg))) {
+  width: auto;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-top: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-bottom: 0;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-6 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  padding-right: 8px;
+}
+
+.emotion-9:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-9:not(:disabled):hover,
+.emotion-9:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-9 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  padding-left: 0;
+  padding-right: 8px;
+}
+
+.emotion-16 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-16:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-18:hover,
+.emotion-18:focus {
+  background: #F5F5F5;
+}
+
+.emotion-18:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-18:active {
+  outline-color: #0074B7;
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+    color="primary"
+    orientation="vertical"
+    role="group"
+  >
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        1
+      </span>
+    </button>
+    <div
+      class="emotion-6 emotion-7"
+    >
+      <div>
+        <button
+          aria-controls="2_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="emotion-8 emotion-9 emotion-3"
+          color="primary"
+          id="2"
+          shape="fill"
+          type="button"
+        >
+          <span
+            class="emotion-4 emotion-5"
+          >
+            <span
+              class="emotion-13 emotion-14"
+            >
+              Dropdown 2
+            </span>
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              role="none"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="2_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-15 emotion-16 emotion-17"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="2"
+            role="menu"
+          >
+            <div
+              class="emotion-18 emotion-19"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 2.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-6 emotion-7"
+    >
+      <div>
+        <button
+          aria-controls="3_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="emotion-8 emotion-9 emotion-3"
+          color="primary"
+          id="3"
+          shape="fill"
+          type="button"
+        >
+          <span
+            class="emotion-4 emotion-5"
+          >
+            <span
+              class="emotion-13 emotion-14"
+            >
+              Dropdown 3
+            </span>
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              role="none"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="3_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-15 emotion-16 emotion-17"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="3"
+            role="menu"
+          >
+            <div
+              class="emotion-18 emotion-19"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 3.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+
+.emotion-0>li>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>li:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li:not(:first-child).emotion-0>li:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:not(:first-child).emotion-0>li>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>li>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:not(:first-child).emotion-0>li>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>li>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child).emotion-0>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child).emotion-0>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-6 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  padding-right: 8px;
+}
+
+.emotion-9:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-9:not(:disabled):hover,
+.emotion-9:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-9 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  padding-left: 0;
+  padding-right: 8px;
+}
+
+.emotion-16 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-16:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-18:hover,
+.emotion-18:focus {
+  background: #F5F5F5;
+}
+
+.emotion-18:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-18:active {
+  outline-color: #0074B7;
+}
+
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+
+.emotion-0>li>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>li:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li:not(:first-child).emotion-0>li:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:not(:first-child).emotion-0>li>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>li>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:not(:first-child).emotion-0>li>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>li>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child).emotion-0>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child).emotion-0>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+}
+
+.emotion-2:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-2:not(:disabled):hover,
+.emotion-2:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-2:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-2 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-4 {
+  visibility: visible;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-6 {
+  display: inline-block;
+  position: relative;
+}
+
+.emotion-9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #3942B0;
+  border: 0;
+  border-color: #3942B0;
+  border-radius: 8px;
+  color: #FFFFFF;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  letter-spacing: inherit;
+  line-height: 24px;
+  margin: 0;
+  min-width: 96px;
+  overflow: hidden;
+  padding: 12px 16px;
+  position: relative;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-transform: uppercase;
+  touch-action: manipulation;
+  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  padding-right: 8px;
+}
+
+.emotion-9:not(:disabled):focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 2px;
+  z-index: 1;
+}
+
+.emotion-9:not(:disabled):hover,
+.emotion-9:not(:disabled):focus {
+  background: #292F7C;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active {
+  background: #1A1E51;
+  color: #FFFFFF;
+}
+
+.emotion-9:not(:disabled):active:after {
+  opacity: 0.4;
+  -webkit-transform: translate(-50%, -50%) scale(0);
+  -moz-transform: translate(-50%, -50%) scale(0);
+  -ms-transform: translate(-50%, -50%) scale(0);
+  transform: translate(-50%, -50%) scale(0);
+  -webkit-transition: -webkit-transform 0s;
+  transition: transform 0s;
+}
+
+.emotion-9 svg {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-13 {
+  padding-left: 0;
+  padding-right: 8px;
+}
+
+.emotion-16 {
+  background: #FFFFFF;
+  border: 1px solid #D4D4D4;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
+  color: #454545;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow: visible;
+  padding-left: 0;
+  position: relative;
+  text-align: left;
+  width: auto;
+  background: #FFFFFF;
+  display: none;
+  max-height: 250px;
+  opacity: 0;
+  outline: 0;
+  overflow-y: auto;
+  padding: 8px 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  white-space: nowrap;
+}
+
+.emotion-16:focus {
+  outline: 2px solid #0074B7;
+  outline-offset: 0;
+}
+
+.emotion-18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #454545;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 16px;
+  font-family: "Work Sans",Helvetica,sans-serif;
+  line-height: 24px;
+  margin: 0;
+  padding: 8px 16px;
+  white-space: nowrap;
+}
+
+.emotion-18:hover,
+.emotion-18:focus {
+  background: #F5F5F5;
+}
+
+.emotion-18:focus {
+  outline-color: #0074B7;
+  outline-offset: -2px;
+}
+
+.emotion-18:active {
+  outline-color: #0074B7;
+}
+
+<div>
+  <div
+    class="emotion-0 emotion-1"
+    color="primary"
+    orientation="horizontal"
+    role="group"
+  >
+    <button
+      class="emotion-2 emotion-3"
+      color="primary"
+      shape="fill"
+      type="button"
+    >
+      <span
+        class="emotion-4 emotion-5"
+      >
+        1
+      </span>
+    </button>
+    <div
+      class="emotion-6 emotion-7"
+    >
+      <div>
+        <button
+          aria-controls="2_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="emotion-8 emotion-9 emotion-3"
+          color="primary"
+          id="2"
+          shape="fill"
+          type="button"
+        >
+          <span
+            class="emotion-4 emotion-5"
+          >
+            <span
+              class="emotion-13 emotion-14"
+            >
+              Dropdown 2
+            </span>
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              role="none"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="2_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-15 emotion-16 emotion-17"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="2"
+            role="menu"
+          >
+            <div
+              class="emotion-18 emotion-19"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 2.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="emotion-6 emotion-7"
+    >
+      <div>
+        <button
+          aria-controls="3_dropdownMenuId"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="emotion-8 emotion-9 emotion-3"
+          color="primary"
+          id="3"
+          shape="fill"
+          type="button"
+        >
+          <span
+            class="emotion-4 emotion-5"
+          >
+            <span
+              class="emotion-13 emotion-14"
+            >
+              Dropdown 3
+            </span>
+            <svg
+              aria-hidden="true"
+              class="icon"
+              data-testid="caretDown"
+              fill="currentColor"
+              height="20"
+              role="none"
+              viewBox="0 0 24 24"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+      <div
+        data-testid="dropdownContentWrapper"
+        id="3_dropdownMenuId"
+        style="position: absolute; left: 0px; top: 0px; z-index: 996;"
+      >
+        <div
+          class="emotion-15 emotion-16 emotion-17"
+          data-testid="dropdownContent"
+          tabindex="-1"
+          width="auto"
+        >
+          <div
+            aria-labelledby="3"
+            role="menu"
+          >
+            <div
+              class="emotion-18 emotion-19"
+              role="menuitem"
+              tabindex="-1"
+            >
+              Menu item 3.1
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ButtonGroup isList Snapshot: isList with noSpace horizontal 1`] = `
+.emotion-0 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: 0;
+}
+
+.emotion-0>li>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>li>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>li:first-child:not(:only-child)>button {
+  margin-left: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child)>button {
+  margin-right: 0;
+}
+
+.emotion-0>li:first-child:not(:only-child)>div {
+  margin-left: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child)>div {
+  margin-right: 0;
+}
+
+.emotion-0>li:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li:not(:first-child).emotion-0>li:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>div:not(:first-child).emotion-0>li>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>li>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>li>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>li>button:not(:first-child).emotion-0>li>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>li>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child)>button {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child)>button {
+  margin-right: 0;
+}
+
+.emotion-0>div:first-child:not(:only-child)>div {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child)>div {
+  margin-right: 0;
+}
+
+.emotion-0>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child).emotion-0>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child)>button {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child)>button {
+  margin-right: 0;
+}
+
+.emotion-0>button:first-child:not(:only-child)>div {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child)>div {
+  margin-right: 0;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child).emotion-0>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
 .emotion-2 {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: contents;
 }
 
 .emotion-4 {
@@ -235,7 +5083,7 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  row-gap: 8px;
+  gap: 0;
 }
 
 .emotion-0>li>div {
@@ -245,7 +5093,6 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
   flex: none;
 }
 
-.emotion-0>li>div div>button:nth-child(2),
 .emotion-0>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -262,6 +5109,14 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
 }
 
 .emotion-0>li:last-child:not(:only-child)>button {
+  margin-right: 0;
+}
+
+.emotion-0>li:first-child:not(:only-child)>div {
+  margin-left: 0;
+}
+
+.emotion-0>li:last-child:not(:only-child)>div {
   margin-right: 0;
 }
 
@@ -334,11 +5189,106 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
   border-right: 1px solid #FFFFFF;
 }
 
+.emotion-0>div {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-0>div:first-child:not(:only-child)>button {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child)>button {
+  margin-right: 0;
+}
+
+.emotion-0>div:first-child:not(:only-child)>div {
+  margin-left: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child)>div {
+  margin-right: 0;
+}
+
+.emotion-0>div:first-child:not(:only-child) button {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>div:nth-child(2) button {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child) button {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>div:not(:first-child).emotion-0>div:not(:last-child) button {
+  border-right: 0;
+}
+
+.emotion-0>div:last-child:not(:only-child) button {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button {
+  margin: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-0>button:first-child:not(:only-child)>button {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child)>button {
+  margin-right: 0;
+}
+
+.emotion-0>button:first-child:not(:only-child)>div {
+  margin-left: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child)>div {
+  margin-right: 0;
+}
+
+.emotion-0>button:first-child:not(:only-child) {
+  border-radius: 8px 0 0 8px;
+  border-right: 0;
+}
+
+.emotion-0>button:nth-child(2) {
+  border-left: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child) {
+  border-radius: 0;
+  border-right: 1px solid #FFFFFF;
+}
+
+.emotion-0>button:not(:first-child).emotion-0>button:not(:last-child) {
+  border-right: 0;
+}
+
+.emotion-0>button:last-child:not(:only-child) {
+  border-radius: 0 8px 8px 0;
+  border-right: 1px solid #FFFFFF;
+}
+
 .emotion-2 {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: contents;
 }
 
 .emotion-4 {
@@ -489,3742 +5439,6 @@ exports[`ButtonGroup Horizontal No Space Removes the border radius around the bu
           3
         </span>
       </button>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`ButtonGroup Vertical No Space Does NOT remove the border radius around the buttons 1`] = `
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-}
-
-.emotion-0>li>div {
-  margin: 0;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-top: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-bottom: 0;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-4:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-4:not(:disabled):hover,
-.emotion-4:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-6 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-}
-
-.emotion-0>li>div {
-  margin: 0;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-top: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-bottom: 0;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-4:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-4:not(:disabled):hover,
-.emotion-4:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-6 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-<div>
-  <ul
-    class="emotion-0 emotion-1"
-    color="primary"
-    data-testid="test-id"
-    orientation="vertical"
-    role="list"
-  >
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <button
-        class="emotion-4 emotion-5"
-        color="primary"
-        data-testid="test-id-4"
-        shape="fill"
-        type="button"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          1
-        </span>
-      </button>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <button
-        class="emotion-4 emotion-5"
-        color="primary"
-        data-testid="test-id-5"
-        shape="fill"
-        type="button"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          2
-        </span>
-      </button>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <button
-        class="emotion-4 emotion-5"
-        color="primary"
-        data-testid="test-id-6"
-        shape="fill"
-        type="button"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          3
-        </span>
-      </button>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`ButtonGroup With dropdowns Snapshot: Horizontal & center alignment 1`] = `
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  row-gap: 8px;
-}
-
-.emotion-0>li>div {
-  margin: 0 4px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0 4px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-left: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-right: 0;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-4:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-4:not(:disabled):hover,
-.emotion-4:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-6 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-10 {
-  display: inline-block;
-  position: relative;
-}
-
-.emotion-13 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-  padding-right: 8px;
-}
-
-.emotion-13:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-13:not(:disabled):hover,
-.emotion-13:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-13 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-17 {
-  padding-left: 0;
-  padding-right: 8px;
-}
-
-.emotion-20 {
-  background: #FFFFFF;
-  border: 1px solid #D4D4D4;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
-  color: #454545;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: visible;
-  padding-left: 0;
-  position: relative;
-  text-align: left;
-  width: auto;
-  background: #FFFFFF;
-  display: none;
-  max-height: 250px;
-  opacity: 0;
-  outline: 0;
-  overflow-y: auto;
-  padding: 8px 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  white-space: nowrap;
-}
-
-.emotion-20:focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 0;
-}
-
-.emotion-22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #454545;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 16px;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  line-height: 24px;
-  margin: 0;
-  padding: 8px 16px;
-  white-space: nowrap;
-}
-
-.emotion-22:hover,
-.emotion-22:focus {
-  background: #F5F5F5;
-}
-
-.emotion-22:focus {
-  outline-color: #0074B7;
-  outline-offset: -2px;
-}
-
-.emotion-22:active {
-  outline-color: #0074B7;
-}
-
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  row-gap: 8px;
-}
-
-.emotion-0>li>div {
-  margin: 0 4px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0 4px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-left: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-right: 0;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-4:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-4:not(:disabled):hover,
-.emotion-4:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-6 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-10 {
-  display: inline-block;
-  position: relative;
-}
-
-.emotion-13 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-  padding-right: 8px;
-}
-
-.emotion-13:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-13:not(:disabled):hover,
-.emotion-13:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-13 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-17 {
-  padding-left: 0;
-  padding-right: 8px;
-}
-
-.emotion-20 {
-  background: #FFFFFF;
-  border: 1px solid #D4D4D4;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
-  color: #454545;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: visible;
-  padding-left: 0;
-  position: relative;
-  text-align: left;
-  width: auto;
-  background: #FFFFFF;
-  display: none;
-  max-height: 250px;
-  opacity: 0;
-  outline: 0;
-  overflow-y: auto;
-  padding: 8px 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  white-space: nowrap;
-}
-
-.emotion-20:focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 0;
-}
-
-.emotion-22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #454545;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 16px;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  line-height: 24px;
-  margin: 0;
-  padding: 8px 16px;
-  white-space: nowrap;
-}
-
-.emotion-22:hover,
-.emotion-22:focus {
-  background: #F5F5F5;
-}
-
-.emotion-22:focus {
-  outline-color: #0074B7;
-  outline-offset: -2px;
-}
-
-.emotion-22:active {
-  outline-color: #0074B7;
-}
-
-<div>
-  <ul
-    class="emotion-0 emotion-1"
-    color="primary"
-    orientation="horizontal"
-    role="list"
-  >
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <button
-        class="emotion-4 emotion-5"
-        color="primary"
-        shape="fill"
-        type="button"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          1
-        </span>
-      </button>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-10 emotion-11"
-      >
-        <div>
-          <button
-            aria-controls="2_dropdownMenuId"
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-12 emotion-13 emotion-5"
-            color="primary"
-            id="2"
-            shape="fill"
-            type="button"
-          >
-            <span
-              class="emotion-6 emotion-7"
-            >
-              <span
-                class="emotion-17 emotion-18"
-              >
-                Dropdown 2
-              </span>
-              <svg
-                aria-hidden="true"
-                class="icon"
-                data-testid="caretDown"
-                fill="currentColor"
-                height="20"
-                role="none"
-                viewBox="0 0 24 24"
-                width="20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          data-testid="dropdownContentWrapper"
-          id="2_dropdownMenuId"
-          style="position: absolute; left: 0px; top: 0px; z-index: 996;"
-        >
-          <div
-            class="emotion-19 emotion-20 emotion-21"
-            data-testid="dropdownContent"
-            tabindex="-1"
-            width="auto"
-          >
-            <div
-              aria-labelledby="2"
-              role="menu"
-            >
-              <div
-                class="emotion-22 emotion-23"
-                role="menuitem"
-                tabindex="-1"
-              >
-                Menu item 2.1
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-10 emotion-11"
-      >
-        <div>
-          <button
-            aria-controls="3_dropdownMenuId"
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-12 emotion-13 emotion-5"
-            color="primary"
-            id="3"
-            shape="fill"
-            type="button"
-          >
-            <span
-              class="emotion-6 emotion-7"
-            >
-              <span
-                class="emotion-17 emotion-18"
-              >
-                Dropdown 3
-              </span>
-              <svg
-                aria-hidden="true"
-                class="icon"
-                data-testid="caretDown"
-                fill="currentColor"
-                height="20"
-                role="none"
-                viewBox="0 0 24 24"
-                width="20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          data-testid="dropdownContentWrapper"
-          id="3_dropdownMenuId"
-          style="position: absolute; left: 0px; top: 0px; z-index: 996;"
-        >
-          <div
-            class="emotion-19 emotion-20 emotion-21"
-            data-testid="dropdownContent"
-            tabindex="-1"
-            width="auto"
-          >
-            <div
-              aria-labelledby="3"
-              role="menu"
-            >
-              <div
-                class="emotion-22 emotion-23"
-                role="menuitem"
-                tabindex="-1"
-              >
-                Menu item 3.1
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`ButtonGroup With dropdowns Snapshot: SplitButton 1`] = `
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: stretch;
-  -ms-flex-pack: stretch;
-  -webkit-justify-content: stretch;
-  justify-content: stretch;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.emotion-0>li>div {
-  margin: 0 0 8px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button,
-.emotion-0>li>div button {
-  width: 100%;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0 0 8px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>button:not([aria-label]):not([title]) {
-  width: 100%;
-}
-
-.emotion-0>li>button[aria-label]:empty,
-.emotion-0>li>button[title]:empty {
-  width: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>button:has(svg):not(:has(:not(svg))) {
-  width: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-top: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-bottom: 0;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  display: inline-block;
-  position: relative;
-}
-
-.emotion-6 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px 0 0 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-6:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-6:not(:disabled):hover,
-.emotion-6:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-6:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-6:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-6 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-8 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-10 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 0 8px 8px 0;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: 40px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  line-height: 1;
-  min-width: 0;
-  padding: 0;
-}
-
-.emotion-10:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-10:not(:disabled):hover,
-.emotion-10:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-10:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-10:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-10 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-15 {
-  background: #FFFFFF;
-  border: 1px solid #D4D4D4;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
-  color: #454545;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: visible;
-  padding-left: 0;
-  position: relative;
-  text-align: left;
-  width: auto;
-  background: #FFFFFF;
-  display: none;
-  max-height: 250px;
-  opacity: 0;
-  outline: 0;
-  overflow-y: auto;
-  padding: 8px 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  white-space: nowrap;
-}
-
-.emotion-15:focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 0;
-}
-
-.emotion-17 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #454545;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 16px;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  line-height: 24px;
-  margin: 0;
-  padding: 8px 16px;
-  white-space: nowrap;
-}
-
-.emotion-17:hover,
-.emotion-17:focus {
-  background: #F5F5F5;
-}
-
-.emotion-17:focus {
-  outline-color: #0074B7;
-  outline-offset: -2px;
-}
-
-.emotion-17:active {
-  outline-color: #0074B7;
-}
-
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: stretch;
-  -ms-flex-pack: stretch;
-  -webkit-justify-content: stretch;
-  justify-content: stretch;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.emotion-0>li>div {
-  margin: 0 0 8px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button,
-.emotion-0>li>div button {
-  width: 100%;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0 0 8px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>button:not([aria-label]):not([title]) {
-  width: 100%;
-}
-
-.emotion-0>li>button[aria-label]:empty,
-.emotion-0>li>button[title]:empty {
-  width: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>button:has(svg):not(:has(:not(svg))) {
-  width: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-top: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-bottom: 0;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  display: inline-block;
-  position: relative;
-}
-
-.emotion-6 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px 0 0 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-6:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-6:not(:disabled):hover,
-.emotion-6:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-6:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-6:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-6 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-8 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-10 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 0 8px 8px 0;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: 40px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  line-height: 1;
-  min-width: 0;
-  padding: 0;
-}
-
-.emotion-10:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-10:not(:disabled):hover,
-.emotion-10:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-10:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-10:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-10 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-15 {
-  background: #FFFFFF;
-  border: 1px solid #D4D4D4;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
-  color: #454545;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: visible;
-  padding-left: 0;
-  position: relative;
-  text-align: left;
-  width: auto;
-  background: #FFFFFF;
-  display: none;
-  max-height: 250px;
-  opacity: 0;
-  outline: 0;
-  overflow-y: auto;
-  padding: 8px 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  white-space: nowrap;
-}
-
-.emotion-15:focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 0;
-}
-
-.emotion-17 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #454545;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 16px;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  line-height: 24px;
-  margin: 0;
-  padding: 8px 16px;
-  white-space: nowrap;
-}
-
-.emotion-17:hover,
-.emotion-17:focus {
-  background: #F5F5F5;
-}
-
-.emotion-17:focus {
-  outline-color: #0074B7;
-  outline-offset: -2px;
-}
-
-.emotion-17:active {
-  outline-color: #0074B7;
-}
-
-<div>
-  <ul
-    class="emotion-0 emotion-1"
-    color="primary"
-    orientation="vertical"
-    role="list"
-  >
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-4 emotion-5"
-      >
-        <div>
-          <button
-            class="emotion-6 emotion-7"
-            color="primary"
-            id="1"
-            shape="leftCap"
-            style="border-right: 0; margin-right: 0px;"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="emotion-8 emotion-9"
-            >
-              Dropdown SplitButton 1
-            </span>
-          </button>
-          <button
-            aria-controls="1_dropdownMenuId"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Toggle menu"
-            class="emotion-10 emotion-7"
-            color="primary"
-            shape="rightCap"
-            style="margin-left: 2px;"
-            type="button"
-          >
-            <span
-              class="emotion-8 emotion-9"
-            >
-              <svg
-                aria-hidden="true"
-                class="icon"
-                data-testid="caretDown"
-                fill="currentColor"
-                height="20"
-                role="none"
-                viewBox="0 0 24 24"
-                width="20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          data-testid="dropdownContentWrapper"
-          id="1_dropdownMenuId"
-          style="position: absolute; left: 0px; top: 0px; z-index: 996;"
-        >
-          <div
-            class="emotion-14 emotion-15 emotion-16"
-            data-testid="dropdownContent"
-            tabindex="-1"
-            width="auto"
-          >
-            <div
-              aria-labelledby="1"
-              role="menu"
-            >
-              <div
-                class="emotion-17 emotion-18"
-                role="menuitem"
-                tabindex="-1"
-              >
-                Menu item 2.1
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-4 emotion-5"
-      >
-        <div>
-          <button
-            class="emotion-6 emotion-7"
-            color="primary"
-            id="2"
-            shape="leftCap"
-            style="border-right: 0; margin-right: 0px;"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="emotion-8 emotion-9"
-            >
-              Dropdown SplitButton 2
-            </span>
-          </button>
-          <button
-            aria-controls="2_dropdownMenuId"
-            aria-expanded="false"
-            aria-haspopup="true"
-            aria-label="Toggle menu"
-            class="emotion-10 emotion-7"
-            color="primary"
-            shape="rightCap"
-            style="margin-left: 2px;"
-            type="button"
-          >
-            <span
-              class="emotion-8 emotion-9"
-            >
-              <svg
-                aria-hidden="true"
-                class="icon"
-                data-testid="caretDown"
-                fill="currentColor"
-                height="20"
-                role="none"
-                viewBox="0 0 24 24"
-                width="20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          data-testid="dropdownContentWrapper"
-          id="2_dropdownMenuId"
-          style="position: absolute; left: 0px; top: 0px; z-index: 996;"
-        >
-          <div
-            class="emotion-14 emotion-15 emotion-16"
-            data-testid="dropdownContent"
-            tabindex="-1"
-            width="auto"
-          >
-            <div
-              aria-labelledby="2"
-              role="menu"
-            >
-              <div
-                class="emotion-17 emotion-18"
-                role="menuitem"
-                tabindex="-1"
-              >
-                Menu item 2.1
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`ButtonGroup With dropdowns Snapshot: Vertical & fill alignment 1`] = `
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: stretch;
-  -ms-flex-pack: stretch;
-  -webkit-justify-content: stretch;
-  justify-content: stretch;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.emotion-0>li>div {
-  margin: 0 0 8px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button,
-.emotion-0>li>div button {
-  width: 100%;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0 0 8px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>button:not([aria-label]):not([title]) {
-  width: 100%;
-}
-
-.emotion-0>li>button[aria-label]:empty,
-.emotion-0>li>button[title]:empty {
-  width: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>button:has(svg):not(:has(:not(svg))) {
-  width: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-top: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-bottom: 0;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-4:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-4:not(:disabled):hover,
-.emotion-4:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-6 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-10 {
-  display: inline-block;
-  position: relative;
-}
-
-.emotion-13 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-  padding-right: 8px;
-}
-
-.emotion-13:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-13:not(:disabled):hover,
-.emotion-13:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-13 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-17 {
-  padding-left: 0;
-  padding-right: 8px;
-}
-
-.emotion-20 {
-  background: #FFFFFF;
-  border: 1px solid #D4D4D4;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
-  color: #454545;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: visible;
-  padding-left: 0;
-  position: relative;
-  text-align: left;
-  width: auto;
-  background: #FFFFFF;
-  display: none;
-  max-height: 250px;
-  opacity: 0;
-  outline: 0;
-  overflow-y: auto;
-  padding: 8px 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  white-space: nowrap;
-}
-
-.emotion-20:focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 0;
-}
-
-.emotion-22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #454545;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 16px;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  line-height: 24px;
-  margin: 0;
-  padding: 8px 16px;
-  white-space: nowrap;
-}
-
-.emotion-22:hover,
-.emotion-22:focus {
-  background: #F5F5F5;
-}
-
-.emotion-22:focus {
-  outline-color: #0074B7;
-  outline-offset: -2px;
-}
-
-.emotion-22:active {
-  outline-color: #0074B7;
-}
-
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: stretch;
-  -ms-flex-pack: stretch;
-  -webkit-justify-content: stretch;
-  justify-content: stretch;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.emotion-0>li>div {
-  margin: 0 0 8px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button,
-.emotion-0>li>div button {
-  width: 100%;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0 0 8px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>button:not([aria-label]):not([title]) {
-  width: 100%;
-}
-
-.emotion-0>li>button[aria-label]:empty,
-.emotion-0>li>button[title]:empty {
-  width: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>button:has(svg):not(:has(:not(svg))) {
-  width: auto;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-top: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-bottom: 0;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-4:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-4:not(:disabled):hover,
-.emotion-4:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-6 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-10 {
-  display: inline-block;
-  position: relative;
-}
-
-.emotion-13 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-  padding-right: 8px;
-}
-
-.emotion-13:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-13:not(:disabled):hover,
-.emotion-13:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-13 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-17 {
-  padding-left: 0;
-  padding-right: 8px;
-}
-
-.emotion-20 {
-  background: #FFFFFF;
-  border: 1px solid #D4D4D4;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
-  color: #454545;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: visible;
-  padding-left: 0;
-  position: relative;
-  text-align: left;
-  width: auto;
-  background: #FFFFFF;
-  display: none;
-  max-height: 250px;
-  opacity: 0;
-  outline: 0;
-  overflow-y: auto;
-  padding: 8px 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  white-space: nowrap;
-}
-
-.emotion-20:focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 0;
-}
-
-.emotion-22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #454545;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 16px;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  line-height: 24px;
-  margin: 0;
-  padding: 8px 16px;
-  white-space: nowrap;
-}
-
-.emotion-22:hover,
-.emotion-22:focus {
-  background: #F5F5F5;
-}
-
-.emotion-22:focus {
-  outline-color: #0074B7;
-  outline-offset: -2px;
-}
-
-.emotion-22:active {
-  outline-color: #0074B7;
-}
-
-<div>
-  <ul
-    class="emotion-0 emotion-1"
-    color="primary"
-    orientation="vertical"
-    role="list"
-  >
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <button
-        class="emotion-4 emotion-5"
-        color="primary"
-        shape="fill"
-        type="button"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          1
-        </span>
-      </button>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-10 emotion-11"
-      >
-        <div>
-          <button
-            aria-controls="2_dropdownMenuId"
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-12 emotion-13 emotion-5"
-            color="primary"
-            id="2"
-            shape="fill"
-            type="button"
-          >
-            <span
-              class="emotion-6 emotion-7"
-            >
-              <span
-                class="emotion-17 emotion-18"
-              >
-                Dropdown 2
-              </span>
-              <svg
-                aria-hidden="true"
-                class="icon"
-                data-testid="caretDown"
-                fill="currentColor"
-                height="20"
-                role="none"
-                viewBox="0 0 24 24"
-                width="20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          data-testid="dropdownContentWrapper"
-          id="2_dropdownMenuId"
-          style="position: absolute; left: 0px; top: 0px; z-index: 996;"
-        >
-          <div
-            class="emotion-19 emotion-20 emotion-21"
-            data-testid="dropdownContent"
-            tabindex="-1"
-            width="auto"
-          >
-            <div
-              aria-labelledby="2"
-              role="menu"
-            >
-              <div
-                class="emotion-22 emotion-23"
-                role="menuitem"
-                tabindex="-1"
-              >
-                Menu item 2.1
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-10 emotion-11"
-      >
-        <div>
-          <button
-            aria-controls="3_dropdownMenuId"
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-12 emotion-13 emotion-5"
-            color="primary"
-            id="3"
-            shape="fill"
-            type="button"
-          >
-            <span
-              class="emotion-6 emotion-7"
-            >
-              <span
-                class="emotion-17 emotion-18"
-              >
-                Dropdown 3
-              </span>
-              <svg
-                aria-hidden="true"
-                class="icon"
-                data-testid="caretDown"
-                fill="currentColor"
-                height="20"
-                role="none"
-                viewBox="0 0 24 24"
-                width="20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          data-testid="dropdownContentWrapper"
-          id="3_dropdownMenuId"
-          style="position: absolute; left: 0px; top: 0px; z-index: 996;"
-        >
-          <div
-            class="emotion-19 emotion-20 emotion-21"
-            data-testid="dropdownContent"
-            tabindex="-1"
-            width="auto"
-          >
-            <div
-              aria-labelledby="3"
-              role="menu"
-            >
-              <div
-                class="emotion-22 emotion-23"
-                role="menuitem"
-                tabindex="-1"
-              >
-                Menu item 3.1
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`ButtonGroup With dropdowns Snapshot: noSpace 1`] = `
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  row-gap: 8px;
-}
-
-.emotion-0>li>div {
-  margin: 0;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-left: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-right: 0;
-}
-
-.emotion-0>li:first-child:not(:only-child) button {
-  border-radius: 8px 0 0 8px;
-  border-right: 0;
-}
-
-.emotion-0>li:nth-child(2) button {
-  border-left: 1px solid #FFFFFF;
-}
-
-.emotion-0>li:not(:first-child) button {
-  border-radius: 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li:not(:first-child).emotion-0>li:not(:last-child) button {
-  border-right: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child) button {
-  border-radius: 0 8px 8px 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>div:first-child:not(:only-child) button {
-  border-radius: 8px 0 0 8px;
-  border-right: 0;
-}
-
-.emotion-0>li>div:nth-child(2) button {
-  border-left: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>div:not(:first-child) button {
-  border-radius: 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>div:not(:first-child).emotion-0>li>div:not(:last-child) button {
-  border-right: 0;
-}
-
-.emotion-0>li>div:last-child:not(:only-child) button {
-  border-radius: 0 8px 8px 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>button:first-child:not(:only-child) {
-  border-radius: 8px 0 0 8px;
-  border-right: 0;
-}
-
-.emotion-0>li>button:nth-child(2) {
-  border-left: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>button:not(:first-child) {
-  border-radius: 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>button:not(:first-child).emotion-0>li>button:not(:last-child) {
-  border-right: 0;
-}
-
-.emotion-0>li>button:last-child:not(:only-child) {
-  border-radius: 0 8px 8px 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-4:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-4:not(:disabled):hover,
-.emotion-4:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-6 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-10 {
-  display: inline-block;
-  position: relative;
-}
-
-.emotion-13 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-  padding-right: 8px;
-}
-
-.emotion-13:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-13:not(:disabled):hover,
-.emotion-13:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-13 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-17 {
-  padding-left: 0;
-  padding-right: 8px;
-}
-
-.emotion-20 {
-  background: #FFFFFF;
-  border: 1px solid #D4D4D4;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
-  color: #454545;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: visible;
-  padding-left: 0;
-  position: relative;
-  text-align: left;
-  width: auto;
-  background: #FFFFFF;
-  display: none;
-  max-height: 250px;
-  opacity: 0;
-  outline: 0;
-  overflow-y: auto;
-  padding: 8px 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  white-space: nowrap;
-}
-
-.emotion-20:focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 0;
-}
-
-.emotion-22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #454545;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 16px;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  line-height: 24px;
-  margin: 0;
-  padding: 8px 16px;
-  white-space: nowrap;
-}
-
-.emotion-22:hover,
-.emotion-22:focus {
-  background: #F5F5F5;
-}
-
-.emotion-22:focus {
-  outline-color: #0074B7;
-  outline-offset: -2px;
-}
-
-.emotion-22:active {
-  outline-color: #0074B7;
-}
-
-.emotion-0 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  row-gap: 8px;
-}
-
-.emotion-0>li>div {
-  margin: 0;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li>div div>button:nth-child(2),
-.emotion-0>li>div button:nth-child(2) {
-  width: 40px;
-}
-
-.emotion-0>li>button {
-  margin: 0;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.emotion-0>li:first-child:not(:only-child)>button {
-  margin-left: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child)>button {
-  margin-right: 0;
-}
-
-.emotion-0>li:first-child:not(:only-child) button {
-  border-radius: 8px 0 0 8px;
-  border-right: 0;
-}
-
-.emotion-0>li:nth-child(2) button {
-  border-left: 1px solid #FFFFFF;
-}
-
-.emotion-0>li:not(:first-child) button {
-  border-radius: 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li:not(:first-child).emotion-0>li:not(:last-child) button {
-  border-right: 0;
-}
-
-.emotion-0>li:last-child:not(:only-child) button {
-  border-radius: 0 8px 8px 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>div:first-child:not(:only-child) button {
-  border-radius: 8px 0 0 8px;
-  border-right: 0;
-}
-
-.emotion-0>li>div:nth-child(2) button {
-  border-left: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>div:not(:first-child) button {
-  border-radius: 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>div:not(:first-child).emotion-0>li>div:not(:last-child) button {
-  border-right: 0;
-}
-
-.emotion-0>li>div:last-child:not(:only-child) button {
-  border-radius: 0 8px 8px 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>button:first-child:not(:only-child) {
-  border-radius: 8px 0 0 8px;
-  border-right: 0;
-}
-
-.emotion-0>li>button:nth-child(2) {
-  border-left: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>button:not(:first-child) {
-  border-radius: 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-0>li>button:not(:first-child).emotion-0>li>button:not(:last-child) {
-  border-right: 0;
-}
-
-.emotion-0>li>button:last-child:not(:only-child) {
-  border-radius: 0 8px 8px 0;
-  border-right: 1px solid #FFFFFF;
-}
-
-.emotion-2 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-}
-
-.emotion-4:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-4:not(:disabled):hover,
-.emotion-4:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-4:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-4 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-6 {
-  visibility: visible;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.emotion-10 {
-  display: inline-block;
-  position: relative;
-}
-
-.emotion-13 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #3942B0;
-  border: 0;
-  border-color: #3942B0;
-  border-radius: 8px;
-  color: #FFFFFF;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  font-size: 16px;
-  font-weight: 500;
-  height: 40px;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  letter-spacing: inherit;
-  line-height: 24px;
-  margin: 0;
-  min-width: 96px;
-  overflow: hidden;
-  padding: 12px 16px;
-  position: relative;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  text-transform: uppercase;
-  touch-action: manipulation;
-  -webkit-transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  transition: background 0.35s,border-color 0.35s,box-shadow 0.35s,color 0.35s;
-  vertical-align: middle;
-  white-space: nowrap;
-  width: auto;
-  padding-right: 8px;
-}
-
-.emotion-13:not(:disabled):focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 2px;
-  z-index: 1;
-}
-
-.emotion-13:not(:disabled):hover,
-.emotion-13:not(:disabled):focus {
-  background: #292F7C;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active {
-  background: #1A1E51;
-  color: #FFFFFF;
-}
-
-.emotion-13:not(:disabled):active:after {
-  opacity: 0.4;
-  -webkit-transform: translate(-50%, -50%) scale(0);
-  -moz-transform: translate(-50%, -50%) scale(0);
-  -ms-transform: translate(-50%, -50%) scale(0);
-  transform: translate(-50%, -50%) scale(0);
-  -webkit-transition: -webkit-transform 0s;
-  transition: transform 0s;
-}
-
-.emotion-13 svg {
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-}
-
-.emotion-17 {
-  padding-left: 0;
-  padding-right: 8px;
-}
-
-.emotion-20 {
-  background: #FFFFFF;
-  border: 1px solid #D4D4D4;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px 0 rgba(0,0,0,0.18);
-  color: #454545;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  overflow: visible;
-  padding-left: 0;
-  position: relative;
-  text-align: left;
-  width: auto;
-  background: #FFFFFF;
-  display: none;
-  max-height: 250px;
-  opacity: 0;
-  outline: 0;
-  overflow-y: auto;
-  padding: 8px 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  white-space: nowrap;
-}
-
-.emotion-20:focus {
-  outline: 2px solid #0074B7;
-  outline-offset: 0;
-}
-
-.emotion-22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #454545;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 16px;
-  font-family: "Work Sans",Helvetica,sans-serif;
-  line-height: 24px;
-  margin: 0;
-  padding: 8px 16px;
-  white-space: nowrap;
-}
-
-.emotion-22:hover,
-.emotion-22:focus {
-  background: #F5F5F5;
-}
-
-.emotion-22:focus {
-  outline-color: #0074B7;
-  outline-offset: -2px;
-}
-
-.emotion-22:active {
-  outline-color: #0074B7;
-}
-
-<div>
-  <ul
-    class="emotion-0 emotion-1"
-    color="primary"
-    orientation="horizontal"
-    role="list"
-  >
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <button
-        class="emotion-4 emotion-5"
-        color="primary"
-        shape="fill"
-        type="button"
-      >
-        <span
-          class="emotion-6 emotion-7"
-        >
-          1
-        </span>
-      </button>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-10 emotion-11"
-      >
-        <div>
-          <button
-            aria-controls="2_dropdownMenuId"
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-12 emotion-13 emotion-5"
-            color="primary"
-            id="2"
-            shape="fill"
-            type="button"
-          >
-            <span
-              class="emotion-6 emotion-7"
-            >
-              <span
-                class="emotion-17 emotion-18"
-              >
-                Dropdown 2
-              </span>
-              <svg
-                aria-hidden="true"
-                class="icon"
-                data-testid="caretDown"
-                fill="currentColor"
-                height="20"
-                role="none"
-                viewBox="0 0 24 24"
-                width="20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          data-testid="dropdownContentWrapper"
-          id="2_dropdownMenuId"
-          style="position: absolute; left: 0px; top: 0px; z-index: 996;"
-        >
-          <div
-            class="emotion-19 emotion-20 emotion-21"
-            data-testid="dropdownContent"
-            tabindex="-1"
-            width="auto"
-          >
-            <div
-              aria-labelledby="2"
-              role="menu"
-            >
-              <div
-                class="emotion-22 emotion-23"
-                role="menuitem"
-                tabindex="-1"
-              >
-                Menu item 2.1
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </li>
-    <li
-      class="emotion-2 emotion-3"
-    >
-      <div
-        class="emotion-10 emotion-11"
-      >
-        <div>
-          <button
-            aria-controls="3_dropdownMenuId"
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="emotion-12 emotion-13 emotion-5"
-            color="primary"
-            id="3"
-            shape="fill"
-            type="button"
-          >
-            <span
-              class="emotion-6 emotion-7"
-            >
-              <span
-                class="emotion-17 emotion-18"
-              >
-                Dropdown 3
-              </span>
-              <svg
-                aria-hidden="true"
-                class="icon"
-                data-testid="caretDown"
-                fill="currentColor"
-                height="20"
-                role="none"
-                viewBox="0 0 24 24"
-                width="20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M16 10.5c0 .1354-.0494.2526-.1483.3518l-3.5 3.5c-.0988.0988-.216.1483-.3517.1483-.1356 0-.2529-.0495-.3517-.1484l-3.5-3.4999C8.0494 10.7529 8 10.6357 8 10.5001c0-.1357.0494-.253.1483-.3518.0989-.0989.2161-.1483.3518-.1483h6.9998c.1354 0 .2526.0494.3518.1483.0992.0989.1486.2161.1483.3518z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-          </button>
-        </div>
-        <div
-          data-testid="dropdownContentWrapper"
-          id="3_dropdownMenuId"
-          style="position: absolute; left: 0px; top: 0px; z-index: 996;"
-        >
-          <div
-            class="emotion-19 emotion-20 emotion-21"
-            data-testid="dropdownContent"
-            tabindex="-1"
-            width="auto"
-          >
-            <div
-              aria-labelledby="3"
-              role="menu"
-            >
-              <div
-                class="emotion-22 emotion-23"
-                role="menuitem"
-                tabindex="-1"
-              >
-                Menu item 3.1
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
     </li>
   </ul>
 </div>

--- a/packages/react-magma-dom/src/components/ButtonGroup/index.tsx
+++ b/packages/react-magma-dom/src/components/ButtonGroup/index.tsx
@@ -26,10 +26,14 @@ export enum ButtonGroupOrientation {
   vertical = 'vertical',
 }
 
-/**
- * @children required
- */
-export interface ButtonGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+type ButtonGroupElement = HTMLDivElement | HTMLUListElement;
+
+export interface ButtonGroupProps
+  extends React.HTMLAttributes<ButtonGroupElement> {
+  /**
+   * @children required
+   */
+  children: React.ReactNode;
   /**
    * Alignment of the dropdown content
    * @default ButtonGroupAlignment.left
@@ -74,6 +78,11 @@ export interface ButtonGroupProps extends React.HTMLAttributes<HTMLDivElement> {
    * @internal
    */
   theme?: ThemeInterface;
+  /**
+   * Renders ButtonGroup as a `<ul>` with children wrapped in `<li>`.
+   * @default false
+   */
+  isList?: boolean;
 }
 
 export interface ButtonGroupContextInterface {
@@ -95,10 +104,14 @@ interface StyledButtonGroupProps {
   orientation?: ButtonGroupOrientation;
   variant?: ButtonVariant;
   theme: ThemeInterface;
+  isList?: boolean;
 }
 
 function buildButtonMargin(props: StyledButtonGroupProps): string {
   if (props.noSpace) {
+    return '0';
+  }
+  if (props.isList) {
     return '0';
   }
   if (props.orientation === ButtonGroupOrientation.horizontal) {
@@ -150,6 +163,10 @@ function buildNoSpaceBorderColor(props: StyledButtonGroupProps): string {
 }
 
 function buildFlex(props: StyledButtonGroupProps): string {
+  if (props.isList) {
+    return 'none';
+  }
+
   return props.alignment === ButtonGroupAlignment.fill &&
     props.orientation === ButtonGroupOrientation.horizontal
     ? '1'
@@ -161,6 +178,15 @@ function buildBorderRight(props: StyledButtonGroupProps): string {
     props.color === ButtonColor.subtle
     ? '0'
     : `1px solid ${props.theme.colors.neutral100}`;
+}
+
+function shouldApplyNoSpaceStyles(props: StyledButtonGroupProps): boolean {
+  return (
+    props.noSpace &&
+    props.orientation === ButtonGroupOrientation.horizontal &&
+    props.variant === ButtonVariant.solid &&
+    props.alignment !== ButtonGroupAlignment.apart
+  );
 }
 
 const buildNoSpaceButtonStyles = (
@@ -202,43 +228,101 @@ const buildNoSpaceButtonStyles = (
   `;
 };
 
-const buildHorizontalMarginReset = () => css`
-  &:first-child:not(:only-child) {
-    > button {
-      margin-left: 0;
+const buildDivChildStyles = (props: StyledButtonGroupProps) => css`
+  margin: ${buildButtonMargin(props)};
+  flex: ${buildFlex(props)};
+  button {
+    // Split button
+    &:nth-child(2) {
+      width: 40px;
     }
-  }
-
-  &:last-child:not(:only-child) {
-    > button {
-      margin-right: 0;
-    }
-  }
-`;
-
-const buildVerticalMarginReset = () => css`
-  &:first-child:not(:only-child) {
-    > button {
-      margin-top: 0;
-    }
-  }
-
-  &:last-child:not(:only-child) {
-    > button {
-      margin-bottom: 0;
-    }
+    width: ${props.alignment === ButtonGroupAlignment.fill
+      ? 'calc(100% - 42px)'
+      : ''};
   }
 `;
 
-function shouldApplyNoSpaceStyles(props: StyledButtonGroupProps): boolean {
-  return (
-    props.noSpace &&
-    props.orientation === ButtonGroupOrientation.horizontal &&
-    props.variant === ButtonVariant.solid &&
-    props.alignment !== ButtonGroupAlignment.apart
-  );
-}
+const buildButtonChildStyles = (props: StyledButtonGroupProps) => css`
+  margin: ${buildButtonMargin(props)};
+  flex: ${buildFlex(props)};
 
+  ${props.alignment === ButtonGroupAlignment.fill &&
+  css`
+    &:not([aria-label]):not([title]) {
+      width: 100%;
+    }
+    &[aria-label]:empty,
+    &[title]:empty {
+      width: auto;
+      flex: none;
+    }
+    &:has(svg):not(:has(:not(svg))) {
+      width: auto;
+      flex: none;
+    }
+  `}
+`;
+
+const buildHorizontalMarginReset = (isList = false) => css`
+  ${isList
+    ? css`
+        &:first-child:not(:only-child) > button {
+          margin-left: 0;
+        }
+        &:last-child:not(:only-child) > button {
+          margin-right: 0;
+        }
+        // SplitButton wrapper
+        &:first-child:not(:only-child) > div {
+          margin-left: 0;
+        }
+        &:last-child:not(:only-child) > div {
+          margin-right: 0;
+        }
+      `
+    : css`
+        &:first-child:not(:only-child) {
+          margin-left: 0;
+        }
+        &:last-child:not(:only-child) {
+          margin-right: 0;
+        }
+      `}
+`;
+
+const buildVerticalMarginReset = (isList = false) => css`
+  ${isList
+    ? css`
+        &:first-child:not(:only-child) > button {
+          margin-top: 0 !important;
+        }
+        &:last-child:not(:only-child) > button {
+          margin-bottom: 0 !important;
+        }
+        // SplitButton wrapper
+        &:first-child:not(:only-child) > div {
+          margin-top: 0 !important;
+        }
+        &:last-child:not(:only-child) > div {
+          margin-bottom: 0 !important;
+        }
+      `
+    : css`
+        &:first-child:not(:only-child) {
+          margin-top: 0;
+        }
+        &:last-child:not(:only-child) {
+          margin-bottom: 0;
+        }
+      `}
+`;
+
+const buildOrientationMarginReset = (props: StyledButtonGroupProps) => css`
+  ${props.orientation === ButtonGroupOrientation.horizontal &&
+  buildHorizontalMarginReset(props.isList)}
+  ${props.orientation === ButtonGroupOrientation.vertical &&
+  buildVerticalMarginReset(props.isList)}
+`;
 const StyledButtonGroup = styled.div<StyledButtonGroupProps>`
   list-style: none;
   margin: 0;
@@ -257,56 +341,36 @@ const StyledButtonGroup = styled.div<StyledButtonGroupProps>`
 
   ${props =>
     props.orientation === ButtonGroupOrientation.horizontal &&
+    !props.isList &&
     css`
       row-gap: ${props.theme.spaceScale.spacing03};
     `}
 
+  ${props =>
+    props.isList &&
+    css`
+      gap: ${props.noSpace ? '0' : props.theme.spaceScale.spacing03};
+    `}
+
+  /* List mode */
+
   > li > div {
-    margin: ${props => buildButtonMargin(props)};
-    flex: ${props => buildFlex(props)};
-    div > button,
-    button {
-      // Split buttons
-      &:nth-child(2) {
-        width: 40px;
-      }
-      width: ${props =>
-        props.alignment === ButtonGroupAlignment.fill ? '100%' : ''};
-    }
+    ${props => buildDivChildStyles(props)}
   }
 
   > li > button {
-    margin: ${props => buildButtonMargin(props)};
-    flex: ${props => buildFlex(props)};
-
-    // Only apply width 100% to buttons that are NOT icon-only buttons
-    ${props =>
-      props.alignment === ButtonGroupAlignment.fill &&
-      css`
-        &:not([aria-label]):not([title]) {
-          width: 100%;
-        }
-        &[aria-label]:empty,
-        &[title]:empty {
-          width: auto;
-          flex: none;
-        }
-        // Check if button has only icon content (no text)
-        &:has(svg):not(:has(:not(svg))) {
-          width: auto;
-          flex: none;
-        }
-      `}
+    ${props => buildButtonChildStyles(props)}
   }
 
   > li {
     ${props =>
+      props.alignment === ButtonGroupAlignment.fill &&
       props.orientation === ButtonGroupOrientation.horizontal &&
-      buildHorizontalMarginReset()}
+      css`
+        flex: 1;
+      `}
 
-    ${props =>
-      props.orientation === ButtonGroupOrientation.vertical &&
-      buildVerticalMarginReset()}
+    ${props => buildOrientationMarginReset(props)}
 
     ${props =>
       shouldApplyNoSpaceStyles(props) &&
@@ -321,10 +385,26 @@ const StyledButtonGroup = styled.div<StyledButtonGroupProps>`
       `};
   }
 
-  // Styles for ToggleButtonGroup
   > li > button {
     ${props =>
-      shouldApplyNoSpaceStyles(props) && buildNoSpaceButtonStyles(props)};
+      shouldApplyNoSpaceStyles(props) && buildNoSpaceButtonStyles(props)}
+  }
+
+  /* Div mode */
+
+  > div {
+    ${props => buildDivChildStyles(props)}
+    ${props => buildOrientationMarginReset(props)}
+    ${props =>
+      shouldApplyNoSpaceStyles(props) &&
+      buildNoSpaceButtonStyles(props, 'button')}
+  }
+
+  > button {
+    ${props => buildButtonChildStyles(props)}
+    ${props => buildOrientationMarginReset(props)}
+    ${props =>
+      shouldApplyNoSpaceStyles(props) && buildNoSpaceButtonStyles(props)}
   }
 `;
 
@@ -332,45 +412,55 @@ const StyledButtonItem = styled.li`
   list-style: none;
   margin: 0;
   padding: 0;
-  display: contents;
 `;
 
-export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
-  (props, ref) => {
-    const {
-      alignment,
-      children,
-      color,
-      isInverse,
-      orientation,
-      noSpace,
-      size,
-      testId,
-      textTransform,
-      variant,
-      ...rest
-    } = props;
-    const context = { variant, color, size, textTransform, isInverse };
-    const theme = React.useContext(ThemeContext);
+export const ButtonGroup = React.forwardRef<
+  ButtonGroupElement,
+  ButtonGroupProps
+>((props, ref) => {
+  const {
+    alignment,
+    children,
+    color,
+    isList = false,
+    isInverse,
+    orientation,
+    noSpace,
+    size,
+    testId,
+    textTransform,
+    variant,
+    role = 'group',
+    ...rest
+  } = props;
+  const context = { variant, color, size, textTransform, isInverse };
+  const theme = React.useContext(ThemeContext);
 
+  const baseStyledGroupProps = {
+    alignment: alignment || ButtonGroupAlignment.left,
+    color: color || ButtonColor.primary,
+    isList,
+    isInverse,
+    orientation: orientation || ButtonGroupOrientation.horizontal,
+    noSpace,
+    variant: variant || ButtonVariant.solid,
+    theme,
+    role,
+    'data-testid': testId,
+    ...rest,
+  };
+
+  if (isList) {
     const wrappedChildren = React.Children.map(children, child => (
       <StyledButtonItem>{child}</StyledButtonItem>
     ));
 
     return (
       <StyledButtonGroup
-        alignment={alignment || ButtonGroupAlignment.left}
-        color={color || ButtonColor.primary}
-        isInverse={isInverse}
-        orientation={orientation || ButtonGroupOrientation.horizontal}
-        noSpace={noSpace}
-        variant={variant || ButtonVariant.solid}
-        theme={theme}
-        ref={ref}
-        data-testid={testId}
-        {...rest}
-        as={'ul'}
+        {...baseStyledGroupProps}
+        as="ul"
         role="list"
+        ref={ref as React.ForwardedRef<HTMLDivElement>}
       >
         <ButtonGroupContext.Provider value={context}>
           {wrappedChildren}
@@ -378,4 +468,15 @@ export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
       </StyledButtonGroup>
     );
   }
-);
+
+  return (
+    <StyledButtonGroup
+      {...baseStyledGroupProps}
+      ref={ref as React.ForwardedRef<HTMLDivElement>}
+    >
+      <ButtonGroupContext.Provider value={context}>
+        {children}
+      </ButtonGroupContext.Provider>
+    </StyledButtonGroup>
+  );
+});

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -120,7 +120,6 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -132,22 +131,49 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -192,24 +218,24 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -219,13 +245,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -237,7 +263,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -245,23 +271,23 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -271,11 +297,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -285,7 +311,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -296,7 +322,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -311,7 +337,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -324,7 +350,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -340,7 +366,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -350,7 +376,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -367,7 +393,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -395,13 +421,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -417,7 +443,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -426,13 +452,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -445,7 +471,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -455,11 +481,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -469,7 +495,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -480,11 +506,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -499,7 +525,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -527,13 +553,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -549,7 +575,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -558,13 +584,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -577,7 +603,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 100%;
 }
 
-.emotion-96 {
+.emotion-92 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -587,11 +613,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-inline-start: 8px;
 }
 
-.emotion-96:focus {
+.emotion-92:focus {
   outline: none;
 }
 
-.emotion-96:focus>*:first-child::after {
+.emotion-92:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -601,7 +627,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   z-index: 2;
 }
 
-.emotion-96>div:first-of-type {
+.emotion-92>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -612,11 +638,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-right: 4px;
 }
 
-.emotion-96>div:first-of-type:hover {
+.emotion-92>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-100 {
+.emotion-96 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -626,7 +652,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   height: 24px;
 }
 
-.emotion-116 {
+.emotion-112 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -670,24 +696,24 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: auto;
 }
 
-.emotion-116:not(:disabled):focus {
+.emotion-112:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-116:not(:disabled):hover,
-.emotion-116:not(:disabled):focus {
+.emotion-112:not(:disabled):hover,
+.emotion-112:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-116:not(:disabled):active {
+.emotion-112:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-116:not(:disabled):active:after {
+.emotion-112:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -697,13 +723,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   transition: transform 0s;
 }
 
-.emotion-116 svg {
+.emotion-112 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-120 {
+.emotion-116 {
   padding-left: 4px;
 }
 
@@ -825,7 +851,6 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -837,22 +862,49 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -897,24 +949,24 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -924,13 +976,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -942,7 +994,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -950,23 +1002,23 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -976,11 +1028,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -990,7 +1042,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -1001,7 +1053,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1016,7 +1068,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -1029,7 +1081,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -1045,7 +1097,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -1055,7 +1107,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -1072,7 +1124,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1100,13 +1152,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -1122,7 +1174,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -1131,13 +1183,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1150,7 +1202,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -1160,11 +1212,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -1174,7 +1226,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -1185,11 +1237,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1204,7 +1256,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1232,13 +1284,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -1254,7 +1306,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -1263,13 +1315,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1282,7 +1334,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: 100%;
 }
 
-.emotion-96 {
+.emotion-92 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -1292,11 +1344,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-inline-start: 8px;
 }
 
-.emotion-96:focus {
+.emotion-92:focus {
   outline: none;
 }
 
-.emotion-96:focus>*:first-child::after {
+.emotion-92:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -1306,7 +1358,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   z-index: 2;
 }
 
-.emotion-96>div:first-of-type {
+.emotion-92>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -1317,11 +1369,11 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding-right: 4px;
 }
 
-.emotion-96>div:first-of-type:hover {
+.emotion-92>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-100 {
+.emotion-96 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -1331,7 +1383,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   height: 24px;
 }
 
-.emotion-116 {
+.emotion-112 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1375,24 +1427,24 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   width: auto;
 }
 
-.emotion-116:not(:disabled):focus {
+.emotion-112:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-116:not(:disabled):hover,
-.emotion-116:not(:disabled):focus {
+.emotion-112:not(:disabled):hover,
+.emotion-112:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-116:not(:disabled):active {
+.emotion-112:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-116:not(:disabled):active:after {
+.emotion-112:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -1402,13 +1454,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   transition: transform 0s;
 }
 
-.emotion-116 svg {
+.emotion-112 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-120 {
+.emotion-116 {
   padding-left: 4px;
 }
 
@@ -1466,77 +1518,69 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
             class="emotion-12 emotion-13"
             id="0_panel"
           >
-            <ul
+            <div
               class="emotion-14 emotion-15"
               color="subtle"
               orientation="horizontal"
-              role="list"
+              role="group"
             >
-              <li
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Expand All
-                  </span>
-                </button>
-              </li>
-              <li
+                  Expand All
+                </span>
+              </button>
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Collapse All
-                  </span>
-                </button>
-              </li>
-            </ul>
+                  Collapse All
+                </span>
+              </button>
+            </div>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <ul
               aria-multiselectable="true"
-              class="emotion-30 emotion-31"
+              class="emotion-26 emotion-27"
               role="tree"
             >
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-32 emotion-33"
+                  class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
                   role="treeitem"
                   title="item-title-1"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-1-itemwrapper"
                     id="item-id-1-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-1"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-1-checkbox"
                           disabled=""
                           id="item-id-1-checkbox"
@@ -1544,13 +1588,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-1-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -1572,7 +1616,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-1-label"
                             id="item-id-1-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -1588,7 +1632,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-48 emotion-33"
+                  class="emotion-44 emotion-29"
                   data-testid="item-id-2"
                   id="item-id-2"
                   role="treeitem"
@@ -1596,32 +1640,32 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                   title="item-title-2"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-2-itemwrapper"
                     id="item-id-2-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-2"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-2-checkbox"
                           id="item-id-2-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-2-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -1642,7 +1686,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-2-label"
                             id="item-id-2-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -1658,26 +1702,26 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-32 emotion-33"
+                  class="emotion-28 emotion-29"
                   data-testid="item-id-3"
                   id="item-id-3"
                   role="treeitem"
                   title="item-title-3"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-3-itemwrapper"
                     id="item-id-3-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-3"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-3-checkbox"
                           disabled=""
                           id="item-id-3-checkbox"
@@ -1685,13 +1729,13 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-3-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -1713,7 +1757,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-3-label"
                             id="item-id-3-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -1729,7 +1773,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-48 emotion-33"
+                  class="emotion-44 emotion-29"
                   data-testid="item-id-4"
                   id="item-id-4"
                   role="treeitem"
@@ -1737,32 +1781,32 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                   title="item-title-4"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-4-itemwrapper"
                     id="item-id-4-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-4"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-4-checkbox"
                           id="item-id-4-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-4-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -1783,7 +1827,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-4-label"
                             id="item-id-4-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -1800,7 +1844,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-96 emotion-33"
+                  class="emotion-92 emotion-29"
                   data-testid="item-id-5"
                   id="item-id-5"
                   role="treeitem"
@@ -1808,12 +1852,12 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                   title="item-title-5"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-5-itemwrapper"
                     id="item-id-5-itemwrapper"
                   >
                     <div
-                      class="emotion-100 emotion-101"
+                      class="emotion-96 emotion-97"
                       data-testid="item-id-5-expand"
                     >
                       <svg
@@ -1833,26 +1877,26 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-5-checkbox"
                           id="item-id-5-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-5-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -1873,7 +1917,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-5-label"
                             id="item-id-5-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -1891,18 +1935,18 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
               </div>
             </ul>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <button
-              class="emotion-116 emotion-19"
+              class="emotion-112 emotion-17"
               color="primary"
               data-testid="showAllBtn"
               shape="fill"
               type="button"
             >
               <span
-                class="emotion-20 emotion-21"
+                class="emotion-18 emotion-19"
               >
                 <svg
                   aria-hidden="true"
@@ -1920,7 +1964,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
                   />
                 </svg>
                 <span
-                  class="emotion-120 emotion-121"
+                  class="emotion-116 emotion-117"
                 >
                   Show All
                 </span>
@@ -2054,7 +2098,6 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -2066,22 +2109,49 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2126,24 +2196,24 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -2153,13 +2223,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -2171,7 +2241,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -2179,23 +2249,23 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -2205,11 +2275,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -2219,7 +2289,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -2230,7 +2300,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2245,7 +2315,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -2258,7 +2328,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -2274,7 +2344,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -2284,7 +2354,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -2301,7 +2371,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2329,13 +2399,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -2351,7 +2421,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -2360,13 +2430,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2379,7 +2449,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -2389,11 +2459,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -2403,7 +2473,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -2414,11 +2484,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2433,7 +2503,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2461,13 +2531,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -2483,7 +2553,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -2492,13 +2562,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2511,7 +2581,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -2521,11 +2591,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -2535,7 +2605,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -2546,7 +2616,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -2556,7 +2626,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -2566,11 +2636,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -2580,7 +2650,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -2591,11 +2661,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -2605,7 +2675,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   height: 24px;
 }
 
-.emotion-96 {
+.emotion-92 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2633,13 +2703,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   margin: 0 8px 0 0;
 }
 
-.emotion-96:before,
-.emotion-96:after {
+.emotion-92:before,
+.emotion-92:after {
   content: '';
   position: absolute;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -2655,7 +2725,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 40px;
 }
 
-.emotion-96 svg {
+.emotion-92 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -2664,13 +2734,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: all 0.2s ease-out;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2714,24 +2784,24 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -2741,13 +2811,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -2869,7 +2939,6 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -2881,22 +2950,49 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2941,24 +3037,24 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -2968,13 +3064,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -2986,7 +3082,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -2994,23 +3090,23 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -3020,11 +3116,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -3034,7 +3130,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -3045,7 +3141,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3060,7 +3156,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -3073,7 +3169,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -3089,7 +3185,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -3099,7 +3195,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -3116,7 +3212,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3144,13 +3240,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -3166,7 +3262,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -3175,13 +3271,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3194,7 +3290,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -3204,11 +3300,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -3218,7 +3314,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -3229,11 +3325,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3248,7 +3344,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3276,13 +3372,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -3298,7 +3394,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -3307,13 +3403,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3326,7 +3422,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -3336,11 +3432,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -3350,7 +3446,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -3361,7 +3457,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -3371,7 +3467,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -3381,11 +3477,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -3395,7 +3491,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -3406,11 +3502,11 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -3420,7 +3516,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   height: 24px;
 }
 
-.emotion-96 {
+.emotion-92 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3448,13 +3544,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   margin: 0 8px 0 0;
 }
 
-.emotion-96:before,
-.emotion-96:after {
+.emotion-92:before,
+.emotion-92:after {
   content: '';
   position: absolute;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -3470,7 +3566,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: 40px;
 }
 
-.emotion-96 svg {
+.emotion-92 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -3479,13 +3575,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: all 0.2s ease-out;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3529,24 +3625,24 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -3556,13 +3652,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -3620,77 +3716,69 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
             class="emotion-12 emotion-13"
             id="0_panel"
           >
-            <ul
+            <div
               class="emotion-14 emotion-15"
               color="subtle"
               orientation="horizontal"
-              role="list"
+              role="group"
             >
-              <li
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Expand All
-                  </span>
-                </button>
-              </li>
-              <li
+                  Expand All
+                </span>
+              </button>
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Collapse All
-                  </span>
-                </button>
-              </li>
-            </ul>
+                  Collapse All
+                </span>
+              </button>
+            </div>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <ul
               aria-multiselectable="true"
-              class="emotion-30 emotion-31"
+              class="emotion-26 emotion-27"
               role="tree"
             >
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-32 emotion-33"
+                  class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
                   role="treeitem"
                   title="item-title-1"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-1-itemwrapper"
                     id="item-id-1-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-1"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-1-checkbox"
                           disabled=""
                           id="item-id-1-checkbox"
@@ -3698,13 +3786,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-1-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -3726,7 +3814,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-1-label"
                             id="item-id-1-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -3742,7 +3830,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
               <div>
                 <li
                   aria-checked="true"
-                  class="emotion-48 emotion-33"
+                  class="emotion-44 emotion-29"
                   data-testid="item-id-2"
                   id="item-id-2"
                   role="treeitem"
@@ -3750,33 +3838,33 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                   title="item-title-2"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-2-itemwrapper"
                     id="item-id-2-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-2"
                           checked=""
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-2-checkbox"
                           id="item-id-2-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-2-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -3797,7 +3885,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-2-label"
                             id="item-id-2-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -3814,19 +3902,19 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-64 emotion-33"
+                  class="emotion-60 emotion-29"
                   data-testid="item-id-3"
                   id="item-id-3"
                   role="treeitem"
                   title="item-title-3"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-3-itemwrapper"
                     id="item-id-3-itemwrapper"
                   >
                     <div
-                      class="emotion-68 emotion-69"
+                      class="emotion-64 emotion-65"
                       data-testid="item-id-3-expand"
                     >
                       <svg
@@ -3846,13 +3934,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-3-checkbox"
                           disabled=""
                           id="item-id-3-checkbox"
@@ -3860,13 +3948,13 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-3-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -3888,7 +3976,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-3-label"
                             id="item-id-3-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -3908,7 +3996,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-4"
                   id="item-id-4"
                   role="treeitem"
@@ -3916,12 +4004,12 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                   title="item-title-4"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-4-itemwrapper"
                     id="item-id-4-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-4-expand"
                     >
                       <svg
@@ -3941,26 +4029,26 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-4-checkbox"
                           id="item-id-4-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-4-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-96 emotion-45"
+                            class="emotion-92 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -3981,7 +4069,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-4-label"
                             id="item-id-4-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -4001,7 +4089,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-5"
                   id="item-id-5"
                   role="treeitem"
@@ -4009,12 +4097,12 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                   title="item-title-5"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-5-itemwrapper"
                     id="item-id-5-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-5-expand"
                     >
                       <svg
@@ -4034,26 +4122,26 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-5-checkbox"
                           id="item-id-5-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-5-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-96 emotion-45"
+                            class="emotion-92 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -4074,7 +4162,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-5-label"
                             id="item-id-5-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -4092,18 +4180,18 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
               </div>
             </ul>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <button
-              class="emotion-120 emotion-19"
+              class="emotion-116 emotion-17"
               color="primary"
               data-testid="showAllBtn"
               shape="fill"
               type="button"
             >
               <span
-                class="emotion-20 emotion-21"
+                class="emotion-18 emotion-19"
               >
                 <svg
                   aria-hidden="true"
@@ -4121,7 +4209,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
                   />
                 </svg>
                 <span
-                  class="emotion-124 emotion-125"
+                  class="emotion-120 emotion-121"
                 >
                   Show All
                 </span>
@@ -4255,7 +4343,6 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -4267,22 +4354,49 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4327,24 +4441,24 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -4354,13 +4468,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -4372,7 +4486,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -4380,23 +4494,23 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -4406,11 +4520,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -4420,7 +4534,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -4431,7 +4545,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4446,7 +4560,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -4459,7 +4573,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -4475,7 +4589,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -4485,7 +4599,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -4502,7 +4616,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4530,13 +4644,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -4552,7 +4666,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -4561,13 +4675,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4580,7 +4694,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -4590,11 +4704,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -4604,7 +4718,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -4615,11 +4729,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4634,7 +4748,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4662,13 +4776,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -4684,7 +4798,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -4693,13 +4807,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4712,7 +4826,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -4722,11 +4836,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -4736,7 +4850,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -4747,7 +4861,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -4757,7 +4871,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -4767,11 +4881,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -4781,7 +4895,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -4792,11 +4906,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -4806,7 +4920,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   height: 24px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4850,24 +4964,24 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -4877,13 +4991,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -5005,7 +5119,6 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -5017,22 +5130,49 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5077,24 +5217,24 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -5104,13 +5244,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -5122,7 +5262,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -5130,23 +5270,23 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -5156,11 +5296,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -5170,7 +5310,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -5181,7 +5321,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5196,7 +5336,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -5209,7 +5349,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -5225,7 +5365,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -5235,7 +5375,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -5252,7 +5392,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5280,13 +5420,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -5302,7 +5442,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -5311,13 +5451,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5330,7 +5470,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -5340,11 +5480,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -5354,7 +5494,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -5365,11 +5505,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5384,7 +5524,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5412,13 +5552,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -5434,7 +5574,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -5443,13 +5583,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5462,7 +5602,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -5472,11 +5612,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -5486,7 +5626,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -5497,7 +5637,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -5507,7 +5647,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -5517,11 +5657,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -5531,7 +5671,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -5542,11 +5682,11 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -5556,7 +5696,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   height: 24px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5600,24 +5740,24 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -5627,13 +5767,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -5691,77 +5831,69 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
             class="emotion-12 emotion-13"
             id="0_panel"
           >
-            <ul
+            <div
               class="emotion-14 emotion-15"
               color="subtle"
               orientation="horizontal"
-              role="list"
+              role="group"
             >
-              <li
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Expand All
-                  </span>
-                </button>
-              </li>
-              <li
+                  Expand All
+                </span>
+              </button>
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Collapse All
-                  </span>
-                </button>
-              </li>
-            </ul>
+                  Collapse All
+                </span>
+              </button>
+            </div>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <ul
               aria-multiselectable="true"
-              class="emotion-30 emotion-31"
+              class="emotion-26 emotion-27"
               role="tree"
             >
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-32 emotion-33"
+                  class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
                   role="treeitem"
                   title="item-title-1"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-1-itemwrapper"
                     id="item-id-1-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-1"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-1-checkbox"
                           disabled=""
                           id="item-id-1-checkbox"
@@ -5769,13 +5901,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-1-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -5797,7 +5929,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-1-label"
                             id="item-id-1-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -5813,7 +5945,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-48 emotion-33"
+                  class="emotion-44 emotion-29"
                   data-testid="item-id-2"
                   id="item-id-2"
                   role="treeitem"
@@ -5821,32 +5953,32 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                   title="item-title-2"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-2-itemwrapper"
                     id="item-id-2-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-2"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-2-checkbox"
                           id="item-id-2-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-2-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -5867,7 +5999,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-2-label"
                             id="item-id-2-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -5884,19 +6016,19 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-64 emotion-33"
+                  class="emotion-60 emotion-29"
                   data-testid="item-id-3"
                   id="item-id-3"
                   role="treeitem"
                   title="item-title-3"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-3-itemwrapper"
                     id="item-id-3-itemwrapper"
                   >
                     <div
-                      class="emotion-68 emotion-69"
+                      class="emotion-64 emotion-65"
                       data-testid="item-id-3-expand"
                     >
                       <svg
@@ -5916,13 +6048,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-3-checkbox"
                           disabled=""
                           id="item-id-3-checkbox"
@@ -5930,13 +6062,13 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-3-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -5958,7 +6090,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-3-label"
                             id="item-id-3-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -5978,7 +6110,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-4"
                   id="item-id-4"
                   role="treeitem"
@@ -5986,12 +6118,12 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                   title="item-title-4"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-4-itemwrapper"
                     id="item-id-4-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-4-expand"
                     >
                       <svg
@@ -6011,26 +6143,26 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-4-checkbox"
                           id="item-id-4-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-4-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -6051,7 +6183,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-4-label"
                             id="item-id-4-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -6071,7 +6203,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-5"
                   id="item-id-5"
                   role="treeitem"
@@ -6079,12 +6211,12 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                   title="item-title-5"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-5-itemwrapper"
                     id="item-id-5-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-5-expand"
                     >
                       <svg
@@ -6104,26 +6236,26 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-5-checkbox"
                           id="item-id-5-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-5-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -6144,7 +6276,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-5-label"
                             id="item-id-5-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -6162,18 +6294,18 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
               </div>
             </ul>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <button
-              class="emotion-120 emotion-19"
+              class="emotion-116 emotion-17"
               color="primary"
               data-testid="showAllBtn"
               shape="fill"
               type="button"
             >
               <span
-                class="emotion-20 emotion-21"
+                class="emotion-18 emotion-19"
               >
                 <svg
                   aria-hidden="true"
@@ -6191,7 +6323,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
                   />
                 </svg>
                 <span
-                  class="emotion-124 emotion-125"
+                  class="emotion-120 emotion-121"
                 >
                   Show All
                 </span>
@@ -6325,7 +6457,6 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -6337,22 +6468,49 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6397,24 +6555,24 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -6424,13 +6582,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -6442,7 +6600,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -6450,23 +6608,23 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -6476,11 +6634,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -6490,7 +6648,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -6501,7 +6659,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6516,7 +6674,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -6529,7 +6687,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -6545,7 +6703,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -6555,7 +6713,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -6572,7 +6730,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6600,13 +6758,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -6622,7 +6780,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -6631,13 +6789,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6650,7 +6808,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -6660,11 +6818,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -6674,7 +6832,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -6685,11 +6843,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6704,7 +6862,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6732,13 +6890,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -6754,7 +6912,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -6763,13 +6921,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6782,7 +6940,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -6792,11 +6950,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -6806,7 +6964,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -6817,7 +6975,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -6827,7 +6985,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -6837,11 +6995,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -6851,7 +7009,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -6862,11 +7020,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -6876,7 +7034,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   height: 24px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -6920,24 +7078,24 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -6947,13 +7105,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -7075,7 +7233,6 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -7087,22 +7244,49 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7147,24 +7331,24 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -7174,13 +7358,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -7192,7 +7376,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -7200,23 +7384,23 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -7226,11 +7410,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -7240,7 +7424,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -7251,7 +7435,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7266,7 +7450,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -7279,7 +7463,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -7295,7 +7479,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -7305,7 +7489,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -7322,7 +7506,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7350,13 +7534,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -7372,7 +7556,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -7381,13 +7565,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7400,7 +7584,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -7410,11 +7594,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -7424,7 +7608,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -7435,11 +7619,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7454,7 +7638,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7482,13 +7666,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -7504,7 +7688,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -7513,13 +7697,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7532,7 +7716,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -7542,11 +7726,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -7556,7 +7740,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -7567,7 +7751,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -7577,7 +7761,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -7587,11 +7771,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -7601,7 +7785,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -7612,11 +7796,11 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -7626,7 +7810,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   height: 24px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -7670,24 +7854,24 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -7697,13 +7881,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -7761,77 +7945,69 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
             class="emotion-12 emotion-13"
             id="0_panel"
           >
-            <ul
+            <div
               class="emotion-14 emotion-15"
               color="subtle"
               orientation="horizontal"
-              role="list"
+              role="group"
             >
-              <li
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Expand All
-                  </span>
-                </button>
-              </li>
-              <li
+                  Expand All
+                </span>
+              </button>
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Collapse All
-                  </span>
-                </button>
-              </li>
-            </ul>
+                  Collapse All
+                </span>
+              </button>
+            </div>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <ul
               aria-multiselectable="true"
-              class="emotion-30 emotion-31"
+              class="emotion-26 emotion-27"
               role="tree"
             >
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-32 emotion-33"
+                  class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
                   role="treeitem"
                   title="item-title-1"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-1-itemwrapper"
                     id="item-id-1-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-1"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-1-checkbox"
                           disabled=""
                           id="item-id-1-checkbox"
@@ -7839,13 +8015,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-1-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -7867,7 +8043,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-1-label"
                             id="item-id-1-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -7883,7 +8059,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-48 emotion-33"
+                  class="emotion-44 emotion-29"
                   data-testid="item-id-2"
                   id="item-id-2"
                   role="treeitem"
@@ -7891,32 +8067,32 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                   title="item-title-2"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-2-itemwrapper"
                     id="item-id-2-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-2"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-2-checkbox"
                           id="item-id-2-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-2-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -7937,7 +8113,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-2-label"
                             id="item-id-2-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -7954,19 +8130,19 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-64 emotion-33"
+                  class="emotion-60 emotion-29"
                   data-testid="item-id-3"
                   id="item-id-3"
                   role="treeitem"
                   title="item-title-3"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-3-itemwrapper"
                     id="item-id-3-itemwrapper"
                   >
                     <div
-                      class="emotion-68 emotion-69"
+                      class="emotion-64 emotion-65"
                       data-testid="item-id-3-expand"
                     >
                       <svg
@@ -7986,13 +8162,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-3-checkbox"
                           disabled=""
                           id="item-id-3-checkbox"
@@ -8000,13 +8176,13 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-3-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -8028,7 +8204,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-3-label"
                             id="item-id-3-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -8048,7 +8224,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-4"
                   id="item-id-4"
                   role="treeitem"
@@ -8056,12 +8232,12 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                   title="item-title-4"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-4-itemwrapper"
                     id="item-id-4-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-4-expand"
                     >
                       <svg
@@ -8081,26 +8257,26 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-4-checkbox"
                           id="item-id-4-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-4-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -8121,7 +8297,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-4-label"
                             id="item-id-4-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -8141,7 +8317,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-5"
                   id="item-id-5"
                   role="treeitem"
@@ -8149,12 +8325,12 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                   title="item-title-5"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-5-itemwrapper"
                     id="item-id-5-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-5-expand"
                     >
                       <svg
@@ -8174,26 +8350,26 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-5-checkbox"
                           id="item-id-5-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-5-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -8214,7 +8390,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-5-label"
                             id="item-id-5-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -8232,18 +8408,18 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
               </div>
             </ul>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <button
-              class="emotion-120 emotion-19"
+              class="emotion-116 emotion-17"
               color="primary"
               data-testid="showAllBtn"
               shape="fill"
               type="button"
             >
               <span
-                class="emotion-20 emotion-21"
+                class="emotion-18 emotion-19"
               >
                 <svg
                   aria-hidden="true"
@@ -8261,7 +8437,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
                   />
                 </svg>
                 <span
-                  class="emotion-124 emotion-125"
+                  class="emotion-120 emotion-121"
                 >
                   Show All
                 </span>
@@ -8395,7 +8571,6 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -8407,22 +8582,49 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -8467,24 +8669,24 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -8494,13 +8696,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -8512,7 +8714,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -8520,23 +8722,23 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -8546,11 +8748,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -8560,7 +8762,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -8571,7 +8773,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8586,7 +8788,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -8599,7 +8801,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -8615,7 +8817,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -8625,7 +8827,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -8642,7 +8844,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -8670,13 +8872,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -8692,7 +8894,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -8701,13 +8903,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8720,7 +8922,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -8730,11 +8932,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -8744,7 +8946,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -8755,11 +8957,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8774,7 +8976,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -8802,13 +9004,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -8824,7 +9026,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -8833,13 +9035,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8852,7 +9054,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -8862,11 +9064,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -8876,7 +9078,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -8887,7 +9089,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -8897,7 +9099,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -8907,11 +9109,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -8921,7 +9123,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -8932,11 +9134,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -8946,7 +9148,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   height: 24px;
 }
 
-.emotion-96 {
+.emotion-92 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -8974,13 +9176,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-96:before,
-.emotion-96:after {
+.emotion-92:before,
+.emotion-92:after {
   content: '';
   position: absolute;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -8996,7 +9198,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-96 svg {
+.emotion-92 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -9005,13 +9207,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9055,24 +9257,24 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -9082,13 +9284,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -9210,7 +9412,6 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -9222,22 +9423,49 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9282,24 +9510,24 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -9309,13 +9537,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -9327,7 +9555,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -9335,23 +9563,23 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -9361,11 +9589,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -9375,7 +9603,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -9386,7 +9614,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9401,7 +9629,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -9414,7 +9642,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -9430,7 +9658,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -9440,7 +9668,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -9457,7 +9685,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9485,13 +9713,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -9507,7 +9735,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -9516,13 +9744,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9535,7 +9763,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -9545,11 +9773,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -9559,7 +9787,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -9570,11 +9798,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9589,7 +9817,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9617,13 +9845,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -9639,7 +9867,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -9648,13 +9876,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9667,7 +9895,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -9677,11 +9905,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -9691,7 +9919,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -9702,7 +9930,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -9712,7 +9940,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -9722,11 +9950,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -9736,7 +9964,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -9747,11 +9975,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -9761,7 +9989,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   height: 24px;
 }
 
-.emotion-96 {
+.emotion-92 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9789,13 +10017,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-96:before,
-.emotion-96:after {
+.emotion-92:before,
+.emotion-92:after {
   content: '';
   position: absolute;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -9811,7 +10039,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-96 svg {
+.emotion-92 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -9820,13 +10048,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -9870,24 +10098,24 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -9897,13 +10125,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -9961,77 +10189,69 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
             class="emotion-12 emotion-13"
             id="0_panel"
           >
-            <ul
+            <div
               class="emotion-14 emotion-15"
               color="subtle"
               orientation="horizontal"
-              role="list"
+              role="group"
             >
-              <li
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Expand All
-                  </span>
-                </button>
-              </li>
-              <li
+                  Expand All
+                </span>
+              </button>
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Collapse All
-                  </span>
-                </button>
-              </li>
-            </ul>
+                  Collapse All
+                </span>
+              </button>
+            </div>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <ul
               aria-multiselectable="true"
-              class="emotion-30 emotion-31"
+              class="emotion-26 emotion-27"
               role="tree"
             >
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-32 emotion-33"
+                  class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
                   role="treeitem"
                   title="item-title-1"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-1-itemwrapper"
                     id="item-id-1-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-1"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-1-checkbox"
                           disabled=""
                           id="item-id-1-checkbox"
@@ -10039,13 +10259,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-1-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -10067,7 +10287,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-1-label"
                             id="item-id-1-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -10083,7 +10303,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
               <div>
                 <li
                   aria-checked="true"
-                  class="emotion-48 emotion-33"
+                  class="emotion-44 emotion-29"
                   data-testid="item-id-2"
                   id="item-id-2"
                   role="treeitem"
@@ -10091,33 +10311,33 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                   title="item-title-2"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-2-itemwrapper"
                     id="item-id-2-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-2"
                           checked=""
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-2-checkbox"
                           id="item-id-2-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-2-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -10138,7 +10358,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-2-label"
                             id="item-id-2-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -10155,19 +10375,19 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-64 emotion-33"
+                  class="emotion-60 emotion-29"
                   data-testid="item-id-3"
                   id="item-id-3"
                   role="treeitem"
                   title="item-title-3"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-3-itemwrapper"
                     id="item-id-3-itemwrapper"
                   >
                     <div
-                      class="emotion-68 emotion-69"
+                      class="emotion-64 emotion-65"
                       data-testid="item-id-3-expand"
                     >
                       <svg
@@ -10187,13 +10407,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-3-checkbox"
                           disabled=""
                           id="item-id-3-checkbox"
@@ -10201,13 +10421,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-3-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -10229,7 +10449,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-3-label"
                             id="item-id-3-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -10249,7 +10469,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-4"
                   id="item-id-4"
                   role="treeitem"
@@ -10257,12 +10477,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                   title="item-title-4"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-4-itemwrapper"
                     id="item-id-4-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-4-expand"
                     >
                       <svg
@@ -10282,26 +10502,26 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-4-checkbox"
                           id="item-id-4-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-4-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-96 emotion-45"
+                            class="emotion-92 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -10322,7 +10542,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-4-label"
                             id="item-id-4-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -10342,7 +10562,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-5"
                   id="item-id-5"
                   role="treeitem"
@@ -10350,12 +10570,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                   title="item-title-5"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-5-itemwrapper"
                     id="item-id-5-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-5-expand"
                     >
                       <svg
@@ -10375,26 +10595,26 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-5-checkbox"
                           id="item-id-5-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-5-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-96 emotion-45"
+                            class="emotion-92 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -10415,7 +10635,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-5-label"
                             id="item-id-5-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -10433,18 +10653,18 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
               </div>
             </ul>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <button
-              class="emotion-120 emotion-19"
+              class="emotion-116 emotion-17"
               color="primary"
               data-testid="showAllBtn"
               shape="fill"
               type="button"
             >
               <span
-                class="emotion-20 emotion-21"
+                class="emotion-18 emotion-19"
               >
                 <svg
                   aria-hidden="true"
@@ -10462,7 +10682,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                   />
                 </svg>
                 <span
-                  class="emotion-124 emotion-125"
+                  class="emotion-120 emotion-121"
                 >
                   Show All
                 </span>
@@ -10596,7 +10816,6 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -10608,22 +10827,49 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -10668,24 +10914,24 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -10695,13 +10941,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -10713,7 +10959,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -10721,23 +10967,23 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -10747,11 +10993,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -10761,7 +11007,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -10772,7 +11018,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10787,7 +11033,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -10800,7 +11046,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -10816,7 +11062,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -10826,7 +11072,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -10843,7 +11089,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -10871,13 +11117,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -10893,7 +11139,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -10902,13 +11148,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10921,7 +11167,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -10931,11 +11177,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -10945,7 +11191,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -10956,11 +11202,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10975,7 +11221,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11003,13 +11249,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -11025,7 +11271,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -11034,13 +11280,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11053,7 +11299,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -11063,11 +11309,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -11077,7 +11323,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -11088,7 +11334,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -11098,7 +11344,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -11108,11 +11354,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -11122,7 +11368,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -11133,11 +11379,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -11147,7 +11393,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   height: 24px;
 }
 
-.emotion-96 {
+.emotion-92 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11175,13 +11421,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-96:before,
-.emotion-96:after {
+.emotion-92:before,
+.emotion-92:after {
   content: '';
   position: absolute;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -11197,7 +11443,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-96 svg {
+.emotion-92 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -11206,13 +11452,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11256,24 +11502,24 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -11283,13 +11529,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -11411,7 +11657,6 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -11423,22 +11668,49 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11483,24 +11755,24 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -11510,13 +11782,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -11528,7 +11800,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -11536,23 +11808,23 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -11562,11 +11834,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -11576,7 +11848,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -11587,7 +11859,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11602,7 +11874,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -11615,7 +11887,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -11631,7 +11903,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -11641,7 +11913,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -11658,7 +11930,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11686,13 +11958,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -11708,7 +11980,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -11717,13 +11989,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11736,7 +12008,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -11746,11 +12018,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -11760,7 +12032,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -11771,11 +12043,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11790,7 +12062,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11818,13 +12090,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -11840,7 +12112,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -11849,13 +12121,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11868,7 +12140,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -11878,11 +12150,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -11892,7 +12164,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -11903,7 +12175,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -11913,7 +12185,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -11923,11 +12195,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -11937,7 +12209,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -11948,11 +12220,11 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -11962,7 +12234,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   height: 24px;
 }
 
-.emotion-96 {
+.emotion-92 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -11990,13 +12262,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   margin: 0 8px 0 0;
 }
 
-.emotion-96:before,
-.emotion-96:after {
+.emotion-92:before,
+.emotion-92:after {
   content: '';
   position: absolute;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -12012,7 +12284,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: 40px;
 }
 
-.emotion-96 svg {
+.emotion-92 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -12021,13 +12293,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: all 0.2s ease-out;
 }
 
-.emotion-96:after {
+.emotion-92:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -12071,24 +12343,24 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -12098,13 +12370,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -12162,77 +12434,69 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
             class="emotion-12 emotion-13"
             id="0_panel"
           >
-            <ul
+            <div
               class="emotion-14 emotion-15"
               color="subtle"
               orientation="horizontal"
-              role="list"
+              role="group"
             >
-              <li
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Expand All
-                  </span>
-                </button>
-              </li>
-              <li
+                  Expand All
+                </span>
+              </button>
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Collapse All
-                  </span>
-                </button>
-              </li>
-            </ul>
+                  Collapse All
+                </span>
+              </button>
+            </div>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <ul
               aria-multiselectable="true"
-              class="emotion-30 emotion-31"
+              class="emotion-26 emotion-27"
               role="tree"
             >
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-32 emotion-33"
+                  class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
                   role="treeitem"
                   title="item-title-1"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-1-itemwrapper"
                     id="item-id-1-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-1"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-1-checkbox"
                           disabled=""
                           id="item-id-1-checkbox"
@@ -12240,13 +12504,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-1-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -12268,7 +12532,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-1-label"
                             id="item-id-1-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -12284,7 +12548,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
               <div>
                 <li
                   aria-checked="true"
-                  class="emotion-48 emotion-33"
+                  class="emotion-44 emotion-29"
                   data-testid="item-id-2"
                   id="item-id-2"
                   role="treeitem"
@@ -12292,33 +12556,33 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                   title="item-title-2"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-2-itemwrapper"
                     id="item-id-2-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-2"
                           checked=""
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-2-checkbox"
                           id="item-id-2-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-2-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -12339,7 +12603,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-2-label"
                             id="item-id-2-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -12356,19 +12620,19 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-64 emotion-33"
+                  class="emotion-60 emotion-29"
                   data-testid="item-id-3"
                   id="item-id-3"
                   role="treeitem"
                   title="item-title-3"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-3-itemwrapper"
                     id="item-id-3-itemwrapper"
                   >
                     <div
-                      class="emotion-68 emotion-69"
+                      class="emotion-64 emotion-65"
                       data-testid="item-id-3-expand"
                     >
                       <svg
@@ -12388,13 +12652,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-3-checkbox"
                           disabled=""
                           id="item-id-3-checkbox"
@@ -12402,13 +12666,13 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-3-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -12430,7 +12694,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-3-label"
                             id="item-id-3-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -12450,7 +12714,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-4"
                   id="item-id-4"
                   role="treeitem"
@@ -12458,12 +12722,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                   title="item-title-4"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-4-itemwrapper"
                     id="item-id-4-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-4-expand"
                     >
                       <svg
@@ -12483,26 +12747,26 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-4-checkbox"
                           id="item-id-4-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-4-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-96 emotion-45"
+                            class="emotion-92 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -12523,7 +12787,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-4-label"
                             id="item-id-4-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -12543,7 +12807,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-5"
                   id="item-id-5"
                   role="treeitem"
@@ -12551,12 +12815,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                   title="item-title-5"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-5-itemwrapper"
                     id="item-id-5-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-5-expand"
                     >
                       <svg
@@ -12576,26 +12840,26 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-5-checkbox"
                           id="item-id-5-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-5-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-96 emotion-45"
+                            class="emotion-92 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -12616,7 +12880,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-5-label"
                             id="item-id-5-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -12634,18 +12898,18 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
               </div>
             </ul>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <button
-              class="emotion-120 emotion-19"
+              class="emotion-116 emotion-17"
               color="primary"
               data-testid="showAllBtn"
               shape="fill"
               type="button"
             >
               <span
-                class="emotion-20 emotion-21"
+                class="emotion-18 emotion-19"
               >
                 <svg
                   aria-hidden="true"
@@ -12663,7 +12927,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
                   />
                 </svg>
                 <span
-                  class="emotion-124 emotion-125"
+                  class="emotion-120 emotion-121"
                 >
                   Show All
                 </span>
@@ -12797,7 +13061,6 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -12809,22 +13072,49 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -12869,24 +13159,24 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -12896,13 +13186,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -12914,7 +13204,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -12922,23 +13212,23 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -12948,11 +13238,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -12962,7 +13252,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -12973,7 +13263,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12988,7 +13278,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -13001,7 +13291,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -13017,7 +13307,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -13027,7 +13317,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -13044,7 +13334,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13072,13 +13362,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -13094,7 +13384,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -13103,13 +13393,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13122,7 +13412,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -13132,11 +13422,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -13146,7 +13436,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -13157,11 +13447,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13176,7 +13466,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13204,13 +13494,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -13226,7 +13516,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -13235,13 +13525,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13254,7 +13544,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -13264,11 +13554,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -13278,7 +13568,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -13289,7 +13579,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -13299,7 +13589,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -13309,11 +13599,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -13323,7 +13613,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -13334,11 +13624,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -13348,7 +13638,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   height: 24px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13392,24 +13682,24 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -13419,13 +13709,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -13547,7 +13837,6 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   flex: none;
 }
 
-.emotion-14>li>div div>button:nth-child(2),
 .emotion-14>li>div button:nth-child(2) {
   width: 40px;
 }
@@ -13559,22 +13848,49 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   flex: none;
 }
 
-.emotion-14>li:first-child:not(:only-child)>button {
+.emotion-14>li:first-child:not(:only-child) {
   margin-left: 0;
 }
 
-.emotion-14>li:last-child:not(:only-child)>button {
+.emotion-14>li:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>div {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>div button:nth-child(2) {
+  width: 40px;
+}
+
+.emotion-14>div:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>div:last-child:not(:only-child) {
+  margin-right: 0;
+}
+
+.emotion-14>button {
+  margin: 0 4px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.emotion-14>button:first-child:not(:only-child) {
+  margin-left: 0;
+}
+
+.emotion-14>button:last-child:not(:only-child) {
   margin-right: 0;
 }
 
 .emotion-16 {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: contents;
-}
-
-.emotion-18 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13619,24 +13935,24 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: auto;
 }
 
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-18:not(:disabled):hover,
-.emotion-18:not(:disabled):focus {
+.emotion-16:not(:disabled):hover,
+.emotion-16:not(:disabled):focus {
   background: rgba(0,0,0,0.05);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active {
+.emotion-16:not(:disabled):active {
   background: rgba(0,0,0,0.1);
   color: #454545;
 }
 
-.emotion-18:not(:disabled):active:after {
+.emotion-16:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -13646,13 +13962,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   transition: transform 0s;
 }
 
-.emotion-18 svg {
+.emotion-16 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-20 {
+.emotion-18 {
   visibility: visible;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -13664,7 +13980,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   align-items: center;
 }
 
-.emotion-28 {
+.emotion-24 {
   display: block;
   height: 16px;
   min-height: 16px;
@@ -13672,23 +13988,23 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 1px;
 }
 
-.emotion-30 {
+.emotion-26 {
   padding: 0;
   margin: 0;
   color: #707070;
   position: static;
 }
 
-.emotion-30 ul {
+.emotion-26 ul {
   padding: 0;
   margin: 0;
 }
 
-.emotion-30 ul li {
+.emotion-26 ul li {
   margin: 0;
 }
 
-.emotion-32 {
+.emotion-28 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -13698,11 +14014,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-inline-start: 40px;
 }
 
-.emotion-32:focus {
+.emotion-28:focus {
   outline: none;
 }
 
-.emotion-32:focus>*:first-child::after {
+.emotion-28:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -13712,7 +14028,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   z-index: 2;
 }
 
-.emotion-32>div:first-of-type {
+.emotion-28>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -13723,7 +14039,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-right: 4px;
 }
 
-.emotion-34 {
+.emotion-30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13738,7 +14054,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   cursor: not-allowed;
 }
 
-.emotion-36 {
+.emotion-32 {
   margin-right: 8px;
   vertical-align: middle;
   display: -webkit-inline-box;
@@ -13751,7 +14067,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: calc(100% - 8px);
 }
 
-.emotion-38 {
+.emotion-34 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -13767,7 +14083,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   position: relative;
 }
 
-.emotion-40 {
+.emotion-36 {
   clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
   position: absolute;
@@ -13777,7 +14093,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 1px;
 }
 
-.emotion-42 {
+.emotion-38 {
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
@@ -13794,7 +14110,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding: 8px 0;
 }
 
-.emotion-44 {
+.emotion-40 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13822,13 +14138,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   margin: 0 8px 0 0;
 }
 
-.emotion-44:before,
-.emotion-44:after {
+.emotion-40:before,
+.emotion-40:after {
   content: '';
   position: absolute;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -13844,7 +14160,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 40px;
 }
 
-.emotion-44 svg {
+.emotion-40 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -13853,13 +14169,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   transition: all 0.2s ease-out;
 }
 
-.emotion-44:after {
+.emotion-40:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-46 {
+.emotion-42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13872,7 +14188,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 100%;
 }
 
-.emotion-48 {
+.emotion-44 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -13882,11 +14198,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-inline-start: 40px;
 }
 
-.emotion-48:focus {
+.emotion-44:focus {
   outline: none;
 }
 
-.emotion-48:focus>*:first-child::after {
+.emotion-44:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -13896,7 +14212,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   z-index: 2;
 }
 
-.emotion-48>div:first-of-type {
+.emotion-44>div:first-of-type {
   position: relative;
   -webkit-padding-start: 40px;
   padding-inline-start: 40px;
@@ -13907,11 +14223,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-right: 4px;
 }
 
-.emotion-48>div:first-of-type:hover {
+.emotion-44>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-50 {
+.emotion-46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13926,7 +14242,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   cursor: default;
 }
 
-.emotion-60 {
+.emotion-56 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -13954,13 +14270,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   margin: 0 8px 0 0;
 }
 
-.emotion-60:before,
-.emotion-60:after {
+.emotion-56:before,
+.emotion-56:after {
   content: '';
   position: absolute;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   border-radius: 50%;
   height: 40px;
   left: -8px;
@@ -13976,7 +14292,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 40px;
 }
 
-.emotion-60 svg {
+.emotion-56 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -13985,13 +14301,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   transition: all 0.2s ease-out;
 }
 
-.emotion-60:after {
+.emotion-56:after {
   background: #3942B0;
   top: -10px;
   left: -10px;
 }
 
-.emotion-62 {
+.emotion-58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14004,7 +14320,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: 100%;
 }
 
-.emotion-64 {
+.emotion-60 {
   color: #454545;
   list-style-type: none;
   cursor: not-allowed;
@@ -14014,11 +14330,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-inline-start: 8px;
 }
 
-.emotion-64:focus {
+.emotion-60:focus {
   outline: none;
 }
 
-.emotion-64:focus>*:first-child::after {
+.emotion-60:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -14028,7 +14344,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   z-index: 2;
 }
 
-.emotion-64>div:first-of-type {
+.emotion-60>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -14039,7 +14355,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-right: 4px;
 }
 
-.emotion-68 {
+.emotion-64 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -14049,7 +14365,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   height: 24px;
 }
 
-.emotion-82 {
+.emotion-78 {
   color: #454545;
   list-style-type: none;
   cursor: default;
@@ -14059,11 +14375,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-inline-start: 8px;
 }
 
-.emotion-82:focus {
+.emotion-78:focus {
   outline: none;
 }
 
-.emotion-82:focus>*:first-child::after {
+.emotion-78:focus>*:first-child::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -14073,7 +14389,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   z-index: 2;
 }
 
-.emotion-82>div:first-of-type {
+.emotion-78>div:first-of-type {
   position: relative;
   -webkit-padding-start: 8px;
   padding-inline-start: 8px;
@@ -14084,11 +14400,11 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding-right: 4px;
 }
 
-.emotion-82>div:first-of-type:hover {
+.emotion-78>div:first-of-type:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.emotion-86 {
+.emotion-82 {
   display: inline-block;
   vertical-align: middle;
   margin-right: 8px;
@@ -14098,7 +14414,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   height: 24px;
 }
 
-.emotion-120 {
+.emotion-116 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -14142,24 +14458,24 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   width: auto;
 }
 
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):focus {
   outline: 2px solid #0074B7;
   outline-offset: 2px;
   z-index: 1;
 }
 
-.emotion-120:not(:disabled):hover,
-.emotion-120:not(:disabled):focus {
+.emotion-116:not(:disabled):hover,
+.emotion-116:not(:disabled):focus {
   background: #E8E9F8;
   color: #3942B0;
 }
 
-.emotion-120:not(:disabled):active {
+.emotion-116:not(:disabled):active {
   background: #BABDE9;
   color: #292F7C;
 }
 
-.emotion-120:not(:disabled):active:after {
+.emotion-116:not(:disabled):active:after {
   opacity: 0.4;
   -webkit-transform: translate(-50%, -50%) scale(0);
   -moz-transform: translate(-50%, -50%) scale(0);
@@ -14169,13 +14485,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   transition: transform 0s;
 }
 
-.emotion-120 svg {
+.emotion-116 svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.emotion-124 {
+.emotion-120 {
   padding-left: 4px;
 }
 
@@ -14233,77 +14549,69 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
             class="emotion-12 emotion-13"
             id="0_panel"
           >
-            <ul
+            <div
               class="emotion-14 emotion-15"
               color="subtle"
               orientation="horizontal"
-              role="list"
+              role="group"
             >
-              <li
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Expand All
-                  </span>
-                </button>
-              </li>
-              <li
+                  Expand All
+                </span>
+              </button>
+              <button
                 class="emotion-16 emotion-17"
+                color="subtle"
+                shape="fill"
+                type="button"
               >
-                <button
+                <span
                   class="emotion-18 emotion-19"
-                  color="subtle"
-                  shape="fill"
-                  type="button"
                 >
-                  <span
-                    class="emotion-20 emotion-21"
-                  >
-                    Collapse All
-                  </span>
-                </button>
-              </li>
-            </ul>
+                  Collapse All
+                </span>
+              </button>
+            </div>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <ul
               aria-multiselectable="true"
-              class="emotion-30 emotion-31"
+              class="emotion-26 emotion-27"
               role="tree"
             >
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-32 emotion-33"
+                  class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
                   role="treeitem"
                   title="item-title-1"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-1-itemwrapper"
                     id="item-id-1-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-1"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-1-checkbox"
                           disabled=""
                           id="item-id-1-checkbox"
@@ -14311,13 +14619,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-1-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -14339,7 +14647,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-1-label"
                             id="item-id-1-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -14355,7 +14663,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
               <div>
                 <li
                   aria-checked="false"
-                  class="emotion-48 emotion-33"
+                  class="emotion-44 emotion-29"
                   data-testid="item-id-2"
                   id="item-id-2"
                   role="treeitem"
@@ -14363,32 +14671,32 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                   title="item-title-2"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-2-itemwrapper"
                     id="item-id-2-itemwrapper"
                   >
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
                           aria-label="item-title-2"
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-2-checkbox"
                           id="item-id-2-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-2-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -14409,7 +14717,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-2-label"
                             id="item-id-2-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -14426,19 +14734,19 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-64 emotion-33"
+                  class="emotion-60 emotion-29"
                   data-testid="item-id-3"
                   id="item-id-3"
                   role="treeitem"
                   title="item-title-3"
                 >
                   <div
-                    class="emotion-34 emotion-35"
+                    class="emotion-30 emotion-31"
                     data-testid="item-id-3-itemwrapper"
                     id="item-id-3-itemwrapper"
                   >
                     <div
-                      class="emotion-68 emotion-69"
+                      class="emotion-64 emotion-65"
                       data-testid="item-id-3-expand"
                     >
                       <svg
@@ -14458,13 +14766,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-3-checkbox"
                           disabled=""
                           id="item-id-3-checkbox"
@@ -14472,13 +14780,13 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-3-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-44 emotion-45"
+                            class="emotion-40 emotion-41"
                             color="#3942B0"
                             disabled=""
                             style="margin-right: 8px;"
@@ -14500,7 +14808,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                             </svg>
                           </span>
                           <span
-                            class="emotion-46 emotion-47"
+                            class="emotion-42 emotion-43"
                             data-testid="item-id-3-label"
                             id="item-id-3-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -14520,7 +14828,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-4"
                   id="item-id-4"
                   role="treeitem"
@@ -14528,12 +14836,12 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                   title="item-title-4"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-4-itemwrapper"
                     id="item-id-4-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-4-expand"
                     >
                       <svg
@@ -14553,26 +14861,26 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-4-checkbox"
                           id="item-id-4-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-4-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -14593,7 +14901,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-4-label"
                             id="item-id-4-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -14613,7 +14921,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                 <li
                   aria-checked="false"
                   aria-expanded="false"
-                  class="emotion-82 emotion-33"
+                  class="emotion-78 emotion-29"
                   data-testid="item-id-5"
                   id="item-id-5"
                   role="treeitem"
@@ -14621,12 +14929,12 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                   title="item-title-5"
                 >
                   <div
-                    class="emotion-50 emotion-35"
+                    class="emotion-46 emotion-31"
                     data-testid="item-id-5-itemwrapper"
                     id="item-id-5-itemwrapper"
                   >
                     <div
-                      class="emotion-86 emotion-69"
+                      class="emotion-82 emotion-65"
                       data-testid="item-id-5-expand"
                     >
                       <svg
@@ -14646,26 +14954,26 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                       </svg>
                     </div>
                     <div
-                      class="emotion-36 emotion-37"
+                      class="emotion-32 emotion-33"
                     >
                       <div
-                        class="emotion-38 emotion-39"
+                        class="emotion-34 emotion-35"
                       >
                         <input
-                          class="emotion-40 emotion-41"
+                          class="emotion-36 emotion-37"
                           data-testid="item-id-5-checkbox"
                           id="item-id-5-checkbox"
                           tabindex="-1"
                           type="checkbox"
                         />
                         <label
-                          class="emotion-42 emotion-43"
+                          class="emotion-38 emotion-39"
                           for="item-id-5-checkbox"
                           style="padding: 0px; width: 100%;"
                         >
                           <span
                             aria-hidden="true"
-                            class="emotion-60 emotion-45"
+                            class="emotion-56 emotion-41"
                             color="#3942B0"
                             style="margin-right: 8px;"
                           >
@@ -14686,7 +14994,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                             </svg>
                           </span>
                           <span
-                            class="emotion-62 emotion-47"
+                            class="emotion-58 emotion-43"
                             data-testid="item-id-5-label"
                             id="item-id-5-label"
                             style="overflow: hidden; text-overflow: ellipsis; width: 230px; display: inline-block;"
@@ -14704,18 +15012,18 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
               </div>
             </ul>
             <span
-              class="emotion-28 emotion-11"
+              class="emotion-24 emotion-11"
               size="16"
             />
             <button
-              class="emotion-120 emotion-19"
+              class="emotion-116 emotion-17"
               color="primary"
               data-testid="showAllBtn"
               shape="fill"
               type="button"
             >
               <span
-                class="emotion-20 emotion-21"
+                class="emotion-18 emotion-19"
               >
                 <svg
                   aria-hidden="true"
@@ -14733,7 +15041,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
                   />
                 </svg>
                 <span
-                  class="emotion-124 emotion-125"
+                  class="emotion-120 emotion-121"
                 >
                   Show All
                 </span>

--- a/website/react-magma-docs/src/pages/api/buttongroup.mdx
+++ b/website/react-magma-docs/src/pages/api/buttongroup.mdx
@@ -284,6 +284,32 @@ export function Example() {
 }
 ```
 
+## List
+
+The `isList` prop allows you to render the `ButtonGroup` as a `<ul>` with `<li>` items. By default, `ButtonGroup` renders as a `<div>`.
+
+```tsx
+import React from 'react';
+
+import { ButtonGroup, Button } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <>
+      <ButtonGroup>
+        <Button>Default 1</Button>
+        <Button>Default 2</Button>
+      </ButtonGroup>
+      <br />
+      <ButtonGroup isList>
+        <Button>List 1</Button>
+        <Button>List 2</Button>
+      </ButtonGroup>
+    </>
+  );
+}
+```
+
 ## ButtonGroup Props
 
 **Any other props supplied will be provided to the wrapping `div` element.**


### PR DESCRIPTION
Closes: #2472

## What I did
-  New feature: Added `isList` prop to `ButtonGroup` for semantic list rendering (`<ul>/<li>`) in addition to the default `<div>`.
-  Docs: Updated documentation and stories to reflect new `isList` and role management features.

## Screenshots


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open Storybook → ButtonGroup → open DevTools → check structure → enable isList → verify structure