### PR TITLE
fix(DatePicker): fix issue with error announcement v2 (#2491)

### DIFF
--- a/.changeset/fix-DatePicker-error-announcement-v2.md
+++ b/.changeset/fix-DatePicker-error-announcement-v2.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DatePicker): fix issue with error announcement v2

--- a/packages/dropzone/src/components/dropzone/Dropzone.test.js
+++ b/packages/dropzone/src/components/dropzone/Dropzone.test.js
@@ -349,16 +349,18 @@ describe('File Uploader', () => {
 
     const ui = <Dropzone maxFiles={1} testId={testId} />;
 
-    const { getByTestId, getByText, rerender } = render(ui);
+    const { getByTestId, getAllByText, rerender } = render(ui);
 
     const dropzone = getByTestId(testId);
     fireDrop(dropzone, data);
 
     await flushPromises(rerender, ui);
 
-    expect(
-      getByText('You must upload a maximum of 1 files.')
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        getAllByText('You must upload a maximum of 1 files.')[0]
+      ).toBeInTheDocument();
+    });
   });
 
   it('shows errors on too few files in the file list', async () => {
@@ -367,16 +369,18 @@ describe('File Uploader', () => {
 
     const ui = <Dropzone minFiles={6} testId={testId} />;
 
-    const { getByTestId, getByText, rerender } = render(ui);
+    const { getByTestId, getAllByText, rerender } = render(ui);
 
     const dropzone = getByTestId(testId);
     fireDrop(dropzone, data);
 
     await flushPromises(rerender, ui);
 
-    expect(
-      getByText('You must upload a minimum of 6 files.')
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        getAllByText('You must upload a minimum of 6 files.')[0]
+      ).toBeInTheDocument();
+    });
   });
 
   it('shows errors on too large of a file in the file list', async () => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -368,19 +368,19 @@ describe('Date Picker', () => {
   });
 
   it('should render a helper message on the date picker input', () => {
-    const { getByText } = render(
+    const { getAllByText } = render(
       <DatePicker labelText="Date Picker Label" helperMessage={helperMessage} />
     );
 
-    expect(getByText(helperMessage)).not.toBeNull();
+    expect(getAllByText(helperMessage)[0]).toBeInTheDocument();
   });
 
   it('should render an error message on the date picker input', () => {
-    const { getByText } = render(
+    const { getAllByText } = render(
       <DatePicker labelText="Date Picker Label" errorMessage={errorMessage} />
     );
 
-    expect(getByText(errorMessage)).not.toBeNull();
+    expect(getAllByText(errorMessage)[0]).toBeInTheDocument();
   });
 
   it('should require the date picker input', () => {
@@ -1344,19 +1344,19 @@ describe('Date Picker', () => {
 
   describe('Date Field Input', () => {
     it('should render a helper message on the date picker input', () => {
-      const { getByText } = render(
+      const { getAllByText } = render(
         <DatePicker isDateFieldInput helperMessage={helperMessage} />
       );
 
-      expect(getByText(helperMessage)).not.toBeNull();
+      expect(getAllByText(helperMessage)[0]).toBeInTheDocument();
     });
 
     it('should render an error message on the date picker input', () => {
-      const { getByText } = render(
+      const { getAllByText } = render(
         <DatePicker isDateFieldInput errorMessage={errorMessage} />
       );
 
-      expect(getByText(errorMessage)).not.toBeNull();
+      expect(getAllByText(errorMessage)[0]).toBeInTheDocument();
     });
 
     it('should increment and decrement the date', () => {
@@ -1575,7 +1575,7 @@ describe('Date Picker', () => {
     });
 
     it('should render error message when user enters an invalid year and on blur', () => {
-      const { getByTestId, getByText, queryByText } = render(
+      const { getByTestId, getAllByText, queryByText } = render(
         <DatePicker isDateFieldInput />
       );
 
@@ -1597,13 +1597,15 @@ describe('Date Picker', () => {
       userEvent.tab();
 
       expect(
-        getByText('Invalid date. Please enter a year between 1900 and 2099.')
+        getAllByText(
+          'Invalid date. Please enter a year between 1900 and 2099.'
+        )[0]
       ).toBeInTheDocument();
     });
 
     it('should render invalid year error message after showing custom error message', () => {
       const customErrorMessage = 'Please, enter a date';
-      const { getByTestId, getByText, queryByText } = render(
+      const { getByTestId, getAllByText, queryByText } = render(
         <DatePicker isDateFieldInput errorMessage={customErrorMessage} />
       );
 
@@ -1611,7 +1613,7 @@ describe('Date Picker', () => {
       const dayInput = getByTestId('day-input');
       const yearInput = getByTestId('year-input');
 
-      expect(getByText(customErrorMessage)).toBeInTheDocument();
+      expect(getAllByText(customErrorMessage)[0]).toBeInTheDocument();
 
       userEvent.type(monthInput, '10');
       userEvent.type(dayInput, '22');
@@ -1628,7 +1630,9 @@ describe('Date Picker', () => {
       userEvent.tab();
 
       expect(
-        getByText('Invalid date. Please enter a year between 1900 and 2099.')
+        getAllByText(
+          'Invalid date. Please enter a year between 1900 and 2099.'
+        )[0]
       ).toBeInTheDocument();
     });
 
@@ -1647,7 +1651,9 @@ describe('Date Picker', () => {
       userEvent.tab();
 
       expect(
-        queryByText('Invalid date. Please enter a year between 1900 and 2099.')
+        getAllByText(
+          'Invalid date. Please enter a year between 1900 and 2099.'
+        )[0]
       ).toBeInTheDocument();
       expect(monthInput).toHaveAttribute('aria-describedby');
 

--- a/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
+++ b/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
@@ -419,26 +419,26 @@ describe('DateTimePicker', () => {
   describe('Error and Helper Messages', () => {
     it('should render error message when provided', () => {
       const errorMessage = 'This field is required';
-      const { getByText } = render(
+      const { getAllByText } = render(
         <DateTimePicker
           labelText="Date Time Picker Label"
           errorMessage={errorMessage}
         />
       );
 
-      expect(getByText(errorMessage)).toBeInTheDocument();
+      expect(getAllByText(errorMessage)[0]).toBeInTheDocument();
     });
 
     it('should render helper message when provided', () => {
       const helperMessage = 'Please select a date and time';
-      const { getByText } = render(
+      const { getAllByText } = render(
         <DateTimePicker
           labelText="Date Time Picker Label"
           helperMessage={helperMessage}
         />
       );
 
-      expect(getByText(helperMessage)).toBeInTheDocument();
+      expect(getAllByText(helperMessage)[0]).toBeInTheDocument();
     });
   });
 
@@ -653,7 +653,7 @@ describe('DateTimePicker', () => {
     it('should apply custom message styles', () => {
       const customStyle = { fontSize: '14px' };
       const helperMessage = 'Helper text';
-      const { getByText } = render(
+      const { getAllByText } = render(
         <DateTimePicker
           labelText="Date Time Picker Label"
           helperMessage={helperMessage}
@@ -661,7 +661,9 @@ describe('DateTimePicker', () => {
         />
       );
 
-      expect(getByText(helperMessage).parentElement).toHaveStyle(customStyle);
+      expect(getAllByText(helperMessage)[0].parentElement).toHaveStyle(
+        customStyle
+      );
     });
   });
 

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.test.js
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.test.js
@@ -51,20 +51,20 @@ describe('FormFieldContainer', () => {
 
   it('Should render an error message', () => {
     const errorMsg = 'Test error message';
-    const { getByText } = render(
+    const { getAllByText } = render(
       <FormFieldContainer errorMessage={errorMsg}>{TEXT}</FormFieldContainer>
     );
 
-    expect(getByText(errorMsg)).toBeInTheDocument();
+    expect(getAllByText(errorMsg)[0]).toBeInTheDocument();
   });
 
   it('Should render a helper message', () => {
     const helperMsg = 'Test helper message';
-    const { getByText } = render(
+    const { getAllByText } = render(
       <FormFieldContainer helperMessage={helperMsg}>{TEXT}</FormFieldContainer>
     );
 
-    expect(getByText(helperMsg)).toBeInTheDocument();
+    expect(getAllByText(helperMsg)[0]).toBeInTheDocument();
   });
 
   it('Should render a large label when input size is large', () => {
@@ -84,7 +84,7 @@ describe('FormFieldContainer', () => {
   it('Should have custom styles', () => {
     const helperMsg = 'Test helper message';
 
-    const { getByText, getByTestId } = render(
+    const { getByText, getAllByText, getByTestId } = render(
       <FormFieldContainer
         containerStyle={{ border: '1px solid red' }}
         labelStyle={{ color: 'green' }}
@@ -99,7 +99,9 @@ describe('FormFieldContainer', () => {
 
     expect(getByTestId(testId)).toHaveStyle('border: 1px solid red');
     expect(getByText(labelText)).toHaveStyle('color: green');
-    expect(getByText(helperMsg).parentElement).toHaveStyle('color: purple');
+    expect(getAllByText(helperMsg)[0].parentElement).toHaveStyle(
+      'color: purple'
+    );
   });
 
   it('Should have a defined width for labels when labelPosition is "left"', () => {

--- a/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
+++ b/packages/react-magma-dom/src/components/FormFieldContainer/FormFieldContainer.tsx
@@ -189,7 +189,7 @@ export const FormFieldContainer = React.forwardRef<
   } = props;
   const theme = React.useContext(ThemeContext);
   const isInverse = useIsInverse(isInverseProp);
-  const { isSafari } = useDeviceDetect();
+  const { isWindows, isChrome } = useDeviceDetect();
 
   const countProps = maxCount || maxLength;
   const counterDescriptionId =
@@ -264,7 +264,7 @@ export const FormFieldContainer = React.forwardRef<
             </InputMessage>
           )}
 
-          {isSafari && (
+          {!(isWindows && isChrome) && (
             <VisuallyHidden>
               <Announce>
                 {(errorMessage || helperMessage) && (

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
@@ -89,7 +89,7 @@ describe('NativeSelect', () => {
 
   it('should render an error state', () => {
     const errorMessage = 'This is an error';
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getAllByText } = render(
       <NativeSelect errorMessage={errorMessage} testId={testId} />
     );
 
@@ -98,7 +98,7 @@ describe('NativeSelect', () => {
       `1px solid ${magma.colors.danger}`
     );
 
-    expect(getByText(errorMessage)).toBeInTheDocument();
+    expect(getAllByText(errorMessage)[0]).toBeInTheDocument();
   });
 
   it('should set aria-invalid on the select when in error state', () => {
@@ -146,7 +146,7 @@ describe('NativeSelect', () => {
 
   it('should render an inverse error state', () => {
     const errorMessage = 'This is an error';
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getAllByText } = render(
       <NativeSelect errorMessage={errorMessage} isInverse testId={testId} />
     );
 
@@ -155,7 +155,7 @@ describe('NativeSelect', () => {
       `1px solid ${magma.colors.danger300}`
     );
 
-    expect(getByText(errorMessage)).toBeInTheDocument();
+    expect(getAllByText(errorMessage)[0]).toBeInTheDocument();
   });
 
   it('should have cycling navigation through options with arrow keys', async () => {

--- a/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
+++ b/packages/react-magma-dom/src/components/TimePicker/TimePicker.test.js
@@ -482,11 +482,11 @@ describe('TimePicker', () => {
   it('should render the timepicker with an error message', () => {
     const message = 'test error';
     const label = 'test label';
-    const { getByText } = render(
+    const { getAllByText } = render(
       <TimePicker errorMessage={message} labelText={label} />
     );
 
-    expect(getByText(message)).toBeInTheDocument();
+    expect(getAllByText(message)[0]).toBeInTheDocument();
   });
 
   it('should render the timepicker with inverse styles', () => {


### PR DESCRIPTION
Closes: #2465

## What I did
Small v4 fix for https://github.com/cengage/react-magma/pull/2468 

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open storybook -> DatePicker -> Date Field Default -> Turn on NVDA/VO -> Set an error message -> Screen reader should announce it -> Set wrong date (e.g. 04/04/0004), and press Tab -> Screen reader should announce new message -> Open Calendar widget -> Set a correct date -> Screen reader should NOT read previous error message (it doesn't exist)