### PR TITLE
chore(TreeView): add warning for additionalContent null rendering

### DIFF
--- a/.changeset/chore-TreeView-additionalContent-props.md
+++ b/.changeset/chore-TreeView-additionalContent-props.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+chore(TreeView): add warning for additionalContent prop in TreeView to ensure it renders content (not null)

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -1715,6 +1715,7 @@ export function Example() {
 
 The `additionalContent` prop allows the adopter to render additional custom content below the label.
 This can include any valid React node, such as text, icons, buttons, tooltips, or other components.
+Passing a React element `<Component />` is always treated as `true`. This means you need to ensure that component you provide for `additionalContent` actually renders something and does not return `null`.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
Closes: #1942

## What I did
After a deeper analysis, we decided not to make changes because it would require either a full rewrite of the component or could impact performance.

Instead, we added a note in the documentation warning users to be responsible with their component and ensure it actually renders something.

## Screenshots
<img width="1728" height="900" alt="image" src="https://github.com/user-attachments/assets/5d4fe21b-eb0f-44fb-b638-2fea1cc7d4f2" />

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open Docs → TreeView → additionalContent → Verify new information about additionalContent
