### PR TITLE
feat(charts): Add titleLevel to chartToolbar config to control

### DIFF
--- a/.changeset/feat-Charts-titleLevel.md
+++ b/.changeset/feat-Charts-titleLevel.md
@@ -1,0 +1,5 @@
+---
+'@react-magma/charts': minor
+---
+
+feat(charts): Add `titleLevel` to `chartToolbar` config to control the heading level (1–6) of the chart title rendered by `CarbonChart`. Defaults to `2`.

--- a/packages/charts/src/components/CarbonChart/CarbonChart.test.js
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.test.js
@@ -848,6 +848,27 @@ describe('CarbonChart', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('should render the chart title as h2 by default', () => {
+      render(<CarbonChart {...toolbarProps} />);
+
+      expect(
+        screen.getByRole('heading', { level: 2, name: chartOptions.title })
+      ).toBeInTheDocument();
+    });
+
+    it('should render the chart title at the level set by titleLevel', () => {
+      render(
+        <CarbonChart {...toolbarProps} chartToolbar={{ titleLevel: 3 }} />
+      );
+
+      expect(
+        screen.getByRole('heading', { level: 3, name: chartOptions.title })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { level: 2, name: chartOptions.title })
+      ).not.toBeInTheDocument();
+    });
+
     it('should always render the more options dropdown with built-in download items', () => {
       render(<CarbonChart {...toolbarProps} />);
 

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -103,6 +103,11 @@ export interface ChartToolbarConfig {
    * @default 2
    */
   tableHeaderLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  /**
+   * Heading level for the chart title.
+   * @default 2
+   */
+  titleLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
 export interface CarbonChartProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -1022,7 +1027,11 @@ function CarbonChartToolbar({
       isInverse={isInverse}
       theme={theme}
     >
-      <ChartTitle isInverse={isInverse} theme={theme}>
+      <ChartTitle
+        as={`h${config.titleLevel ?? 2}` as keyof JSX.IntrinsicElements}
+        isInverse={isInverse}
+        theme={theme}
+      >
         {resolvedTitle}
       </ChartTitle>
       <ToolbarActions theme={theme}>

--- a/packages/charts/src/components/CarbonChart/CarbonChartBar.stories.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChartBar.stories.tsx
@@ -18,12 +18,19 @@ export default {
       control: { type: 'select' },
       options: Object.values(CarbonChartType),
     },
+    titleLevel: {
+      control: { type: 'select' },
+      options: [1, 2, 3, 4, 5, 6],
+      description: 'Heading level for the chart title (h1–h6).',
+    },
   },
 } as Meta;
 
-const Template: StoryFn<CarbonChartProps> = args => (
+const Template: StoryFn<
+  CarbonChartProps & { titleLevel?: 1 | 2 | 3 | 4 | 5 | 6 }
+> = ({ titleLevel, ...args }) => (
   <Card isInverse={args.isInverse} style={{ padding: '12px' }}>
-    <CarbonChart {...args} />
+    <CarbonChart {...args} chartToolbar={{ titleLevel }} />
   </Card>
 );
 


### PR DESCRIPTION
  ## What I did
  - Added a new `titleLevel` option to `chartToolbar` for `CarbonChart`.
  - This lets consumers control the semantic heading level (`h1`-`h6`) used for the chart title.
  - The default remains `h2`, so existing usage is unchanged.
  - Added unit tests for the default heading level and custom `titleLevel`.
  - Added a Storybook control for `titleLevel`.


  ## Screenshots
  N/A - no visual change expected. This changes the rendered heading level for accessibility/semantic structure.

  ## Checklist
  - [x] changeset has been added
  - [ ] Pull request is assigned, labels have been added and ticket is linked
  - [x] Pull request description is descriptive and testing steps are listed
  - [x] Corresponding changes to the documentation have been made
  - [ ] New and existing unit tests pass locally with the proposed changes
  - [x] Tests that prove the fix is effective or that the feature works have been added

  ## How to test
- In Storybook, open the `CarbonChartBar` story and change `titleLevel` between `1` and `6`.
- Verify the chart title renders with the selected heading level and defaults to `h2` when `titleLevel` is not provided.