### PR TITLE
fix(PasswordInput): fix styles for the custom button

### DIFF
--- a/.changeset/fix-PasswordInput-broken-styles.md
+++ b/.changeset/fix-PasswordInput-broken-styles.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(PasswordInput): Fix styles for the custom button

--- a/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.test.js
+++ b/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { act, render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent, waitFor } from '@testing-library/react';
 
 import { axe } from '../../../axe-helper';
 import { I18nContext } from '../../i18n';
@@ -270,6 +270,82 @@ describe('i18n', () => {
     expect(getByText(shown.announce)).toBeInTheDocument();
     expect(getByLabelText(hidden.ariaLabel)).toBeInTheDocument();
     expect(getByText(hidden.buttonText)).toBeInTheDocument();
+  });
+});
+
+describe('custom button text width measurement', () => {
+  it('measures button width after mount and applies it to input style', async () => {
+    const labelText = 'test label';
+    const MOCKED_WIDTH = 90;
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return MOCKED_WIDTH;
+      },
+    });
+
+    const { getByLabelText } = render(
+      <PasswordInput
+        labelText={labelText}
+        showPasswordButtonText="Reveal"
+        hidePasswordButtonText="Conceal"
+      />
+    );
+
+    await waitFor(() => {
+      const input = getByLabelText(labelText);
+      expect(input).toHaveStyle(`width: calc(100% - ${MOCKED_WIDTH + 3}px)`);
+    });
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return 0;
+      },
+    });
+  });
+
+  it('re-measures button width after toggling password visibility', async () => {
+    const labelText = 'test label';
+    let mockedWidth = 60;
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return mockedWidth;
+      },
+    });
+
+    const { getByLabelText, getByText } = render(
+      <PasswordInput
+        labelText={labelText}
+        showPasswordButtonText="Reveal"
+        hidePasswordButtonText="Conceal longer"
+      />
+    );
+
+    await waitFor(() => {
+      expect(getByLabelText(labelText)).toHaveStyle(
+        `width: calc(100% - ${mockedWidth + 3}px)`
+      );
+    });
+
+    mockedWidth = 100;
+    fireEvent.click(getByText('Reveal').parentElement);
+
+    await waitFor(() => {
+      expect(getByLabelText(labelText)).toHaveStyle(
+        `width: calc(100% - ${mockedWidth + 3}px)`
+      );
+    });
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return 0;
+      },
+    });
   });
 });
 

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -127,14 +127,19 @@ export const PasswordInput = React.forwardRef<
     SHOW_PASSWORD_BUTTON_TEXT === i18n.password.shown.buttonText &&
     HIDE_PASSWORD_BUTTON_TEXT === i18n.password.hidden.buttonText;
 
-  const buttonRef = React.useRef<HTMLButtonElement>();
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
   const [buttonWidth, setButtonWidth] = React.useState<number>(0);
 
   React.useLayoutEffect(() => {
     if (buttonRef.current && !usesDefaultText) {
       setButtonWidth(buttonRef.current.offsetWidth);
     }
-  }, [usesDefaultText, SHOW_PASSWORD_BUTTON_TEXT, HIDE_PASSWORD_BUTTON_TEXT]);
+  }, [
+    usesDefaultText,
+    passwordShown,
+    SHOW_PASSWORD_BUTTON_TEXT,
+    HIDE_PASSWORD_BUTTON_TEXT,
+  ]);
 
   const getButtonWidth = () => {
     if (usesDefaultText) {
@@ -152,6 +157,7 @@ export const PasswordInput = React.forwardRef<
     } else if (inputSize === InputSize.large && usesDefaultText) {
       return { width: 'calc(100% - 64px)' };
     } else {
+      // right margin (3px) so input doesn't overflow
       return { width: `calc(100% - ${buttonWidth + 3}px)` };
     }
   };

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -128,16 +128,19 @@ export const PasswordInput = React.forwardRef<
     HIDE_PASSWORD_BUTTON_TEXT === i18n.password.hidden.buttonText;
 
   const buttonRef = React.useRef<HTMLButtonElement>();
+  const [buttonWidth, setButtonWidth] = React.useState<number>(0);
+
+  React.useLayoutEffect(() => {
+    if (buttonRef.current && !usesDefaultText) {
+      setButtonWidth(buttonRef.current.offsetWidth);
+    }
+  }, [usesDefaultText, SHOW_PASSWORD_BUTTON_TEXT, HIDE_PASSWORD_BUTTON_TEXT]);
 
   const getButtonWidth = () => {
     if (usesDefaultText) {
-      if (inputSize === InputSize.large) {
-        return '64px';
-      }
-
-      return '54px';
-    } else {
-      return `${buttonRef?.current?.offsetWidth}px`;
+      return inputSize === InputSize.large ? '64px' : '54px';
+    } else if (buttonWidth !== 0) {
+      return `${buttonWidth}px`;
     }
   };
 
@@ -149,7 +152,7 @@ export const PasswordInput = React.forwardRef<
     } else if (inputSize === InputSize.large && usesDefaultText) {
       return { width: 'calc(100% - 64px)' };
     } else {
-      return { width: `calc(100% - ${buttonRef?.current?.offsetWidth}px)` };
+      return { width: `calc(100% - ${buttonWidth + 3}px)` };
     }
   };
 


### PR DESCRIPTION
Closes: #2526

## What I did
The button width was previously measured during render before the DOM was ready. Now it’s measured in useLayoutEffect and stored in state, so the correct width is applied on first paint and updates when the text changes.

## Screenshots
<!-- Include screenshot of your change, when applicable -->
#### Before:
<img width="361" height="97" alt="Screenshot 2026-05-21 at 17 41 39" src="https://github.com/user-attachments/assets/29a07822-eb84-48bb-92ad-97a0809d5245" />
 
 #### After:
<img width="361" height="97" alt="Screenshot 2026-06-03 at 14 52 46" src="https://github.com/user-attachments/assets/24ae9d6d-4e13-4e7a-99c7-98e677fa2f90" />


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open PasswordInput in Storybook → select Custom Text → check the styles and verify the correct behavior.