### PR TITLE
fix(Accordion): fix invalid ARIA attribute

### DIFF
--- a/.changeset/fix-Accordion-invalid-aria.md
+++ b/.changeset/fix-Accordion-invalid-aria.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Accordion): fix invalid ARIA attribute

--- a/packages/react-magma-dom/src/components/Accordion/AccordionPanel.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/AccordionPanel.tsx
@@ -54,6 +54,7 @@ export const AccordionPanel = React.forwardRef<
         isInverse={isInverse}
         ref={ref}
         theme={theme}
+        role="region"
       >
         {children}
       </StyledPanel>

--- a/packages/react-magma-dom/src/components/Accordion/useAccordionItem.ts
+++ b/packages/react-magma-dom/src/components/Accordion/useAccordionItem.ts
@@ -39,8 +39,8 @@ export function useAccordionItem(props: UseAccordionItemProps) {
 
   const idPrefix = useGenerateId(index.toString());
 
-  const buttonId = `${idPrefix}_btn`;
-  const panelId = `${idPrefix}_panel`;
+  const buttonId = `accordion_${idPrefix}_btn`;
+  const panelId = `accordion_${idPrefix}_panel`;
 
   React.useEffect(() => {
     const newIsExpanded = isMulti

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -1475,10 +1475,10 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
         class="emotion-4 emotion-5"
       >
         <button
-          aria-controls="0_panel"
+          aria-controls="accordion_0_panel"
           aria-expanded="true"
           class="emotion-6 emotion-7"
-          id="0_btn"
+          id="accordion_0_btn"
         >
           <span
             class="emotion-8 emotion-9"
@@ -1514,9 +1514,10 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
         >
           <div
             aria-hidden="false"
-            aria-labelledby="0_btn"
+            aria-labelledby="accordion_0_btn"
             class="emotion-12 emotion-13"
-            id="0_panel"
+            id="accordion_0_panel"
+            role="region"
           >
             <div
               class="emotion-14 emotion-15"
@@ -3673,10 +3674,10 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
         class="emotion-4 emotion-5"
       >
         <button
-          aria-controls="0_panel"
+          aria-controls="accordion_0_panel"
           aria-expanded="true"
           class="emotion-6 emotion-7"
-          id="0_btn"
+          id="accordion_0_btn"
         >
           <span
             class="emotion-8 emotion-9"
@@ -3712,9 +3713,10 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
         >
           <div
             aria-hidden="false"
-            aria-labelledby="0_btn"
+            aria-labelledby="accordion_0_btn"
             class="emotion-12 emotion-13"
-            id="0_panel"
+            id="accordion_0_panel"
+            role="region"
           >
             <div
               class="emotion-14 emotion-15"
@@ -5788,10 +5790,10 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
         class="emotion-4 emotion-5"
       >
         <button
-          aria-controls="0_panel"
+          aria-controls="accordion_0_panel"
           aria-expanded="true"
           class="emotion-6 emotion-7"
-          id="0_btn"
+          id="accordion_0_btn"
         >
           <span
             class="emotion-8 emotion-9"
@@ -5827,9 +5829,10 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
         >
           <div
             aria-hidden="false"
-            aria-labelledby="0_btn"
+            aria-labelledby="accordion_0_btn"
             class="emotion-12 emotion-13"
-            id="0_panel"
+            id="accordion_0_panel"
+            role="region"
           >
             <div
               class="emotion-14 emotion-15"
@@ -7902,10 +7905,10 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
         class="emotion-4 emotion-5"
       >
         <button
-          aria-controls="0_panel"
+          aria-controls="accordion_0_panel"
           aria-expanded="true"
           class="emotion-6 emotion-7"
-          id="0_btn"
+          id="accordion_0_btn"
         >
           <span
             class="emotion-8 emotion-9"
@@ -7941,9 +7944,10 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
         >
           <div
             aria-hidden="false"
-            aria-labelledby="0_btn"
+            aria-labelledby="accordion_0_btn"
             class="emotion-12 emotion-13"
-            id="0_panel"
+            id="accordion_0_panel"
+            role="region"
           >
             <div
               class="emotion-14 emotion-15"
@@ -10146,10 +10150,10 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
         class="emotion-4 emotion-5"
       >
         <button
-          aria-controls="0_panel"
+          aria-controls="accordion_0_panel"
           aria-expanded="true"
           class="emotion-6 emotion-7"
-          id="0_btn"
+          id="accordion_0_btn"
         >
           <span
             class="emotion-8 emotion-9"
@@ -10185,9 +10189,10 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
         >
           <div
             aria-hidden="false"
-            aria-labelledby="0_btn"
+            aria-labelledby="accordion_0_btn"
             class="emotion-12 emotion-13"
-            id="0_panel"
+            id="accordion_0_panel"
+            role="region"
           >
             <div
               class="emotion-14 emotion-15"
@@ -12391,10 +12396,10 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
         class="emotion-4 emotion-5"
       >
         <button
-          aria-controls="0_panel"
+          aria-controls="accordion_0_panel"
           aria-expanded="true"
           class="emotion-6 emotion-7"
-          id="0_btn"
+          id="accordion_0_btn"
         >
           <span
             class="emotion-8 emotion-9"
@@ -12430,9 +12435,10 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
         >
           <div
             aria-hidden="false"
-            aria-labelledby="0_btn"
+            aria-labelledby="accordion_0_btn"
             class="emotion-12 emotion-13"
-            id="0_panel"
+            id="accordion_0_panel"
+            role="region"
           >
             <div
               class="emotion-14 emotion-15"
@@ -14506,10 +14512,10 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
         class="emotion-4 emotion-5"
       >
         <button
-          aria-controls="0_panel"
+          aria-controls="accordion_0_panel"
           aria-expanded="true"
           class="emotion-6 emotion-7"
-          id="0_btn"
+          id="accordion_0_btn"
         >
           <span
             class="emotion-8 emotion-9"
@@ -14545,9 +14551,10 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
         >
           <div
             aria-hidden="false"
-            aria-labelledby="0_btn"
+            aria-labelledby="accordion_0_btn"
             class="emotion-12 emotion-13"
-            id="0_panel"
+            id="accordion_0_panel"
+            role="region"
           >
             <div
               class="emotion-14 emotion-15"


### PR DESCRIPTION
Closes: #2483

## What I did
Updated ID generation used in Accordion ARIA attributes.

Added missing `region` role to resolve accessibility issues reported in Storybook.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open Storybook -> Navigate to `Accordion` -> Run Axe accessibility checks -> Verify there are no ARIA-related accessibility errors -> Open the Accessibility tab -> Confirm there are no reported issues
