### PR TITLE
fix(Chart): fix ARIA prohibited attribute usage in SVG elements

### DIFF
--- a/.changeset/chart-fix-aria-prohibited-attr.md
+++ b/.changeset/chart-fix-aria-prohibited-attr.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+Chart: fix ARIA prohibited attribute usage in SVG elements

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -1204,16 +1204,6 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
     const ChartType = allCharts[type] as any;
 
-    // Adding aria-label to main SVG container
-    React.useEffect(() => {
-      if (ariaLabel) {
-        document.querySelectorAll('.graph-frame ').forEach(div => {
-          div.setAttribute('aria-label', ariaLabel);
-        });
-      }
-    });
-
-    // Fix aria-prohibited-attr: add role to <g> elements that have aria-label (axes, ticks)
     React.useEffect(() => {
       const timer = setTimeout(() => {
         if (internalRef.current) {

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -38,6 +38,7 @@ import {
 } from 'react-magma-icons';
 
 import { useCarbonModalFocusManagement } from '../../hooks/useCarbonModalFocusManagement';
+// @ts-ignore
 import './carbon-charts.css';
 import {
   ChartFullscreenButton,
@@ -1202,6 +1203,36 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
     };
 
     const ChartType = allCharts[type] as any;
+
+    // Adding aria-label to main SVG container
+    React.useEffect(() => {
+      if (ariaLabel) {
+        document.querySelectorAll('.graph-frame ').forEach(div => {
+          div.setAttribute('aria-label', ariaLabel);
+        });
+      }
+    });
+
+    // Fix aria-prohibited-attr: add role to <g> elements that have aria-label (axes, ticks)
+    React.useEffect(() => {
+      const timer = setTimeout(() => {
+        if (internalRef.current) {
+          internalRef.current
+            .querySelectorAll<SVGGElement>('g[aria-label]')
+            .forEach(g => {
+              const role = g.getAttribute('role');
+
+              if (!role) {
+                g.setAttribute('role', 'img');
+              } else if (role === 'graphics-object group') {
+                g.setAttribute('role', 'graphics-object');
+              }
+            });
+        }
+      }, 0);
+
+      return () => clearTimeout(timer);
+    }, [type, dataSet]);
 
     const groupsLength = Object.keys(buildColors()).length;
 


### PR DESCRIPTION
Closes: #2328

## What I did
The fix adds aria-hidden="true" to the main <svg> element after render, hiding its invalid child attributes from screen readers.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
- Storybook: Open the CarbonChart, 'Area' component story in Storybook -> Open the A11y tab  -> Verify no aria-prohibited-attr violation appears

- Docs: Navigate to the 'Chart Demos' component page in the docs -> Run axe -> Verify no aria-prohibited-attr issue appears



