### PR TITLE
fix(docs): point v2 docs/landing links to 2.6.2

### DIFF
--- a/.changeset/v2-docs-link-262.md
+++ b/.changeset/v2-docs-link-262.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+Point the v2 documentation link to 2.6.2 in the previous-versions table and landing dropdown, so /version/2.6.2 resolves.

--- a/.changeset/v2-docs-link-262.md
+++ b/.changeset/v2-docs-link-262.md
@@ -1,5 +1,6 @@
 ---
+'react-magma-landing': patch
 'react-magma-docs': patch
 ---
 
-Point the v2 documentation link to 2.6.2 in the previous-versions table and landing dropdown, so /version/2.6.2 resolves.
+Point the v2 documentation link to 2.6.2 in the landing version list (and generated _redirects) and the previous-versions table, so /version/2.6.2 resolves.

--- a/website/react-magma-docs/src/pages/api-intro/versions.mdx
+++ b/website/react-magma-docs/src/pages/api-intro/versions.mdx
@@ -88,7 +88,7 @@ return (
   <TableCell key={`row${i}-docs`}>
     {semver.gte(row.version, '4.0.0') ||
     row.version === '3.11.0' ||
-    row.version === '2.6.0' ? (
+    row.version === '2.6.2' ? (
       <a href={`https://react-magma.cengage.com/version/${row.version}`}>
         Docs
       </a>

--- a/website/react-magma-landing/scripts/build.js
+++ b/website/react-magma-landing/scripts/build.js
@@ -8,7 +8,7 @@ const semver = require('semver');
 
 const english = new Intl.DateTimeFormat('en');
 
-const SUPPORTED_LEGACY_VERSIONS = ['2.6.0', '3.11.0'];
+const SUPPORTED_LEGACY_VERSIONS = ['2.6.2', '3.11.0'];
 
 const cleanVersions = ({ versions, time, tags }) => {
   return semver


### PR DESCRIPTION
Bumps SUPPORTED_LEGACY_VERSIONS and the versions-table docs link from 2.6.0 to 2.6.2 so the landing dropdown + generated _redirects proxy /version/2.6.2/.

Closes: #

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
