### PR TITLE
chore: enter prerelease mode + changeset to redeploy landing (v2 2.6.2)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,12 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@react-magma/charts": "14.0.0",
+    "@react-magma/dropzone": "14.0.0",
+    "react-magma-dom": "5.0.0",
+    "react-magma-docs": "6.0.1",
+    "react-magma-landing": "1.1.8"
+  },
+  "changesets": []
+}

--- a/.changeset/redeploy-landing-262.md
+++ b/.changeset/redeploy-landing-262.md
@@ -1,0 +1,6 @@
+---
+'react-magma-landing': patch
+'react-magma-docs': patch
+---
+
+Redeploy landing + docs so the v2 link bump to 2.6.2 (/version/2.6.2 routing) takes effect.


### PR DESCRIPTION
Merge carries .changeset/pre.json so publish's 'Exit Prerelease Mode' step succeeds (main otherwise isn't in pre mode -> changeset pre exit fails).

Closes: #

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
