### PR TITLE
fix(landing): add repository field so npm provenance publish passes

### DIFF
--- a/website/react-magma-landing/package.json
+++ b/website/react-magma-landing/package.json
@@ -4,6 +4,11 @@
   "description": "",
   "keywords": [],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cengage/react-magma.git",
+    "directory": "website/react-magma-landing"
+  },
   "main": "index.js",
   "scripts": {
     "build": "node scripts/build.js",


### PR DESCRIPTION
changeset publish failed (E422) on react-magma-landing because npm provenance requires a matching repository.url; it was missing. Mirrors the field on the other published packages.

Closes: #

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [ ] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [ ] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
