### PR TITLE
fix(Dropdown): Fix Escape key propagation in nested dropdown

### DIFF
--- a/.changeset/fix-Dropdown-stop-propagation.md
+++ b/.changeset/fix-Dropdown-stop-propagation.md
@@ -1,0 +1,6 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): Fix Escape key propagation in nested dropdown
+

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -32,6 +32,7 @@ import {
   ButtonGroupOrientation,
 } from '../ButtonGroup';
 import { Card, CardBody } from '../Card';
+import { Popover, PopoverContent, PopoverTrigger } from '../Popover';
 
 import {
   Dropdown,
@@ -1088,4 +1089,27 @@ export const DropdownExpandableMenuWithSorting = {
       </div>
     );
   },
+};
+
+export const DropdownInsidePopover = {
+  render: args => (
+    <div style={{ margin: '200px auto', textAlign: 'center' }}>
+      <Popover>
+        <PopoverTrigger>
+          <Button>Open Popover</Button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <div style={{ padding: '16px', minHeight: '150px' }}>
+            <Dropdown {...args}>
+              <DropdownButton>Open Dropdown</DropdownButton>
+              <DropdownContent>
+                <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+                <DropdownMenuItem>Menu item 2</DropdownMenuItem>
+              </DropdownContent>
+            </Dropdown>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  ),
 };

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -1639,4 +1639,30 @@ describe('Dropdown', () => {
       expect(svg).toHaveAttribute('width', magma.iconSizes.xSmall.toString());
     });
   });
+
+  it('should stop Escape key propagation so parent containers do not receive it', async () => {
+    const parentKeyDownHandler = jest.fn();
+
+    const { getByTestId } = render(
+      <div role="presentation" onKeyDown={parentKeyDownHandler}>
+        <Dropdown testId="dropdown">
+          <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
+          <DropdownContent>
+            <DropdownMenuItem>Menu item</DropdownMenuItem>
+          </DropdownContent>
+        </Dropdown>
+      </div>
+    );
+
+    await userEvent.click(getByTestId('dropdownButton'));
+    expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'block');
+
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{Escape}');
+
+    expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+    expect(parentKeyDownHandler).not.toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'Escape' })
+    );
+  });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -205,6 +205,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
     function handleKeyDown(event: React.KeyboardEvent) {
       if (event.key === 'Escape') {
         event.nativeEvent.stopImmediatePropagation();
+        event.stopPropagation();
         closeDropdown(event);
         toggleRef.current?.focus();
       }


### PR DESCRIPTION
Closes: #2534

## What I did
Added stopPropagation on Escape key to prevent event bubbling in nested dropdowns.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open Storybook -> Dropdown -> Dropdown Inside Popover -> verify Escape key behavior