### PR TITLE
fix(chart): add accessible chart role and aria-label

### DIFF
--- a/.changeset/chart-add-accessible-role.md
+++ b/.changeset/chart-add-accessible-role.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+Chart: add accessible chart role and aria-label

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -1343,6 +1343,9 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
           theme={theme}
           className={`carbon-chart-wrapper${chartToolbar ? ' has-magma-toolbar' : ''}`}
           groupsLength={groupsLength < 6 ? groupsLength : 14}
+          role="region"
+          aria-label={ariaLabel || chartTitle}
+          aria-roledescription="chart"
           {...rest}
         >
           <ChartContentWrapper>


### PR DESCRIPTION
Closes: #2338

## What I did
Added the correct role and aria-label to the chart. Also removed the code that was adding similar accessibility functionality.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open Docs -> Charts Demos -> turn on a screen reader -> navigate to a chart -> verify that the screen reader announces the chart role and the aria-label (which defaults to the chart title if no aria-label is provided)
