### PR TITLE
fix(Treeview): fix TreeView keyboard focus trap after collapse

### DIFF
--- a/.changeset/fix-Treeview-focus-trap.md
+++ b/.changeset/fix-Treeview-focus-trap.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Treeview): fix keyboard focus trap after collapse

--- a/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
+++ b/packages/react-magma-dom/src/components/TreeView/useTreeItem.ts
@@ -247,14 +247,14 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
   let focusIndex = getFocusIndex(treeItemRefArray?.current);
 
   React.useEffect(() => {
-    treeItemRefArray?.current.map(itemRef => {
-      if (!itemRef.current) {
-        treeItemRefArray.current = treeItemRefArray.current.filter(
-          item => itemRef.current !== item.current
-        );
-      }
-    });
-  }, [treeItemRefArray]);
+    if (!treeItemRefArray?.current) {
+      return;
+    }
+
+    treeItemRefArray.current = treeItemRefArray.current.filter(
+      itemRef => itemRef.current !== null
+    );
+  }, [treeItemRefArray, expandedSet]);
 
   const focusFirst = () => {
     const filteredRefArray = filterNullEntries(treeItemRefArray);
@@ -362,6 +362,7 @@ export function useTreeItem(props: UseTreeItemProps, forwardedRef) {
     const filteredRefArray = filterNullEntries(treeItemRefArray);
     const curr = filteredRefArray['current'];
     const arrLength = curr.length;
+    const focusIndex = getFocusIndex(curr);
 
     if (
       [


### PR DESCRIPTION
Closes: #1930

## What I did
I updated the logic to recalculate the index so keyboard focus works correctly when collapsing items during arrow key navigation.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Test with arrow keys:
Storybook → TreeView → no icons → open third nested TreeItem → collapse it → navigate through the entire TreeView → verify that full navigation works correctly across all items.
