### PR TITLE
fix(Storybook): resolve accessibility violations in Storybook stories

### DIFF
--- a/.changeset/fix-storybook-a11y-issues.md
+++ b/.changeset/fix-storybook-a11y-issues.md
@@ -1,0 +1,12 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Storybook): Fix accessibility issues in stories:
+
+- Input: add labels to native inputs, hide decorative icons from screen readers
+- Table: remove invalid `aria-sort` from checkbox header cell
+- Tabs: fix `aria-controls` pointing to correct ScrollSpy panel id
+- ProgressBar: add visually hidden label to custom color input
+- ToggleButton: remove incorrect `id` assignment from button element
+- TreeView: move `aria-live` region inside `treeitem` to fix `aria-required-children` violation

--- a/.changeset/fix-storybook-a11y-issues.md
+++ b/.changeset/fix-storybook-a11y-issues.md
@@ -2,12 +2,10 @@
 'react-magma-dom': patch
 ---
 
-fix(Storybook): Fix accessibility issues in stories:
+fix(a11y): Fix accessibility violations:
 
-- Input: add labels to native inputs, hide decorative icons from screen readers
+- Input: hide decorative icons from screen readers
 - Table: remove invalid `aria-sort` from checkbox header cell
 - Tabs: fix `aria-controls` pointing to correct ScrollSpy panel id
-- ProgressBar: add visually hidden label to custom color input
 - ToggleButton: remove incorrect `id` assignment from button element
-- TreeView: move `aria-live` region inside `treeitem` to fix `aria-required-children` violation
-- TreeView: add `aria-disabled` to treeitem to fix `color-contrast` violation on disabled items
+- TreeView: Fix `aria-required-children` and `color-contrast` accessibility violations

--- a/.changeset/fix-storybook-a11y-issues.md
+++ b/.changeset/fix-storybook-a11y-issues.md
@@ -10,3 +10,4 @@ fix(Storybook): Fix accessibility issues in stories:
 - ProgressBar: add visually hidden label to custom color input
 - ToggleButton: remove incorrect `id` assignment from button element
 - TreeView: move `aria-live` region inside `treeitem` to fix `aria-required-children` violation
+- TreeView: add `aria-disabled` to treeitem to fix `color-contrast` violation on disabled items

--- a/packages/react-magma-dom/src/components/Input/Input.stories.tsx
+++ b/packages/react-magma-dom/src/components/Input/Input.stories.tsx
@@ -819,17 +819,29 @@ export function TimeInput() {
       />
       <Spacer size={32} />
       <Paragraph>Native inputs:</Paragraph>
-      <Paragraph style={{ marginBottom: '8px' }}>Hours</Paragraph>
       <div style={{ display: 'flex', flexDirection: 'column', width: '264px' }}>
+        <label
+          htmlFor="native-hours"
+          style={{ marginBottom: '8px', display: 'block' }}
+        >
+          Hours
+        </label>
         <input
+          id="native-hours"
           type={InputType.number}
           min={1}
           max={60}
           value={hours}
           onChange={event => onChangeTimedDuration(event, 'hours', minutes)}
         />
-        <Paragraph style={{ marginBottom: '8px' }}>Minutes</Paragraph>
+        <label
+          htmlFor="native-minutes"
+          style={{ marginBottom: '8px', display: 'block' }}
+        >
+          Minutes
+        </label>
         <input
+          id="native-minutes"
           type={InputType.number}
           min={1}
           max={60}

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -786,8 +786,9 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
             />
             {icon && !onIconClick && (
               <IconWrapper
-                role="img"
+                role={iconAriaLabel ? 'img' : undefined}
                 aria-label={iconAriaLabel}
+                aria-hidden={iconAriaLabel ? undefined : true}
                 iconPosition={iconPosition}
                 inputSize={inputSize ?? InputSize.medium}
                 isInverse={props.isInverse}

--- a/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/react-magma-dom/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -116,6 +116,8 @@ export const CustomColor = {
             <ProgressBar {...args} color={customColor} />
             <br />
             <Input
+              labelText="Custom color"
+              isLabelVisuallyHidden
               value={customColor}
               onChange={e => setCustomColor(e.target.value)}
             />

--- a/packages/react-magma-dom/src/components/Table/TableRow.tsx
+++ b/packages/react-magma-dom/src/components/Table/TableRow.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { transparentize } from 'polished';
 
-import { getAriaSort, getAriaSortLabel, getTableSortIcon } from './utils';
+import { getAriaSortLabel, getTableSortIcon } from './utils';
 import { I18nContext } from '../../i18n';
 import { magma } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
@@ -336,11 +336,6 @@ export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
             density={tableContext.density}
             hasSquareCorners={tableContext.hasSquareCorners}
             isInverse={tableContext.isInverse}
-            aria-sort={
-              tableContext.isSortableBySelected
-                ? getAriaSort(sortDirection)
-                : undefined
-            }
             style={{
               background: isHovering
                 ? transparentize(0.93, theme.colors.neutral900)

--- a/packages/react-magma-dom/src/components/Tabs/Tab.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/Tab.tsx
@@ -363,7 +363,7 @@ export const Tab = React.forwardRef<HTMLButtonElement, TabProps>(
       >
         <StyledTab
           {...rest}
-          aria-controls={panelId}
+          aria-controls={rest['aria-controls'] ?? panelId}
           aria-selected={isActive}
           data-testid={testId}
           disabled={disabled}

--- a/packages/react-magma-dom/src/components/Tabs/TabsScrollSpyContainer.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/TabsScrollSpyContainer.tsx
@@ -104,6 +104,7 @@ export const TabsScrollSpyContainer = React.forwardRef<
             testId={`tab${i}`}
             onClick={() => onClick(option)}
             data-scrollspy-id={option.hash}
+            aria-controls={option.hash}
           >
             {option.title}
           </Tab>

--- a/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.tsx
@@ -192,7 +192,6 @@ export const ToggleButton = React.forwardRef<
     color: ButtonColor.subtle,
     disabled: disabled,
     theme: theme,
-    id: context.descriptionId,
     isInverse: inverseCheck,
     onClick: context.exclusive ? handleClickExclusive : handleClick,
     ref: ref,

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -726,6 +726,7 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
         <div style={treeItemStyles}>
           <StyledTreeItem
             {...rest}
+            aria-disabled={isDisabled || null}
             aria-expanded={hasOwnTreeItems ? expanded : null}
             aria-selected={selectedItem}
             aria-checked={shouldShowCheckbox ? ariaCheckedValue : null}

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -867,16 +867,16 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
                 );
               }
             )}
+            {isMacOS && (
+              <VisuallyHidden>
+                <Announce>
+                  {expanded
+                    ? i18n.expansionState.expanded
+                    : i18n.expansionState.collapsed}
+                </Announce>
+              </VisuallyHidden>
+            )}
           </StyledTreeItem>
-          {isMacOS && (
-            <VisuallyHidden>
-              <Announce>
-                {expanded
-                  ? i18n.expansionState.expanded
-                  : i18n.expansionState.collapsed}
-              </Announce>
-            </VisuallyHidden>
-          )}
         </div>
       </TreeItemContext.Provider>
     );

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -1562,6 +1562,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
@@ -1703,6 +1704,7 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   class="emotion-28 emotion-29"
                   data-testid="item-id-3"
                   id="item-id-3"
@@ -3761,6 +3763,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
@@ -3903,6 +3906,7 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   aria-expanded="false"
                   class="emotion-60 emotion-29"
                   data-testid="item-id-3"
@@ -5877,6 +5881,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
@@ -6018,6 +6023,7 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   aria-expanded="false"
                   class="emotion-60 emotion-29"
                   data-testid="item-id-3"
@@ -7992,6 +7998,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
@@ -8133,6 +8140,7 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   aria-expanded="false"
                   class="emotion-60 emotion-29"
                   data-testid="item-id-3"
@@ -10237,6 +10245,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
@@ -10379,6 +10388,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   aria-expanded="false"
                   class="emotion-60 emotion-29"
                   data-testid="item-id-3"
@@ -12483,6 +12493,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
@@ -12625,6 +12636,7 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   aria-expanded="false"
                   class="emotion-60 emotion-29"
                   data-testid="item-id-3"
@@ -14599,6 +14611,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   class="emotion-28 emotion-29"
                   data-testid="item-id-1"
                   id="item-id-1"
@@ -14740,6 +14753,7 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
               <div>
                 <li
                   aria-checked="false"
+                  aria-disabled="true"
                   aria-expanded="false"
                   class="emotion-60 emotion-29"
                   data-testid="item-id-3"


### PR DESCRIPTION
Closes: #1973

## What I did
Fixed multiple accessibility violations found in Storybook stories across several components:

- **Input:** added labels to native inputs; hid decorative icons from screen readers 
  - [1) Issue](https://github.com/cengage/react-magma/issues/1856#issuecomment-3372383712) 
  - [2) Issue](https://github.com/cengage/react-magma/issues/1856#issuecomment-3372387595)
- **Table:** removed invalid `aria-sort` from the checkbox header cell 
  - [Issue](https://github.com/cengage/react-magma/issues/1857#issuecomment-3376736898)
- **Tabs:** fixed `aria-controls` pointing to the correct `ScrollSpy` panel id
  - [Issue](https://github.com/cengage/react-magma/issues/1857#issuecomment-3376810072)
- **ProgressBar:** added a visually hidden label to the custom color input
  - [Issue](https://github.com/cengage/react-magma/issues/1859#issuecomment-3385880486)
- **ToggleButton:** removed incorrect id assignment from the button element
  - [Issue](https://github.com/cengage/react-magma/issues/1859#issuecomment-3385899926)
- **TreeView:** moved aria-live region inside `Treeitem` to fix `aria-required-children` ARIA violation
  - [Issue](https://github.com/cengage/react-magma/issues/1859#issuecomment-3385935835)


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test

Open Storybook -> Navigate to the affected stories: Input, Table, Tabs, ProgressBar, ToggleButton, TreeView
-> Open the Accessibility tab -> Verify there are no Critical or Serious violations flagged by axe