### PR TITLE
fix(DateTimePicker): prevent crash when entering invalid date in input

### DIFF
--- a/.changeset/fix-datetimepicker-crash-invalid-date.md
+++ b/.changeset/fix-datetimepicker-crash-invalid-date.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DateTimePicker): prevent crash when entering invalid date in input

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -425,7 +425,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
 
         const pattern = /^\d{2}\/\d{2}\/\d{4}$/;
 
-        if (pattern.test(splitValue)) {
+        if (pattern.test(splitValue) && isValid(validDay)) {
           setChosenDate(validDay);
         }
 

--- a/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
+++ b/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
@@ -595,6 +595,34 @@ describe('DateTimePicker', () => {
   });
 
   describe('Edge Cases', () => {
+    it('should not crash when typing an invalid date with correct format (e.g. 05/35/2026)', async () => {
+      const { getByPlaceholderText } = render(
+        <DateTimePicker labelText="Date Time Picker Label" />
+      );
+
+      const input = getByPlaceholderText('mm/dd/yyyy hh:mm AM');
+
+      await expect(userEvent.type(input, '05/35/2026')).resolves.not.toThrow();
+
+      expect(input).toBeInTheDocument();
+    });
+
+    it('should not call onDateChange when an invalid date is typed', async () => {
+      const onDateChange = jest.fn();
+      const { getByPlaceholderText } = render(
+        <DateTimePicker
+          labelText="Date Time Picker Label"
+          onDateChange={onDateChange}
+        />
+      );
+
+      const input = getByPlaceholderText('mm/dd/yyyy hh:mm AM');
+
+      await userEvent.type(input, '05/35/2026');
+
+      expect(onDateChange).not.toHaveBeenCalled();
+    });
+
     it('should handle null/undefined values gracefully', () => {
       const { getByPlaceholderText } = render(
         <DateTimePicker labelText="Date Time Picker Label" value={null} />


### PR DESCRIPTION
Closes: #2513

## What I did
Fixed a crash in DateTimePicker that happened when typing an invalid date like 05/35/2026


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open DateTimePicker -> Basic Usage section -> Type an invalid date (e.g. 05/35/2026) -> Confirm no error
