### PR TITLE
V4/feat(TreeView): support clicking anywhere on a folder to expand/collapse it for `selectable.off`

### DIFF
--- a/.changeset/feat-TreeView-click-anywhere-expand-selectable-off.md
+++ b/.changeset/feat-TreeView-click-anywhere-expand-selectable-off.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(TreeView): support clicking anywhere on a folder to expand/collapse it for `selectable.off`

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -479,9 +479,13 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
           !selectParents &&
           hasOwnTreeItems
         ) {
-          event.preventDefault();
-          event.stopPropagation();
+          onExpandedClicked(event);
 
+          return;
+        }
+
+        // In selectable=off mode, clicking anywhere on a parent item toggles expand/collapse
+        if (selectable === TreeViewSelectable.off && hasOwnTreeItems) {
           onExpandedClicked(event);
 
           return;

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -4404,6 +4404,186 @@ describe('TreeView', () => {
     });
   });
 
+  describe('click anywhere on a folder toggles expand/collapse in selectable.off', () => {
+    it('expands a folder when clicking the label in selectable=off mode', () => {
+      const { getByTestId } = render(
+        <TreeView ariaLabel="TreeView" selectable={TreeViewSelectable.off}>
+          <TreeItem label="Parent" itemId="parent" testId="parent">
+            <TreeItem label="Child" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parent = getByTestId('parent');
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+
+      userEvent.click(getByTestId('parent-label'));
+
+      expect(parent).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('collapses a folder when clicking the label again in selectable=off mode', () => {
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.off}
+          initialExpandedItems={['parent']}
+        >
+          <TreeItem label="Parent" itemId="parent" testId="parent">
+            <TreeItem label="Child" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parent = getByTestId('parent');
+      expect(parent).toHaveAttribute('aria-expanded', 'true');
+
+      userEvent.click(getByTestId('parent-label'));
+
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('expands a folder when clicking the item wrapper in selectable=off mode', () => {
+      const { getByTestId } = render(
+        <TreeView ariaLabel="TreeView" selectable={TreeViewSelectable.off}>
+          <TreeItem label="Parent" itemId="parent" testId="parent">
+            <TreeItem label="Child" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parent = getByTestId('parent');
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+
+      userEvent.click(getByTestId('parent-itemwrapper'));
+
+      expect(parent).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('fires onExpandedChange when clicking a folder in selectable=off mode', () => {
+      const onExpandedChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.off}
+          onExpandedChange={onExpandedChange}
+        >
+          <TreeItem label="Parent" itemId="parent" testId="parent">
+            <TreeItem label="Child" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      userEvent.click(getByTestId('parent-label'));
+
+      expect(onExpandedChange).toHaveBeenCalled();
+      const lastCallArgs = onExpandedChange.mock.calls.pop();
+      expect(lastCallArgs[1]).toEqual(['parent']);
+    });
+
+    it('does nothing when clicking a leaf item in selectable=off mode', () => {
+      const onExpandedChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.off}
+          onExpandedChange={onExpandedChange}
+        >
+          <TreeItem label="Leaf" itemId="leaf" testId="leaf" />
+        </TreeView>
+      );
+
+      const leaf = getByTestId('leaf');
+      expect(leaf).not.toHaveAttribute('aria-expanded');
+
+      userEvent.click(getByTestId('leaf-label'));
+
+      expect(leaf).not.toHaveAttribute('aria-expanded');
+      expect(onExpandedChange).not.toHaveBeenCalled();
+    });
+
+    it('does not expand a disabled folder when clicked in selectable=off mode', () => {
+      const onExpandedChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.off}
+          onExpandedChange={onExpandedChange}
+        >
+          <TreeItem label="Parent" itemId="parent" testId="parent" isDisabled>
+            <TreeItem label="Child" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parent = getByTestId('parent');
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+
+      userEvent.click(getByTestId('parent-label'));
+
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+      expect(onExpandedChange).not.toHaveBeenCalled();
+    });
+
+    it('does not toggle expansion when clicking a folder in single-select mode with selectParents=true (default)', () => {
+      const onExpandedChange = jest.fn();
+      const onSelectedItemChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.single}
+          onExpandedChange={onExpandedChange}
+          onSelectedItemChange={onSelectedItemChange}
+        >
+          <TreeItem label="Parent" itemId="parent" testId="parent">
+            <TreeItem label="Child" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parent = getByTestId('parent');
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+
+      userEvent.click(getByTestId('parent-label'));
+
+      // Selection happens, but expansion does NOT toggle on row click.
+      expect(parent).toHaveAttribute('aria-selected', 'true');
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+      expect(onSelectedItemChange).toHaveBeenCalled();
+      expect(onExpandedChange).not.toHaveBeenCalled();
+    });
+
+    it('does not toggle expansion when clicking a folder row in multi-select mode', () => {
+      const onExpandedChange = jest.fn();
+
+      const { getByTestId } = render(
+        <TreeView
+          ariaLabel="TreeView"
+          selectable={TreeViewSelectable.multi}
+          onExpandedChange={onExpandedChange}
+        >
+          <TreeItem label="Parent" itemId="parent" testId="parent">
+            <TreeItem label="Child" itemId="child" testId="child" />
+          </TreeItem>
+        </TreeView>
+      );
+
+      const parent = getByTestId('parent');
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+
+      // Clicking the row wrapper should NOT toggle expansion in multi mode;
+      // the dedicated expand button is the only way to expand/collapse here.
+      userEvent.click(getByTestId('parent-itemwrapper'));
+
+      expect(parent).toHaveAttribute('aria-expanded', 'false');
+      expect(onExpandedChange).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Dynamically updating tree', () => {
     it('should update when children are dynamically rendered inside an empty parent', () => {
       const DynamicChildrenTest = () => {

--- a/website/react-magma-docs/src/pages/api/tree-view.mdx
+++ b/website/react-magma-docs/src/pages/api/tree-view.mdx
@@ -541,6 +541,8 @@ In a TreeView with `TreeViewSelectable.single`, you can control whether parent i
 
 By default, the `selectParents` prop is set to `true`, allowing parent items to be selected normally. When set to `false`, clicking on parent items will only expand/collapse them, while child items (leaves) can still be selected as usual.
 
+In `TreeViewSelectable.off` mode, there is nothing to select, so clicking anywhere on a folder row toggles its expanded/collapsed state by default.
+
 ```tsx
 import React from 'react';
 


### PR DESCRIPTION
Closes: #2480
Cherry-pick #2552

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Support clicking anywhere on a folder to expand/collapse it for `selectable.off`

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook -> TreeView -> Select `Selectable.off` -> Check behavior
Open Docs -> TreeView -> Select Parents section -> Check new description