### PR TITLE
fix(DatePicker): add role="dialog" and aria-modal="true" to calendar

### DIFF
--- a/.changeset/a11y-datepicker-dialog-role.md
+++ b/.changeset/a11y-datepicker-dialog-role.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DatePicker): add role="dialog" and aria-modal="true" to calendar container

--- a/.changeset/fix-useFocusLock.md
+++ b/.changeset/fix-useFocusLock.md
@@ -1,0 +1,6 @@
+---
+'react-magma-dom': patch
+---
+
+fix(useFocusLock): fix focus trap for modal and date picker, including nested DatePicker focus order.
+

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { format } from 'date-fns';
 
 import { CalendarContext } from './CalendarContext';
@@ -34,7 +34,7 @@ describe('Calendar Day', () => {
     expect(getByText(format(defaultDate, 'd'))).toBeInTheDocument();
   });
 
-  it('focuses if current day', () => {
+  it('focuses if current day', async () => {
     const defaultDate = new Date(2019, 0, 17);
     const { container } = render(
       <CalendarContext.Provider
@@ -56,9 +56,11 @@ describe('Calendar Day', () => {
       </CalendarContext.Provider>
     );
 
-    expect(container.querySelector(':focus')).toHaveAttribute(
-      'aria-label',
-      ` ${format(defaultDate, 'EEEE, MMMM do yyyy')}  (Selected)`
+    await waitFor(() =>
+      expect(container.querySelector(':focus')).toHaveAttribute(
+        'aria-label',
+        ` ${format(defaultDate, 'EEEE, MMMM do yyyy')}  (Selected)`
+      )
     );
   });
 

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
@@ -234,7 +234,22 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
 
   React.useEffect(() => {
     if (dateFocused && isSameDay(day, focusedDate)) {
-      dayRef.current.focus();
+      const calendarDialog = dayRef.current?.closest('[role="dialog"]');
+
+      if (calendarDialog?.contains(document.activeElement)) {
+        dayRef.current.focus();
+
+        return;
+      }
+
+      const activeOnSchedule = document.activeElement;
+      const focusFrame = requestAnimationFrame(() => {
+        if (document.activeElement === activeOnSchedule) {
+          dayRef.current?.focus();
+        }
+      });
+
+      return () => cancelAnimationFrame(focusFrame);
     }
   }, [focusedDate, dateFocused, day]);
 

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, act } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CalendarContext } from './CalendarContext';
@@ -46,7 +46,7 @@ describe('Calendar Month', () => {
         </CalendarContext.Provider>
       );
 
-      expect(getByTestId('month-picker')).toHaveFocus();
+      await waitFor(() => expect(getByTestId('month-picker')).toHaveFocus());
       await userEvent.tab();
       expect(getByTestId('year-picker')).toHaveFocus();
       await userEvent.tab();
@@ -129,7 +129,7 @@ describe('Calendar Month', () => {
         </CalendarContext.Provider>
       );
 
-      expect(getByTestId('month-picker')).toHaveFocus();
+      await waitFor(() => expect(getByTestId('month-picker')).toHaveFocus());
 
       await userEvent.tab({ shift: true });
       expect(getByLabelText(/close calendar/i)).toHaveFocus();

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -157,7 +157,12 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
   const helperButtonRef = React.useRef<any>();
   const context = React.useContext(CalendarContext);
   const prevCalendarOpened = usePrevious(props.calendarOpened);
-  const focusTrapElement = useFocusLock(props.calendarOpened);
+  const focusTrapElement = useFocusLock(
+    props.calendarOpened,
+    undefined,
+    undefined,
+    !props.focusOnOpen
+  );
   const monthContainerRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.stories.tsx
@@ -9,6 +9,7 @@ import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
 import { Button } from '../Button';
 import { LabelPosition } from '../Label';
+import { Modal } from '../Modal';
 
 import { DatePicker } from '.';
 
@@ -303,6 +304,41 @@ export const DateFieldDefault = {
           onChange={handleChange}
           errorMessage={hasErrorMessage()}
         />
+      </>
+    );
+  },
+
+  args: {
+    ...Default.args,
+  },
+};
+
+export const InsideModal = {
+  render: args => {
+    const [modalOpen, setModalOpen] = React.useState(false);
+    const [chosenDate, setChosenDate] = React.useState<Date | undefined>();
+
+    return (
+      <>
+        <Button onClick={() => setModalOpen(true)}>Open Modal</Button>
+        <Modal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+          header="DatePicker inside Modal"
+        >
+          <DatePicker
+            {...args}
+            labelText="Date"
+            onDateChange={d => setChosenDate(d)}
+            value={chosenDate}
+            isClearable
+          />
+          {chosenDate && (
+            <p>
+              <strong>Chosen date:</strong> {chosenDate.toLocaleDateString()}
+            </p>
+          )}
+        </Modal>
       </>
     );
   },

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -225,7 +225,7 @@ describe('Date Picker', () => {
     });
 
     expect(selectedDateButton).toBeInTheDocument();
-    expect(selectedDateButton).toHaveFocus();
+    await waitFor(() => expect(selectedDateButton).toHaveFocus());
 
     await act(async () => {
       await userEvent.keyboard('[ArrowLeft]');
@@ -272,7 +272,7 @@ describe('Date Picker', () => {
     await userEvent.click(button);
 
     expect(selectedDateButton).toBeInTheDocument();
-    expect(selectedDateButton).toHaveFocus();
+    await waitFor(() => expect(selectedDateButton).toHaveFocus());
 
     for (let i = 0; i < 8; i++) {
       await userEvent.tab();
@@ -577,7 +577,7 @@ describe('Date Picker', () => {
 
     await userEvent.click(getByLabelText('Toggle Calendar Widget'));
 
-    expect(getByText('17')).toBe(document.activeElement);
+    await waitFor(() => expect(getByText('17')).toBe(document.activeElement));
   });
 
   it('should focus on today when none valid date in input', async () => {
@@ -604,7 +604,7 @@ describe('Date Picker', () => {
     expect(getByText(year)).not.toBeNull();
 
     const todayElement = container.querySelector('[aria-current="date"]');
-    expect(todayElement).toHaveFocus();
+    await waitFor(() => expect(todayElement).toHaveFocus());
   });
 
   it('should focus on min date when it min date after today', async () => {
@@ -620,7 +620,7 @@ describe('Date Picker', () => {
 
     await userEvent.click(getByLabelText('Toggle Calendar Widget'));
 
-    expect(getByText(focusedDay)).toHaveFocus();
+    await waitFor(() => expect(getByText(focusedDay)).toHaveFocus());
   });
 
   it('should go to the previous month when the previous month button is clicked', async () => {
@@ -715,6 +715,12 @@ describe('Date Picker', () => {
     expect(getByTestId('calendarContainer')).toHaveStyleRule(
       'display',
       'block'
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('calendarContainer')).toContainElement(
+        document.activeElement
+      )
     );
 
     await userEvent.keyboard('{Escape}');

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.test.js
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { HelperInformation } from './HelperInformation';
@@ -44,6 +44,10 @@ describe('Calendar Month', () => {
     const { getByLabelText } = render(<HelperInformation isOpen />);
 
     const button = getByLabelText('Close Calendar Widget');
+
+    await waitFor(() =>
+      expect(getByLabelText('Back to Calendar')).toHaveFocus()
+    );
 
     await userEvent.tab();
 

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -707,6 +707,9 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
                 opened={calendarOpened}
                 isInverse={isInverse}
                 theme={theme}
+                role="dialog"
+                aria-modal="true"
+                aria-label={i18n.datePicker.calendarOpenAnnounce}
               >
                 <CalendarMonth
                   focusOnOpen={calendarOpened && Boolean(focusedDate)}

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -4,6 +4,7 @@ import {
   act,
   fireEvent,
   render,
+  waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -475,11 +476,13 @@ describe('Modal', () => {
       foreignModal.style.display = 'none';
       document.body.appendChild(foreignModal);
 
-      render(
+      const { getByText } = render(
         <Modal header="Hello" isOpen onClose={onCloseSpy}>
           Modal Content
         </Modal>
       );
+
+      await waitFor(() => expect(getByText('Hello')).toHaveFocus());
 
       await userEvent.keyboard('{Escape}');
 
@@ -520,6 +523,8 @@ describe('Modal', () => {
           </Modal>
         </>
       );
+
+      await waitFor(() => expect(getByText('Hello')).toHaveFocus());
 
       await userEvent.keyboard('{Escape}');
 
@@ -922,6 +927,8 @@ describe('Modal', () => {
         </>
       );
 
+      await waitFor(() => expect(getByText('Hello again')).toHaveFocus());
+
       await userEvent.keyboard('{Escape}');
 
       expect(onEscKeyDown).toHaveBeenCalled();
@@ -936,7 +943,7 @@ describe('Modal', () => {
   });
 
   describe('focus trap', () => {
-    it('should focus the header element upon opening the modal', () => {
+    it('should focus the header element upon opening the modal', async () => {
       const { rerender, getByText } = render(
         <>
           <button>Open</button>
@@ -957,10 +964,10 @@ describe('Modal', () => {
         </>
       );
 
-      expect(getByText('Hello')).toHaveFocus();
+      await waitFor(() => expect(getByText('Hello')).toHaveFocus());
     });
 
-    it('should focus the close button upon opening the modal when the modal if there is no header', () => {
+    it('should focus the close button upon opening the modal when the modal if there is no header', async () => {
       const { rerender, getByTestId, getByText } = render(
         <>
           <button>Open</button>
@@ -981,10 +988,10 @@ describe('Modal', () => {
         </>
       );
 
-      expect(getByTestId('modal-closebtn')).toHaveFocus();
+      await waitFor(() => expect(getByTestId('modal-closebtn')).toHaveFocus());
     });
 
-    it('should focus the first actionable element element upon opening the modal if there is no header and close button', () => {
+    it('should focus the first actionable element element upon opening the modal if there is no header and close button', async () => {
       const { rerender, getByText, getByTestId } = render(
         <>
           <button>Open</button>
@@ -1005,10 +1012,10 @@ describe('Modal', () => {
         </>
       );
 
-      expect(getByTestId('closeButton')).toHaveFocus();
+      await waitFor(() => expect(getByTestId('closeButton')).toHaveFocus());
     });
 
-    it('should not focus the first element if there is no heading and nothing else to focus', () => {
+    it('should not focus the first element if there is no heading and nothing else to focus', async () => {
       const { rerender, getByText } = render(
         <>
           <button>Open</button>
@@ -1029,7 +1036,7 @@ describe('Modal', () => {
         </>
       );
 
-      expect(getByText('Modal Content')).toHaveFocus();
+      await waitFor(() => expect(getByText('Modal Content')).toHaveFocus());
     });
 
     it('should handle tab and loop it through the modal', async () => {
@@ -1065,6 +1072,8 @@ describe('Modal', () => {
           </Modal>
         </>
       );
+
+      await waitFor(() => expect(getByText('Hello')).toHaveFocus());
 
       await userEvent.tab();
 
@@ -1122,6 +1131,8 @@ describe('Modal', () => {
         </>
       );
 
+      await waitFor(() => expect(getByText('Modal Content')).toHaveFocus());
+
       await userEvent.tab();
 
       expect(getByText('Modal Content')).toHaveFocus();
@@ -1160,6 +1171,8 @@ describe('Modal', () => {
           </Modal>
         </>
       );
+
+      await waitFor(() => expect(getByText('Hello')).toHaveFocus());
 
       await userEvent.tab({ shift: true });
 
@@ -1211,6 +1224,8 @@ describe('Modal', () => {
           </Modal>
         </>
       );
+
+      await waitFor(() => expect(getByText('Hello')).toHaveFocus());
 
       await userEvent.tab({ shift: true });
 

--- a/packages/react-magma-dom/src/hooks/useFocusLock.test.js
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.test.js
@@ -15,6 +15,7 @@ const TEST_ID_FIRST_DISABLED_BUTTON_INSIDE_MODAL =
   'test-id-first-disabled-button-inside';
 const TEST_ID_SECOND_DISABLED_BUTTON_INSIDE_MODAL =
   'test-id-second-disabled-button-inside';
+const TEST_ID_HIDDEN_BUTTON_INSIDE_MODAL = 'test-id-hidden-button-inside';
 
 const OneActiveElemet = () => {
   const [showModal, setShowModal] = React.useState(false);
@@ -155,6 +156,61 @@ const OneDisabledElemet = () => {
         Show Working Focus Lock Area
       </Button>
     </>
+  );
+};
+
+const LastElementsAreHiddenByAncestor = () => {
+  const [showModal, setShowModal] = React.useState(false);
+  const focus = useFocusLock(showModal);
+
+  return (
+    <>
+      {showModal && (
+        <div ref={focus}>
+          <Button testId={TEST_ID_FIRST_ACTIVE_BUTTON_INSIDE_MODAL}>
+            This is a first active button
+          </Button>
+          <Button testId={TEST_ID_SECOND_ACTIVE_BUTTON_INSIDE_MODAL}>
+            This is a last visible button
+          </Button>
+          <div style={{ display: 'none' }}>
+            <Button testId={TEST_ID_HIDDEN_BUTTON_INSIDE_MODAL}>
+              This is a button hidden by an ancestor
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Button
+        onClick={() => setShowModal(!showModal)}
+        testId={TEST_ID_BUTTON_OUTSIDE_MODAL}
+      >
+        Show Working Focus Lock Area
+      </Button>
+    </>
+  );
+};
+
+const NestedFocusLocks = () => {
+  const [showInner, setShowInner] = React.useState(false);
+  const outerFocus = useFocusLock(true);
+  const innerFocus = useFocusLock(showInner);
+
+  return (
+    <div ref={outerFocus}>
+      <Button
+        onClick={() => setShowInner(true)}
+        testId={TEST_ID_FIRST_ACTIVE_BUTTON_INSIDE_MODAL}
+      >
+        Open inner lock
+      </Button>
+      {showInner && (
+        <div ref={innerFocus}>
+          <Button testId="test-id-inner-first">Inner first</Button>
+          <Button testId="test-id-inner-last">Inner last</Button>
+        </div>
+      )}
+    </div>
   );
 };
 
@@ -343,6 +399,59 @@ describe('useFocusLock', () => {
     expect(firstDisabledButtonInsideModal).not.toHaveFocus();
     expect(secondDisabledButtonInsideModal).not.toHaveFocus();
     expect(secondActiveButtonInsideModal).toHaveFocus();
+  });
+
+  it('should skip elements hidden by an ancestor and loop tab from the last visible element', async () => {
+    const { getByTestId } = render(<LastElementsAreHiddenByAncestor />);
+
+    await userEvent.click(getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL));
+
+    const firstButton = getByTestId(TEST_ID_FIRST_ACTIVE_BUTTON_INSIDE_MODAL);
+    const lastVisibleButton = getByTestId(
+      TEST_ID_SECOND_ACTIVE_BUTTON_INSIDE_MODAL
+    );
+    const hiddenButton = getByTestId(TEST_ID_HIDDEN_BUTTON_INSIDE_MODAL);
+
+    await waitFor(() => expect(firstButton).toHaveFocus());
+
+    await userEvent.tab();
+
+    expect(lastVisibleButton).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(hiddenButton).not.toHaveFocus();
+    expect(firstButton).toHaveFocus();
+
+    await userEvent.tab({ shift: true });
+
+    expect(hiddenButton).not.toHaveFocus();
+    expect(lastVisibleButton).toHaveFocus();
+  });
+
+  it('should keep tab inside a nested lock instead of looping the outer one', async () => {
+    const { getByTestId } = render(<NestedFocusLocks />);
+
+    await userEvent.click(
+      getByTestId(TEST_ID_FIRST_ACTIVE_BUTTON_INSIDE_MODAL)
+    );
+
+    const innerFirstButton = getByTestId('test-id-inner-first');
+    const innerLastButton = getByTestId('test-id-inner-last');
+
+    await waitFor(() => expect(innerFirstButton).toHaveFocus());
+
+    await userEvent.tab();
+
+    expect(innerLastButton).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(innerFirstButton).toHaveFocus();
+
+    await userEvent.tab({ shift: true });
+
+    expect(innerLastButton).toHaveFocus();
   });
 
   it('should focus on last active element if there is no tabbable elements', async () => {

--- a/packages/react-magma-dom/src/hooks/useFocusLock.test.js
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { useFocusLock } from './useFocusLock';
@@ -177,7 +177,7 @@ describe('useFocusLock', () => {
 
     expect(activeButtonInsideModal).toBeInTheDocument();
     expect(activeButtonInsideModal).not.toBeDisabled();
-    expect(activeButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(activeButtonInsideModal).toHaveFocus());
   });
 
   it('should stay inside the modal after pressing tab if there is one active element', async () => {
@@ -198,7 +198,7 @@ describe('useFocusLock', () => {
 
     expect(activeButtonInsideModal).toBeInTheDocument();
     expect(activeButtonInsideModal).not.toBeDisabled();
-    expect(activeButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(activeButtonInsideModal).toHaveFocus());
 
     await userEvent.tab();
 
@@ -225,7 +225,7 @@ describe('useFocusLock', () => {
 
     expect(activeButtonInsideModal).toBeInTheDocument();
     expect(activeButtonInsideModal).not.toBeDisabled();
-    expect(activeButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(activeButtonInsideModal).toHaveFocus());
   });
 
   it('should focus on last active element after shift + tab', async () => {
@@ -244,7 +244,7 @@ describe('useFocusLock', () => {
 
     expect(firstActiveButtonInsideModal).toBeInTheDocument();
     expect(firstActiveButtonInsideModal).not.toBeDisabled();
-    expect(firstActiveButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(firstActiveButtonInsideModal).toHaveFocus());
 
     await userEvent.tab({ shift: true });
 
@@ -275,7 +275,7 @@ describe('useFocusLock', () => {
 
     expect(firstActiveButtonInsideModal).toBeInTheDocument();
     expect(firstActiveButtonInsideModal).not.toBeDisabled();
-    expect(firstActiveButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(firstActiveButtonInsideModal).toHaveFocus());
 
     await userEvent.tab();
 
@@ -316,7 +316,7 @@ describe('useFocusLock', () => {
 
     expect(firstActiveButtonInsideModal).toBeInTheDocument();
     expect(firstActiveButtonInsideModal).not.toBeDisabled();
-    expect(firstActiveButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(firstActiveButtonInsideModal).toHaveFocus());
 
     await userEvent.tab();
 
@@ -360,7 +360,7 @@ describe('useFocusLock', () => {
     expect(disabledButtonInsideModal).toBeDisabled();
     expect(disabledButtonInsideModal).not.toHaveFocus();
 
-    expect(getByText('Test text')).toHaveFocus();
+    await waitFor(() => expect(getByText('Test text')).toHaveFocus());
 
     await userEvent.tab();
 

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -89,7 +89,8 @@ const activeFocusLockRoots = new Set<HTMLElement>();
 export function useFocusLock(
   active: boolean,
   header?: React.MutableRefObject<FocusableElement>,
-  body?: React.MutableRefObject<FocusableElement>
+  body?: React.MutableRefObject<FocusableElement>,
+  autoFocusOnActivate = true
 ): React.MutableRefObject<any> {
   const rootNode = React.useRef<HTMLElement>(null);
   const focusableItems = React.useRef<Array<HTMLElement>>([]);
@@ -135,15 +136,40 @@ export function useFocusLock(
         observer.observe(root, { childList: true, subtree: true });
       }
 
-      if (header && header.current) {
-        header.current.focus();
-      } else if (focusableItems.current && focusableItems.current.length > 0) {
-        const { 0: firstItem } = focusableItems.current;
+      // Defer the initial focus to the next frame so the browser can update
+      // the accessibility tree first (e.g. after a `display: none` toggle).
+      let focusFrame: number;
 
-        firstItem.focus();
-      } else if (body && body.current) {
-        (body.current.firstChild as HTMLElement).setAttribute('tabIndex', '-1');
-        (body.current.firstChild as HTMLElement).focus();
+      if (autoFocusOnActivate) {
+        const activeOnActivate = document.activeElement;
+
+        focusFrame = requestAnimationFrame(() => {
+          const activeElement = document.activeElement;
+
+          if (
+            activeElement !== activeOnActivate &&
+            activeElement !== document.body
+          ) {
+            return;
+          }
+
+          if (header && header.current) {
+            header.current.focus();
+          } else if (
+            focusableItems.current &&
+            focusableItems.current.length > 0
+          ) {
+            const { 0: firstItem } = focusableItems.current;
+
+            firstItem.focus();
+          } else if (body && body.current) {
+            (body.current.firstChild as HTMLElement).setAttribute(
+              'tabIndex',
+              '-1'
+            );
+            (body.current.firstChild as HTMLElement).focus();
+          }
+        });
       }
 
       return () => {
@@ -151,10 +177,11 @@ export function useFocusLock(
           activeFocusLockRoots.delete(root);
         }
 
+        cancelAnimationFrame(focusFrame);
         observer.disconnect();
       };
     }
-  }, [active, header, body]);
+  }, [active, header, body, autoFocusOnActivate]);
 
   React.useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -84,8 +84,12 @@ function deduplicateTabStops(allFocusable: HTMLElement[]): HTMLElement[] {
  * by an ancestor.
  */
 function isElementVisible(element: HTMLElement): boolean {
-  if (typeof element.checkVisibility === 'function') {
-    return element.checkVisibility();
+  const elementWithVisibility = element as HTMLElement & {
+    checkVisibility?: () => boolean;
+  };
+
+  if (typeof elementWithVisibility.checkVisibility === 'function') {
+    return elementWithVisibility.checkVisibility();
   }
 
   for (

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -80,6 +80,30 @@ function deduplicateTabStops(allFocusable: HTMLElement[]): HTMLElement[] {
 }
 
 /**
+ * Checks that the element is actually visible, including being hidden
+ * by an ancestor.
+ */
+function isElementVisible(element: HTMLElement): boolean {
+  if (typeof element.checkVisibility === 'function') {
+    return element.checkVisibility();
+  }
+
+  for (
+    let node: HTMLElement | null = element;
+    node;
+    node = node.parentElement
+  ) {
+    const style = window.getComputedStyle(node);
+
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
  * Module-level registry of currently active focus-lock root elements.
  * Used in Safari to prevent an outer lock from handling Tab for elements
  * that belong to an inner (descendant) lock.
@@ -104,14 +128,11 @@ export function useFocusLock(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), video'
       ) || []
     ).filter((element): element is HTMLElement => {
-      const style = window.getComputedStyle(element);
-
       return (
         element instanceof HTMLElement &&
-        style.display !== 'none' &&
-        style.visibility !== 'hidden' &&
         !element.hasAttribute('disabled') &&
-        element.tabIndex >= 0
+        element.tabIndex >= 0 &&
+        isElementVisible(element)
       );
     });
 
@@ -181,6 +202,8 @@ export function useFocusLock(
         observer.disconnect();
       };
     }
+
+    return undefined;
   }, [active, header, body, autoFocusOnActivate]);
 
   React.useEffect(() => {
@@ -237,11 +260,14 @@ export function useFocusLock(
               lockRoot.contains(activeElement)
           );
 
+        if (isInsideNestedLock) {
+          return;
+        }
+
         if (
           length > 0 &&
           (isEventInsideCurrentLock || isSafari) &&
           !isActiveElementTracked &&
-          !isInsideNestedLock &&
           (isActiveElementInsideCurrentLock || activeElement === document.body)
         ) {
           event.preventDefault();


### PR DESCRIPTION
Closes: #2471

## What I did
Added aria-modal and role="dialog" to the DatePicker container to improve accessibility.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. Open the DatePicker Storybook.
2. Turn on a screen reader.
3. Open the DatePicker widget.
4. Move focus to the widget.
5. Verify that the screen reader announces it as a dialog.
