### PR TITLE
fix(Chart): fix ARIA prohibited attribute usage in SVG elements

### DIFF
--- a/.changeset/chart-fix-aria-prohibited-attr.md
+++ b/.changeset/chart-fix-aria-prohibited-attr.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+Chart: fix ARIA prohibited attribute usage in SVG elements

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -39,6 +39,7 @@ import {
 } from 'react-magma-icons';
 
 import { useCarbonModalFocusManagement } from '../../hooks/useCarbonModalFocusManagement';
+// @ts-ignore
 import './carbon-charts.css';
 import {
   ChartFullscreenButton,
@@ -1328,6 +1329,26 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
         wrapper.removeEventListener('keydown', onKeyDown);
       };
     }, [type]);
+
+    React.useEffect(() => {
+      const timer = setTimeout(() => {
+        if (internalRef.current) {
+          internalRef.current
+            .querySelectorAll<SVGGElement>('g[aria-label]')
+            .forEach(g => {
+              const role = g.getAttribute('role');
+
+              if (!role) {
+                g.setAttribute('role', 'img');
+              } else if (role === 'graphics-object group') {
+                g.setAttribute('role', 'graphics-object');
+              }
+            });
+        }
+      }, 0);
+
+      return () => clearTimeout(timer);
+    }, [type, dataSet]);
 
     const groupsLength = Object.keys(colorScale).length;
 


### PR DESCRIPTION
Closes: #2328

## What I did
The fix adds aria-hidden="true" to the main element after render, hiding its invalid child attributes from screen readers.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Storybook: Open the CarbonChart, 'Area' component story in Storybook -> Open the A11y tab -> Verify no aria-prohibited-attr violation appears

Docs: Navigate to the 'Chart Demos' component page in the docs -> Run axe -> Verify no aria-prohibited-attr issue appears