### PR TITLE
fix(Charts): announce legend isolation state to screen readers (#2576)

### DIFF
--- a/.changeset/a11y-charts-legend-announcement.md
+++ b/.changeset/a11y-charts-legend-announcement.md
@@ -1,0 +1,5 @@
+---
+'@react-magma/charts': patch
+---
+
+fix(Charts): announce legend isolation state to screen readers

--- a/packages/charts/src/components/CarbonChart/CarbonChart.test.js
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.test.js
@@ -18,10 +18,14 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }));
 
-// Capture MutationObserver callbacks so we can trigger them manually
-let mutationObserverCallback;
+// Capture MutationObserver callbacks so we can trigger them manually.
+// Multiple observers may be created per component; we collect all of them and
+// call each one so that no observer is silently skipped.
+let mutationObserverCallbacks = [];
+const mutationObserverCallback = mutations =>
+  mutationObserverCallbacks.forEach(cb => cb(mutations));
 global.MutationObserver = jest.fn().mockImplementation(callback => {
-  mutationObserverCallback = callback;
+  mutationObserverCallbacks.push(callback);
   return {
     observe: jest.fn(),
     disconnect: jest.fn(),
@@ -630,6 +634,7 @@ describe('CarbonChart', () => {
     let otherButton;
 
     beforeEach(() => {
+      mutationObserverCallbacks = [];
       jest.useFakeTimers();
       jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
         cb(0);
@@ -1089,6 +1094,10 @@ describe('CarbonChart', () => {
 
   describe('Legend accessibility wrap', () => {
     const testId = 'legend-a11y';
+
+    beforeEach(() => {
+      mutationObserverCallbacks = [];
+    });
 
     it('wraps the Carbon legend in a fieldset with a legend caption derived from the chart title', () => {
       const { getByTestId } = render(

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -25,11 +25,13 @@ import {
 import styled from '@emotion/styled';
 import { transparentize } from 'polished';
 import {
+  Announce,
   DropdownDivider,
   DropdownMenuItem,
   ThemeInterface,
   ThemeContext,
   useIsInverse,
+  VisuallyHidden,
 } from 'react-magma-dom';
 import {
   FullscreenExitIcon,
@@ -1123,7 +1125,9 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
     const [isTableOpen, setIsTableOpen] = React.useState(false);
     const [isFullscreen, setIsFullscreen] = React.useState(false);
+    const [legendAnnouncement, setLegendAnnouncement] = React.useState('');
     const lastTableTriggerRef = React.useRef<HTMLButtonElement | null>(null);
+    const legendAnnouncedRef = React.useRef(false);
 
     const mergedRef = React.useCallback(
       (node: HTMLDivElement | null) => {
@@ -1230,7 +1234,9 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
         if (parent?.tagName === 'FIELDSET') {
           const existingCaption = parent.querySelector('legend');
 
-          if (existingCaption) existingCaption.textContent = legendLabel;
+          if (existingCaption && existingCaption.textContent !== legendLabel) {
+            existingCaption.textContent = legendLabel;
+          }
 
           return;
         }
@@ -1416,6 +1422,52 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       return () => clearTimeout(timer);
     }, [type, dataSet]);
 
+    React.useEffect(() => {
+      const wrapper = internalRef.current;
+
+      if (!wrapper) return;
+
+      const observer = new MutationObserver(() => {
+        const allItems = wrapper.querySelectorAll<HTMLElement>(
+          '.legend-item:not(.additional)'
+        );
+
+        if (allItems.length <= 1) return;
+
+        const activeLabels: string[] = [];
+
+        allItems.forEach(el => {
+          const checkbox = el.querySelector<HTMLElement>('.checkbox');
+          const label = el.querySelector('p');
+
+          if (checkbox?.getAttribute('aria-checked') === 'true' && label) {
+            activeLabels.push(label.textContent?.trim() || '');
+          }
+        });
+
+        if (activeLabels.length === 1) {
+          if (!legendAnnouncedRef.current) {
+            legendAnnouncedRef.current = true;
+            setLegendAnnouncement(`Only ${activeLabels[0]} is selected`);
+          }
+        } else if (activeLabels.length === allItems.length) {
+          legendAnnouncedRef.current = false;
+          setLegendAnnouncement('All items selected');
+        } else {
+          legendAnnouncedRef.current = false;
+          setLegendAnnouncement('');
+        }
+      });
+
+      observer.observe(wrapper, {
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['aria-checked'],
+      });
+
+      return () => observer.disconnect();
+    }, [type, dataSet]);
+
     const groupsLength = Object.keys(colorScale).length;
 
     const showTable = chartToolbar?.showAsTable !== false;
@@ -1424,6 +1476,9 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
     return (
       <FullscreenRoot ref={mergedRef} isInverse={isInverse} theme={theme}>
+        <VisuallyHidden>
+          <Announce>{legendAnnouncement}</Announce>
+        </VisuallyHidden>
         <CarbonChartWrapper
           data-testid={testId}
           isInverse={isInverse}


### PR DESCRIPTION
Closes: #2328

Cherry-pick from PR #2576

## What I did
Added announcements for chart checkboxes to improve accessibility. Screen reader now properly announces state changes when selecting a single checkbox or all checkboxes.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. Open Storybook.
2. Open the Charts example.
3. Turn on the screen reader.
4. Select any checkbox (so only one item is selected).
5. Verify what is announced.
6. Select it again so all items become selected.
7. Verify what is announced.
