### PR TITLE
fix(charts): dedupe legend fieldset and announce legend context for VoiceOver (#2589)

### DIFF
--- a/.changeset/a11y-charts-legend-fieldset-dedup.md
+++ b/.changeset/a11y-charts-legend-fieldset-dedup.md
@@ -1,0 +1,5 @@
+---
+'@react-magma/charts': patch
+---
+
+fix(charts): dedupe legend fieldset and announce legend context for VoiceOver

--- a/packages/charts/src/components/CarbonChart/CarbonChart.test.js
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.test.js
@@ -1168,6 +1168,37 @@ describe('CarbonChart', () => {
       expect(after[0]).toBe(before[0]);
     });
 
+    it('unwraps the stale fieldset when Carbon re-renders the legend deeper inside it', () => {
+      const { getByTestId } = render(
+        <CarbonChart
+          testId={testId}
+          dataSet={dataSet}
+          options={chartOptions}
+          type={CarbonChartType.bar}
+        />
+      );
+      const wrapper = getByTestId(testId);
+
+      const staleFieldset = wrapper.querySelector('.cds--cc--legend-fieldset');
+      const legend = staleFieldset.querySelector('.cds--cc--legend');
+
+      act(() => {
+        const layoutChild = document.createElement('div');
+        layoutChild.className = 'layout-child legend';
+        staleFieldset.append(layoutChild);
+        layoutChild.append(legend);
+        mutationObserverCallback?.();
+      });
+
+      const fieldsets = wrapper.querySelectorAll('.cds--cc--legend-fieldset');
+      expect(fieldsets).toHaveLength(1);
+      expect(
+        fieldsets[0].querySelector('.cds--cc--legend-fieldset')
+      ).toBeNull();
+      expect(fieldsets[0].contains(legend)).toBe(true);
+      expect(fieldsets[0].querySelectorAll(':scope > legend')).toHaveLength(1);
+    });
+
     it('replaces Carbon\'s generic "Data groups" aria-label with semantic list roles on the legend and its items', () => {
       const { getByTestId } = render(
         <CarbonChart
@@ -1181,14 +1212,51 @@ describe('CarbonChart', () => {
 
       const legend = wrapper.querySelector('.cds--cc--legend');
       expect(legend).not.toBeNull();
-      expect(legend.getAttribute('aria-label')).toBeNull();
-      expect(legend.getAttribute('role')).toBe('list');
 
-      const items = legend.querySelectorAll('.legend-item');
+      const itemsHost = legend.matches('[data-name="legend-items"]')
+        ? legend
+        : legend.querySelector('[data-name="legend-items"]') || legend;
+      expect(itemsHost.getAttribute('aria-label')).toBeNull();
+      expect(itemsHost.getAttribute('role')).toBe('list');
+
+      if (itemsHost !== legend) {
+        expect(legend.getAttribute('role')).toBeNull();
+        expect(legend.getAttribute('aria-label')).toBeNull();
+      }
+
+      const items = itemsHost.querySelectorAll('.legend-item');
       expect(items.length).toBeGreaterThan(0);
       items.forEach(item => {
         expect(item.getAttribute('role')).toBe('listitem');
       });
+    });
+
+    it('restores list semantics when Carbon re-applies role="group" and aria-label on the items container', () => {
+      const { getByTestId } = render(
+        <CarbonChart
+          testId={testId}
+          dataSet={dataSet}
+          options={chartOptions}
+          type={CarbonChartType.bar}
+        />
+      );
+      const wrapper = getByTestId(testId);
+
+      const itemsHost = wrapper.querySelector('[data-name="legend-items"]');
+      expect(itemsHost).not.toBeNull();
+      expect(itemsHost.getAttribute('role')).toBe('list');
+
+      act(() => {
+        itemsHost.setAttribute('role', 'group');
+        itemsHost.setAttribute('aria-label', 'Data groups');
+        mutationObserverCallback();
+      });
+      act(() => {
+        mutationObserverCallback();
+      });
+
+      expect(itemsHost.getAttribute('role')).toBe('list');
+      expect(itemsHost.getAttribute('aria-label')).toBeNull();
     });
 
     it('uses translated legend instructions from I18nContext', () => {

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -30,6 +30,7 @@ import {
   DropdownMenuItem,
   ThemeInterface,
   ThemeContext,
+  useDeviceDetect,
   useIsInverse,
   VisuallyHidden,
 } from 'react-magma-dom';
@@ -1126,8 +1127,11 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
     const [isTableOpen, setIsTableOpen] = React.useState(false);
     const [isFullscreen, setIsFullscreen] = React.useState(false);
     const [legendAnnouncement, setLegendAnnouncement] = React.useState('');
+    const legendGroupAnnounceRef = React.useRef<HTMLDivElement | null>(null);
     const lastTableTriggerRef = React.useRef<HTMLButtonElement | null>(null);
     const legendAnnouncedRef = React.useRef(false);
+    const selectionSignatureRef = React.useRef<string | undefined>(undefined);
+    const { isMacOS, isChrome } = useDeviceDetect();
 
     const mergedRef = React.useCallback(
       (node: HTMLDivElement | null) => {
@@ -1215,11 +1219,37 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       if (!container) return;
 
       const applyListSemantics = (legend: Element) => {
-        legend.removeAttribute('aria-label');
-        legend.setAttribute('role', 'list');
-        legend
-          .querySelectorAll('.legend-item')
-          .forEach(item => item.setAttribute('role', 'listitem'));
+        const itemsHost = legend.matches('[data-name="legend-items"]')
+          ? legend
+          : legend.querySelector('[data-name="legend-items"]') || legend;
+
+        itemsHost.removeAttribute('aria-label');
+
+        if (itemsHost.getAttribute('role') !== 'list') {
+          itemsHost.setAttribute('role', 'list');
+        }
+
+        legend.querySelectorAll('.legend-item').forEach(item => {
+          if (item.getAttribute('role') !== 'listitem') {
+            item.setAttribute('role', 'listitem');
+          }
+        });
+
+        container.querySelectorAll('[role="list"]').forEach(el => {
+          if (el !== itemsHost && el.contains(itemsHost)) {
+            el.removeAttribute('role');
+          }
+        });
+        container.querySelectorAll('[aria-label="Data groups"]').forEach(el => {
+          if (el !== itemsHost && el.contains(itemsHost)) {
+            el.removeAttribute('aria-label');
+          }
+        });
+      };
+
+      const unwrapFieldset = (fieldset: Element) => {
+        fieldset.querySelector(':scope > legend')?.remove();
+        fieldset.replaceWith(...Array.from(fieldset.childNodes));
       };
 
       const wrapLegend = () => {
@@ -1229,10 +1259,21 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
         applyListSemantics(legend);
 
-        const parent = legend.parentElement;
+        const closestFieldset = legend.closest(
+          'fieldset.cds--cc--legend-fieldset'
+        );
 
-        if (parent?.tagName === 'FIELDSET') {
-          const existingCaption = parent.querySelector('legend');
+        container
+          .querySelectorAll('fieldset.cds--cc--legend-fieldset')
+          .forEach(fieldset => {
+            if (fieldset !== closestFieldset) {
+              unwrapFieldset(fieldset);
+            }
+          });
+
+        if (closestFieldset) {
+          const existingCaption =
+            closestFieldset.querySelector(':scope > legend');
 
           if (existingCaption && existingCaption.textContent !== legendLabel) {
             existingCaption.textContent = legendLabel;
@@ -1253,10 +1294,70 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       wrapLegend();
       const observer = new MutationObserver(wrapLegend);
 
-      observer.observe(container, { childList: true, subtree: true });
+      observer.observe(container, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['role', 'aria-label'],
+      });
 
       return () => observer.disconnect();
     }, [legendLabel]);
+
+    React.useEffect(() => {
+      const container = internalRef.current;
+
+      if (!container || !isMacOS || !isChrome) return;
+
+      let announceTimer: ReturnType<typeof setTimeout>;
+      let alternateSuffix = false;
+
+      const closestLegend = (node: EventTarget | null) =>
+        node instanceof Element ? node.closest('.cds--cc--legend') : null;
+
+      const handleFocusIn = (event: FocusEvent) => {
+        const enteredLegend = closestLegend(event.target);
+        const cameFromLegend = closestLegend(event.relatedTarget);
+
+        if (enteredLegend && !cameFromLegend) {
+          if (legendGroupAnnounceRef.current) {
+            legendGroupAnnounceRef.current.textContent = '';
+          }
+
+          clearTimeout(announceTimer);
+          announceTimer = setTimeout(() => {
+            if (legendGroupAnnounceRef.current) {
+              alternateSuffix = !alternateSuffix;
+              legendGroupAnnounceRef.current.textContent =
+                legendLabel + (alternateSuffix ? ' ' : '');
+            }
+          }, 250);
+        }
+      };
+
+      const handleFocusOut = (event: FocusEvent) => {
+        const leftLegend =
+          closestLegend(event.target) && !closestLegend(event.relatedTarget);
+
+        // Reset once focus leaves the legend so re-entering announces again.
+        if (leftLegend) {
+          clearTimeout(announceTimer);
+
+          if (legendGroupAnnounceRef.current) {
+            legendGroupAnnounceRef.current.textContent = '';
+          }
+        }
+      };
+
+      container.addEventListener('focusin', handleFocusIn);
+      container.addEventListener('focusout', handleFocusOut);
+
+      return () => {
+        clearTimeout(announceTimer);
+        container.removeEventListener('focusin', handleFocusIn);
+        container.removeEventListener('focusout', handleFocusOut);
+      };
+    }, [isMacOS, isChrome, legendLabel]);
 
     const handleModalDownloadCsv = React.useCallback(() => {
       downloadCsv(dataSet as Array<Record<string, unknown>>, chartTitle);
@@ -1445,6 +1546,20 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
           }
         });
 
+        // Carbon re-applies aria-checked (with the same values) on every
+        // render, which still triggers this observer. Only announce when the
+        // selection actually changed, otherwise unrelated re-renders (e.g.
+        // the legend group announcement) cause phantom announcements.
+        const selectionSignature = `${activeLabels.join('|')}::${allItems.length}`;
+
+        if (selectionSignatureRef.current === selectionSignature) return;
+
+        const isFirstRun = selectionSignatureRef.current === undefined;
+
+        selectionSignatureRef.current = selectionSignature;
+
+        if (isFirstRun) return;
+
         if (activeLabels.length === 1) {
           if (!legendAnnouncedRef.current) {
             legendAnnouncedRef.current = true;
@@ -1460,6 +1575,7 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       });
 
       observer.observe(wrapper, {
+        childList: true,
         subtree: true,
         attributes: true,
         attributeFilter: ['aria-checked'],
@@ -1478,6 +1594,9 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       <FullscreenRoot ref={mergedRef} isInverse={isInverse} theme={theme}>
         <VisuallyHidden>
           <Announce>{legendAnnouncement}</Announce>
+        </VisuallyHidden>
+        <VisuallyHidden>
+          <div aria-live="polite" ref={legendGroupAnnounceRef} />
         </VisuallyHidden>
         <CarbonChartWrapper
           data-testid={testId}


### PR DESCRIPTION
Closes: #2440
Cherry-pick #2589

## What I did
Dedupe legend fieldset in DOM and announce legend context for VoiceOver


## Checklist 
- [X] changeset has been added
- [X] Pull request is assigned, labels have been added and ticket is linked
- [X] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [X] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open Storybook/Docs -> Charts -> Open devtools -> Check that checkboxes are wrapped in fieldset + legend -> Turn on NVDA/VO -> Move focus to the checkboxes -> legend should be announced