### PR TITLE
fix(Accordion): stop overriding Heading styles inside AccordionPanel

### DIFF
--- a/.changeset/accordion-panel-heading-styles.md
+++ b/.changeset/accordion-panel-heading-styles.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Accordion): stop overriding Heading styles inside AccordionPanel

--- a/packages/react-magma-dom/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/Accordion.stories.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuItem,
 } from '../Dropdown';
 import { Flex, FlexBehavior } from '../Flex';
+import { Heading } from '../Heading';
 import { Input } from '../Input';
 import { Modal } from '../Modal';
 import { Select } from '../Select';
@@ -365,5 +366,25 @@ export const WithDropdown = {
   args: {
     isInverse: false,
     isMulti: false,
+  },
+};
+
+export const WithHeadings = {
+  render: (args: any) => (
+    <Accordion {...args}>
+      <AccordionItem>
+        <Heading level={2}>
+          <AccordionButton>Section with heading trigger</AccordionButton>
+        </Heading>
+        <AccordionPanel>
+          <Heading level={3}>Panel heading</Heading>
+          <p>Content for section lorem ipsum.</p>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  ),
+
+  args: {
+    defaultIndex: [0],
   },
 };

--- a/packages/react-magma-dom/src/components/Accordion/Accordion.test.js
+++ b/packages/react-magma-dom/src/components/Accordion/Accordion.test.js
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import { axe } from '../../../axe-helper';
 import { Button } from '../Button';
+import { Heading } from '../Heading';
 
 import { Accordion, AccordionItem, AccordionButton, AccordionPanel } from '.';
 
@@ -68,6 +69,26 @@ describe('Accordion', () => {
     expect(btn).toHaveStyleRule('background', 'transparent');
     expect(panel).toHaveStyleRule('background', 'transparent');
     expect(accordion).toHaveStyleRule('background', 'transparent');
+  });
+
+  it('should not override the styles of a Heading nested inside an AccordionPanel', () => {
+    const { getByTestId } = render(
+      <Accordion defaultIndex={[0]}>
+        <AccordionItem testId="item">
+          <Heading level={2}>
+            <AccordionButton>Section 1</AccordionButton>
+          </Heading>
+          <AccordionPanel>
+            <Heading level={3}>Panel heading</Heading>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    const item = getByTestId('item');
+
+    expect(item).toHaveStyleRule('font', 'inherit', { target: '>h2' });
+    expect(item).not.toHaveStyleRule('font', 'inherit', { target: ' h3' });
   });
 
   it('should render the component a left-aligned icon', () => {

--- a/packages/react-magma-dom/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/AccordionItem.tsx
@@ -23,12 +23,12 @@ export interface AccordionItemProps
 }
 
 const StyledItem = styled.div`
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
+  & > h1,
+  & > h2,
+  & > h3,
+  & > h4,
+  & > h5,
+  & > h6 {
     background: none;
     color: inherit;
     font: inherit;

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -18,12 +18,12 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -749,12 +749,12 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -1997,12 +1997,12 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -2838,12 +2838,12 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -4243,12 +4243,12 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -5019,12 +5019,12 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -6358,12 +6358,12 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -7134,12 +7134,12 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -8473,12 +8473,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -9314,12 +9314,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -10719,12 +10719,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -11560,12 +11560,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -12965,12 +12965,12 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -13741,12 +13741,12 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;


### PR DESCRIPTION
Closes: #2582 

## What I did
Bug fix (non-breaking change which fixes an issue).                                                                                                                                                       

Scoped the `AccordionItem` heading reset to direct-child headings only (`& > h1..h6`). It previously used an unscoped descendant selector, so it also overrode the styles of any `<Heading>` placed inside an `AccordionPanel`. The trigger heading (a direct child of `AccordionItem`, per the documented `<AccordionItem><h3><AccordionButton/></h3>` pattern) still inherits the button styles; headings in the panel content now keep their own typography.                                                                                                                                                                                           

Scope is limited to the styling issue only — per the maintainer comment on the ticket, the `level` prop is required, so no default-level change was made to `Heading`. 

## Screenshots
Before:
<img width="649" height="285" alt="image" src="https://github.com/user-attachments/assets/3a27e629-8fda-4af8-9603-3bcc10a6fb8f" />

After:
<img width="695" height="291" alt="image" src="https://github.com/user-attachments/assets/ffcfcb8c-7b3d-4a72-b1fd-b59726694ddb" />


## Checklist
- [x] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
1. Open the **Accordion -> WithHeadings** story in Storybook.
2. Verify the `<Heading>` inside the `AccordionPanel` renders with its normal heading typography.
3. Verify the heading wrapping the `AccordionButton` (trigger) still inherits the button styles — unchanged.
