### PR TITLE
fix(Treeview): Add dependencies to update Treeitem state on expanded state

### DIFF
--- a/.changeset/fix-Treeview-collapse-state-icon.md
+++ b/.changeset/fix-Treeview-collapse-state-icon.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(TreeView): Add missing useCallback dependencies for folder collapse.

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -453,6 +453,16 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
       [getInteractiveElements, interactiveElements, isInsideTreeItem]
     );
 
+    const onExpandedClicked = React.useCallback(
+      (event: React.SyntheticEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        handleExpandedChange(event, itemId);
+      },
+      [handleExpandedChange, itemId]
+    );
+
     const handleOnClick = React.useCallback(
       (event: React.MouseEvent) => {
         if (isDisabled) {
@@ -495,7 +505,15 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
           handleClick(event, itemId);
         }
       },
-      [isDisabled, selectable, handleClick, itemId]
+      [
+        isDisabled,
+        selectable,
+        handleClick,
+        itemId,
+        onExpandedClicked,
+        hasOwnTreeItems,
+        selectParents,
+      ]
     );
 
     const defaultIcon = React.useMemo(
@@ -619,16 +637,6 @@ const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
         labelText,
         checkboxChangeHandler,
       ]
-    );
-
-    const onExpandedClicked = React.useCallback(
-      (event: React.SyntheticEvent) => {
-        event.preventDefault();
-        event.stopPropagation();
-
-        handleExpandedChange(event, itemId);
-      },
-      [handleExpandedChange, itemId]
     );
 
     const handleExpandClick = React.useCallback(


### PR DESCRIPTION
Closes: #2598 

## What I did
- Add dependencies to update treeitem state on expanded 

## Screenshots


## Checklist 
[Screencast from 2026-07-17 16-55-04.webm](https://github.com/user-attachments/assets/dee375af-2939-41fe-9b65-eb51c5538d33)

- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
 Launch Caldera UI -> Content -> click on the `Treeitem` a few times -> the folder icon was changed every time.
