### PR TITLE
fix(TreeView): Add missing useCallback dependencies for folder collapse

### DIFF
--- a/.changeset/fix-Treeview-collapse-state-icon.md
+++ b/.changeset/fix-Treeview-collapse-state-icon.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(TreeView): Add missing useCallback dependencies for folder collapse.

--- a/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
+++ b/packages/react-magma-dom/src/components/TreeView/TreeItem.tsx
@@ -603,47 +603,58 @@ export const TreeItemComponent = React.forwardRef<HTMLLIElement, TreeItemProps>(
       [isDisabled, onExpandedClicked]
     );
 
-    const handleOnClick = (event: React.MouseEvent) => {
-      if (isDisabled) {
-        event.stopPropagation();
+    const handleOnClick = React.useCallback(
+      (event: React.MouseEvent) => {
+        if (isDisabled) {
+          event.stopPropagation();
 
-        return;
-      }
+          return;
+        }
 
-      const currentElement = event.target as HTMLElement;
-      const interactiveElement = currentElement.closest<HTMLElement>(
-        'button, [role="button"], a[href], input, select, textarea, [role="menuitem"]'
-      );
+        const currentElement = event.target as HTMLElement;
+        const interactiveElement = currentElement.closest<HTMLElement>(
+          'button, [role="button"], a[href], input, select, textarea, [role="menuitem"]'
+        );
 
-      // Preventing selecting the item when clicking on interactive elements when `selectable` is `single`
-      if (interactiveElement) {
-        event.stopPropagation();
+        // Preventing selecting the item when clicking on interactive elements when `selectable` is `single`
+        if (interactiveElement) {
+          event.stopPropagation();
 
-        return;
-      }
+          return;
+        }
 
-      // If selectParents is false and this is a parent item, handle expand/collapse instead of selection
-      if (
-        selectable === TreeViewSelectable.single &&
-        !selectParents &&
-        hasOwnTreeItems
-      ) {
-        onExpandedClicked(event);
+        // If selectParents is false and this is a parent item, handle expand/collapse instead of selection
+        if (
+          selectable === TreeViewSelectable.single &&
+          !selectParents &&
+          hasOwnTreeItems
+        ) {
+          onExpandedClicked(event);
 
-        return;
-      }
+          return;
+        }
 
-      // In selectable=off mode, clicking anywhere on a parent item toggles expand/collapse
-      if (selectable === TreeViewSelectable.off && hasOwnTreeItems) {
-        onExpandedClicked(event);
+        // In selectable=off mode, clicking anywhere on a parent item toggles expand/collapse
+        if (selectable === TreeViewSelectable.off && hasOwnTreeItems) {
+          onExpandedClicked(event);
 
-        return;
-      }
+          return;
+        }
 
-      if (selectable === TreeViewSelectable.single) {
-        handleClick(event, itemId);
-      }
-    };
+        if (selectable === TreeViewSelectable.single) {
+          handleClick(event, itemId);
+        }
+      },
+      [
+        isDisabled,
+        selectable,
+        handleClick,
+        itemId,
+        onExpandedClicked,
+        hasOwnTreeItems,
+        selectParents,
+      ]
+    );
 
     const tabIndex = React.useMemo(() => {
       if (isDisabled) {


### PR DESCRIPTION
Closes: #2598 
Cherry-pick #2601

## What I did
- Add dependencies to update treeitem state on expanded 

## Screenshots


## Checklist 
[Screencast from 2026-07-17 16-55-04.webm](https://github.com/user-attachments/assets/dee375af-2939-41fe-9b65-eb51c5538d33)

- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
 Launch Caldera UI -> Content -> click on the `Treeitem` a few times -> the folder icon was changed every time.
