### PR TITLE
fix(DatePicker): return focus to the calendar toggle button not the clear button

### DIFF
--- a/.changeset/fix-datepicker-focus-return.md
+++ b/.changeset/fix-datepicker-focus-return.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DatePicker): return focus to the calendar toggle button, not the clear button

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -974,6 +974,58 @@ describe('Date Picker', () => {
       expect(container.querySelector('table')).not.toBeVisible();
     });
 
+    describe('Focus returns to the calendar toggle button, not the clear button', () => {
+      it('Escape returns focus to the toggle button after a date has been selected, with isClearable', async () => {
+        const { getByLabelText, getAllByText } = render(
+          <DatePicker isClearable labelText={labelText} />
+        );
+
+        const toggleButton = getByLabelText('Toggle Calendar Widget');
+
+        await userEvent.click(toggleButton);
+        await userEvent.click(getAllByText('15')[0]);
+
+        await userEvent.click(toggleButton);
+        await userEvent.keyboard('{Escape}');
+
+        expect(toggleButton).toHaveFocus();
+      });
+
+      it('Close button returns focus to the toggle button after a date has been selected, with isClearable', async () => {
+        const { getByLabelText, getAllByText } = render(
+          <DatePicker isClearable labelText={labelText} />
+        );
+
+        const toggleButton = getByLabelText('Toggle Calendar Widget');
+
+        await userEvent.click(toggleButton);
+        await userEvent.click(getAllByText('15')[0]);
+
+        await userEvent.click(toggleButton);
+        await userEvent.click(getByLabelText('Close Calendar Widget'));
+
+        expect(toggleButton).toHaveFocus();
+      });
+
+      it('does not throw and refocuses the toggle button after selecting a date, clearing it, then pressing Escape', async () => {
+        const { getByLabelText, getAllByText, getByTestId } = render(
+          <DatePicker isClearable labelText={labelText} />
+        );
+
+        const toggleButton = getByLabelText('Toggle Calendar Widget');
+
+        await userEvent.click(toggleButton);
+        await userEvent.click(getAllByText('15')[0]);
+
+        await userEvent.click(getByTestId('clear-button'));
+
+        await userEvent.click(toggleButton);
+        await userEvent.keyboard('{Escape}');
+
+        expect(toggleButton).toHaveFocus();
+      });
+    });
+
     it('Enter', async () => {
       const defaultDate = new Date();
       const { getByLabelText, container } = render(

--- a/packages/react-magma-dom/src/components/InputBase/index.tsx
+++ b/packages/react-magma-dom/src/components/InputBase/index.tsx
@@ -821,7 +821,6 @@ export const InputBase = React.forwardRef<HTMLInputElement, InputBaseProps>(
                 isInverse={props.isInverse}
                 onClick={handleClearInput}
                 onKeyDown={onIconKeyDown}
-                ref={iconRef}
                 shape={ButtonShape.fill}
                 size={
                   inputSize === InputSize.large


### PR DESCRIPTION
Closes: #2515

## What I did
Removed unnecessary ref for the clear button.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

- Open Storybook -> DatePicker (clearing the date) -> Open the date picker widget -> Choose any date -> Open the date picker widget again -> Press the Esc key -> Verify that focus returns to the trigger button, not the clear button -> Remove the selected date -> Open the widget and press Esc -> Verify that focus does not disappear.
