### PR TITLE
fix(PasswordInput): resize toggle button to fit custom text and cap its width at half the input (#2584)

### DIFF
--- a/.changeset/password-input-dynamic-button-width.md
+++ b/.changeset/password-input-dynamic-button-width.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(PasswordInput): resize toggle button to fit custom text and cap its width at half the input

--- a/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.test.js
+++ b/packages/react-magma-dom/src/components/PasswordInput/PasswordInput.test.js
@@ -347,6 +347,53 @@ describe('custom button text width measurement', () => {
       },
     });
   });
+
+  it('limits the custom text button to half of the input container width and truncates overflowing text', async () => {
+    const CONTAINER_WIDTH = 200;
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return CONTAINER_WIDTH;
+      },
+    });
+
+    const { getByText } = render(
+      <PasswordInput
+        labelText="test label"
+        showPasswordButtonText="Reveal my long password"
+        hidePasswordButtonText="Conceal"
+      />
+    );
+
+    const button = getByText('Reveal my long password').parentElement;
+
+    await waitFor(() => {
+      expect(button).toHaveStyle(
+        `max-width: ${Math.floor(CONTAINER_WIDTH / 2)}px`
+      );
+    });
+
+    expect(button).toHaveStyle('overflow: hidden');
+    expect(button).toHaveStyle('text-overflow: ellipsis');
+    expect(button).toHaveStyle('white-space: nowrap');
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return 0;
+      },
+    });
+  });
+
+  it('keeps the fixed width for the default button text', () => {
+    const { getByText } = render(<PasswordInput labelText="test label" />);
+
+    const button = getByText('Show').parentElement;
+
+    expect(button).toHaveStyle('width: 54px');
+    expect(button).toHaveStyle('max-width: 54px');
+  });
 });
 
 it('Does not violate accessibility standards', () => {

--- a/packages/react-magma-dom/src/components/PasswordInput/index.tsx
+++ b/packages/react-magma-dom/src/components/PasswordInput/index.tsx
@@ -129,10 +129,35 @@ export const PasswordInput = React.forwardRef<
 
   const buttonRef = React.useRef<HTMLButtonElement | null>(null);
   const [buttonWidth, setButtonWidth] = React.useState<number>(0);
+  const [maxButtonWidth, setMaxButtonWidth] = React.useState<number>(0);
 
   React.useLayoutEffect(() => {
-    if (buttonRef.current && !usesDefaultText) {
-      setButtonWidth(buttonRef.current.offsetWidth);
+    const button = buttonRef.current;
+
+    if (!button || usesDefaultText) {
+      return;
+    }
+
+    const container = button.closest('div');
+
+    const updateWidths = () => {
+      if (container) {
+        setMaxButtonWidth(Math.floor(container.offsetWidth / 2));
+      }
+      setButtonWidth(button.offsetWidth);
+    };
+
+    updateWidths();
+
+    if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+      const resizeObserver = new (window as any).ResizeObserver(updateWidths);
+
+      resizeObserver.observe(button);
+      if (container) {
+        resizeObserver.observe(container);
+      }
+
+      return () => resizeObserver.disconnect();
     }
   }, [
     usesDefaultText,
@@ -144,9 +169,17 @@ export const PasswordInput = React.forwardRef<
   const getButtonWidth = () => {
     if (usesDefaultText) {
       return inputSize === InputSize.large ? '64px' : '54px';
-    } else if (buttonWidth !== 0) {
-      return `${buttonWidth}px`;
     }
+
+    return undefined;
+  };
+
+  const getButtonMaxWidth = () => {
+    if (usesDefaultText) {
+      return getButtonWidth();
+    }
+
+    return maxButtonWidth > 0 ? `${maxButtonWidth}px` : undefined;
   };
 
   const getInputStyle = () => {
@@ -216,7 +249,10 @@ export const PasswordInput = React.forwardRef<
                 margin: '0 3px 0 0',
                 width: getButtonWidth(),
                 minWidth: 0,
-                maxWidth: getButtonWidth(),
+                maxWidth: getButtonMaxWidth(),
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
               }}
               type={ButtonType.button}
               variant={ButtonVariant.link}

--- a/website/react-magma-docs/src/pages/api/password-input.mdx
+++ b/website/react-magma-docs/src/pages/api/password-input.mdx
@@ -52,6 +52,8 @@ The following option props can be used to override various text strings that app
 
 When using multiple password fields, ensure the `showPasswordButtonAriaLabel` and `hidePasswordButtonAriaLabel` include the field's label to help screen reader users identify which field each button controls.
 
+The toggle button's maximum width is limited to half of the input width.
+
 ```tsx
 import React from 'react';
 


### PR DESCRIPTION
Closes: #2536

## What I did
Fixed the resize behavior of the custom toggle button. Added size constraints based on the text length to prevent the button from taking up all the available input space.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. Open the password input Custom Text story.
2. Change the "show" or "hide" text to a longer word.
3. Verify that the toggle button resizes correctly.
