### PR TITLE
feat(Dropdown): add apiRef prop for imperative open/close control

### DIFF
--- a/.changeset/dropdown-apiref.md
+++ b/.changeset/dropdown-apiref.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Dropdown): add `apiRef` prop for imperative open/close control

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -39,6 +39,7 @@ import { PopoverTrigger } from '../Popover/PopoverTrigger';
 import {
   Dropdown,
   DropdownAlignment,
+  DropdownApi,
   DropdownDropDirection,
   DropdownProps,
 } from './index';
@@ -1110,4 +1111,35 @@ export const DropdownInsidePopover = {
       </Popover>
     </div>
   ),
+};
+
+export const ProgrammaticControl = {
+  render: args => {
+    const dropdownApiRef = React.useRef<DropdownApi>();
+
+    function handleOpen(event: React.SyntheticEvent) {
+      dropdownApiRef.current?.openDropdownManually(event);
+    }
+
+    function handleClose(event: React.SyntheticEvent) {
+      dropdownApiRef.current?.closeDropdownManually(event);
+    }
+
+    return (
+      <div style={{ margin: '150px auto', textAlign: 'center' }}>
+        <ButtonGroup>
+          <Button onClick={handleOpen}>Open</Button>
+          <Button onClick={handleClose}>Close</Button>
+        </ButtonGroup>
+        <Spacer size={12} />
+        <Dropdown {...args} apiRef={dropdownApiRef}>
+          <DropdownButton>Dropdown</DropdownButton>
+          <DropdownContent>
+            <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+            <DropdownMenuItem>Menu item 2</DropdownMenuItem>
+          </DropdownContent>
+        </Dropdown>
+      </div>
+    );
+  },
 };

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { transparentize } from 'polished';
 import {
@@ -409,6 +409,33 @@ describe('Dropdown', () => {
 
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'block');
     expect(onOpen).toHaveBeenCalled();
+  });
+
+  it('should open and close the dropdown manually with an api ref', async () => {
+    const dropdownApiRef = React.createRef();
+
+    const { getByTestId } = render(
+      <Dropdown apiRef={dropdownApiRef} testId="dropdown">
+        <DropdownButton>Toggle me</DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    );
+
+    expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+
+    await act(async () => {
+      dropdownApiRef.current.openDropdownManually();
+    });
+
+    expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'block');
+
+    await act(async () => {
+      dropdownApiRef.current.closeDropdownManually();
+    });
+
+    expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
   });
 
   it('should close the menu when menu is blurred', async () => {

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -46,6 +46,13 @@ export interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   alignment?: DropdownAlignment;
   /**
+   * The ref object that allows Dropdown manipulation.
+   * Actions available:
+   * openDropdownManually(event): void - Opens the dropdown manually.
+   * closeDropdownManually(event): void - Closes the dropdown manually.
+   */
+  apiRef?: React.MutableRefObject<DropdownApi | undefined>;
+  /**
    * Position of the dropdown content
    * @default DropdownDropDirection.down
    * @deprecated = true
@@ -78,6 +85,11 @@ export interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default Width of longest menu item
    */
   width?: string | number;
+}
+
+export interface DropdownApi {
+  openDropdownManually(event): void;
+  closeDropdownManually(event): void;
 }
 
 const Container = styled.div`
@@ -128,6 +140,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
     const {
       activeIndex,
       alignment,
+      apiRef,
       children,
       dropDirection,
       maxHeight,
@@ -190,6 +203,19 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
 
       onClose && typeof onClose === 'function' && onClose(event);
     }
+
+    React.useEffect(() => {
+      if (apiRef) {
+        apiRef.current = {
+          openDropdownManually(event) {
+            openDropdown();
+          },
+          closeDropdownManually(event) {
+            closeDropdown(event);
+          },
+        };
+      }
+    }, []);
 
     function getFilteredItem(): [any, number] {
       const filteredItems = itemRefArray.current.filter(

--- a/packages/react-magma-dom/src/index.ts
+++ b/packages/react-magma-dom/src/index.ts
@@ -72,7 +72,7 @@ export {
   DropdownAlignment,
   DropdownDropDirection,
 } from './components/Dropdown';
-export type { DropdownProps } from './components/Dropdown';
+export type { DropdownProps, DropdownApi } from './components/Dropdown';
 export { DropdownContent } from './components/Dropdown/DropdownContent';
 export type { DropdownContentProps } from './components/Dropdown/DropdownContent';
 export { DropdownDivider } from './components/Dropdown/DropdownDivider';

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -1060,6 +1060,52 @@ export function Example() {
 }
 ```
 
+## Controlled Dropdown with API Ref
+
+You can programmatically control the dropdown by providing an `apiRef`. The Dropdown API exposes `openDropdownManually` and `closeDropdownManually` to open and close the dropdown when needed.
+
+```tsx
+import React from 'react';
+
+import {
+  Dropdown,
+  DropdownButton,
+  DropdownContent,
+  DropdownMenuItem,
+  DropdownApi,
+  Button,
+  ButtonGroup,
+} from 'react-magma-dom';
+
+export function Example() {
+  const dropdownApiRef = React.useRef<DropdownApi>();
+
+  function handleOpen(event: React.SyntheticEvent) {
+    dropdownApiRef.current?.openDropdownManually(event);
+  }
+
+  function handleClose(event: React.SyntheticEvent) {
+    dropdownApiRef.current?.closeDropdownManually(event);
+  }
+
+  return (
+    <>
+      <ButtonGroup>
+        <Button onClick={handleOpen}>Open</Button>
+        <Button onClick={handleClose}>Close</Button>
+      </ButtonGroup>
+      <Dropdown apiRef={dropdownApiRef}>
+        <DropdownButton>Dropdown</DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item 2</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    </>
+  );
+}
+```
+
 ## Dropdown Props
 
 **Any other props supplied will be provided to the wrapping `div` element.**


### PR DESCRIPTION
Closes: #2541

## What I did
New feature (non-breaking change which adds functionality).                                                                                                                                               

Added an `apiRef` prop to `Dropdown` so it can be controlled imperatively via a ref, mirroring the existing `apiRef` contract already used by `Popover`.

- New `DropdownApi` type exposing `openDropdownManually(event)` and `closeDropdownManually(event)`, wired to the component's existing open/close logic.
- `DropdownApi` is exported so consumers can type `React.useRef<DropdownApi>()`.
- Scope matches the library convention: `apiRef` exposes open/close only (as Popover and DatePicker do) — Dropdown internals are intentionally not exposed.

Additive and backward-compatible: a new optional prop, no existing behavior changed.

## Checklist 
- [x] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
1. Open the **Dropdown → ProgrammaticControl** story in Storybook.
2. Click **Open** — the dropdown opens without interacting with the trigger button.
3. Click **Close** — the dropdown closes.
4. (Docs) See the new **"Controlled Dropdown with API Ref"** section on the Dropdown API page. 
