### PR TITLE
fix(DatePicker): add role="dialog" and aria-modal="true" to calendar (#2571)

### DIFF
--- a/.changeset/a11y-datepicker-dialog-role.md
+++ b/.changeset/a11y-datepicker-dialog-role.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(DatePicker): add role="dialog" and aria-modal="true" to calendar container

--- a/.changeset/fix-useFocusLock.md
+++ b/.changeset/fix-useFocusLock.md
@@ -1,0 +1,6 @@
+---
+'react-magma-dom': patch
+---
+
+fix(useFocusLock): fix focus trap for modal and date picker, including nested DatePicker focus order
+

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.test.js
@@ -8,6 +8,21 @@ import { CalendarDay } from './CalendarDay';
 import { magma } from '../../theme/magma';
 
 describe('Calendar Day', () => {
+  let requestAnimationFrameSpy;
+
+  beforeEach(() => {
+    requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+  });
+
   it('renders a day', () => {
     const defaultDate = new Date(2019, 0, 17);
     const { getByText } = render(

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarDay.tsx
@@ -232,7 +232,22 @@ export const CalendarDay: React.FunctionComponent<CalendarDayProps> = (
 
   React.useEffect(() => {
     if (dateFocused && isSameDay(day, focusedDate)) {
-      dayRef.current.focus();
+      const calendarDialog = dayRef.current?.closest('[role="dialog"]');
+
+      if (calendarDialog?.contains(document.activeElement)) {
+        dayRef.current.focus();
+
+        return;
+      }
+
+      const activeOnSchedule = document.activeElement;
+      const focusFrame = requestAnimationFrame(() => {
+        if (document.activeElement === activeOnSchedule) {
+          dayRef.current?.focus();
+        }
+      });
+
+      return () => cancelAnimationFrame(focusFrame);
     }
   }, [focusedDate, dateFocused, day]);
 

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.test.js
@@ -8,13 +8,23 @@ import { CalendarMonth } from './CalendarMonth';
 import { getCalendarMonthWeeks } from './utils';
 
 describe('Calendar Month', () => {
+  let requestAnimationFrameSpy;
+
   beforeEach(() => {
     jest.useFakeTimers();
+
+    requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback(0);
+        return 0;
+      });
   });
 
   afterEach(() => {
     jest.useRealTimers();
     jest.resetAllMocks();
+    requestAnimationFrameSpy.mockRestore();
   });
 
   const keyBoardInstructionsText =

--- a/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/CalendarMonth.tsx
@@ -157,7 +157,12 @@ export const CalendarMonth: React.FunctionComponent<CalendarMonthProps> = (
   const helperButtonRef = React.useRef<any>();
   const context = React.useContext(CalendarContext);
   const prevCalendarOpened = usePrevious(props.calendarOpened);
-  const focusTrapElement = useFocusLock(props.calendarOpened);
+  const focusTrapElement = useFocusLock(
+    props.calendarOpened,
+    undefined,
+    undefined,
+    !props.focusOnOpen
+  );
   const monthContainerRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.stories.tsx
@@ -9,6 +9,7 @@ import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
 import { Button } from '../Button';
 import { LabelPosition } from '../Label';
+import { Modal } from '../Modal';
 
 import { DatePicker } from '.';
 
@@ -304,6 +305,41 @@ export const DateFieldDefault = {
           onChange={handleChange}
           errorMessage={hasErrorMessage()}
         />
+      </>
+    );
+  },
+
+  args: {
+    ...Default.args,
+  },
+};
+
+export const InsideModal = {
+  render: args => {
+    const [modalOpen, setModalOpen] = React.useState(false);
+    const [chosenDate, setChosenDate] = React.useState<Date | undefined>();
+
+    return (
+      <>
+        <Button onClick={() => setModalOpen(true)}>Open Modal</Button>
+        <Modal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+          header="DatePicker inside Modal"
+        >
+          <DatePicker
+            {...args}
+            labelText="Date"
+            onDateChange={d => setChosenDate(d)}
+            value={chosenDate}
+            isClearable
+          />
+          {chosenDate && (
+            <p>
+              <strong>Chosen date:</strong> {chosenDate.toLocaleDateString()}
+            </p>
+          )}
+        </Modal>
       </>
     );
   },

--- a/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/DatePicker.test.js
@@ -63,6 +63,21 @@ const errorMessage = 'Error message';
 const helperMessage = 'Helper message';
 
 describe('Date Picker', () => {
+  let requestAnimationFrameSpy;
+
+  beforeEach(() => {
+    requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+  });
+
   it('should find element by testId', () => {
     const testId = 'test-id';
     const { getByTestId } = render(

--- a/packages/react-magma-dom/src/components/DatePicker/HelperInformation.test.js
+++ b/packages/react-magma-dom/src/components/DatePicker/HelperInformation.test.js
@@ -9,12 +9,22 @@ import { defaultI18n } from '../../i18n/default';
 import { magma } from '../../theme/magma';
 
 describe('Calendar Month', () => {
+  let requestAnimationFrameSpy;
+
   beforeEach(() => {
     jest.useFakeTimers();
+
+    requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback(0);
+        return 0;
+      });
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    requestAnimationFrameSpy.mockRestore();
   });
 
   it('helper information should be visible when open', async () => {

--- a/packages/react-magma-dom/src/components/DatePicker/index.tsx
+++ b/packages/react-magma-dom/src/components/DatePicker/index.tsx
@@ -700,6 +700,9 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
                 opened={calendarOpened}
                 isInverse={isInverse}
                 theme={theme}
+                role="dialog"
+                aria-modal="true"
+                aria-label={i18n.datePicker.calendarOpenAnnounce}
               >
                 <CalendarMonth
                   focusOnOpen={calendarOpened && Boolean(focusedDate)}

--- a/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
+++ b/packages/react-magma-dom/src/components/DateTimePicker/DateTimePicker.test.js
@@ -10,6 +10,21 @@ import { magma } from '../../theme/magma';
 import { DateTimePicker } from '.';
 
 describe('DateTimePicker', () => {
+  let requestAnimationFrameSpy;
+
+  beforeEach(() => {
+    requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+  });
+
   it('should find element by testId', () => {
     const testId = 'test-id';
     const { getByTestId } = render(

--- a/packages/react-magma-dom/src/components/Modal/Modal.test.js
+++ b/packages/react-magma-dom/src/components/Modal/Modal.test.js
@@ -12,6 +12,21 @@ import { Button } from '../Button';
 import { Modal } from '.';
 
 describe('Modal', () => {
+  let requestAnimationFrameSpy;
+
+  beforeEach(() => {
+    requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+  });
+
   describe('a11y', () => {
     it('With header, does not violate accessibility standards', async () => {
       const { baseElement } = render(

--- a/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
+++ b/packages/react-magma-dom/src/components/TreeView/TreeView.test.js
@@ -2491,7 +2491,12 @@ describe('TreeView', () => {
     });
 
     describe('inside and outside TreeView', () => {
-      it('should trap focus inside TreeView, then restore and move focus outside TreeView component', () => {
+      const nextAnimationFrame = () =>
+        act(async () => {
+          await new Promise(resolve => requestAnimationFrame(resolve));
+        });
+
+      it('should trap focus inside TreeView, then restore and move focus outside TreeView component', async () => {
         const { getByTestId, getByText } = render(
           <>
             <TreeView testId="treeview" initialExpandedItems={['item']}>
@@ -2528,6 +2533,7 @@ describe('TreeView', () => {
           code: 'Enter',
           ctrlKey: true,
         });
+        await nextAnimationFrame();
         expect(button1).toHaveFocus();
 
         userEvent.tab();
@@ -2552,7 +2558,7 @@ describe('TreeView', () => {
         expect(outsideButton).toHaveFocus();
       });
 
-      it('should trap focus inside parent TreeItem', () => {
+      it('should trap focus inside parent TreeItem', async () => {
         const { getByTestId, getByText } = render(
           <TreeView testId="treeview" initialExpandedItems={['item']}>
             <TreeItem
@@ -2584,6 +2590,7 @@ describe('TreeView', () => {
           code: 'Enter',
           ctrlKey: true,
         });
+        await nextAnimationFrame();
         expect(parentButton).toHaveFocus();
 
         userEvent.tab();

--- a/packages/react-magma-dom/src/hooks/useFocusLock.test.js
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { useFocusLock } from './useFocusLock';
@@ -15,6 +15,7 @@ const TEST_ID_FIRST_DISABLED_BUTTON_INSIDE_MODAL =
   'test-id-first-disabled-button-inside';
 const TEST_ID_SECOND_DISABLED_BUTTON_INSIDE_MODAL =
   'test-id-second-disabled-button-inside';
+const TEST_ID_HIDDEN_BUTTON_INSIDE_MODAL = 'test-id-hidden-button-inside';
 
 const OneActiveElemet = () => {
   const [showModal, setShowModal] = React.useState(false);
@@ -158,8 +159,63 @@ const OneDisabledElemet = () => {
   );
 };
 
+const LastElementsAreHiddenByAncestor = () => {
+  const [showModal, setShowModal] = React.useState(false);
+  const focus = useFocusLock(showModal);
+
+  return (
+    <>
+      {showModal && (
+        <div ref={focus}>
+          <Button testId={TEST_ID_FIRST_ACTIVE_BUTTON_INSIDE_MODAL}>
+            This is a first active button
+          </Button>
+          <Button testId={TEST_ID_SECOND_ACTIVE_BUTTON_INSIDE_MODAL}>
+            This is a last visible button
+          </Button>
+          <div style={{ display: 'none' }}>
+            <Button testId={TEST_ID_HIDDEN_BUTTON_INSIDE_MODAL}>
+              This is a button hidden by an ancestor
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Button
+        onClick={() => setShowModal(!showModal)}
+        testId={TEST_ID_BUTTON_OUTSIDE_MODAL}
+      >
+        Show Working Focus Lock Area
+      </Button>
+    </>
+  );
+};
+
+const NestedFocusLocks = () => {
+  const [showInner, setShowInner] = React.useState(false);
+  const outerFocus = useFocusLock(true);
+  const innerFocus = useFocusLock(showInner);
+
+  return (
+    <div ref={outerFocus}>
+      <Button
+        onClick={() => setShowInner(true)}
+        testId={TEST_ID_FIRST_ACTIVE_BUTTON_INSIDE_MODAL}
+      >
+        Open inner lock
+      </Button>
+      {showInner && (
+        <div ref={innerFocus}>
+          <Button testId="test-id-inner-first">Inner first</Button>
+          <Button testId="test-id-inner-last">Inner last</Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
 describe('useFocusLock', () => {
-  it('should focus on active element', () => {
+  it('should focus on active element', async () => {
     const { getByTestId } = render(<OneActiveElemet />);
 
     const buttonOutsideModal = getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL);
@@ -177,10 +233,10 @@ describe('useFocusLock', () => {
 
     expect(activeButtonInsideModal).toBeInTheDocument();
     expect(activeButtonInsideModal).not.toBeDisabled();
-    expect(activeButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(activeButtonInsideModal).toHaveFocus());
   });
 
-  it('should stay inside the modal after pressing tab if there is one active element', () => {
+  it('should stay inside the modal after pressing tab if there is one active element', async () => {
     const { getByTestId } = render(<OneActiveElemet />);
 
     const buttonOutsideModal = getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL);
@@ -198,14 +254,14 @@ describe('useFocusLock', () => {
 
     expect(activeButtonInsideModal).toBeInTheDocument();
     expect(activeButtonInsideModal).not.toBeDisabled();
-    expect(activeButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(activeButtonInsideModal).toHaveFocus());
 
     userEvent.tab();
 
     expect(activeButtonInsideModal).toHaveFocus();
   });
 
-  it('should focus on first active element if first element in the modal is disabled', () => {
+  it('should focus on first active element if first element in the modal is disabled', async () => {
     const { getByTestId } = render(<FirstElementIsDisabled />);
 
     const buttonOutsideModal = getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL);
@@ -225,10 +281,10 @@ describe('useFocusLock', () => {
 
     expect(activeButtonInsideModal).toBeInTheDocument();
     expect(activeButtonInsideModal).not.toBeDisabled();
-    expect(activeButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(activeButtonInsideModal).toHaveFocus());
   });
 
-  it('should focus on last active element after shift + tab', () => {
+  it('should focus on last active element after shift + tab', async () => {
     const { getByTestId } = render(<TwoActiveElemets />);
 
     const buttonOutsideModal = getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL);
@@ -244,7 +300,7 @@ describe('useFocusLock', () => {
 
     expect(firstActiveButtonInsideModal).toBeInTheDocument();
     expect(firstActiveButtonInsideModal).not.toBeDisabled();
-    expect(firstActiveButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(firstActiveButtonInsideModal).toHaveFocus());
 
     userEvent.tab({ shift: true });
 
@@ -258,7 +314,7 @@ describe('useFocusLock', () => {
     expect(secondActiveButtonInsideModal).not.toHaveFocus();
     expect(firstActiveButtonInsideModal).toHaveFocus();
   });
-  it('should focus on first active element after last tab', () => {
+  it('should focus on first active element after last tab', async () => {
     const { getByTestId } = render(<TwoActiveElemets />);
 
     const buttonOutsideModal = getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL);
@@ -274,7 +330,7 @@ describe('useFocusLock', () => {
 
     expect(firstActiveButtonInsideModal).toBeInTheDocument();
     expect(firstActiveButtonInsideModal).not.toBeDisabled();
-    expect(firstActiveButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(firstActiveButtonInsideModal).toHaveFocus());
 
     userEvent.tab();
 
@@ -289,7 +345,7 @@ describe('useFocusLock', () => {
     expect(firstActiveButtonInsideModal).toHaveFocus();
   });
 
-  it('should focus correctly if first and last elements are disabled', () => {
+  it('should focus correctly if first and last elements are disabled', async () => {
     const { getByTestId } = render(<FirstAndLastElementsAreDisabled />);
 
     const buttonOutsideModal = getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL);
@@ -315,7 +371,7 @@ describe('useFocusLock', () => {
 
     expect(firstActiveButtonInsideModal).toBeInTheDocument();
     expect(firstActiveButtonInsideModal).not.toBeDisabled();
-    expect(firstActiveButtonInsideModal).toHaveFocus();
+    await waitFor(() => expect(firstActiveButtonInsideModal).toHaveFocus());
 
     userEvent.tab();
 
@@ -344,7 +400,60 @@ describe('useFocusLock', () => {
     expect(secondActiveButtonInsideModal).toHaveFocus();
   });
 
-  it('should focus on last active element if there is no tabbable elements', () => {
+  it('should skip elements hidden by an ancestor and loop tab from the last visible element', async () => {
+    const { getByTestId } = render(<LastElementsAreHiddenByAncestor />);
+
+    await userEvent.click(getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL));
+
+    const firstButton = getByTestId(TEST_ID_FIRST_ACTIVE_BUTTON_INSIDE_MODAL);
+    const lastVisibleButton = getByTestId(
+      TEST_ID_SECOND_ACTIVE_BUTTON_INSIDE_MODAL
+    );
+    const hiddenButton = getByTestId(TEST_ID_HIDDEN_BUTTON_INSIDE_MODAL);
+
+    await waitFor(() => expect(firstButton).toHaveFocus());
+
+    await userEvent.tab();
+
+    expect(lastVisibleButton).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(hiddenButton).not.toHaveFocus();
+    expect(firstButton).toHaveFocus();
+
+    await userEvent.tab({ shift: true });
+
+    expect(hiddenButton).not.toHaveFocus();
+    expect(lastVisibleButton).toHaveFocus();
+  });
+
+  it('should keep tab inside a nested lock instead of looping the outer one', async () => {
+    const { getByTestId } = render(<NestedFocusLocks />);
+
+    await userEvent.click(
+      getByTestId(TEST_ID_FIRST_ACTIVE_BUTTON_INSIDE_MODAL)
+    );
+
+    const innerFirstButton = getByTestId('test-id-inner-first');
+    const innerLastButton = getByTestId('test-id-inner-last');
+
+    await waitFor(() => expect(innerFirstButton).toHaveFocus());
+
+    await userEvent.tab();
+
+    expect(innerLastButton).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(innerFirstButton).toHaveFocus();
+
+    await userEvent.tab({ shift: true });
+
+    expect(innerLastButton).toHaveFocus();
+  });
+
+  it('should focus on last active element if there is no tabbable elements', async () => {
     const { getByTestId, getByText } = render(<OneDisabledElemet />);
 
     const buttonOutsideModal = getByTestId(TEST_ID_BUTTON_OUTSIDE_MODAL);
@@ -359,7 +468,7 @@ describe('useFocusLock', () => {
     expect(disabledButtonInsideModal).toBeDisabled();
     expect(disabledButtonInsideModal).not.toHaveFocus();
 
-    expect(getByText('Test text')).toHaveFocus();
+    await waitFor(() => expect(getByText('Test text')).toHaveFocus());
 
     userEvent.tab();
 

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -80,6 +80,34 @@ function deduplicateTabStops(allFocusable: HTMLElement[]): HTMLElement[] {
 }
 
 /**
+ * Checks that the element is actually visible, including being hidden
+ * by an ancestor.
+ */
+function isElementVisible(element: HTMLElement): boolean {
+  const elementWithVisibility = element as HTMLElement & {
+    checkVisibility?: () => boolean;
+  };
+
+  if (typeof elementWithVisibility.checkVisibility === 'function') {
+    return elementWithVisibility.checkVisibility();
+  }
+
+  for (
+    let node: HTMLElement | null = element;
+    node;
+    node = node.parentElement
+  ) {
+    const style = window.getComputedStyle(node);
+
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
  * Module-level registry of currently active focus-lock root elements.
  * Used in Safari to prevent an outer lock from handling Tab for elements
  * that belong to an inner (descendant) lock.
@@ -89,7 +117,8 @@ const activeFocusLockRoots = new Set<HTMLElement>();
 export function useFocusLock(
   active: boolean,
   header?: React.MutableRefObject<FocusableElement>,
-  body?: React.MutableRefObject<FocusableElement>
+  body?: React.MutableRefObject<FocusableElement>,
+  autoFocusOnActivate = true
 ): React.MutableRefObject<any> {
   const rootNode = React.useRef<HTMLElement>(null);
   const focusableItems = React.useRef<Array<HTMLElement>>([]);
@@ -106,10 +135,9 @@ export function useFocusLock(
       const style = window.getComputedStyle(element);
       return (
         element instanceof HTMLElement &&
-        style.display !== 'none' &&
-        style.visibility !== 'hidden' &&
         !element.hasAttribute('disabled') &&
-        element.tabIndex >= 0
+        element.tabIndex >= 0 &&
+        isElementVisible(element)
       );
     });
 
@@ -134,25 +162,53 @@ export function useFocusLock(
         observer.observe(root, { childList: true, subtree: true });
       }
 
-      if (header && header.current) {
-        header.current.focus();
-      } else if (focusableItems.current && focusableItems.current.length > 0) {
-        const { 0: firstItem } = focusableItems.current;
+      // Defer the initial focus to the next frame so the browser can update
+      // the accessibility tree first (e.g. after a `display: none` toggle).
+      let focusFrame: number;
 
-        firstItem.focus();
-      } else if (body && body.current) {
-        (body.current.firstChild as HTMLElement).setAttribute('tabIndex', '-1');
-        (body.current.firstChild as HTMLElement).focus();
+      if (autoFocusOnActivate) {
+        const activeOnActivate = document.activeElement;
+
+        focusFrame = requestAnimationFrame(() => {
+          const activeElement = document.activeElement;
+
+          if (
+            activeElement !== activeOnActivate &&
+            activeElement !== document.body
+          ) {
+            return;
+          }
+
+          if (header && header.current) {
+            header.current.focus();
+          } else if (
+            focusableItems.current &&
+            focusableItems.current.length > 0
+          ) {
+            const { 0: firstItem } = focusableItems.current;
+
+            firstItem.focus();
+          } else if (body && body.current) {
+            (body.current.firstChild as HTMLElement).setAttribute(
+              'tabIndex',
+              '-1'
+            );
+            (body.current.firstChild as HTMLElement).focus();
+          }
+        });
       }
       return () => {
         if (root) {
           activeFocusLockRoots.delete(root);
         }
 
+        cancelAnimationFrame(focusFrame);
         observer.disconnect();
       };
     }
-  }, [active, header, body]);
+
+    return undefined;
+  }, [active, header, body, autoFocusOnActivate]);
 
   React.useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
@@ -208,11 +264,14 @@ export function useFocusLock(
               lockRoot.contains(activeElement)
           );
 
+        if (isInsideNestedLock) {
+          return;
+        }
+
         if (
           length > 0 &&
           (isEventInsideCurrentLock || isSafari) &&
           !isActiveElementTracked &&
-          !isInsideNestedLock &&
           (isActiveElementInsideCurrentLock || activeElement === document.body)
         ) {
           event.preventDefault();

--- a/packages/react-magma-dom/src/hooks/useFocusLock.ts
+++ b/packages/react-magma-dom/src/hooks/useFocusLock.ts
@@ -132,7 +132,6 @@ export function useFocusLock(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), video'
       ) || []
     ).filter((element): element is HTMLElement => {
-      const style = window.getComputedStyle(element);
       return (
         element instanceof HTMLElement &&
         !element.hasAttribute('disabled') &&


### PR DESCRIPTION
Closes: #2471

## What I did
Added aria-modal and role="dialog" to the DatePicker container to improve accessibility.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. Open the DatePicker Storybook.
2. Turn on a screen reader.
3. Open the DatePicker widget.
4. Move focus to the widget.
5. Verify that the screen reader announces it as a dialog.

