### PR TITLE
feat(Dropdown): add mainButtonRef prop to split button

### DIFF
--- a/.changeset/fix-dropdown-split-button-refs.md
+++ b/.changeset/fix-dropdown-split-button-refs.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+feat(Dropdown): add `primaryButtonRef` prop to pass a ref to the split button's left action button

--- a/.changeset/fix-dropdown-split-button-refs.md
+++ b/.changeset/fix-dropdown-split-button-refs.md
@@ -2,4 +2,4 @@
 'react-magma-dom': patch
 ---
 
-feat(Dropdown): add `primaryButtonRef` prop to pass a ref to the split button's left action button
+feat(Dropdown): add `mainButtonRef` prop to pass a ref to the split button's left action button

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -786,6 +786,7 @@ export const FlippedItems = {
 const CustomRefTemplate: StoryFn<DropdownProps> = args => {
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const splitButtonRef = React.useRef<HTMLButtonElement>(null);
+  const primaryButtonRef = React.useRef<HTMLButtonElement>(null);
 
   function handleClose(event: React.SyntheticEvent) {
     buttonRef.current?.focus();
@@ -793,6 +794,10 @@ const CustomRefTemplate: StoryFn<DropdownProps> = args => {
 
   function handleSplitClose(event: React.SyntheticEvent) {
     splitButtonRef.current?.focus();
+  }
+
+  function handleSplitPrimaryClose() {
+    primaryButtonRef.current?.focus();
   }
 
   return (
@@ -815,6 +820,18 @@ const CustomRefTemplate: StoryFn<DropdownProps> = args => {
       <Dropdown {...args} onClose={handleSplitClose}>
         <DropdownSplitButton aria-label="Split" ref={splitButtonRef}>
           Split Dropdown
+        </DropdownSplitButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+      <Dropdown {...args} onClose={handleSplitPrimaryClose}>
+        <DropdownSplitButton
+          aria-label="Split"
+          primaryButtonRef={primaryButtonRef}
+        >
+          Split Primary Ref
         </DropdownSplitButton>
         <DropdownContent>
           <DropdownMenuItem>Menu item 1</DropdownMenuItem>

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -786,7 +786,7 @@ export const FlippedItems = {
 const CustomRefTemplate: StoryFn<DropdownProps> = args => {
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const splitButtonRef = React.useRef<HTMLButtonElement>(null);
-  const primaryButtonRef = React.useRef<HTMLButtonElement>(null);
+  const mainButtonRef = React.useRef<HTMLButtonElement>(null);
 
   function handleClose(event: React.SyntheticEvent) {
     buttonRef.current?.focus();
@@ -796,8 +796,8 @@ const CustomRefTemplate: StoryFn<DropdownProps> = args => {
     splitButtonRef.current?.focus();
   }
 
-  function handleSplitPrimaryClose() {
-    primaryButtonRef.current?.focus();
+  function handleSplitMainClose() {
+    mainButtonRef.current?.focus();
   }
 
   return (
@@ -826,12 +826,9 @@ const CustomRefTemplate: StoryFn<DropdownProps> = args => {
           <DropdownMenuItem>Menu item number two</DropdownMenuItem>
         </DropdownContent>
       </Dropdown>
-      <Dropdown {...args} onClose={handleSplitPrimaryClose}>
-        <DropdownSplitButton
-          aria-label="Split"
-          primaryButtonRef={primaryButtonRef}
-        >
-          Split Primary Ref
+      <Dropdown {...args} onClose={handleSplitMainClose}>
+        <DropdownSplitButton aria-label="Split" mainButtonRef={mainButtonRef}>
+          Split Main Ref
         </DropdownSplitButton>
         <DropdownContent>
           <DropdownMenuItem>Menu item 1</DropdownMenuItem>

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -250,14 +250,11 @@ describe('Dropdown', () => {
     });
   });
 
-  it('should attach primaryButtonRef to the left action button', async () => {
-    const primaryButtonRef = React.createRef();
+  it('should attach mainButtonRef to the left action button', async () => {
+    const mainButtonRef = React.createRef();
     const { getByText } = render(
       <Dropdown>
-        <DropdownSplitButton
-          aria-label="Split"
-          primaryButtonRef={primaryButtonRef}
-        >
+        <DropdownSplitButton aria-label="Split" mainButtonRef={mainButtonRef}>
           Toggle me
         </DropdownSplitButton>
         <DropdownContent />
@@ -265,7 +262,7 @@ describe('Dropdown', () => {
     );
 
     await waitFor(() => {
-      expect(primaryButtonRef.current).toBe(
+      expect(mainButtonRef.current).toBe(
         getByText('Toggle me').closest('button')
       );
     });

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -234,6 +234,43 @@ describe('Dropdown', () => {
     });
   });
 
+  it('should attach forwarded ref to the dropdown toggle button', async () => {
+    const splitButtonRef = React.createRef();
+    const { getByLabelText } = render(
+      <Dropdown>
+        <DropdownSplitButton aria-label="Split" ref={splitButtonRef}>
+          Toggle me
+        </DropdownSplitButton>
+        <DropdownContent />
+      </Dropdown>
+    );
+
+    await waitFor(() => {
+      expect(splitButtonRef.current).toBe(getByLabelText('Split'));
+    });
+  });
+
+  it('should attach primaryButtonRef to the left action button', async () => {
+    const primaryButtonRef = React.createRef();
+    const { getByText } = render(
+      <Dropdown>
+        <DropdownSplitButton
+          aria-label="Split"
+          primaryButtonRef={primaryButtonRef}
+        >
+          Toggle me
+        </DropdownSplitButton>
+        <DropdownContent />
+      </Dropdown>
+    );
+
+    await waitFor(() => {
+      expect(primaryButtonRef.current).toBe(
+        getByText('Toggle me').closest('button')
+      );
+    });
+  });
+
   it('should render a split dropdown with leading icon', async () => {
     const { getByTestId, container } = render(
       <Dropdown>

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -109,6 +109,7 @@ interface DropdownContextInterface {
   setFloating?: (node: ReferenceType) => void;
   setReference?: (node: ReferenceType) => void;
   toggleRef?: any;
+  leftButtonRef?: React.MutableRefObject<HTMLButtonElement>;
   width?: string;
 }
 
@@ -146,6 +147,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
 
     const ownRef = React.useRef<any>();
     const toggleRef = React.useRef<HTMLButtonElement>(null);
+    const leftButtonRef = React.useRef<HTMLButtonElement>(null);
     const menuRef = React.useRef<any>([]);
     const dropdownButtonId = React.useRef<string>('');
 
@@ -184,7 +186,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         const relatedTarget = event.relatedTarget;
 
         if (!isElementInteractive(relatedTarget)) {
-          toggleRef.current?.focus();
+          (leftButtonRef.current ?? toggleRef.current)?.focus();
         }
       }
 
@@ -207,7 +209,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         event.nativeEvent.stopImmediatePropagation();
         event.stopPropagation();
         closeDropdown(event);
-        toggleRef.current?.focus();
+        (leftButtonRef.current ?? toggleRef.current)?.focus();
       }
 
       if (event.key === 'ArrowDown') {
@@ -335,6 +337,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         setReference: refs.setReference,
         setFloating: refs.setFloating,
         toggleRef,
+        leftButtonRef,
         width: widthString,
       }),
       [
@@ -358,6 +361,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
         refs.setReference,
         refs.setFloating,
         toggleRef,
+        leftButtonRef,
         widthString,
       ]
     );

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -46,9 +46,9 @@ export interface DropdownSplitButtonProps extends ButtonStyles {
    */
   onClick?: () => void;
   /**
-   * Ref for the primary action button (left side).
+   * Ref for the main action button (left side).
    */
-  primaryButtonRef?: React.Ref<HTMLButtonElement>;
+  mainButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 export const DropdownSplitButton = React.forwardRef<
@@ -66,7 +66,7 @@ export const DropdownSplitButton = React.forwardRef<
     'aria-label': ariaLabel,
     children,
     id,
-    primaryButtonRef,
+    mainButtonRef,
     variant = ButtonVariant.solid,
     onClick,
     leadingIcon,
@@ -75,7 +75,7 @@ export const DropdownSplitButton = React.forwardRef<
 
   const ref = useForkedRef(forwardedRef, resolvedContext.toggleRef);
   const splitButtonRef = React.useRef<HTMLButtonElement>(null);
-  const primaryRef = useForkedRef(splitButtonRef, primaryButtonRef ?? null);
+  const mainRef = useForkedRef(splitButtonRef, mainButtonRef ?? null);
 
   resolvedContext.dropdownButtonId.current = useGenerateId(id);
 
@@ -133,7 +133,7 @@ export const DropdownSplitButton = React.forwardRef<
     style: { borderRight: 0, marginRight: 0 },
     variant,
     tabIndex: 0,
-    ref: primaryRef,
+    ref: mainRef,
   };
 
   return (

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -75,7 +75,11 @@ export const DropdownSplitButton = React.forwardRef<
 
   const ref = useForkedRef(forwardedRef, resolvedContext.toggleRef);
   const splitButtonRef = React.useRef<HTMLButtonElement>(null);
-  const mainRef = useForkedRef(splitButtonRef, mainButtonRef ?? null);
+  const mainRef = useForkedRef(
+    splitButtonRef,
+    mainButtonRef ? resolvedContext.leftButtonRef : null,
+    mainButtonRef ?? null
+  );
 
   resolvedContext.dropdownButtonId.current = useGenerateId(id);
 

--- a/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/DropdownSplitButton.tsx
@@ -6,6 +6,10 @@ import {
   IconProps,
 } from 'react-magma-icons';
 
+import { DropdownContext, DropdownDropDirection } from './Dropdown';
+import { I18nContext } from '../../i18n';
+import { ThemeContext } from '../../theme/ThemeContext';
+import { resolveProps, useForkedRef, useGenerateId } from '../../utils';
 import {
   Button,
   ButtonColor,
@@ -13,12 +17,8 @@ import {
   ButtonStyles,
   ButtonVariant,
 } from '../Button';
-import { getIconSize, IconButton } from '../IconButton';
-import { DropdownContext, DropdownDropDirection } from './Dropdown';
-import { I18nContext } from '../../i18n';
-import { ThemeContext } from '../../theme/ThemeContext';
-import { resolveProps, useForkedRef, useGenerateId } from '../../utils';
 import { ButtonGroupContext } from '../ButtonGroup';
+import { getIconSize, IconButton } from '../IconButton';
 
 export interface DropdownSplitButtonProps extends ButtonStyles {
   /**
@@ -45,6 +45,10 @@ export interface DropdownSplitButtonProps extends ButtonStyles {
    * Function that fires when the button is clicked
    */
   onClick?: () => void;
+  /**
+   * Ref for the primary action button (left side).
+   */
+  primaryButtonRef?: React.Ref<HTMLButtonElement>;
 }
 
 export const DropdownSplitButton = React.forwardRef<
@@ -62,6 +66,7 @@ export const DropdownSplitButton = React.forwardRef<
     'aria-label': ariaLabel,
     children,
     id,
+    primaryButtonRef,
     variant = ButtonVariant.solid,
     onClick,
     leadingIcon,
@@ -70,6 +75,7 @@ export const DropdownSplitButton = React.forwardRef<
 
   const ref = useForkedRef(forwardedRef, resolvedContext.toggleRef);
   const splitButtonRef = React.useRef<HTMLButtonElement>(null);
+  const primaryRef = useForkedRef(splitButtonRef, primaryButtonRef ?? null);
 
   resolvedContext.dropdownButtonId.current = useGenerateId(id);
 
@@ -118,20 +124,17 @@ export const DropdownSplitButton = React.forwardRef<
     return theme.spaceScale.spacing01;
   }
 
-  const sharedButtonProps = React.useMemo(
-    () => ({
-      ...other,
-      id: resolvedContext.dropdownButtonId.current,
-      isInverse: resolvedContext.isInverse,
-      onClick: handleButtonClick,
-      shape: ButtonShape.leftCap,
-      style: { borderRight: 0, marginRight: 0 },
-      variant,
-      tabIndex: 0,
-      ref: splitButtonRef,
-    }),
-    [props]
-  );
+  const sharedButtonProps = {
+    ...other,
+    id: resolvedContext.dropdownButtonId.current,
+    isInverse: resolvedContext.isInverse,
+    onClick: handleButtonClick,
+    shape: ButtonShape.leftCap,
+    style: { borderRight: 0, marginRight: 0 },
+    variant,
+    tabIndex: 0,
+    ref: primaryRef,
+  };
 
   return (
     <div ref={context.setReference}>

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -1000,6 +1000,8 @@ By default the consumer is expected to handle the focusing of elements when item
 you should focus the trigger button on closing of the dropdown. For this you can use a `ref` passed to the `DropdownButton` or `DropdownSplitButton` and focus that ref in
 the `onClose` function passed to the `Dropdown` component.
 
+For `DropdownSplitButton`, the forwarded `ref` targets the dropdown toggle button (right side). Use `primaryButtonRef` to target the left action button.
+
 ```tsx
 import React from 'react';
 

--- a/website/react-magma-docs/src/pages/api/dropdown.mdx
+++ b/website/react-magma-docs/src/pages/api/dropdown.mdx
@@ -1000,7 +1000,7 @@ By default the consumer is expected to handle the focusing of elements when item
 you should focus the trigger button on closing of the dropdown. For this you can use a `ref` passed to the `DropdownButton` or `DropdownSplitButton` and focus that ref in
 the `onClose` function passed to the `Dropdown` component.
 
-For `DropdownSplitButton`, the forwarded `ref` targets the dropdown toggle button (right side). Use `primaryButtonRef` to target the left action button.
+For `DropdownSplitButton`, the forwarded `ref` targets the dropdown toggle button (right side). Use `mainButtonRef` to target the left action button.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
Closes: #1849

## What I did
Added a new primaryButtonRef prop to pass a ref to the primary (left) button of the Split Button dropdown.

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. Open the Dropdown Storybook
2. Open the Custom Ref Template example (second Split Button example)
3. Verify that focus is returned to the primary (left) button of the Split Button
