### PR TITLE
V4/fix(ToggleButtonGroup): add `role` prop

### DIFF
--- a/.changeset/fix-ToggleButtonGroup-ToggleButton-add-role-prop.md
+++ b/.changeset/fix-ToggleButtonGroup-ToggleButton-add-role-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(ToggleButtonGroup): add `role` prop

--- a/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-magma-dom/src/components/ToggleButton/ToggleButton.tsx
@@ -10,7 +10,10 @@ import { ThemeContext } from '../../theme/ThemeContext';
 import { XOR } from '../../utils';
 import { Button, ButtonColor, ButtonProps, ButtonSize } from '../Button';
 import { IconButton } from '../IconButton';
-import { ToggleButtonGroupContext } from '../ToggleButtonGroup';
+import {
+  ToggleButtonGroupContext,
+  ToggleButtonGroupRole,
+} from '../ToggleButtonGroup';
 
 export interface ToggleButtonTextProps extends ButtonProps {
   /**
@@ -72,6 +75,26 @@ export type ToggleButtonProps = XOR<
   ToggleButtonTextProps,
   ToggleButtonIconProps
 >;
+
+export enum ToggleButtonRole {
+  radio = 'radio',
+  switch = 'switch',
+  tab = 'tab',
+}
+
+export function getToggleButtonRole(
+  groupRole?: ToggleButtonGroupRole,
+  exclusive?: boolean
+): ToggleButtonRole {
+  if (groupRole === ToggleButtonGroupRole.tablist) {
+    return ToggleButtonRole.tab;
+  }
+  if (groupRole === ToggleButtonGroupRole.radiogroup) {
+    return ToggleButtonRole.radio;
+  }
+
+  return exclusive ? ToggleButtonRole.radio : ToggleButtonRole.switch;
+}
 
 //Sets the icon width for icon only Toggle Buttons
 export function setIconWidth(props: ToggleButtonIconProps) {
@@ -151,7 +174,8 @@ export const ToggleButton = React.forwardRef<
   }, [isChecked]);
 
   const inverseCheck = context.isInverse || isInverse;
-  const roleCheck = context.exclusive ? 'radio' : 'switch';
+  const roleCheck = getToggleButtonRole(context.role, context.exclusive);
+  const usesAriaSelected = roleCheck === ToggleButtonRole.tab;
 
   const handleClick = (event: any) => {
     if (
@@ -186,7 +210,9 @@ export const ToggleButton = React.forwardRef<
 
   const sharedToggleButtonProps = {
     ...other,
-    'aria-checked': isSelected,
+    ...(usesAriaSelected
+      ? { 'aria-selected': isSelected }
+      : { 'aria-checked': isSelected }),
     color: ButtonColor.subtle,
     disabled: disabled,
     theme: theme,

--- a/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
+++ b/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.tsx
@@ -14,7 +14,11 @@ import { ButtonSize } from '../Button';
 import { Container } from '../Container';
 import { ToggleButton } from '../ToggleButton';
 
-import { ToggleButtonGroup, ToggleButtonGroupProps } from '.';
+import {
+  ToggleButtonGroup,
+  ToggleButtonGroupProps,
+  ToggleButtonGroupRole,
+} from '.';
 
 const Template: StoryFn<ToggleButtonGroupProps> = args => (
   <ToggleButtonGroup
@@ -99,6 +103,10 @@ export default {
         options: ButtonSize,
       },
     },
+    role: {
+      control: { type: 'select' },
+      options: Object.values(ToggleButtonGroupRole),
+    },
   },
 } as Meta;
 
@@ -174,5 +182,39 @@ export const DifferentToggleButtons = {
   args: {
     noSpace: false,
     ...Default.args,
+  },
+};
+
+export const TablistPattern = {
+  render: args => {
+    const [view, setView] = React.useState('teacher');
+
+    return (
+      <>
+        <ToggleButtonGroup
+          {...args}
+          value={view}
+          onChange={(_event, value) => value && setView(value)}
+        >
+          <ToggleButton value="teacher" aria-controls="view-panel">
+            Teacher View
+          </ToggleButton>
+          <ToggleButton value="student" aria-controls="view-panel">
+            Student View
+          </ToggleButton>
+        </ToggleButtonGroup>
+        <div id="view-panel" role="tabpanel" style={{ padding: '16px 0' }}>
+          {view === 'teacher'
+            ? 'Showing the teacher view of the course.'
+            : 'Showing the student view of the course.'}
+        </div>
+      </>
+    );
+  },
+
+  args: {
+    enforced: true,
+    exclusive: true,
+    role: 'tablist',
   },
 };

--- a/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -207,4 +207,111 @@ describe('ToggleButtonGroup', () => {
     fireEvent.click(buttonOne);
     expect(onChangeMock).toHaveBeenCalledTimes(1);
   });
+
+  describe('Role configuration', () => {
+    it('Defaults the container to role="group"', () => {
+      const { getByTestId } = render(
+        <ToggleButtonGroup testId={testId}>
+          <ToggleButton value="one">{TEXT}</ToggleButton>
+        </ToggleButtonGroup>
+      );
+
+      expect(getByTestId(testId)).toHaveAttribute('role', 'group');
+    });
+
+    it('Honors a custom role on the container ("radiogroup")', () => {
+      const { getByTestId } = render(
+        <ToggleButtonGroup testId={testId} exclusive role="radiogroup">
+          <ToggleButton value="one" testId={`${testId}-btn`}>
+            {TEXT}
+          </ToggleButton>
+        </ToggleButtonGroup>
+      );
+
+      expect(getByTestId(testId)).toHaveAttribute('role', 'radiogroup');
+      // Children keep their existing semantics in radiogroup mode.
+      expect(getByTestId(`${testId}-btn`)).toHaveAttribute('role', 'radio');
+      expect(getByTestId(`${testId}-btn`)).toHaveAttribute(
+        'aria-checked',
+        'false'
+      );
+    });
+
+    it('Renders a tablist container with tab-roled children using aria-selected', () => {
+      const { getByTestId } = render(
+        <ToggleButtonGroup
+          testId={testId}
+          exclusive
+          enforced
+          role="tablist"
+          value="one"
+        >
+          <ToggleButton value="one" testId={`${testId}-btn-1`}>
+            Teacher View
+          </ToggleButton>
+          <ToggleButton value="two" testId={`${testId}-btn-2`}>
+            Student View
+          </ToggleButton>
+        </ToggleButtonGroup>
+      );
+
+      expect(getByTestId(testId)).toHaveAttribute('role', 'tablist');
+
+      const buttonOne = getByTestId(`${testId}-btn-1`);
+      const buttonTwo = getByTestId(`${testId}-btn-2`);
+
+      expect(buttonOne).toHaveAttribute('role', 'tab');
+      expect(buttonTwo).toHaveAttribute('role', 'tab');
+
+      expect(buttonOne).toHaveAttribute('aria-selected', 'true');
+      expect(buttonTwo).toHaveAttribute('aria-selected', 'false');
+      expect(buttonOne).not.toHaveAttribute('aria-checked');
+
+      fireEvent.click(buttonTwo);
+      expect(buttonOne).toHaveAttribute('aria-selected', 'false');
+      expect(buttonTwo).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('Renders radios for a radiogroup role', () => {
+      const { getByTestId } = render(
+        <ToggleButtonGroup testId={testId} exclusive role="radiogroup">
+          <ToggleButton value="one" testId={`${testId}-1`}>
+            {TEXT}
+          </ToggleButton>
+          <ToggleButton value="two" testId={`${testId}-2`}>
+            {TEXT}
+          </ToggleButton>
+        </ToggleButtonGroup>
+      );
+
+      const buttonOne = getByTestId(`${testId}-1`);
+      const buttonTwo = getByTestId(`${testId}-2`);
+
+      // radiogroup always renders radios, never switches.
+      expect(buttonOne).toHaveAttribute('role', 'radio');
+      expect(buttonTwo).toHaveAttribute('role', 'radio');
+      expect(buttonOne).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('Renders tabs with aria-selected for a tablist role', () => {
+      const { getByTestId } = render(
+        <ToggleButtonGroup testId={testId} exclusive enforced role="tablist">
+          <ToggleButton value="one" testId={`${testId}-1`}>
+            {TEXT}
+          </ToggleButton>
+          <ToggleButton value="two" testId={`${testId}-2`}>
+            {TEXT}
+          </ToggleButton>
+        </ToggleButtonGroup>
+      );
+
+      const buttonOne = getByTestId(`${testId}-1`);
+      const buttonTwo = getByTestId(`${testId}-2`);
+
+      expect(buttonOne).toHaveAttribute('role', 'tab');
+      expect(buttonTwo).toHaveAttribute('role', 'tab');
+      expect(buttonOne).toHaveAttribute('aria-selected', 'false');
+      expect(buttonOne).not.toHaveAttribute('aria-checked');
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react-magma-dom/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -7,10 +7,17 @@ import { ButtonColor, ButtonSize } from '../Button';
 import { ButtonGroup, ButtonGroupProps } from '../ButtonGroup';
 import { ToggleButton, ToggleButtonProps } from '../ToggleButton/ToggleButton';
 
-/**
- * @children required
- */
-export interface ToggleButtonGroupProps extends ButtonGroupProps {
+export enum ToggleButtonGroupRole {
+  group = 'group',
+  radiogroup = 'radiogroup',
+  tablist = 'tablist',
+}
+
+export interface ToggleButtonGroupProps extends Omit<ButtonGroupProps, 'role'> {
+  /**
+   * @children required
+   */
+  children: React.ReactNode;
   /**
    * Description for aria-describedby
    */
@@ -34,6 +41,15 @@ export interface ToggleButtonGroupProps extends ButtonGroupProps {
     value?: string
   ) => void;
   /**
+   * ARIA role for the group container. `tablist` renders children as tabs
+   * (`aria-selected`); `radiogroup` renders them as radios (`aria-checked`);
+   * `group` renders radios or switches based on `exclusive`. `tablist` and
+   * `radiogroup` are single-select patterns, so pair them with `exclusive`
+   * (and `enforced` for tabs, to keep one selected at all times).
+   * @default ToggleButtonGroupRole.group
+   */
+  role?: ToggleButtonGroupRole;
+  /**
    * @internal
    */
   testId?: string;
@@ -54,6 +70,7 @@ export interface ToggleButtonGroupContextInterface {
   isInverse?: boolean;
   enforced?: boolean;
   exclusive?: boolean;
+  role?: ToggleButtonGroupRole;
   selected?: boolean;
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -77,6 +94,7 @@ export const ToggleButtonGroup = React.forwardRef<
     isInverse,
     noSpace,
     onChange,
+    role = ToggleButtonGroupRole.group,
     size,
     value,
     testId,
@@ -167,7 +185,7 @@ export const ToggleButtonGroup = React.forwardRef<
       isInverse={isInverse}
       noSpace={noSpace}
       ref={ref}
-      role="group"
+      role={role}
       size={size}
       testId={testId}
       theme={theme}
@@ -181,6 +199,7 @@ export const ToggleButtonGroup = React.forwardRef<
           enforced,
           exclusive,
           onChange: handleChange,
+          role,
           size,
         }}
       >

--- a/website/react-magma-docs/src/pages/api/toggle-button-group.mdx
+++ b/website/react-magma-docs/src/pages/api/toggle-button-group.mdx
@@ -211,6 +211,82 @@ export function Example() {
 }
 ```
 
+## Role and Accessibility
+
+By default, a Toggle Button Group renders with `role="group"`, and its buttons use `role="radio"` (when `exclusive`) or `role="switch"` (otherwise). Use the `role` prop to expose the correct semantics to assistive technology when the group does something other than toggle independent options.
+
+Choose the role based on what selecting a button actually does:
+
+- **`group`** (default) — a set of related toggles that act on other content (for example, text alignment). Use `exclusive` for a single-choice set of radios, or leave it off for independent on/off switches.
+- **`radiogroup`** — a single-choice selection that is semantically a radio group. The buttons are always announced as radios; pair the role with `exclusive` so the single-select behavior matches the radio group semantics.
+- **`tablist`** — buttons that switch between different views or sections of the page. Each button is rendered as a `tab` with `aria-selected`, following the [WAI-ARIA Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). Pair with `exclusive` and `enforced` so exactly one tab is always selected, and connect each button to its panel with `aria-controls` and `role="tabpanel"`.
+
+### Tablist
+
+Use `role="tablist"` when selecting a button switches the visible content, such as a "Teacher view" / "Student view" toggle. This announces the control as a set of tabs rather than radio buttons, matching its behavior.
+
+```tsx
+import React from 'react';
+
+import { ToggleButton, ToggleButtonGroup } from 'react-magma-dom';
+
+export function Example() {
+  const [view, setView] = React.useState('teacher');
+
+  return (
+    <>
+      <ToggleButtonGroup
+        role="tablist"
+        exclusive
+        enforced
+        value={view}
+        onChange={(_event, value) => {
+          if (value) {
+            setView(value);
+          }
+        }}
+      >
+        <ToggleButton value="teacher" aria-controls="course-view-panel">
+          Teacher view
+        </ToggleButton>
+        <ToggleButton value="student" aria-controls="course-view-panel">
+          Student view
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <div
+        id="course-view-panel"
+        role="tabpanel"
+        style={{ paddingTop: '12px' }}
+      >
+        {view === 'teacher'
+          ? 'Showing the teacher view of the course.'
+          : 'Showing the student view of the course.'}
+      </div>
+    </>
+  );
+}
+```
+
+### Radio Group
+
+Use `role="radiogroup"` for a single-choice selection that should be announced as a radio group. The buttons render as radios regardless, so pair the role with `exclusive` to keep the single-select behavior consistent with the radio group semantics.
+
+```tsx
+import React from 'react';
+
+import { ToggleButton, ToggleButtonGroup } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <ToggleButtonGroup role="radiogroup" exclusive value="medium">
+      <ToggleButton value="low">Low</ToggleButton>
+      <ToggleButton value="medium">Medium</ToggleButton>
+      <ToggleButton value="high">High</ToggleButton>
+    </ToggleButtonGroup>
+  );
+}
+```
+
 ## No Space
 
 Removes margins and border radius on each button then applies the border-radius around the container.


### PR DESCRIPTION
Closes: #2473
Cherry-pick #2580

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Added `role` prop for `Toggle Button Group` and `Toggle Button` components

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook -> Toggle Button Group -> Actions -> Check new role -> Open devTools -> Check new roles for `Toggle Button Group` and `Toggle Button`
Open docs -> Toggle Button Group and Toggle Button -> Check new props