### PR TITLE
fix(Tag): Prevent spreading ARIA attributes onto the inner label `span` to resolve `aria-allowed-attr` violation. (#2555)

### DIFF
--- a/.changeset/fix-Tag-invalid-aria-on-label-span.md
+++ b/.changeset/fix-Tag-invalid-aria-on-label-span.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tag): prevent spreading ARIA attributes onto the inner label `span` to resolve `aria-allowed-attr` violation.

--- a/packages/react-magma-dom/src/components/Tag/Tag.tsx
+++ b/packages/react-magma-dom/src/components/Tag/Tag.tsx
@@ -220,14 +220,6 @@ function buildSvgOpacity(props) {
 }
 
 function buildTagPadding(props) {
-  if (props.icon) {
-    switch (props.size) {
-      case 'small':
-        return `0 ${props.theme.spaceScale.spacing02}`;
-      default:
-        return `${props.theme.spaceScale.spacing02} 6px`;
-    }
-  }
   switch (props.size) {
     case 'small':
       return `0 ${props.theme.spaceScale.spacing02}`;
@@ -237,14 +229,6 @@ function buildTagPadding(props) {
 }
 
 function buildLabelPadding(props) {
-  if (props.icon) {
-    switch (props.size) {
-      case 'small':
-        return `0 ${props.theme.spaceScale.spacing02}`;
-      default:
-        return `0 ${props.theme.spaceScale.spacing03}`;
-    }
-  }
   switch (props.size) {
     case 'small':
       return `0 ${props.theme.spaceScale.spacing02}`;
@@ -320,7 +304,6 @@ const StyledSpan = styled.span<{
 
 const LabelWrap = styled.span<{
   size: string;
-  icon?: any;
 }>`
   padding: ${buildLabelPadding};
 `;
@@ -382,7 +365,7 @@ export const Tag = React.forwardRef<HTMLButtonElement, TagProps>(
         {...rest}
       >
         {icon}
-        <LabelWrap size={size} theme={theme} {...rest}>
+        <LabelWrap size={size} theme={theme}>
           {children}
         </LabelWrap>
         {onDelete && <CancelIcon size={theme.iconSizes.small} />}


### PR DESCRIPTION
Closes: #2554
Cherry-pick #2555

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Prevent spreading ARIA attributes onto the inner label `span` to resolve `aria-allowed-attr` violation.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Pull the branch -> Open Storybook locally -> Tag -> Pass some props (e.g., color/background-color/aria-label) -> Check passed props in devtools