### PR TITLE
feat(Tag): Add Tag color options

### DIFF
--- a/.changeset/tag-data-viz-colors.md
+++ b/.changeset/tag-data-viz-colors.md
@@ -1,0 +1,5 @@
+---
+"react-magma-dom": minor
+---
+
+Add data visualization color tokens and new Tag color options.

--- a/packages/react-magma-dom/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-magma-dom/src/components/Tag/Tag.stories.tsx
@@ -8,15 +8,30 @@ import { Card, CardBody } from '../Card';
 
 import { Tag, TagColor, TagProps, TagSize } from '.';
 
+const dataVizTagColors = [
+  { color: TagColor.blue, label: 'Blue' },
+  { color: TagColor.teal, label: 'Teal' },
+  { color: TagColor.pink, label: 'Pink' },
+  { color: TagColor.purple, label: 'Purple' },
+];
+
+const tagColorExamples = [
+  { color: TagColor.primary, label: 'Primary' },
+  ...dataVizTagColors,
+];
+
+const tagGroupStyles: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '8px',
+};
+
 const Template: StoryFn<TagProps> = args => {
   return (
     <Card isInverse={args.isInverse}>
       <CardBody>
-        <p>
+        <p style={tagGroupStyles}>
           <Tag {...args}>Default</Tag>
-          <Tag {...args} color={TagColor.primary}>
-            Primary
-          </Tag>
           <Tag {...args} color={TagColor.highContrast}>
             High Contrast
           </Tag>
@@ -24,7 +39,14 @@ const Template: StoryFn<TagProps> = args => {
             Low Contrast
           </Tag>
         </p>
-        <p>
+        <p style={tagGroupStyles}>
+          {tagColorExamples.map(({ color, label }) => (
+            <Tag {...args} color={color} key={color}>
+              {label}
+            </Tag>
+          ))}
+        </p>
+        <p style={tagGroupStyles}>
           <Tag {...args} icon={<AccountCircleIcon />}>
             Default Icon
           </Tag>
@@ -46,7 +68,14 @@ const Template: StoryFn<TagProps> = args => {
             Low Contrast Icon
           </Tag>
         </p>
-        <p>
+        <p style={tagGroupStyles}>
+          {dataVizTagColors.map(({ color, label }) => (
+            <Tag {...args} color={color} icon={<AccountCircleIcon />} key={color}>
+              {label} Icon
+            </Tag>
+          ))}
+        </p>
+        <p style={tagGroupStyles}>
           <Tag {...args} size={TagSize.small}>
             Default Small
           </Tag>
@@ -60,7 +89,14 @@ const Template: StoryFn<TagProps> = args => {
             Low Contrast Small
           </Tag>
         </p>
-        <p>
+        <p style={tagGroupStyles}>
+          {dataVizTagColors.map(({ color, label }) => (
+            <Tag {...args} color={color} key={color} size={TagSize.small}>
+              {label} Small
+            </Tag>
+          ))}
+        </p>
+        <p style={tagGroupStyles}>
           <Tag {...args} icon={<AccountCircleIcon />} size={TagSize.small}>
             Default Small Icon
           </Tag>
@@ -89,7 +125,7 @@ const Template: StoryFn<TagProps> = args => {
             Low Contrast Small Icon
           </Tag>
         </p>
-        <p>
+        <p style={tagGroupStyles}>
           <Tag
             size={args.size}
             color={args.color}
@@ -112,6 +148,38 @@ const Template: StoryFn<TagProps> = args => {
           >
             Deletetable
           </Tag>
+        </p>
+        <p style={tagGroupStyles}>
+          {dataVizTagColors.map(({ color, label }) => (
+            <Tag
+              color={color}
+              disabled={args.disabled}
+              isInverse={args.isInverse}
+              key={color}
+              onDelete={() => {
+                console.log('clicked');
+              }}
+              size={args.size}
+            >
+              {label} Deletable
+            </Tag>
+          ))}
+        </p>
+        <p style={tagGroupStyles}>
+          {dataVizTagColors.map(({ color, label }) => (
+            <Tag
+              color={color}
+              disabled={args.disabled}
+              isInverse={args.isInverse}
+              key={color}
+              onDelete={() => {
+                console.log('clicked');
+              }}
+              size={TagSize.small}
+            >
+              {label} Small Deletable
+            </Tag>
+          ))}
         </p>
       </CardBody>
     </Card>

--- a/packages/react-magma-dom/src/components/Tag/Tag.test.js
+++ b/packages/react-magma-dom/src/components/Tag/Tag.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, fireEvent, getByTestId } from '@testing-library/react';
 import { transparentize } from 'polished';
-import { AccountCircleIcon, CancelIcon } from 'react-magma-icons';
+import { AccountCircleIcon } from 'react-magma-icons';
 
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
@@ -10,6 +10,70 @@ import { magma } from '../../theme/magma';
 import { Tag, TagColor, TagSize } from '.';
 
 const TEXT = 'Text Label';
+
+const DATA_VIZ_TAG_COLORS = [
+  {
+    color: TagColor.blue,
+    label: 'blue',
+    light: {
+      background: magma.colors.dataVizBlue200,
+      border: magma.colors.dataVizBlue700,
+      text: magma.colors.dataVizBlue700,
+    },
+    inverse: {
+      background: magma.colors.dataVizBlue700,
+      border: magma.colors.dataVizBlue500,
+      borderTransparency: 0.5,
+      text: magma.colors.dataVizBlue200,
+    },
+  },
+  {
+    color: TagColor.teal,
+    label: 'teal',
+    light: {
+      background: magma.colors.dataVizTeal400,
+      backgroundTransparency: 0.85,
+      border: magma.colors.dataVizTeal700,
+      text: magma.colors.dataVizTeal700,
+    },
+    inverse: {
+      background: magma.colors.dataVizTeal700,
+      border: magma.colors.dataVizTeal500,
+      borderTransparency: 0.3,
+      text: magma.colors.dataVizTeal200,
+    },
+  },
+  {
+    color: TagColor.pink,
+    label: 'pink',
+    light: {
+      background: magma.colors.dataVizPink200,
+      border: magma.colors.dataVizPink700,
+      text: magma.colors.dataVizPink700,
+    },
+    inverse: {
+      background: magma.colors.dataVizPink700,
+      border: magma.colors.dataVizPink500,
+      borderTransparency: 0.3,
+      text: magma.colors.dataVizPink200,
+    },
+  },
+  {
+    color: TagColor.purple,
+    label: 'purple',
+    light: {
+      background: magma.colors.dataVizPurple200,
+      border: magma.colors.dataVizPurple700,
+      text: magma.colors.dataVizPurple700,
+    },
+    inverse: {
+      background: magma.colors.dataVizPurple700,
+      border: magma.colors.dataVizPurple500,
+      borderTransparency: 0.3,
+      text: magma.colors.dataVizPurple200,
+    },
+  },
+];
 
 describe('Tag', () => {
   it('should render the tag', () => {
@@ -47,14 +111,27 @@ describe('Tag', () => {
       const { getByText } = render(<Tag>{TEXT}</Tag>);
       const tag = getByText('Text Label').parentElement;
 
-      expect(tag).toHaveStyleRule('background', magma.colors.neutral300);
+      expect(tag).toHaveStyleRule(
+        'background',
+        transparentize(0.6, magma.colors.neutral300)
+      );
+      expect(tag).toHaveStyleRule(
+        'border',
+        `1px solid ${magma.colors.neutral300}`
+      );
+      expect(tag).toHaveStyleRule('box-sizing', 'border-box');
     });
 
     it('Should render a Tag with a primary background', () => {
       const { getByText } = render(<Tag color={TagColor.primary}>{TEXT}</Tag>);
       const tag = getByText('Text Label').parentElement;
 
-      expect(tag).toHaveStyleRule('background', magma.colors.primary);
+      expect(tag).toHaveStyleRule('background', magma.colors.primary100);
+      expect(tag).toHaveStyleRule('color', magma.colors.primary500);
+      expect(tag).toHaveStyleRule(
+        'border',
+        `1px solid ${transparentize(0.85, magma.colors.primary500)}`
+      );
     });
 
     it('Should render a Tag with a high contrast background', () => {
@@ -73,6 +150,27 @@ describe('Tag', () => {
       const tag = getByText('Text Label').parentElement;
 
       expect(tag).toHaveStyleRule('background', magma.colors.neutral100);
+      expect(tag).toHaveStyleRule(
+        'border',
+        `1px solid ${magma.colors.neutral300}`
+      );
+    });
+
+    DATA_VIZ_TAG_COLORS.forEach(({ color, label, light }) => {
+      it(`Should render a ${label} Tag`, () => {
+        const { getByText } = render(<Tag color={color}>{TEXT}</Tag>);
+        const tag = getByText('Text Label').parentElement;
+
+        expect(tag).toHaveStyleRule(
+          'background',
+          transparentize(light.backgroundTransparency || 0.6, light.background)
+        );
+        expect(tag).toHaveStyleRule('color', light.text);
+        expect(tag).toHaveStyleRule(
+          'border',
+          `1px solid ${transparentize(0.85, light.border)}`
+        );
+      });
     });
   });
 
@@ -129,8 +227,8 @@ describe('Tag', () => {
 
       expect(tag).toHaveStyleRule('background', magma.colors.neutral100);
       expect(tag).toHaveStyleRule(
-        'box-shadow',
-        `0 0 0 1px ${magma.colors.neutral300}`
+        'border',
+        `1px solid ${magma.colors.neutral300}`
       );
     });
   });
@@ -188,8 +286,8 @@ describe('Tag', () => {
 
       expect(tag).toHaveStyleRule('background', 'none');
       expect(tag).toHaveStyleRule(
-        'box-shadow',
-        `0 0 0 1px ${transparentize(0.8, magma.colors.neutral100)}`
+        'border',
+        `1px solid ${transparentize(0.8, magma.colors.neutral100)}`
       );
     });
   });
@@ -199,7 +297,14 @@ describe('Tag', () => {
       const { getByText } = render(<Tag isInverse>{TEXT}</Tag>);
       const tag = getByText('Text Label').parentElement;
 
-      expect(tag).toHaveStyleRule('background', magma.colors.neutral);
+      expect(tag).toHaveStyleRule(
+        'background',
+        transparentize(0.5, magma.colors.neutral900)
+      );
+      expect(tag).toHaveStyleRule(
+        'border',
+        `1px solid ${transparentize(0.7, magma.colors.neutral100)}`
+      );
     });
 
     it('Should render a inverse Tag with a primary background', () => {
@@ -210,7 +315,15 @@ describe('Tag', () => {
       );
       const tag = getByText('Text Label').parentElement;
 
-      expect(tag).toHaveStyleRule('background', magma.colors.tertiary500);
+      expect(tag).toHaveStyleRule(
+        'background',
+        transparentize(0.2, magma.colors.primary500)
+      );
+      expect(tag).toHaveStyleRule('color', magma.colors.primary100);
+      expect(tag).toHaveStyleRule(
+        'border',
+        `1px solid ${magma.colors.primary400}`
+      );
     });
 
     it('Should render a inverse Tag with a high contrast background', () => {
@@ -233,6 +346,35 @@ describe('Tag', () => {
       const tag = getByText('Text Label').parentElement;
 
       expect(tag).toHaveStyleRule('background', 'none');
+      expect(tag).toHaveStyleRule('color', magma.colors.neutral100);
+      expect(tag).toHaveStyleRule(
+        'border',
+        `1px solid ${transparentize(0.7, magma.colors.neutral100)}`
+      );
+    });
+
+    DATA_VIZ_TAG_COLORS.forEach(({ color, label, inverse }) => {
+      it(`Should render an inverse ${label} Tag`, () => {
+        const { getByText } = render(
+          <Tag color={color} isInverse>
+            {TEXT}
+          </Tag>
+        );
+        const tag = getByText('Text Label').parentElement;
+
+        expect(tag).toHaveStyleRule(
+          'background',
+          transparentize(0.5, inverse.background)
+        );
+        expect(tag).toHaveStyleRule('color', inverse.text);
+        expect(tag).toHaveStyleRule(
+          'border',
+          `1px solid ${transparentize(
+            inverse.borderTransparency,
+            inverse.border
+          )}`
+        );
+      });
     });
   });
 
@@ -246,6 +388,7 @@ describe('Tag', () => {
       const tag = getByText('Text Label').parentElement;
 
       expect(tag).toHaveStyleRule('padding', `0 ${magma.spaceScale.spacing02}`);
+      expect(tag).toHaveStyleRule('height', magma.spaceScale.spacing06);
     });
 
     it('Should render a small Tag size with an icon', () => {
@@ -257,6 +400,7 @@ describe('Tag', () => {
       const tag = getByText('Text Label').parentElement;
 
       expect(tag).toHaveStyleRule('padding', `0 ${magma.spaceScale.spacing02}`);
+      expect(tag).toHaveStyleRule('height', magma.spaceScale.spacing06);
     });
 
     it('Should render a medium Tag size with an icon', () => {
@@ -271,6 +415,8 @@ describe('Tag', () => {
         'padding',
         `${magma.spaceScale.spacing02} 6px`
       );
+      expect(tag).toHaveStyleRule('height', magma.spaceScale.spacing08);
+      expect(tag).toHaveStyleRule('font-weight', '500');
     });
   });
 
@@ -339,6 +485,23 @@ describe('Tag', () => {
 
       fireEvent.click(tag);
       expect(onTagDelete).toHaveBeenCalled();
+    });
+
+    it('Should render the close icon with the tag text color', () => {
+      const onTagDelete = jest.fn();
+      const { getByTestId } = render(
+        <Tag onDelete={onTagDelete} testId={testId}>
+          {TEXT}
+        </Tag>
+      );
+      const tag = getByTestId(testId);
+
+      expect(tag).toHaveStyleRule('color', 'currentColor', {
+        target: 'svg:last-child',
+      });
+      expect(tag).toHaveStyleRule('opacity', 'inherit', {
+        target: 'svg:last-child',
+      });
     });
 
     it('Should have a focus state', () => {

--- a/packages/react-magma-dom/src/components/Tag/Tag.tsx
+++ b/packages/react-magma-dom/src/components/Tag/Tag.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { transparentize } from 'polished';
-import { CancelIcon, IconProps } from 'react-magma-icons';
+import { CloseIcon, IconProps } from 'react-magma-icons';
 
 import { I18nContext } from '../../i18n';
 import { useIsInverse } from '../../inverse';
@@ -16,6 +16,10 @@ export enum TagColor {
   primary = 'primary',
   lowContrast = 'lowContrast',
   highContrast = 'highContrast',
+  blue = 'blue',
+  teal = 'teal',
+  pink = 'pink',
+  purple = 'purple',
 }
 
 export enum TagSize {
@@ -84,27 +88,122 @@ export interface ClickableTagProps extends BaseTagProps {
 
 export type TagProps = XOR<DeletableTagProps, ClickableTagProps>;
 
-function buildBoxShadow(props) {
-  if (props.color === 'lowContrast') {
-    if (props.isInverse) {
-      if (props.disabled) {
-        return `0 0 0 1px ${transparentize(
+function getDataVizTagColor(props) {
+  switch (props.color) {
+    case TagColor.blue:
+      return {
+        background: props.theme.colors.dataVizBlue200,
+        border: props.theme.colors.dataVizBlue700,
+        text: props.theme.colors.dataVizBlue700,
+        inverseBackground: props.theme.colors.dataVizBlue700,
+        inverseBorder: props.theme.colors.dataVizBlue500,
+        inverseBorderTransparency: 0.5,
+        inverseText: props.theme.colors.dataVizBlue200,
+      };
+    case TagColor.teal:
+      return {
+        background: props.theme.colors.dataVizTeal400,
+        backgroundTransparency: 0.85,
+        border: props.theme.colors.dataVizTeal700,
+        text: props.theme.colors.dataVizTeal700,
+        inverseBackground: props.theme.colors.dataVizTeal700,
+        inverseBorder: props.theme.colors.dataVizTeal500,
+        inverseBorderTransparency: 0.3,
+        inverseText: props.theme.colors.dataVizTeal200,
+      };
+    case TagColor.pink:
+      return {
+        background: props.theme.colors.dataVizPink200,
+        border: props.theme.colors.dataVizPink700,
+        text: props.theme.colors.dataVizPink700,
+        inverseBackground: props.theme.colors.dataVizPink700,
+        inverseBorder: props.theme.colors.dataVizPink500,
+        inverseBorderTransparency: 0.3,
+        inverseText: props.theme.colors.dataVizPink200,
+      };
+    case TagColor.purple:
+      return {
+        background: props.theme.colors.dataVizPurple200,
+        border: props.theme.colors.dataVizPurple700,
+        text: props.theme.colors.dataVizPurple700,
+        inverseBackground: props.theme.colors.dataVizPurple700,
+        inverseBorder: props.theme.colors.dataVizPurple500,
+        inverseBorderTransparency: 0.3,
+        inverseText: props.theme.colors.dataVizPurple200,
+      };
+    default:
+      return null;
+  }
+}
+
+function buildBorder(props) {
+  const dataVizColor = getDataVizTagColor(props);
+  const isDefaultColor = !props.color || props.color === TagColor.default;
+
+  if (props.disabled) {
+    if (props.color === TagColor.lowContrast) {
+      if (props.isInverse) {
+        return `1px solid ${transparentize(
           0.8,
           props.theme.colors.neutral100
         )}`;
       }
 
-      return `0 0 0 1px ${transparentize(0.5, props.theme.colors.neutral100)}`;
-    }
-    if (props.disabled) {
-      return `0 0 0 1px ${props.theme.colors.neutral300}`;
+      return `1px solid ${props.theme.colors.neutral300}`;
     }
 
-    return `inset 0 0 0  1px ${props.theme.colors.neutral400}`;
+    if (isDefaultColor) {
+      if (props.isInverse) {
+        return `1px solid ${transparentize(0.8, props.theme.colors.neutral100)}`;
+      }
+
+      return `1px solid ${props.theme.colors.neutral300}`;
+    }
+
+    return `1px solid transparent`;
   }
+
+  if (dataVizColor) {
+    if (props.isInverse) {
+      return `1px solid ${transparentize(
+        dataVizColor.inverseBorderTransparency,
+        dataVizColor.inverseBorder
+      )}`;
+    }
+
+    return `1px solid ${transparentize(0.85, dataVizColor.border)}`;
+  }
+
+  if (props.color === TagColor.primary) {
+    if (props.isInverse) {
+      return `1px solid ${props.theme.colors.primary400}`;
+    }
+
+    return `1px solid ${transparentize(0.85, props.theme.colors.primary500)}`;
+  }
+
+  if (isDefaultColor) {
+    if (props.isInverse) {
+      return `1px solid ${transparentize(0.7, props.theme.colors.neutral100)}`;
+    }
+
+    return `1px solid ${props.theme.colors.neutral300}`;
+  }
+
+  if (props.color === TagColor.lowContrast) {
+    if (props.isInverse) {
+      return `1px solid ${transparentize(0.7, props.theme.colors.neutral100)}`;
+    }
+
+    return `1px solid ${props.theme.colors.neutral300}`;
+  }
+
+  return `1px solid transparent`;
 }
 
 function buildButtonBackground(props) {
+  const dataVizColor = getDataVizTagColor(props);
+
   if (props.isInverse) {
     if (props.disabled) {
       // Disabled inverse state background colors
@@ -119,15 +218,19 @@ function buildButtonBackground(props) {
       }
     }
     // Inverse background colors
+    if (dataVizColor) {
+      return transparentize(0.5, dataVizColor.inverseBackground);
+    }
+
     switch (props.color) {
       case 'primary':
-        return props.theme.colors.tertiary500;
+        return transparentize(0.2, props.theme.colors.primary500);
       case 'lowContrast':
         return `none;`;
       case 'highContrast':
         return props.theme.colors.neutral100;
       default:
-        return props.theme.colors.neutral500;
+        return transparentize(0.5, props.theme.colors.neutral900);
     }
   } else if (props.disabled && !props.isInverse) {
     // Disabled state background colors
@@ -142,19 +245,28 @@ function buildButtonBackground(props) {
     }
   }
   // Default state background colors
+  if (dataVizColor) {
+    return transparentize(
+      dataVizColor.backgroundTransparency || 0.6,
+      dataVizColor.background
+    );
+  }
+
   switch (props.color) {
     case 'primary':
-      return props.theme.colors.primary;
+      return props.theme.colors.primary100;
     case 'lowContrast':
       return props.theme.colors.neutral100;
     case 'highContrast':
       return props.theme.colors.neutral700;
     default:
-      return props.theme.colors.neutral300;
+      return transparentize(0.6, props.theme.colors.neutral300);
   }
 }
 
 function buildButtonTextColor(props) {
+  const dataVizColor = getDataVizTagColor(props);
+
   if (props.isInverse) {
     if (props.disabled) {
       // Disabled inverse state text colors
@@ -171,11 +283,15 @@ function buildButtonTextColor(props) {
       }
     }
     // Inverse text colors
+    if (dataVizColor) {
+      return dataVizColor.inverseText;
+    }
+
     switch (props.color) {
       case 'primary':
-        return props.theme.colors.primary600;
+        return props.theme.colors.primary100;
       case 'lowContrast':
-        return props.theme.colors.tertiary500;
+        return props.theme.colors.neutral100;
       case 'highContrast':
         return props.theme.colors.neutral700;
       default:
@@ -186,9 +302,13 @@ function buildButtonTextColor(props) {
     return transparentize(0.4, props.theme.colors.neutral500);
   }
   // Default state text colors
+  if (dataVizColor) {
+    return dataVizColor.text;
+  }
+
   switch (props.color) {
     case 'primary':
-      return props.theme.colors.neutral100;
+      return props.theme.colors.primary500;
     case 'highContrast':
       return props.theme.colors.neutral100;
     case 'lowContrast':
@@ -262,11 +382,11 @@ function buildLabelPadding(props) {
 }
 
 const TagStyling = props => css`
-  border: ${props.theme.tag.border};
+  border: ${buildBorder(props)};
   border-radius: ${props.theme.spaceScale.spacing05};
+  box-sizing: border-box;
   background: ${buildButtonBackground(props)};
   color: ${buildButtonTextColor(props)};
-  box-shadow: ${buildBoxShadow(props)};
   font-family: ${props.theme.bodyFont};
   display: ${props.theme.tag.display};
   align-items: ${props.theme.tag.alignItems};
@@ -274,10 +394,13 @@ const TagStyling = props => css`
   font-size: ${props.size === 'small'
     ? `${props.theme.typeScale.size01.fontSize}`
     : `${props.theme.typeScale.size02.fontSize}`};
-  font-weight: ${props.size === 'small' ? `500` : `inherit`};
+  font-weight: 500;
   letter-spacing: ${props.size === 'small'
     ? `${props.theme.typeScale.size01.letterSpacing}`
     : `${props.theme.typeScale.size02.letterSpacing}`};
+  height: ${props.size === 'small'
+    ? props.theme.spaceScale.spacing06
+    : props.theme.spaceScale.spacing08};
   min-width: ${props.size === 'small'
     ? props.theme.spaceScale.spacing10
     : props.theme.spaceScale.spacing12};
@@ -292,7 +415,8 @@ const TagStyling = props => css`
       : `${props.theme.iconSizes.small}px`};
   }
   svg:last-child {
-    opacity: ${buildSvgOpacity(props)};
+    color: currentColor;
+    opacity: inherit;
     width: ${props.size === 'small'
       ? `${props.theme.iconSizes.xSmall}px`
       : `${props.theme.iconSizes.small}px`};
@@ -393,7 +517,7 @@ export const Tag = React.forwardRef<HTMLButtonElement, TagProps>(
         <LabelWrap size={size} theme={theme} {...rest}>
           {children}
         </LabelWrap>
-        {onDelete && <CancelIcon size={theme.iconSizes.small} />}
+        {onDelete && <CloseIcon size={theme.iconSizes.small} />}
       </StyledTag>
     );
   }

--- a/packages/react-magma-dom/src/theme/magma.ts
+++ b/packages/react-magma-dom/src/theme/magma.ts
@@ -67,6 +67,36 @@ export interface Colors {
   success600: string;
   success700: string;
 
+  dataVizBlue200: string;
+  dataVizBlue400: string;
+  dataVizBlue500: string;
+  dataVizBlue700: string;
+
+  dataVizPink200: string;
+  dataVizPink400: string;
+  dataVizPink500: string;
+  dataVizPink700: string;
+
+  dataVizGreen200: string;
+  dataVizGreen400: string;
+  dataVizGreen500: string;
+  dataVizGreen700: string;
+
+  dataVizOrange200: string;
+  dataVizOrange400: string;
+  dataVizOrange500: string;
+  dataVizOrange700: string;
+
+  dataVizPurple200: string;
+  dataVizPurple400: string;
+  dataVizPurple500: string;
+  dataVizPurple700: string;
+
+  dataVizTeal200: string;
+  dataVizTeal400: string;
+  dataVizTeal500: string;
+  dataVizTeal700: string;
+
   focus: string;
   focusInverse: string;
 
@@ -468,6 +498,38 @@ const successColors = {
   success700: '#0F5323',
 };
 
+const dataVizColors = {
+  dataVizBlue200: '#85D4FF',
+  dataVizBlue400: '#1FB0FF',
+  dataVizBlue500: '#009AF3',
+  dataVizBlue700: '#005F96',
+
+  dataVizPink200: '#FF99BD',
+  dataVizPink400: '#FF337A',
+  dataVizPink500: '#E0004D',
+  dataVizPink700: '#8F0033',
+
+  dataVizGreen200: '#C7FF99',
+  dataVizGreen400: '#65E000',
+  dataVizGreen500: '#1EA746',
+  dataVizGreen700: '#136A2D',
+
+  dataVizOrange200: '#FFB685',
+  dataVizOrange400: '#FF9147',
+  dataVizOrange500: '#FA6600',
+  dataVizOrange700: '#B84900',
+
+  dataVizPurple200: '#E9AFE7',
+  dataVizPurple400: '#D45ED0',
+  dataVizPurple500: '#B12FAD',
+  dataVizPurple700: '#711E6E',
+
+  dataVizTeal200: '#99FFF5',
+  dataVizTeal400: '#00E0CA',
+  dataVizTeal500: '#00A393',
+  dataVizTeal700: '#005249',
+};
+
 const colors = {
   primary: primaryColors.primary500,
   secondary: secondaryColors.secondary500,
@@ -485,6 +547,7 @@ const colors = {
   ...dangerColors,
   ...warningColors,
   ...successColors,
+  ...dataVizColors,
 
   focus: infoColors.info500,
   focusInverse: infoColors.info200,

--- a/website/react-magma-docs/src/pages/design-intro/colors.mdx
+++ b/website/react-magma-docs/src/pages/design-intro/colors.mdx
@@ -1232,4 +1232,563 @@ We use green to celebrate success. The success colors are commonly used in the a
   </ColorSwatch>
 </div>
 
+## Data Visualization
+
+Data visualization colors are intended for charts, tags, and other categorical color uses. These colors should be used for distinction across data series, not to communicate semantic states like success, warning, or danger.
+
+<div className="swatch-rows">
+  <ColorSwatch
+    color={magma.colors.dataVizBlue700}
+    passesDarkTest={false}
+    passesLightTest
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizBlue700</p>
+        <p>Data Visualization Blue 700</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizBlue700}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>0,95,150</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizBlue500}
+    passesDarkTest={false}
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizBlue500</p>
+        <p>Data Visualization Blue 500</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizBlue500}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>0,154,243</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizBlue400}
+    passesDarkTest={false}
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizBlue400</p>
+        <p>Data Visualization Blue 400</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizBlue400}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>31,176,255</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizBlue200}
+    passesDarkTest
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizBlue200</p>
+        <p>Data Visualization Blue 200</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizBlue200}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>133,212,255</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizPink700}
+    passesDarkTest={false}
+    passesLightTest
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizPink700</p>
+        <p>Data Visualization Pink 700</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizPink700}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>143,0,51</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizPink500}
+    passesDarkTest={false}
+    passesLightTest
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizPink500</p>
+        <p>Data Visualization Pink 500</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizPink500}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>224,0,77</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizPink400}
+    passesDarkTest={false}
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizPink400</p>
+        <p>Data Visualization Pink 400</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizPink400}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>255,51,122</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizPink200}
+    passesDarkTest
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizPink200</p>
+        <p>Data Visualization Pink 200</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizPink200}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>255,153,189</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizGreen700}
+    passesDarkTest={false}
+    passesLightTest
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizGreen700</p>
+        <p>Data Visualization Green 700</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizGreen700}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>19,106,45</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizGreen500}
+    passesDarkTest={false}
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizGreen500</p>
+        <p>Data Visualization Green 500</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizGreen500}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>30,167,70</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizGreen400}
+    passesDarkTest
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizGreen400</p>
+        <p>Data Visualization Green 400</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizGreen400}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>101,224,0</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizGreen200}
+    passesDarkTest
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizGreen200</p>
+        <p>Data Visualization Green 200</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizGreen200}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>199,255,153</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizOrange700}
+    passesDarkTest={false}
+    passesLightTest
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizOrange700</p>
+        <p>Data Visualization Orange 700</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizOrange700}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>184,73,0</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizOrange500}
+    passesDarkTest={false}
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizOrange500</p>
+        <p>Data Visualization Orange 500</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizOrange500}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>250,102,0</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizOrange400}
+    passesDarkTest={false}
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizOrange400</p>
+        <p>Data Visualization Orange 400</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizOrange400}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>255,145,71</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizOrange200}
+    passesDarkTest
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizOrange200</p>
+        <p>Data Visualization Orange 200</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizOrange200}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>255,182,133</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizPurple700}
+    passesDarkTest={false}
+    passesLightTest
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizPurple700</p>
+        <p>Data Visualization Purple 700</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizPurple700}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>113,30,110</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizPurple500}
+    passesDarkTest={false}
+    passesLightTest
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizPurple500</p>
+        <p>Data Visualization Purple 500</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizPurple500}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>177,47,173</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizPurple400}
+    passesDarkTest={false}
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizPurple400</p>
+        <p>Data Visualization Purple 400</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizPurple400}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>212,94,208</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizPurple200}
+    passesDarkTest
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizPurple200</p>
+        <p>Data Visualization Purple 200</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizPurple200}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>233,175,231</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizTeal700}
+    passesDarkTest={false}
+    passesLightTest
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizTeal700</p>
+        <p>Data Visualization Teal 700</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizTeal700}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>0,82,73</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizTeal500}
+    passesDarkTest={false}
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizTeal500</p>
+        <p>Data Visualization Teal 500</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizTeal500}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>0,163,147</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizTeal400}
+    passesDarkTest
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizTeal400</p>
+        <p>Data Visualization Teal 400</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizTeal400}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>0,224,202</p>
+      </div>
+    </div>
+  </ColorSwatch>
+  <ColorSwatch
+    color={magma.colors.dataVizTeal200}
+    passesDarkTest
+    passesLightTest={false}
+  >
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Name</p>
+        <p>dataVizTeal200</p>
+        <p>Data Visualization Teal 200</p>
+      </div>
+    </div>
+    <div className="color-detail-container">
+      <div className="color-detail">
+        <p className="detail-label">Hex</p>
+        <p className="color-hex">{magma.colors.dataVizTeal200}</p>
+      </div>
+      <div className="color-detail">
+        <p className="detail-label">RGB</p>
+        <p>153,255,245</p>
+      </div>
+    </div>
+  </ColorSwatch>
+</div>
+
 </PageContent>


### PR DESCRIPTION
Summary:

- Adds data visualization color tokens to the theme
- Adds blue, teal, pink, and purple Tag color options
- Updates Tag borders, inverse colors, fixed heights, text weight, and dismiss icon styling
- Updates Storybook examples and Color docs page