### PR TITLE
Revert "fix(Accordion): stop overriding Heading styles inside AccordionPanel (#2600)"

### DIFF
--- a/.changeset/accordion-panel-heading-styles.md
+++ b/.changeset/accordion-panel-heading-styles.md
@@ -1,5 +1,0 @@
----
-'react-magma-dom': patch
----
-
-fix(Accordion): stop overriding Heading styles inside AccordionPanel

--- a/packages/react-magma-dom/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/Accordion.stories.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenuItem,
 } from '../Dropdown';
 import { Flex, FlexBehavior } from '../Flex';
-import { Heading } from '../Heading';
 import { Input } from '../Input';
 import { Modal } from '../Modal';
 import { Select } from '../Select';
@@ -366,25 +365,5 @@ export const WithDropdown = {
   args: {
     isInverse: false,
     isMulti: false,
-  },
-};
-
-export const WithHeadings = {
-  render: (args: any) => (
-    <Accordion {...args}>
-      <AccordionItem>
-        <Heading level={2}>
-          <AccordionButton>Section with heading trigger</AccordionButton>
-        </Heading>
-        <AccordionPanel>
-          <Heading level={3}>Panel heading</Heading>
-          <p>Content for section lorem ipsum.</p>
-        </AccordionPanel>
-      </AccordionItem>
-    </Accordion>
-  ),
-
-  args: {
-    defaultIndex: [0],
   },
 };

--- a/packages/react-magma-dom/src/components/Accordion/Accordion.test.js
+++ b/packages/react-magma-dom/src/components/Accordion/Accordion.test.js
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event';
 
 import { axe } from '../../../axe-helper';
 import { Button } from '../Button';
-import { Heading } from '../Heading';
 
 import { Accordion, AccordionItem, AccordionButton, AccordionPanel } from '.';
 
@@ -69,26 +68,6 @@ describe('Accordion', () => {
     expect(btn).toHaveStyleRule('background', 'transparent');
     expect(panel).toHaveStyleRule('background', 'transparent');
     expect(accordion).toHaveStyleRule('background', 'transparent');
-  });
-
-  it('should not override the styles of a Heading nested inside an AccordionPanel', () => {
-    const { getByTestId } = render(
-      <Accordion defaultIndex={[0]}>
-        <AccordionItem testId="item">
-          <Heading level={2}>
-            <AccordionButton>Section 1</AccordionButton>
-          </Heading>
-          <AccordionPanel>
-            <Heading level={3}>Panel heading</Heading>
-          </AccordionPanel>
-        </AccordionItem>
-      </Accordion>
-    );
-
-    const item = getByTestId('item');
-
-    expect(item).toHaveStyleRule('font', 'inherit', { target: '>h2' });
-    expect(item).not.toHaveStyleRule('font', 'inherit', { target: ' h3' });
   });
 
   it('should render the component a left-aligned icon', () => {

--- a/packages/react-magma-dom/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/AccordionItem.tsx
@@ -23,12 +23,12 @@ export interface AccordionItemProps
 }
 
 const StyledItem = styled.div`
-  & > h1,
-  & > h2,
-  & > h3,
-  & > h4,
-  & > h5,
-  & > h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     background: none;
     color: inherit;
     font: inherit;

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -18,12 +18,12 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -749,12 +749,12 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -1999,12 +1999,12 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -2840,12 +2840,12 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -4247,12 +4247,12 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -5023,12 +5023,12 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -6364,12 +6364,12 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -7140,12 +7140,12 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -8481,12 +8481,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -9322,12 +9322,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -10729,12 +10729,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -11570,12 +11570,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -12977,12 +12977,12 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -13753,12 +13753,12 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding: 0;
 }
 
-.emotion-4>h1,
-.emotion-4>h2,
-.emotion-4>h3,
-.emotion-4>h4,
-.emotion-4>h5,
-.emotion-4>h6 {
+.emotion-4 h1,
+.emotion-4 h2,
+.emotion-4 h3,
+.emotion-4 h4,
+.emotion-4 h5,
+.emotion-4 h6 {
   background: none;
   color: inherit;
   font: inherit;


### PR DESCRIPTION

Closes: #2582

## What I did
This reverts commit 661cf8d61e32d1bbdf6288c1b4383be00a4e6a94 - changes that broke the documentation navigation styles.


## Screenshots
Before revert: 
<img width="257" height="519" alt="Screenshot 2026-08-05 at 15 38 44" src="https://github.com/user-attachments/assets/8e7c22ea-05c6-45cb-9a56-3d790e8c4b79" />

After revert:
<img width="305" height="419" alt="Screenshot 2026-08-05 at 15 39 15" src="https://github.com/user-attachments/assets/57f08dd3-3443-4ee1-9260-32adcab1f782" />


## How to test
Open docs
