### PR TITLE
fix(RadioGroup): use `containerStyle` in docs example

### DIFF
--- a/.changeset/radio-example-style-prop.md
+++ b/.changeset/radio-example-style-prop.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(RadioGroup): use `containerStyle` in docs example

--- a/website/react-magma-docs/src/pages/api/radio.mdx
+++ b/website/react-magma-docs/src/pages/api/radio.mdx
@@ -329,7 +329,7 @@ import { RadioGroup, Radio } from 'react-magma-dom';
 export function Example() {
   return (
     <RadioGroup
-      style={{ border: '2px solid yellow', padding: '10px' }}
+      containerStyle={{ border: '2px solid yellow', padding: '10px' }}
       labelStyle={{ color: 'blue', textTransform: 'uppercase' }}
       labelText="Custom styles"
       id="customGroup"


### PR DESCRIPTION
Closes: #1881

## What I did
Replaced the non-existent style prop with the correct containerStyle prop in the RadioGroup docs example.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes
- [ ] Tests that prove the fix is effective or that the feature works have been added

## How to test

- Open the Radio Button docs.
- Go to the Custom Styles example.
- Verify that the new prop is applied.
- Verify that the custom styles are applied correctly.
