### PR TITLE
fix(docs): prevent doubled padding on MainNav accordion trigger headings

### DIFF
--- a/.changeset/mainnav-accordion-trigger-heading-padding.md
+++ b/.changeset/mainnav-accordion-trigger-heading-padding.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(docs): prevent doubled padding on MainNav accordion trigger headings

--- a/website/react-magma-docs/src/components/MainNav/index.js
+++ b/website/react-magma-docs/src/components/MainNav/index.js
@@ -103,6 +103,20 @@ const Heading2 = styled.h2`
 const StyledAccordionButton = styled(AccordionButton)`
   border-top: 0;
   ${headingStyles};
+  /* Button owns the padding; strip the nested Heading's box so it doesn't double. */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    background: none;
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
+    margin: 0;
+    padding: 0;
+  }
   &:hover {
     ${LinkHoverStyles};
   }


### PR DESCRIPTION
Closes: #2582

## What I did

Fixes the documentation sidebar regression introduced by #2600, without reverting it.

#2600 correctly scoped the `AccordionItem` heading reset to direct-child headings (`& > h1..h6`) so a `<Heading>` inside an `AccordionPanel` keeps its typography (the actual #2582 bug). But it surfaced a latent issue in the docs nav: `MainNav` nests `<Heading2>` **inside** `StyledAccordionButton`, and both the button and that heading apply `headingStyles` (`padding: 8px 18px`). The old unscoped reset was silently zeroing the inner heading's box; once #2600 scoped it, the inner padding stacked on top of the button's, so every accordion trigger grew from 40px to 56px.

The button already owns the padding, so this neutralizes the nested heading's box inside `StyledAccordionButton` — a docs-only change. The nav no longer depends on react-magma's reset at all, so it can't regress again from future changes to that selector. `react-magma-dom` is untouched; #2600 stays as-is.

This supersedes the revert in #2657 (reverting would reintroduce the #2582 panel-heading bug).

Type of change: Bug fix (documentation only, non-breaking).

## Screenshots
Before
<img width="262" height="375" alt="image" src="https://github.com/user-attachments/assets/1e58cadb-6616-4878-9c1c-9580f248a085" />

After
<img width="263" height="369" alt="image" src="https://github.com/user-attachments/assets/2a00128c-d7aa-4455-bd1f-e99b2a010c83" />


## Checklist
- [x] changeset has been added
- [ ] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [ ] New and existing unit tests pass locally with the proposed changes — N/A: `MainNav` has no unit-test harness (docs site); verified by measuring computed styles on the running build (see How to test)
- [ ] Tests that prove the fix is effective or that the feature works have been added — N/A for the same reason; verification is manual/measured

## How to test

Open the docs preview
Optional DevTools check: the `<h2>` inside a trigger `<button>` has computed `padding: 0` (previously `8px 18px`, which made the trigger render taller).

Components affected: docs `MainNav` only. No `react-magma-dom` components changed.
