### PR TITLE
fix(Dropdown): fix expanded and collapsed state announcements

### DIFF
--- a/.changeset/fix-dropdown-state-announcement.md
+++ b/.changeset/fix-dropdown-state-announcement.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Dropdown): fix expanded and collapsed state announcements

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -575,6 +575,60 @@ describe('Dropdown', () => {
     expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
   });
 
+  it('should announce expanded and collapsed states on macOS only', async () => {
+    const originalUserAgent = navigator.userAgent;
+
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15',
+    });
+
+    const { getByText, unmount } = render(
+      <Dropdown>
+        <DropdownButton>Toggle me</DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    );
+
+    expect(getByText('Dropdown menu collapsed')).toBeInTheDocument();
+
+    await userEvent.click(getByText('Toggle me'));
+
+    expect(getByText('Dropdown menu expanded')).toBeInTheDocument();
+
+    await userEvent.click(getByText('Toggle me'));
+
+    expect(getByText('Dropdown menu collapsed')).toBeInTheDocument();
+
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36',
+    });
+
+    unmount();
+
+    const { queryByText } = render(
+      <Dropdown>
+        <DropdownButton>Toggle me</DropdownButton>
+        <DropdownContent>
+          <DropdownMenuItem>Menu item</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    );
+
+    expect(queryByText('Dropdown menu collapsed')).toBeNull();
+    expect(queryByText('Dropdown menu expanded')).toBeNull();
+
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      value: originalUserAgent,
+    });
+  });
+
   it('go to the first or next item when the down arrow key is pressed', async () => {
     const { getByText, getByTestId } = render(
       <Dropdown testId="dropdown">

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -12,6 +12,8 @@ import {
 import { ReferenceType } from '@floating-ui/react-dom/dist/floating-ui.react-dom';
 
 import { useDescendants } from '../../hooks/useDescendants';
+import { useDeviceDetect } from '../../hooks/useDeviceDetect';
+import { I18nContext } from '../../i18n';
 import { useIsInverse } from '../../inverse';
 import {
   isElementInteractive,
@@ -19,7 +21,9 @@ import {
   useForkedRef,
   useGenerateId,
 } from '../../utils';
+import { Announce } from '../Announce';
 import { ButtonGroupContext } from '../ButtonGroup';
+import { VisuallyHidden } from '../VisuallyHidden';
 
 export enum DropdownDropDirection {
   down = 'down', //default
@@ -150,6 +154,8 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
     const dropdownButtonId = React.useRef<string>('');
 
     const ref = useForkedRef(forwardedRef, ownRef);
+    const i18n = React.useContext(I18nContext);
+    const { isMacOS } = useDeviceDetect();
 
     const [itemRefArray, registerDropdownMenuItem] = useDescendants();
 
@@ -371,6 +377,15 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
           onKeyDown={isOpen ? handleKeyDown : null}
           onBlur={handleDropdownBlur}
         >
+          {isMacOS && (
+            <VisuallyHidden>
+              <Announce>
+                {isOpen
+                  ? i18n.dropdown.expandedAnnounce
+                  : i18n.dropdown.collapsedAnnounce}
+              </Announce>
+            </VisuallyHidden>
+          )}
           {children}
         </Container>
       </DropdownContext.Provider>

--- a/packages/react-magma-dom/src/i18n/default.ts
+++ b/packages/react-magma-dom/src/i18n/default.ts
@@ -167,6 +167,8 @@ export const defaultI18n: I18nInterface = {
   },
   dateTimePickerLabel: 'Pick a date and time',
   dropdown: {
+    expandedAnnounce: 'Dropdown menu expanded',
+    collapsedAnnounce: 'Dropdown menu collapsed',
     toggleMenuAriaLabel: 'Toggle menu',
   },
   dropzone: {

--- a/packages/react-magma-dom/src/i18n/interface.ts
+++ b/packages/react-magma-dom/src/i18n/interface.ts
@@ -183,6 +183,8 @@ export interface I18nInterface {
   };
   dateTimePickerLabel: string;
   dropdown: {
+    expandedAnnounce: string;
+    collapsedAnnounce: string;
     toggleMenuAriaLabel: string;
   };
   dropzone: {


### PR DESCRIPTION
Closes: #2563

## What I did
Fix the announcement for the Dropdown state on Mac, using a similar solution to the Select component with an additional announcement for VoiceOver.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. Open Storybook.
2. Open any Select example.
3. Turn on VoiceOver.
4. Check the announcement.