### PR TITLE
fix(Accordion): stop overriding Heading styles inside AccordionPanel (v4 backport of #2600 + #2661)

### DIFF
--- a/.changeset/accordion-panel-heading-styles.md
+++ b/.changeset/accordion-panel-heading-styles.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Accordion): stop overriding Heading styles inside AccordionPanel

--- a/.changeset/mainnav-accordion-trigger-heading-padding.md
+++ b/.changeset/mainnav-accordion-trigger-heading-padding.md
@@ -1,0 +1,5 @@
+---
+'react-magma-docs': patch
+---
+
+fix(docs): prevent doubled padding on MainNav accordion trigger headings

--- a/packages/react-magma-dom/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/Accordion.stories.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuItem,
 } from '../Dropdown';
 import { Flex, FlexBehavior } from '../Flex';
+import { Heading } from '../Heading';
 import { Input } from '../Input';
 import { Modal } from '../Modal';
 import { Select } from '../Select';
@@ -367,5 +368,25 @@ export const WithDropdown = {
   args: {
     isInverse: false,
     isMulti: false,
+  },
+};
+
+export const WithHeadings = {
+  render: (args: any) => (
+    <Accordion {...args}>
+      <AccordionItem>
+        <Heading level={2}>
+          <AccordionButton>Section with heading trigger</AccordionButton>
+        </Heading>
+        <AccordionPanel>
+          <Heading level={3}>Panel heading</Heading>
+          <p>Content for section lorem ipsum.</p>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  ),
+
+  args: {
+    defaultIndex: [0],
   },
 };

--- a/packages/react-magma-dom/src/components/Accordion/Accordion.test.js
+++ b/packages/react-magma-dom/src/components/Accordion/Accordion.test.js
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { axe } from '../../../axe-helper';
 import { magma } from '../../theme/magma';
 import { Button } from '../Button';
+import { Heading } from '../Heading';
 
 import { Accordion, AccordionItem, AccordionButton, AccordionPanel } from '.';
 
@@ -82,6 +83,26 @@ describe('Accordion', () => {
     expect(btn).toHaveStyleRule('background', 'transparent');
     expect(panel).toHaveStyleRule('background', 'transparent');
     expect(accordion).toHaveStyleRule('background', 'transparent');
+  });
+
+  it('should not override the styles of a Heading nested inside an AccordionPanel', () => {
+    const { getByTestId } = render(
+      <Accordion defaultIndex={[0]}>
+        <AccordionItem testId="item">
+          <Heading level={2}>
+            <AccordionButton>Section 1</AccordionButton>
+          </Heading>
+          <AccordionPanel>
+            <Heading level={3}>Panel heading</Heading>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    const item = getByTestId('item');
+
+    expect(item).toHaveStyleRule('font', 'inherit', { target: '>h2' });
+    expect(item).not.toHaveStyleRule('font', 'inherit', { target: ' h3' });
   });
 
   it('should render the component a left-aligned icon', () => {

--- a/packages/react-magma-dom/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react-magma-dom/src/components/Accordion/AccordionItem.tsx
@@ -22,12 +22,12 @@ export interface AccordionItemProps
 }
 
 const StyledItem = styled.div`
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
+  & > h1,
+  & > h2,
+  & > h3,
+  & > h4,
+  & > h5,
+  & > h6 {
     background: none;
     color: inherit;
     font: inherit;

--- a/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/react-magma-dom/src/components/TreeView/__snapshots__/TreeView.test.js.snap
@@ -18,12 +18,12 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -749,12 +749,12 @@ exports[`TreeView tree with hidden items can uncheck all items by clicking on th
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -1999,12 +1999,12 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -2840,12 +2840,12 @@ exports[`TreeView tree with hidden items clicking show all displays the rest of 
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -4247,12 +4247,12 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -5023,12 +5023,12 @@ exports[`TreeView tree with hidden items expand all and collapse all should work
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -6364,12 +6364,12 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -7140,12 +7140,12 @@ exports[`TreeView tree with hidden items expand all should work correctly with d
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -8481,12 +8481,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -9322,12 +9322,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -10729,12 +10729,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -11570,12 +11570,12 @@ exports[`TreeView tree with hidden items renders tree with some items preselecte
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -12977,12 +12977,12 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;
@@ -13753,12 +13753,12 @@ exports[`TreeView tree with hidden items renders tree with some items, and click
   padding: 0;
 }
 
-.emotion-4 h1,
-.emotion-4 h2,
-.emotion-4 h3,
-.emotion-4 h4,
-.emotion-4 h5,
-.emotion-4 h6 {
+.emotion-4>h1,
+.emotion-4>h2,
+.emotion-4>h3,
+.emotion-4>h4,
+.emotion-4>h5,
+.emotion-4>h6 {
   background: none;
   color: inherit;
   font: inherit;

--- a/website/react-magma-docs/src/components/MainNav/index.js
+++ b/website/react-magma-docs/src/components/MainNav/index.js
@@ -103,6 +103,20 @@ const Heading2 = styled.h2`
 const StyledAccordionButton = styled(AccordionButton)`
   border-top: 0;
   ${headingStyles};
+  /* Button owns the padding; strip the nested Heading's box so it doesn't double. */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    background: none;
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
+    margin: 0;
+    padding: 0;
+  }
   &:hover {
     ${LinkHoverStyles};
   }


### PR DESCRIPTION
Closes: #2582

## What I did

Backported two upstream fixes to the **v4** track as a single PR — [#2600](https://github.com/cengage/react-magma/pull/2600) and [#2661](https://github.com/cengage/react-magma/pull/2661). They ship together because the second repairs a regression introduced by the first.

**1. `fix(Accordion)`: stop overriding Heading styles inside AccordionPanel** — `react-magma-dom`

`AccordionItem` used an unscoped descendant selector, so its heading reset leaked into *any* `<Heading>` placed inside an `AccordionPanel`, stripping that content's typography. The reset is now scoped to direct children:

```diff
-  h1, h2, h3, h4, h5, h6 {
+  & > h1, & > h2, & > h3, & > h4, & > h5, & > h6 {
```

The trigger heading (a direct child) still inherits button styles as documented; headings in panel content keep their own typography.

**2. `fix(docs)`: prevent doubled padding on MainNav accordion trigger headings** — `react-magma-docs`

`MainNav` renders a `<Heading2>` inside `StyledAccordionButton`, and both apply `padding: 8px 18px`. Once the reset above no longer reached the inner heading, that padding stacked and trigger height grew **40px → 56px**. The nested heading's box is now neutralized in the docs' own styles, so the nav no longer depends on `react-magma-dom`'s reset and can't regress from future changes to it.

**Type of change:** Bug fix (non-breaking change which fixes an issue) — one library fix plus one documentation-only fix.

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. **Storybook → Accordion → WithHeadings** — headings inside `AccordionPanel` render with normal heading typography; the trigger heading keeps button styling.
2. **Docs preview → sidebar** — expand/collapse top-level nav sections; trigger height stays **40px**, not 56px.
3. **Regression check** — the trigger heading still inherits button color, font, and hover/focus states.

**Edge cases**
- Multiple headings nested at different depths inside a single `AccordionPanel`.
- `AccordionItem` with no heading in its panel (unchanged behavior).
- Inverse / dark-surface accordions — the change is selector-scoping only, no color logic.

**Components affected**
- `Accordion` / `AccordionItem` (`react-magma-dom`) — public API; narrows a style reset, no export, prop, type, or DOM changes.
- `TreeView` — snapshot-only churn from the selector change, no behavioral change.
- `MainNav` (`react-magma-docs`) — docs site only.
