### PR TITLE
feat(Dropdown): add apiRef prop to control the dropdown state (#2648)

### DIFF
--- a/.changeset/feat-dropdown-api-ref.md
+++ b/.changeset/feat-dropdown-api-ref.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+feat(Dropdown): add `apiRef` prop to open and close the dropdown programmatically

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.stories.tsx
@@ -37,6 +37,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../Popover';
 import {
   Dropdown,
   DropdownAlignment,
+  DropdownApi,
   DropdownDropDirection,
   DropdownProps,
 } from './index';
@@ -1088,6 +1089,43 @@ export const DropdownExpandableMenuWithSorting = {
         ))}
       </div>
     );
+  },
+};
+
+const ApiRefTemplate: StoryFn<DropdownProps> = args => {
+  const dropdownApiRef = React.useRef<DropdownApi>();
+
+  function handleContentKeyDown(event: React.KeyboardEvent) {
+    const isCloseCombo = event.altKey && event.key === 'ArrowUp';
+
+    if (!isCloseCombo) {
+      return;
+    }
+
+    event.stopPropagation();
+    dropdownApiRef.current?.closeDropdownManually(event);
+  }
+
+  return (
+    <div style={{ margin: '150px auto', textAlign: 'center' }}>
+      <Paragraph>Open the dropdown, then press Alt + ArrowUp.</Paragraph>
+      <Spacer size={16} />
+      <Dropdown {...args} apiRef={dropdownApiRef}>
+        <DropdownButton>Dropdown with apiRef</DropdownButton>
+        <DropdownContent onKeyDown={handleContentKeyDown}>
+          <DropdownMenuItem>Menu item 1</DropdownMenuItem>
+          <DropdownMenuItem>Menu item number two</DropdownMenuItem>
+        </DropdownContent>
+      </Dropdown>
+    </div>
+  );
+};
+
+export const ApiRef = {
+  render: ApiRefTemplate,
+
+  args: {
+    ...Default.args,
   },
 };
 

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.test.js
@@ -1665,4 +1665,96 @@ describe('Dropdown', () => {
       expect.objectContaining({ key: 'Escape' })
     );
   });
+
+  describe('apiRef', () => {
+    const ApiRefDropdown = ({ onClose, onOpen }) => {
+      const apiRef = React.useRef();
+
+      function handleContentKeyDown(event) {
+        if (event.key === 'x') {
+          event.stopPropagation();
+          apiRef.current.closeDropdownManually(event);
+        }
+      }
+
+      return (
+        <>
+          <button
+            data-testid="outsideButton"
+            onClick={() => apiRef.current.openDropdownManually()}
+          >
+            Open from outside
+          </button>
+          <Dropdown apiRef={apiRef} onClose={onClose} onOpen={onOpen}>
+            <DropdownButton testId="dropdownButton">Toggle me</DropdownButton>
+            <DropdownContent onKeyDown={handleContentKeyDown}>
+              <DropdownMenuItem>Menu item</DropdownMenuItem>
+            </DropdownContent>
+          </Dropdown>
+        </>
+      );
+    };
+
+    it('should close the dropdown from a custom keydown handler', async () => {
+      const onClose = jest.fn();
+
+      const { getByTestId } = render(<ApiRefDropdown onClose={onClose} />);
+
+      await userEvent.click(getByTestId('dropdownButton'));
+      expect(getByTestId('dropdownContent')).toHaveStyleRule(
+        'display',
+        'block'
+      );
+
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('x');
+
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('should return focus to the toggle button when closed from inside the dropdown', async () => {
+      const { getByTestId } = render(<ApiRefDropdown />);
+
+      await userEvent.click(getByTestId('dropdownButton'));
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('x');
+
+      expect(getByTestId('dropdownButton')).toHaveFocus();
+    });
+
+    it('should open the dropdown', async () => {
+      const onOpen = jest.fn();
+
+      const { getByTestId } = render(<ApiRefDropdown onOpen={onOpen} />);
+
+      expect(getByTestId('dropdownContent')).toHaveStyleRule('display', 'none');
+
+      await userEvent.click(getByTestId('outsideButton'));
+
+      expect(getByTestId('dropdownContent')).toHaveStyleRule(
+        'display',
+        'block'
+      );
+      expect(onOpen).toHaveBeenCalled();
+    });
+
+    it('should call the current onClose handler and not a stale one', async () => {
+      const firstOnClose = jest.fn();
+      const secondOnClose = jest.fn();
+
+      const { getByTestId, rerender } = render(
+        <ApiRefDropdown onClose={firstOnClose} />
+      );
+
+      rerender(<ApiRefDropdown onClose={secondOnClose} />);
+
+      await userEvent.click(getByTestId('dropdownButton'));
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('x');
+
+      expect(secondOnClose).toHaveBeenCalled();
+      expect(firstOnClose).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-magma-dom/src/components/Dropdown/Dropdown.tsx
@@ -33,6 +33,11 @@ export enum DropdownAlignment {
   end = 'end',
 }
 
+export interface DropdownApi {
+  closeDropdownManually(event: React.SyntheticEvent): void;
+  openDropdownManually(event: React.SyntheticEvent): void;
+}
+
 export interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Index of the item that will active/selected. If none is provided, no item will appear active
@@ -45,6 +50,13 @@ export interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
    * @deprecated = true
    */
   alignment?: DropdownAlignment;
+  /**
+   * The ref object that allows Dropdown manipulation.
+   * Actions available:
+   * closeDropdownManually(event: React.SyntheticEvent): void - Closes the dropdown manually.
+   * openDropdownManually(event: React.SyntheticEvent): void - Opens the dropdown manually.
+   */
+  apiRef?: React.MutableRefObject<DropdownApi | undefined>;
   /**
    * Position of the dropdown content
    * @default DropdownDropDirection.down
@@ -128,6 +140,7 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
     const {
       activeIndex,
       alignment,
+      apiRef,
       children,
       dropDirection,
       maxHeight,
@@ -190,6 +203,27 @@ export const Dropdown = React.forwardRef<HTMLDivElement, DropdownProps>(
 
       onClose && typeof onClose === 'function' && onClose(event);
     }
+
+    React.useEffect(() => {
+      if (apiRef) {
+        apiRef.current = {
+          closeDropdownManually(event) {
+            const hasFocusInside = ownRef.current?.contains(
+              document.activeElement
+            );
+
+            closeDropdown(event);
+
+            if (hasFocusInside) {
+              toggleRef.current?.focus();
+            }
+          },
+          openDropdownManually(event) {
+            openDropdown();
+          },
+        };
+      }
+    });
 
     function getFilteredItem(): [any, number] {
       const filteredItems = itemRefArray.current.filter(

--- a/packages/react-magma-dom/src/index.ts
+++ b/packages/react-magma-dom/src/index.ts
@@ -75,6 +75,7 @@ export {
   DropdownAlignment,
   DropdownDropDirection,
   DropdownProps,
+  DropdownApi,
 } from './components/Dropdown';
 export {
   DropdownContent,


### PR DESCRIPTION
Closes: #2541

## What I did
Following the same approach as Popover, I added an apiRef to control the Dropdown state.


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
Open the Storybook -> API Ref example -> Verify that everything works
