### PR TITLE
fix(Select, MultiSelect): render disabled preselected items as select…

### DIFF
--- a/.changeset/select-disabled-preselected-items.md
+++ b/.changeset/select-disabled-preselected-items.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Select, MultiSelect): render disabled preselected items as selected values

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.stories.tsx
@@ -73,6 +73,27 @@ export const Disabled = {
   },
 };
 
+const DisabledItemsTemplate: StoryFn<NativeSelectProps> = args => (
+  <NativeSelect {...args} defaultValue="red">
+    <option value="red" disabled>
+      Red-Disabled
+    </option>
+    <option value="green">Green</option>
+    <option value="blue">Blue</option>
+    <option value="purple">Purple mountain majesty</option>
+  </NativeSelect>
+);
+
+export const WithDisabledItems = {
+  render: DisabledItemsTemplate,
+
+  args: {
+    isInverse: false,
+    labelText: 'Select with disabled preselected item',
+    testId: 'native-select-disabled-items',
+  },
+};
+
 const WithContentTemplate: StoryFn<NativeSelectProps> = args => {
   const helpLinkLabel = 'Learn more';
   const onHelpLinkClick = () => {

--- a/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
+++ b/packages/react-magma-dom/src/components/NativeSelect/NativeSelect.test.js
@@ -43,6 +43,37 @@ describe('NativeSelect', () => {
     );
   });
 
+  it('should display a disabled option that is preselected via defaultValue', () => {
+    const { getByTestId } = render(
+      <NativeSelect labelText="Colors" testId={testId} defaultValue="red">
+        <option value="red" disabled>
+          Red
+        </option>
+        <option value="blue">Blue</option>
+      </NativeSelect>
+    );
+
+    expect(getByTestId(testId).value).toEqual('red');
+  });
+
+  it('should display a disabled option that is preselected via value (controlled)', () => {
+    const { getByTestId } = render(
+      <NativeSelect
+        labelText="Colors"
+        testId={testId}
+        value="red"
+        onChange={() => {}}
+      >
+        <option value="red" disabled>
+          Red
+        </option>
+        <option value="blue">Blue</option>
+      </NativeSelect>
+    );
+
+    expect(getByTestId(testId).value).toEqual('red');
+  });
+
   it('should render a disabled inverse select', () => {
     const { getByTestId } = render(
       <NativeSelect disabled isInverse testId={testId} />

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.test.js
@@ -278,6 +278,48 @@ describe('MultiSelect', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should render disabled items preselected via initialSelectedItems', () => {
+    const disabledItems = [
+      { label: 'Red', value: 'red', disabled: true },
+      { label: 'Blue', value: 'blue' },
+      { label: 'Green', value: 'green' },
+    ];
+
+    const { getByText } = render(
+      <MultiSelect
+        isMulti
+        labelText={labelText}
+        items={disabledItems}
+        initialSelectedItems={[disabledItems[0]]}
+      />
+    );
+
+    expect(getByText('Red', { selector: 'button' })).toBeInTheDocument();
+  });
+
+  it('should allow removing a disabled preselected item', () => {
+    const disabledItems = [
+      { label: 'Red', value: 'red', disabled: true },
+      { label: 'Blue', value: 'blue' },
+      { label: 'Green', value: 'green' },
+    ];
+
+    const { getByText, queryByText } = render(
+      <MultiSelect
+        isMulti
+        labelText={labelText}
+        items={disabledItems}
+        initialSelectedItems={[disabledItems[0]]}
+      />
+    );
+
+    fireEvent.click(getByText('Red', { selector: 'button' }));
+
+    expect(
+      queryByText('Red', { selector: 'button' })
+    ).not.toBeInTheDocument();
+  });
+
   it('should announce the removal of a selected item', () => {
     const { getByText } = render(
       <MultiSelect

--- a/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
+++ b/packages/react-magma-dom/src/components/Select/MultiSelect.tsx
@@ -74,11 +74,8 @@ export function MultiSelect<T>(props: MultiSelectProps<T>) {
       i => itemToString(i) === itemToString(itemToCheck)
     );
 
-    return (
-      !isItemDisabled(itemToCheck) &&
-      itemIndex !== -1 &&
-      !isItemDisabled(items[itemIndex])
-    );
+    // Only reject items not in the list; disabled items may be preselected values
+    return itemIndex !== -1;
   }
 
   function getFilteredItemIndex(item: T, filteredItems: T[]) {

--- a/packages/react-magma-dom/src/components/Select/Select.test.js
+++ b/packages/react-magma-dom/src/components/Select/Select.test.js
@@ -295,6 +295,92 @@ describe('Select', () => {
     expect(getByTestId('selectedItemText').textContent).not.toEqual('Pink');
   });
 
+  it('should render a disabled item preselected via initialSelectedItem', () => {
+    const disabledItems = [
+      { label: 'Red', value: 'red', disabled: true },
+      { label: 'Blue', value: 'blue' },
+      { label: 'Green', value: 'green' },
+    ];
+
+    const { getByTestId } = render(
+      <Select
+        labelText={labelText}
+        items={disabledItems}
+        initialSelectedItem={disabledItems[0]}
+      />
+    );
+
+    expect(getByTestId('selectedItemText').textContent).toEqual('Red');
+  });
+
+  it('should render a disabled item preselected via selectedItem (controlled)', () => {
+    const disabledItems = [
+      { label: 'Red', value: 'red', disabled: true },
+      { label: 'Blue', value: 'blue' },
+      { label: 'Green', value: 'green' },
+    ];
+
+    const { getByTestId } = render(
+      <Select
+        labelText={labelText}
+        items={disabledItems}
+        selectedItem={disabledItems[0]}
+        onSelectedItemChange={() => {}}
+      />
+    );
+
+    expect(getByTestId('selectedItemText').textContent).toEqual('Red');
+  });
+
+  it('should restore a disabled defaultSelectedItem when cleared', () => {
+    const disabledItems = [
+      { label: 'Red', value: 'red' },
+      { label: 'Blue', value: 'blue', disabled: true },
+      { label: 'Green', value: 'green' },
+    ];
+
+    const { getByTestId } = render(
+      <Select
+        labelText={labelText}
+        items={disabledItems}
+        initialSelectedItem={disabledItems[0]}
+        defaultSelectedItem={disabledItems[1]}
+        isClearable
+      />
+    );
+
+    expect(getByTestId('selectedItemText').textContent).toEqual('Red');
+
+    fireEvent.click(getByTestId('clearIndicator'));
+
+    expect(getByTestId('selectedItemText').textContent).toEqual('Blue');
+  });
+
+  it('should not allow a disabled preselected item to be reselected from the menu', () => {
+    const disabledItems = [
+      { label: 'Red', value: 'red', disabled: true },
+      { label: 'Blue', value: 'blue' },
+      { label: 'Green', value: 'green' },
+    ];
+
+    const { getByLabelText, getByText, getByTestId } = render(
+      <Select
+        labelText={labelText}
+        items={disabledItems}
+        initialSelectedItem={disabledItems[0]}
+      />
+    );
+
+    const renderedSelect = getByLabelText(labelText, { selector: 'div' });
+    fireEvent.click(renderedSelect);
+
+    expect(getByText('Red', { selector: 'li' })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(getByTestId('selectedItemText').textContent).toEqual('Red');
+  });
+
   it('should disable the select', () => {
     const { getByLabelText } = render(
       <Select labelText={labelText} items={items} disabled />

--- a/packages/react-magma-dom/src/components/Select/Select.tsx
+++ b/packages/react-magma-dom/src/components/Select/Select.tsx
@@ -73,11 +73,8 @@ export function Select<T>(props: SelectProps<T>) {
       i => itemToString(i) === itemToString(itemToCheck)
     );
 
-    if (
-      itemIndex === -1 ||
-      isItemDisabled(itemToCheck) ||
-      isItemDisabled(items[itemIndex])
-    ) {
+    // Only reject items not in the list; a disabled item is still a valid selected value
+    if (itemIndex === -1) {
       return { [key]: null };
     }
 

--- a/website/react-magma-docs/src/pages/api/native-select.mdx
+++ b/website/react-magma-docs/src/pages/api/native-select.mdx
@@ -104,6 +104,34 @@ export function Example() {
 }
 ```
 
+## Disabled Items
+
+Add the `disabled` attribute to an individual `<option>` to disable it. A disabled option cannot be chosen from the list and is skipped by keyboard navigation.
+
+A disabled option may still be displayed as the current value when it represents an existing value, such as an archived or no-longer-available option. Preselect it with `value` (controlled) or `defaultValue` (uncontrolled) and it remains shown as selected while staying non-selectable in the list.
+
+```tsx
+import React from 'react';
+
+import { NativeSelect } from 'react-magma-dom';
+
+export function Example() {
+  return (
+    <NativeSelect
+      labelText="Select with disabled preselected item"
+      defaultValue="red"
+      fieldId="example-disabled-items"
+    >
+      <option value="red" disabled>
+        Red-Disabled
+      </option>
+      <option value="green">Green</option>
+      <option value="blue">Blue</option>
+    </NativeSelect>
+  );
+}
+```
+
 ## Error
 
 ```tsx

--- a/website/react-magma-docs/src/pages/api/select.mdx
+++ b/website/react-magma-docs/src/pages/api/select.mdx
@@ -163,9 +163,11 @@ export function Example() {
 
 ## Disabled Items
 
-To disable specific items in the `Select` component, add a `disabled: true` property to each item object. Disabled items specified as `defaultSelectedItem` or `initialSelectedItem` will not be selected by default or initially. If `initialHighlightedIndex` points to a `disabled` item, the component will not highlight it.
+To disable specific items in the `Select` component, add a `disabled: true` property to the item object.
 
-Example:
+Disabled items cannot be selected from the menu and are skipped by keyboard highlight and navigation. If `initialHighlightedIndex` points to a `disabled` item, it will not be highlighted.
+
+A disabled item is still shown as selected when it is a preselected value — via `selectedItem`, `initialSelectedItem`, or `defaultSelectedItem` — so an existing or no-longer-available value stays visible. In `MultiSelect`, a selected disabled item can still be removed.
 
 ```tsx
 import React from 'react';


### PR DESCRIPTION
Closes: #2514

## What I did

Disabled items passed as a **preselected value** are now rendered as the selected value instead of being stripped to the placeholder.

Previously `Select` and `MultiSelect` discarded any disabled item provided via `selectedItem`/`selectedItems`, `initialSelectedItem`/`initialSelectedItems`, or `defaultSelectedItem`/`defaultSelectedItems`, falling back to the placeholder. Now an archived / inactive / no-longer-available option is shown as the current value, while staying non-selectable and skipped by keyboard navigation in the menu. Disabled `MultiSelect` chips remain removable.

- `Select` — `getValidItem` no longer rejects disabled items; it only rejects items not present in the `items` list.
- `MultiSelect` — `checkSelectedItemValidity` mirrors the same change.
- `NativeSelect` — no code change needed (a native `<select>` already displays a disabled option preselected via `value`/`defaultValue`); added a story, tests, and docs to cover it.

**Type of change:** New feature (non-breaking change which adds functionality). Also includes a documentation change.

## Screenshots
`NativeSelect`
<img width="638" height="230" alt="image" src="https://github.com/user-attachments/assets/7b22494d-2951-41fc-a4ce-b2a37fea3726" />
<img width="647" height="189" alt="image" src="https://github.com/user-attachments/assets/28cb5cb4-75fc-4437-89ec-79d0f30c7528" />

`Select`
<img width="553" height="349" alt="image" src="https://github.com/user-attachments/assets/9fbfa1a8-8b25-487b-950a-df4280270837" />
<img width="651" height="362" alt="image" src="https://github.com/user-attachments/assets/a3b81c60-a325-4358-b668-8677411b66bd" />


Visually a disabled preselected value looks like a normal selected value (greyed in the menu). See Storybook:
- `Select` → **WithDisabledItems** / **MultiWithDisabledItems**
- `NativeSelect` → **WithDisabledItems**

## Checklist
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

**Components affected:** `Select`, `MultiSelect` (behavior); `NativeSelect` (docs/story/tests only — behavior unchanged).

**Select**
1. Pass a disabled item as `initialSelectedItem`, `selectedItem`, or `defaultSelectedItem` → the field shows that item, not the placeholder.
2. Open the menu → the disabled item has `aria-disabled="true"`, is skipped by keyboard highlight/navigation, and cannot be clicked/selected.
3. With `isClearable` and a disabled `defaultSelectedItem`: clear the field → the disabled default is restored.

**MultiSelect**
4. Pass a disabled item in `initialSelectedItems`/`selectedItems` → it renders as a chip and can be removed; the disabled option stays non-selectable in the menu.

**NativeSelect**
5. Preselect a disabled `<option>` via `value` (controlled) or `defaultValue` (uncontrolled) → it displays as the current value; it can't be chosen from the list and is skipped by arrow-key navigation.

**Edge case**
6. A preselected item that is **not** in the `items` list is still rejected (placeholder shown) — only the disabled-but-present case changed.

Docs: `/api/select` → *Disabled Items*, `/api/native-select` → *Disabled Items*.
