### PR TITLE
fix(Tabs): prevent scroll button focus outline from being clipped (#2650)

### DIFF
--- a/.changeset/tabs-scroll-button-focus.md
+++ b/.changeset/tabs-scroll-button-focus.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': patch
+---
+
+fix(Tabs): prevent scroll button focus outline from being clipped

--- a/packages/react-magma-dom/src/components/Tabs/Tabs.test.js
+++ b/packages/react-magma-dom/src/components/Tabs/Tabs.test.js
@@ -299,6 +299,29 @@ describe('Tabs', () => {
     );
   });
 
+  it('should inset the scroll button focus outline so it is not clipped', () => {
+    const { getByTestId } = render(
+      <Tabs>
+        <Tab>Tab 1</Tab>
+      </Tabs>
+    );
+
+    expect(getByTestId('buttonPrev')).toHaveStyleRule(
+      'outline-offset',
+      '-2px',
+      {
+        target: ':focus',
+      }
+    );
+    expect(getByTestId('buttonNext')).toHaveStyleRule(
+      'outline-offset',
+      '-2px',
+      {
+        target: ':focus',
+      }
+    );
+  });
+
   it('should change panels on tab button click', () => {
     const { getAllByText, queryByText } = render(
       <TabsContainer activeIndex={0}>

--- a/packages/react-magma-dom/src/components/Tabs/TabsScrollButtons.tsx
+++ b/packages/react-magma-dom/src/components/Tabs/TabsScrollButtons.tsx
@@ -44,6 +44,10 @@ const StyledScrollButton = styled.button<ScrollButtonProps>`
   top: 0;
   width: 44px;
 
+  &:focus {
+    outline-offset: -2px;
+  }
+
   ${props =>
     props.orientation === 'vertical' &&
     css`


### PR DESCRIPTION
Closes: #1926

## What I did

Fixed the keyboard focus outline being clipped on the up/down scroll arrows in **Scrollable Vertical Tabs**.

The scroll arrow buttons (`ButtonPrev`/`ButtonNext`) sit flush against the top/bottom edge of the scroll area. Their focus outline was drawn at a non-negative offset, so a wrapping container with `overflow: hidden` (e.g. the fixed-height vertical example) clipped it. The fix insets the outline (`outline-offset: -2px` on `:focus`) so the ring renders inside the button and isn't clipped. The global focus style already supplies the (inverse-aware) outline color/width, so only the offset needed overriding. Horizontal scrollable tabs are unaffected.

**Type of change:** Bug fix (non-breaking change which fixes an issue) — a11y.

## Screenshots
<img width="374" height="312" alt="image" src="https://github.com/user-attachments/assets/375d5db4-9351-4650-b4a8-ba31a36cb3bf" />
<img width="377" height="300" alt="image" src="https://github.com/user-attachments/assets/c4ab4077-56dc-4bf5-b75a-9c06ce9eafc9" />


## Checklist
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made <!-- N/A: bug fix, no API/behavior change -->
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

**Component affected:** `Tabs` (scroll arrow buttons in the vertical scrollable variant).

1. Open `/api/tabs` → **Scrollable Vertical Tabs** (the example wraps `Tabs` in a fixed-height, `overflow: hidden` container).
2. Focus / tab to the up (▲) and down (▼) scroll arrows.
3. The focus outline is fully visible (inset) on both arrows — no longer clipped.
4. Confirm the horizontal **Scrollable Tabs** arrows and the inverse variant still show a correct focus ring.

Automated: `Tabs.test.js` asserts `outline-offset: -2px` on `:focus` for `buttonPrev`/`buttonNext` (full Tabs suite: 81 passing).
