### PR TITLE
feat(charts): add `additionalContent` prop for additional content between toolbar and chart (#2673)

### DIFF
--- a/.changeset/charts-additional-content.md
+++ b/.changeset/charts-additional-content.md
@@ -1,0 +1,6 @@
+---
+'@react-magma/charts': minor
+'react-magma-docs': patch
+---
+
+feat(charts): add `additionalContent` prop for additional content between toolbar and chart

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -157,6 +157,16 @@ export interface CarbonChartProps extends React.HTMLAttributes<HTMLDivElement> {
    * toolbar is automatically disabled.
    */
   chartToolbar?: ChartToolbarConfig;
+  /**
+   * Custom content rendered below the toolbar row and above the chart itself,
+   * for example a filter. Requires `chartToolbar`; ignored without it.
+   *
+   * Providing this lays the toolbar out in normal flow instead of overlaying
+   * the single row Carbon reserves for its title, so the rendered height
+   * becomes toolbar + content + chart rather than the chart box alone. Set
+   * `options.height` so the chart still has a definite height of its own.
+   */
+  additionalContent?: React.ReactNode;
 }
 
 const ChartContentWrapper = styled.div`
@@ -165,6 +175,7 @@ const ChartContentWrapper = styled.div`
 `;
 
 const FullscreenRoot = styled.div<{
+  isFlowLayout?: boolean;
   isInverse?: boolean;
   theme: ThemeInterface;
 }>`
@@ -177,9 +188,34 @@ const FullscreenRoot = styled.div<{
       props.isInverse
         ? props.theme.colors.primary700
         : props.theme.colors.neutral100};
+
+    ${props =>
+      props.isFlowLayout
+        ? `
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    padding: 2em;
+
+    .carbon-chart-wrapper,
+    .carbon-chart-content {
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    .cds--chart-holder {
+      flex: 1 1 auto;
+      height: auto !important;
+      min-height: 0;
+    }
+    `
+        : `
     .cds--chart-holder {
       height: 100vh !important;
     }
+    `}
   }
 `;
 
@@ -700,6 +736,7 @@ interface ExtendedChartOptions extends ChartOptions {
 }
 
 const ToolbarWrapper = styled.div<{
+  isFlowLayout?: boolean;
   isFullscreen?: boolean;
   isInverse?: boolean;
   theme: ThemeInterface;
@@ -707,11 +744,19 @@ const ToolbarWrapper = styled.div<{
   align-items: center;
   display: flex;
   justify-content: space-between;
-  left: ${props => (props.isFullscreen ? '2em' : '0')};
-  position: absolute;
-  right: ${props => (props.isFullscreen ? '2em' : '0')};
-  top: ${props => (props.isFullscreen ? '2em' : '0')};
   z-index: 2;
+
+  ${props =>
+    props.isFlowLayout
+      ? `
+  position: relative;
+  `
+      : `
+  left: ${props.isFullscreen ? '2em' : '0'};
+  position: absolute;
+  right: ${props.isFullscreen ? '2em' : '0'};
+  top: ${props.isFullscreen ? '2em' : '0'};
+  `}
 
   button {
     color: ${props =>
@@ -756,6 +801,11 @@ const TitleGroup = styled.div<{ theme: ThemeInterface }>`
 const TitleSlot = styled.div`
   align-items: center;
   display: flex;
+`;
+
+const ChartSlot = styled.div<{ theme: ThemeInterface }>`
+  margin: ${props => props.theme.spaceScale.spacing05} 0
+    ${props => props.theme.spaceScale.spacing06};
 `;
 
 const ToolbarActions = styled.div<{ theme: ThemeInterface }>`
@@ -1033,6 +1083,7 @@ const ALL_CHARTS: Record<CarbonChartType, React.ComponentType<any>> = {
 interface InternalToolbarProps {
   config: ChartToolbarConfig;
   dataSet: Array<Record<string, unknown>>;
+  isFlowLayout: boolean;
   isInverse: boolean;
   isTableOpen: boolean;
   isFullscreen: boolean;
@@ -1046,6 +1097,7 @@ interface InternalToolbarProps {
 function CarbonChartToolbar({
   config,
   dataSet,
+  isFlowLayout,
   isInverse,
   isTableOpen,
   isFullscreen,
@@ -1094,6 +1146,7 @@ function CarbonChartToolbar({
 
   return (
     <ToolbarWrapper
+      isFlowLayout={isFlowLayout}
       isFullscreen={isFullscreen}
       isInverse={isInverse}
       theme={theme}
@@ -1152,6 +1205,7 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       type,
       dataSet,
       options,
+      additionalContent,
       ariaLabel,
       chartToolbar,
       ...rest
@@ -1186,6 +1240,8 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       ? chartToolbar.fullscreen !== false
       : false;
 
+    const isFlowLayout = Boolean(chartToolbar && additionalContent);
+
     const savedHeightRef = React.useRef<string>('');
 
     React.useEffect(() => {
@@ -1197,7 +1253,8 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
         const chartHolder =
           internalRef.current?.querySelector<HTMLElement>('.cds--chart-holder');
-        if (chartHolder) {
+
+        if (chartHolder && !isFlowLayout) {
           if (isFs) {
             savedHeightRef.current = chartHolder.style.height;
             chartHolder.style.height = '100vh';
@@ -1212,11 +1269,11 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
         // Restore height if the component unmounts while in fullscreen.
         const chartHolder =
           internalRef.current?.querySelector<HTMLElement>('.cds--chart-holder');
-        if (chartHolder && document.fullscreenElement) {
+        if (chartHolder && document.fullscreenElement && !isFlowLayout) {
           chartHolder.style.height = savedHeightRef.current;
         }
       };
-    }, [fullscreenEnabled]);
+    }, [fullscreenEnabled, isFlowLayout]);
 
     const openTableModal = React.useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -1430,8 +1487,13 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       isInverse,
     ]);
 
+    const { title: _title, ...optionsWithoutTitle } = options as Record<
+      string,
+      unknown
+    >;
+
     const newOptions = {
-      ...options,
+      ...(isFlowLayout ? optionsWithoutTitle : options),
       theme: isInverse ? ChartTheme.G100 : ChartTheme.WHITE,
       color: {
         scale: colorScale,
@@ -1628,7 +1690,12 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
     if (!ChartType) return null;
 
     return (
-      <FullscreenRoot ref={mergedRef} isInverse={isInverse} theme={theme}>
+      <FullscreenRoot
+        ref={mergedRef}
+        isFlowLayout={isFlowLayout}
+        isInverse={isInverse}
+        theme={theme}
+      >
         <VisuallyHidden>
           <Announce>{legendAnnouncement}</Announce>
         </VisuallyHidden>
@@ -1639,14 +1706,16 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
           data-testid={testId}
           isInverse={isInverse}
           theme={theme}
-          className={`carbon-chart-wrapper${chartToolbar ? ' has-magma-toolbar' : ''}`}
+          className={`carbon-chart-wrapper${
+            chartToolbar && !isFlowLayout ? ' has-magma-toolbar' : ''
+          }`}
           groupsLength={groupsLength < 6 ? groupsLength : 14}
           role="region"
           aria-label={ariaLabel || chartTitle}
           aria-roledescription="chart"
           {...rest}
         >
-          <ChartContentWrapper>
+          <ChartContentWrapper className="carbon-chart-content">
             {chartToolbar && (
               /*
                * Slot content comes from the adopter, so it resolves
@@ -1658,6 +1727,7 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
                 <CarbonChartToolbar
                   config={chartToolbar}
                   dataSet={dataSet as Array<Record<string, unknown>>}
+                  isFlowLayout={isFlowLayout}
                   isInverse={isInverse}
                   isTableOpen={isTableOpen}
                   isFullscreen={isFullscreen}
@@ -1667,6 +1737,9 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
                   title={chartTitle}
                   wrapperRef={internalRef}
                 />
+                {isFlowLayout && (
+                  <ChartSlot theme={theme}>{additionalContent}</ChartSlot>
+                )}
               </InverseContext.Provider>
             )}
             <ChartType data={dataSet} options={newOptions} />

--- a/packages/charts/src/components/ChartTable/ChartTable.stories.tsx
+++ b/packages/charts/src/components/ChartTable/ChartTable.stories.tsx
@@ -10,6 +10,7 @@ import {
   ButtonVariant,
   Card,
   IconButton,
+  Select,
   Tooltip,
 } from 'react-magma-dom';
 import { InfoIcon } from 'react-magma-icons';
@@ -233,5 +234,58 @@ export const TitleSlots = {
     title: 'Chapter Performance',
     type: CarbonChartType.bar,
     dataSet: barDataSet,
+  },
+};
+
+const chapterFilters = [
+  { label: 'All Chapters', value: 'all' },
+  { label: 'Chapters 1-2', value: 'ch-1-2' },
+  { label: 'Chapters 3-4', value: 'ch-3-4' },
+];
+
+const chaptersByFilter: Record<string, string[]> = {
+  'ch-1-2': ['Chapter 1', 'Chapter 2'],
+  'ch-3-4': ['Chapter 3', 'Chapter 4'],
+};
+
+export const AdditionalContent = {
+  render: ({ isInverse }: Pick<CarbonChartProps, 'isInverse'>) => {
+    const [filter, setFilter] = React.useState(chapterFilters[0]);
+    const chapters = chaptersByFilter[filter.value];
+    const dataSet = chapters
+      ? barDataSet.filter(row => chapters.includes(row.group))
+      : barDataSet;
+
+    return (
+      <Card isInverse={isInverse} style={{ padding: '12px' }}>
+        <CarbonChart
+          isInverse={isInverse}
+          type={CarbonChartType.bar}
+          dataSet={dataSet}
+          options={{
+            title: 'Chapter Performance',
+            axes: {
+              left: { mapsTo: 'value' },
+              bottom: { mapsTo: 'group', scaleType: ScaleTypes.LABELS },
+            },
+            height: '400px',
+          }}
+          chartToolbar={{ titleSuffix: <ChartInfoTooltip /> }}
+          additionalContent={
+            <Select
+              items={chapterFilters}
+              labelText="Filter by"
+              selectedItem={filter}
+              onSelectedItemChange={changes =>
+                setFilter(changes.selectedItem ?? chapterFilters[0])
+              }
+            />
+          }
+        />
+      </Card>
+    );
+  },
+  args: {
+    isInverse: false,
   },
 };

--- a/website/react-magma-docs/src/pages/data-visualization/chart-demos.mdx
+++ b/website/react-magma-docs/src/pages/data-visualization/chart-demos.mdx
@@ -2551,7 +2551,7 @@ export function Example() {
             labelText="Filter by"
             selectedItem={filter}
             onSelectedItemChange={changes =>
-              setFilter(changes.selectedItem ?? chapterFilters[0])
+              setFilter(changes.selectedItem || chapterFilters[0])
             }
           />
         }

--- a/website/react-magma-docs/src/pages/data-visualization/chart-demos.mdx
+++ b/website/react-magma-docs/src/pages/data-visualization/chart-demos.mdx
@@ -2494,6 +2494,73 @@ export function Example() {
 }
 ```
 
+### Custom content between the title and the chart
+
+The `additionalContent` prop renders custom controls below the toolbar and above the chart. It requires `chartToolbar` and is ignored without it. In the example below the `Select` is wired to component state, so choosing a range re-renders the chart with the matching bars.
+
+**Always set `options.height`** when using this prop. The toolbar switches from overlay to normal flow, so toolbar + content + chart stack together. Without a fixed chart height, when your content expands (dropdown opens, validation error shows), the container shrinks and Carbon redraws the chart, causing layout thrashing. A fixed height lets your content expand freely without affecting the chart.
+
+```tsx
+import React from 'react';
+
+import { CarbonChart, CarbonChartType } from '@react-magma/charts';
+import { Card, Select } from 'react-magma-dom';
+
+const barDataSet = [
+  { group: 'Chapter 1', value: 85 },
+  { group: 'Chapter 2', value: 72 },
+  { group: 'Chapter 3', value: 91 },
+  { group: 'Chapter 4', value: 64 },
+];
+
+const chapterFilters = [
+  { label: 'All Chapters', value: 'all' },
+  { label: 'Chapters 1-2', value: 'ch-1-2' },
+  { label: 'Chapters 3-4', value: 'ch-3-4' },
+];
+
+const chaptersByFilter = {
+  'ch-1-2': ['Chapter 1', 'Chapter 2'],
+  'ch-3-4': ['Chapter 3', 'Chapter 4'],
+};
+
+export function Example() {
+  const [filter, setFilter] = React.useState(chapterFilters[0]);
+  const chapters = chaptersByFilter[filter.value];
+  const dataSet = chapters
+    ? barDataSet.filter(row => chapters.includes(row.group))
+    : barDataSet;
+
+  return (
+    <Card style={{ padding: '12px' }}>
+      <CarbonChart
+        type={CarbonChartType.bar}
+        dataSet={dataSet}
+        options={{
+          title: 'Chapter Performance',
+          axes: {
+            left: { mapsTo: 'value' },
+            bottom: { mapsTo: 'group', scaleType: 'labels' },
+          },
+          height: '400px',
+        }}
+        chartToolbar={{}}
+        additionalContent={
+          <Select
+            items={chapterFilters}
+            labelText="Filter by"
+            selectedItem={filter}
+            onSelectedItemChange={changes =>
+              setFilter(changes.selectedItem ?? chapterFilters[0])
+            }
+          />
+        }
+      />
+    </Card>
+  );
+}
+```
+
 ### Selective button visibility
 
 Disable individual toolbar buttons by setting `showAsTable` or `fullscreen` to `false`.

--- a/website/react-magma-docs/src/pages/data-visualization/introduction.mdx
+++ b/website/react-magma-docs/src/pages/data-visualization/introduction.mdx
@@ -130,7 +130,13 @@ export function Example() {
 }
 ```
 
-See [Chart Demos](../chart-demos) for examples of every chart type with the accessible toolbar enabled, and the [Toolbar customization](../chart-demos#toolbar_customization) section for advanced configurations (custom menu items, table columns, chart title heading level, custom content around the title, button visibility, inverse theme).
+See [Chart Demos](../chart-demos) for examples of every chart type with the accessible toolbar enabled, and the [Toolbar customization](../chart-demos#toolbar_customization) section for advanced configurations (custom menu items, table columns, chart title heading level, custom content around the title and between the title and the chart, button visibility, inverse theme).
+
+### Content between the title and the chart
+
+`additionalContent` is a prop on `CarbonChart` itself rather than on `chartToolbar`. It renders below the toolbar row and above the chart, which is where interactive controls such as filters belong — the title row only has space for inline content the height of an icon.
+
+It requires `chartToolbar`, changes how the chart's total height is composed, and needs `options.height` set. See [Custom content between the title and the chart](../chart-demos#custom_content_between_the_title_and_the_chart) for the reasoning and a working example.
 
 ### Chart toolbar props
 


### PR DESCRIPTION
Closes: #2660

## What I did

What we did: Added additionalContent prop to place custom controls (filters, selects) between toolbar and chart.

- Why: Toolbar was an overlay before, now content stacks normally: toolbar → your content → chart.

- About options.height: When adding content, set chart height explicitly (e.g., height: '400px'). Without it, when your content expands (select opens) - container shrinks and Carbon redraws entire chart → layout thrashing. With fixed height - your content expands freely, chart stays stable.

- CSS changes: Removed complex :not() selectors. Content is now isolated via separate component. (Cleaner approach)


## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test

1. CarbonChart → ChartToolbar → AdditionalContent
2. Docs → Chart Demos → Custom content between the title and the chart
