### PR TITLE
feat(Combobox): add `hasSelectedItemContent` prop

### DIFF
--- a/.changeset/combobox-selected-item-content.md
+++ b/.changeset/combobox-selected-item-content.md
@@ -1,0 +1,5 @@
+---
+'react-magma-dom': minor
+---
+
+feat(Combobox): add `hasSelectedItemContent` to display the selected item's `leadingIcon` and `secondaryText` inside the input

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
@@ -1399,21 +1399,25 @@ const locationItems: LocationOption[] = [
   },
 ];
 
+function locationItemBorderColor(props) {
+  if (!props.isFocused) {
+    return 'transparent';
+  }
+
+  return props.isInverse
+    ? props.theme.colors.focusInverse
+    : props.theme.colors.focus;
+}
+
 const LocationListItem = styled.li<{
   isFocused?: boolean;
   isInverse?: boolean;
   theme?: ThemeInterface;
 }>`
   align-items: center;
-  background: ${props => {
-    if (props.isFocused) {
-      return props.isInverse
-        ? props.theme.colors.primary600
-        : props.theme.colors.neutral200;
-    }
-
-    return 'transparent';
-  }};
+  background: transparent;
+  border: 2px solid;
+  border-color: ${props => locationItemBorderColor(props)};
   cursor: pointer;
   display: flex;
   gap: ${props => props.theme.spaceScale.spacing03};
@@ -1425,6 +1429,7 @@ const LocationListItem = styled.li<{
       props.isInverse
         ? props.theme.colors.primary600
         : props.theme.colors.neutral200};
+    border-color: ${props => locationItemBorderColor(props)};
   }
 `;
 
@@ -1526,6 +1531,7 @@ export const SelectedItemContent = {
     hasSelectedItemContent: true,
     isClearable: true,
     disableCreateItem: true,
+    isTypeahead: true,
   },
 };
 
@@ -1546,5 +1552,66 @@ export const SelectedItemContentInverse = {
   args: {
     ...SelectedItemContent.args,
     isInverse: true,
+  },
+};
+
+function makeLocationItems(count) {
+  return Array.from({ length: count }, (_, index) => ({
+    label: `Location ${index + 1}`,
+    value: `location-${index + 1}`,
+    secondaryText: `Intervention Library > Location ${index + 1}`,
+    leadingIcon: <FolderIcon aria-hidden />,
+  }));
+}
+
+const largeLocationItems = makeLocationItems(2000);
+
+export const SelectedItemContentLargeList = {
+  render: args => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const [openMs, setOpenMs] = React.useState<number | null>(null);
+    const openStartRef = React.useRef<number | null>(null);
+
+    function handleIsOpenChange(changes) {
+      if (changes.isOpen) {
+        openStartRef.current = performance.now();
+      }
+      setIsOpen(Boolean(changes.isOpen));
+    }
+
+    React.useEffect(() => {
+      if (isOpen && openStartRef.current !== null) {
+        setOpenMs(performance.now() - openStartRef.current);
+        openStartRef.current = null;
+      }
+    }, [isOpen]);
+
+    return (
+      <>
+        <p>
+          Items: <strong>{largeLocationItems.length.toLocaleString()}</strong>
+          {' · '}Menu open render:{' '}
+          <strong>
+            {openMs === null
+              ? '—'
+              : `${(openMs / 1000).toFixed(2)} s (${Math.round(openMs)} ms)`}
+          </strong>
+        </p>
+        <Combobox
+          {...args}
+          components={{ Item: LocationItem }}
+          defaultItems={largeLocationItems}
+          onIsOpenChange={handleIsOpenChange}
+        />
+      </>
+    );
+  },
+
+  args: {
+    labelText: 'Location',
+    placeholder: 'Select a location...',
+    hasSelectedItemContent: true,
+    isClearable: true,
+    disableCreateItem: true,
   },
 };

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.stories.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
+import styled from '@emotion/styled';
 import { Meta } from '@storybook/react-webpack5';
+import { FolderIcon } from 'react-magma-icons';
 import { action } from 'storybook/actions';
 
+import { ThemeInterface } from '../../theme/magma';
 import { Button, ButtonType } from '../Button';
 import { Card } from '../Card';
 import { CardBody } from '../Card/CardBody';
@@ -1346,5 +1349,202 @@ export const ControlledItems = {
         onItemCreated={onItemCreated}
       />
     );
+  },
+};
+
+type LocationOption = {
+  label: string;
+  value: string;
+  leadingIcon?: React.ReactNode;
+  secondaryText?: React.ReactNode;
+};
+
+const locationItems: LocationOption[] = [
+  {
+    label: 'Top level',
+    value: 'top-level',
+    secondaryText: 'Not inside any folder',
+    leadingIcon: <FolderIcon aria-hidden />,
+  },
+  {
+    label: 'Teaching & Student Editions',
+    value: 'teaching',
+    secondaryText: 'Teaching & Student Editions',
+    leadingIcon: <FolderIcon aria-hidden />,
+  },
+  {
+    label: 'Teacher Toolkit: Course Essentials',
+    value: 'toolkit',
+    secondaryText: 'Teacher Toolkit: Course Essentials',
+    leadingIcon: <FolderIcon aria-hidden />,
+  },
+  {
+    label: 'Implementation',
+    value: 'implementation',
+    secondaryText: 'Teacher Toolkit: Course Essentials > Implementation',
+    leadingIcon: <FolderIcon aria-hidden />,
+  },
+  {
+    label: 'Standards and Correlations',
+    value: 'standards',
+    secondaryText:
+      'Teacher Toolkit: Course Essentials > Standards and Correlations',
+    leadingIcon: <FolderIcon aria-hidden />,
+  },
+  {
+    label: 'Surface Area and Volume',
+    value: 'surface-area',
+    secondaryText: 'Intervention Library > Surface Area and Volume',
+    leadingIcon: <FolderIcon aria-hidden />,
+  },
+];
+
+const LocationListItem = styled.li<{
+  isFocused?: boolean;
+  isInverse?: boolean;
+  theme?: ThemeInterface;
+}>`
+  align-items: center;
+  background: ${props => {
+    if (props.isFocused) {
+      return props.isInverse
+        ? props.theme.colors.primary600
+        : props.theme.colors.neutral200;
+    }
+
+    return 'transparent';
+  }};
+  cursor: pointer;
+  display: flex;
+  gap: ${props => props.theme.spaceScale.spacing03};
+  padding: ${props => props.theme.spaceScale.spacing03}
+    ${props => props.theme.spaceScale.spacing05};
+
+  &:hover {
+    background: ${props =>
+      props.isInverse
+        ? props.theme.colors.primary600
+        : props.theme.colors.neutral200};
+  }
+`;
+
+const LocationIcon = styled.span<{
+  isInverse?: boolean;
+  theme?: ThemeInterface;
+}>`
+  align-items: center;
+  color: ${props =>
+    props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral500};
+  display: flex;
+  flex-shrink: 0;
+`;
+
+const LocationItemText = styled.span`
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+`;
+
+const LocationItemPrimary = styled.span<{
+  isInverse?: boolean;
+  theme?: ThemeInterface;
+}>`
+  color: ${props =>
+    props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral700};
+`;
+
+const LocationItemSecondary = styled.span<{
+  isInverse?: boolean;
+  theme?: ThemeInterface;
+}>`
+  color: ${props =>
+    props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral500};
+  font-size: ${props => props.theme.typeScale.size01.fontSize};
+  line-height: ${props => props.theme.typeScale.size01.lineHeight};
+`;
+
+const LocationItem = props => {
+  const {
+    itemRef,
+    item,
+    itemString,
+    isFocused,
+    isInverse,
+    isSelected,
+    isDisabled,
+    theme,
+    ...rest
+  } = props;
+
+  return (
+    <LocationListItem
+      {...rest}
+      ref={itemRef}
+      aria-disabled={isDisabled}
+      aria-selected={isSelected}
+      data-highlighted={isFocused}
+      isFocused={isFocused}
+      isInverse={isInverse}
+      theme={theme}
+    >
+      <LocationIcon isInverse={isInverse} theme={theme}>
+        {item.leadingIcon}
+      </LocationIcon>
+      <LocationItemText>
+        <LocationItemPrimary isInverse={isInverse} theme={theme}>
+          {itemString}
+        </LocationItemPrimary>
+        {item.secondaryText && (
+          <LocationItemSecondary isInverse={isInverse} theme={theme}>
+            {item.secondaryText}
+          </LocationItemSecondary>
+        )}
+      </LocationItemText>
+    </LocationListItem>
+  );
+};
+
+export const SelectedItemContent = {
+  render: args => (
+    <Combobox
+      {...args}
+      components={{ Item: LocationItem }}
+      defaultItems={locationItems}
+      initialSelectedItem={locationItems[5]}
+    />
+  ),
+
+  args: {
+    labelText: 'Location',
+    placeholder: 'Select a location...',
+    hasSelectedItemContent: true,
+    isClearable: true,
+    disableCreateItem: true,
+  },
+};
+
+export const SelectedItemContentInverse = {
+  render: args => (
+    <Card isInverse>
+      <CardBody>
+        <Combobox
+          {...args}
+          components={{ Item: LocationItem }}
+          defaultItems={locationItems}
+          initialSelectedItem={locationItems[5]}
+        />
+      </CardBody>
+    </Card>
+  ),
+
+  args: {
+    ...SelectedItemContent.args,
+    isInverse: true,
   },
 };

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -1304,4 +1304,167 @@ describe('Combobox', () => {
       expect(getByText('Blue')).toHaveAttribute('aria-selected', 'true');
     });
   });
+
+  describe('hasSelectedItemContent', () => {
+    const contentItems = [
+      {
+        label: 'Surface Area and Volume',
+        value: 'surface-area',
+        secondaryText: 'Intervention Library > Surface Area and Volume',
+        leadingIcon: <svg data-testid="leading-icon" />,
+      },
+      {
+        label: 'Top level',
+        value: 'top-level',
+        secondaryText: 'Not inside any folder',
+      },
+    ];
+
+    it('shows the selected item leading icon and secondary text inside the input', () => {
+      const { getByText, getByTestId } = render(
+        <Combobox
+          labelText={labelText}
+          items={contentItems}
+          hasSelectedItemContent
+          initialSelectedItem={contentItems[0]}
+        />
+      );
+
+      expect(
+        getByText('Intervention Library > Surface Area and Volume')
+      ).toBeInTheDocument();
+      expect(getByTestId('leading-icon')).toBeInTheDocument();
+    });
+
+    it('keeps the input value in sync with the selected item', () => {
+      const { getByLabelText } = render(
+        <Combobox
+          labelText={labelText}
+          items={contentItems}
+          hasSelectedItemContent
+          initialSelectedItem={contentItems[0]}
+        />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, { selector: 'input' });
+
+      expect(renderedCombobox.value).toEqual('Surface Area and Volume');
+    });
+
+    it('marks the selected item preview as aria-hidden so it is not announced twice', () => {
+      const { getByText } = render(
+        <Combobox
+          labelText={labelText}
+          items={contentItems}
+          hasSelectedItemContent
+          initialSelectedItem={contentItems[0]}
+        />
+      );
+
+      const secondaryText = getByText(
+        'Intervention Library > Surface Area and Volume'
+      );
+
+      expect(secondaryText.closest('[aria-hidden="true"]')).toBeInTheDocument();
+    });
+
+    it('does not render the secondary text inside the input without the prop', () => {
+      const { queryByText } = render(
+        <Combobox
+          labelText={labelText}
+          items={contentItems}
+          initialSelectedItem={contentItems[0]}
+        />
+      );
+
+      expect(
+        queryByText('Intervention Library > Surface Area and Volume')
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the selected item preview while the menu is open', async () => {
+      const { getByLabelText, getByText, queryByText } = render(
+        <Combobox
+          labelText={labelText}
+          items={contentItems}
+          hasSelectedItemContent
+          initialSelectedItem={contentItems[0]}
+        />
+      );
+
+      expect(
+        getByText('Intervention Library > Surface Area and Volume')
+      ).toBeInTheDocument();
+
+      const renderedCombobox = getByLabelText(labelText, { selector: 'input' });
+
+      await userEvent.click(renderedCombobox);
+
+      await waitFor(() => {
+        expect(
+          queryByText('Intervention Library > Surface Area and Volume')
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('hides the selected item preview when the input is focused', async () => {
+      const { getByLabelText, getByText, queryByText } = render(
+        <Combobox
+          labelText={labelText}
+          items={contentItems}
+          hasSelectedItemContent
+          initialSelectedItem={contentItems[0]}
+        />
+      );
+
+      expect(
+        getByText('Intervention Library > Surface Area and Volume')
+      ).toBeInTheDocument();
+
+      const renderedCombobox = getByLabelText(labelText, { selector: 'input' });
+
+      act(() => {
+        renderedCombobox.focus();
+      });
+
+      await waitFor(() => {
+        expect(
+          queryByText('Intervention Library > Surface Area and Volume')
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('restores the selected item preview after the input is blurred', async () => {
+      const { getByLabelText, getByText, queryByText } = render(
+        <Combobox
+          labelText={labelText}
+          items={contentItems}
+          hasSelectedItemContent
+          initialSelectedItem={contentItems[0]}
+        />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, { selector: 'input' });
+
+      act(() => {
+        renderedCombobox.focus();
+      });
+
+      await waitFor(() => {
+        expect(
+          queryByText('Intervention Library > Surface Area and Volume')
+        ).not.toBeInTheDocument();
+      });
+
+      act(() => {
+        renderedCombobox.blur();
+      });
+
+      await waitFor(() => {
+        expect(
+          getByText('Intervention Library > Surface Area and Volume')
+        ).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.test.js
@@ -1466,5 +1466,23 @@ describe('Combobox', () => {
         ).toBeInTheDocument();
       });
     });
+
+    it('does not crash for non-string primitive items (e.g. numbers) when the feature is omitted', () => {
+      const numericItems = [1, 2, 3];
+
+      const { getByLabelText } = render(
+        <Combobox
+          labelText={labelText}
+          items={numericItems}
+          itemToString={item => (item ? `Item ${item}` : '')}
+          initialSelectedItem={2}
+        />
+      );
+
+      const renderedCombobox = getByLabelText(labelText, { selector: 'input' });
+
+      expect(renderedCombobox).toBeInTheDocument();
+      expect(renderedCombobox.value).toEqual('Item 2');
+    });
   });
 });

--- a/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/Combobox.tsx
@@ -30,6 +30,7 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
     disableCreateItem,
     errorMessage,
     hasError,
+    hasSelectedItemContent,
     helperMessage,
     initialSelectedItem,
     inputStyle,
@@ -364,17 +365,21 @@ export function InternalCombobox<T>(props: ComboboxProps<T>) {
         })}
         getToggleButtonProps={getToggleButtonProps}
         hasError={hasError}
+        hasSelectedItemContent={hasSelectedItemContent}
         innerRef={ref}
         inputStyle={inputStyle}
         isInverse={isInverse}
         isLoading={isLoading}
+        isOpen={isOpen}
         isTypeahead={isTypeahead}
+        itemToString={itemToString}
         onInputBlur={onInputBlur}
         onInputFocus={onInputFocus}
         onInputKeyDown={handleOnKeyDown}
         onInputKeyPress={onInputKeyPress}
         onInputKeyUp={onInputKeyUp}
         placeholder={placeholder}
+        selectedItem={selectedItem}
         setReference={refs.setReference}
         toggleButtonRef={toggleButtonRef}
       >

--- a/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
@@ -219,7 +219,7 @@ interface ComboboxInputProps<T> {
   isLoading?: boolean;
   isOpen?: boolean;
   isTypeahead?: boolean;
-  itemToString?: (item: T) => string;
+  itemToString?: (item: T | null) => string;
   onInputBlur?: (event: React.FocusEvent) => void;
   onInputFocus?: (event: React.FocusEvent) => void;
   onInputKeyDown?: (event: any) => void;

--- a/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
@@ -310,8 +310,9 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
     isWindows && !selectedItem ? placeholder : undefined;
 
   const selectedItemObject =
+    hasSelectedItemContent &&
     selectedItem &&
-    typeof selectedItem !== 'string' &&
+    typeof selectedItem === 'object' &&
     instanceOfDefaultItemObject(selectedItem)
       ? selectedItem
       : undefined;

--- a/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/ComboboxInput.tsx
@@ -14,6 +14,7 @@ import useDeviceDetect from '../../hooks/useDeviceDetect';
 import { ThemeInterface } from '../../theme/magma';
 import { ThemeContext } from '../../theme/ThemeContext';
 import { inputBaseStyles } from '../InputBase';
+import { instanceOfDefaultItemObject } from '../Select';
 import { defaultComponents, SelectComponents } from '../Select/components';
 import { SelectedItemsWrapper } from '../Select/shared';
 
@@ -86,7 +87,7 @@ const InputContainer = styled.div<{
     `}
 `;
 
-const StyledInput = styled.input`
+const StyledInput = styled.input<{ hideText?: boolean }>`
   ${inputBaseStyles}
   display: flex;
   flex-grow: 1;
@@ -98,6 +99,106 @@ const StyledInput = styled.input`
   &:focus {
     outline: 0;
   }
+
+  ${props =>
+    props.hideText &&
+    css`
+      color: transparent;
+      caret-color: transparent;
+    `}
+`;
+
+const SelectedItemContent = styled.div<{
+  theme?: ThemeInterface;
+}>`
+  align-items: center;
+  bottom: 0;
+  display: flex;
+  gap: ${props => props.theme.spaceScale.spacing03};
+  left: 0;
+  overflow: hidden;
+  padding-left: ${props => props.theme.spaceScale.spacing03};
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  top: 0;
+`;
+
+const SelectedItemIcon = styled.span<{
+  disabled?: boolean;
+  isInverse?: boolean;
+  theme?: ThemeInterface;
+}>`
+  align-items: center;
+  color: ${props => {
+    if (props.disabled) {
+      return props.isInverse
+        ? transparentize(0.6, props.theme.colors.neutral100)
+        : transparentize(0.4, props.theme.colors.neutral500);
+    }
+
+    return props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral500;
+  }};
+  display: flex;
+  flex-shrink: 0;
+`;
+
+const SelectedItemText = styled.span`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const SelectedItemPrimaryText = styled.span<{
+  disabled?: boolean;
+  isInverse?: boolean;
+  theme?: ThemeInterface;
+}>`
+  color: ${props => {
+    if (props.disabled) {
+      return props.isInverse
+        ? transparentize(0.6, props.theme.colors.neutral100)
+        : transparentize(0.4, props.theme.colors.neutral500);
+    }
+
+    return props.isInverse
+      ? props.theme.colors.neutral100
+      : props.theme.colors.neutral700;
+  }};
+  font-family: ${props => props.theme.bodyFont};
+  font-size: ${props => props.theme.typeScale.size03.fontSize};
+  line-height: 18px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const SelectedItemSecondaryText = styled.span<{
+  disabled?: boolean;
+  isInverse?: boolean;
+  theme?: ThemeInterface;
+}>`
+  color: ${props => {
+    if (props.disabled) {
+      return props.isInverse
+        ? transparentize(0.7, props.theme.colors.neutral100)
+        : transparentize(0.4, props.theme.colors.neutral500);
+    }
+
+    return props.isInverse
+      ? transparentize(0.3, props.theme.colors.neutral100)
+      : props.theme.colors.neutral500;
+  }};
+  font-family: ${props => props.theme.bodyFont};
+  font-size: ${props => props.theme.typeScale.size01.fontSize};
+  line-height: ${props => props.theme.typeScale.size01.lineHeight};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 interface ComboboxInputProps<T> {
@@ -110,12 +211,15 @@ interface ComboboxInputProps<T> {
     options?: UseComboboxGetToggleButtonPropsOptions
   ) => any;
   hasError?: boolean;
+  hasSelectedItemContent?: boolean;
   innerRef?: React.Ref<HTMLInputElement>;
   inputStyle?: React.CSSProperties;
   disabled?: boolean;
   isInverse?: boolean;
   isLoading?: boolean;
+  isOpen?: boolean;
   isTypeahead?: boolean;
+  itemToString?: (item: T) => string;
   onInputBlur?: (event: React.FocusEvent) => void;
   onInputFocus?: (event: React.FocusEvent) => void;
   onInputKeyDown?: (event: any) => void;
@@ -123,7 +227,7 @@ interface ComboboxInputProps<T> {
   onInputKeyUp?: (event: any) => void;
   placeholder?: string;
   selectedItems?: React.ReactNode;
-  selectedItem?: React.ReactNode;
+  selectedItem?: T;
   setReference?: (node: ReferenceType) => void;
   toggleButtonRef?: React.Ref<HTMLButtonElement>;
 }
@@ -137,12 +241,15 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
     getInputProps,
     getToggleButtonProps,
     hasError,
+    hasSelectedItemContent,
     innerRef,
     inputStyle,
     disabled,
     isInverse,
     isLoading,
+    isOpen,
     isTypeahead,
+    itemToString,
     onInputBlur,
     onInputFocus,
     onInputKeyDown,
@@ -202,6 +309,26 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
   const selectedItemAriaLabel =
     isWindows && !selectedItem ? placeholder : undefined;
 
+  const selectedItemObject =
+    selectedItem &&
+    typeof selectedItem !== 'string' &&
+    instanceOfDefaultItemObject(selectedItem)
+      ? selectedItem
+      : undefined;
+  const selectedItemLeadingIcon = selectedItemObject?.leadingIcon;
+  const selectedItemSecondaryText = selectedItemObject?.secondaryText;
+
+  const showSelectedItemContent = Boolean(
+    hasSelectedItemContent &&
+      !isOpen &&
+      !isFocused &&
+      selectedItemObject &&
+      (selectedItemLeadingIcon || selectedItemSecondaryText)
+  );
+
+  const selectedItemPrimaryText =
+    selectedItemObject && itemToString ? itemToString(selectedItem) : '';
+
   return (
     <div ref={setReference}>
       <ComboBoxContainer
@@ -225,17 +352,52 @@ export function ComboboxInput<T>(props: ComboboxInputProps<T>) {
           theme={theme}
           ref={innerRef}
         >
-          <SelectedItemsWrapper aria-label={selectedItemAriaLabel}>
+          <SelectedItemsWrapper
+            aria-label={selectedItemAriaLabel}
+            isRelative={showSelectedItemContent}
+          >
             {selectedItems}
             <StyledInput
               {...inputProps}
               aria-describedby={ariaDescribedBy}
               aria-invalid={hasError}
               disabled={disabled}
+              hideText={showSelectedItemContent}
               isInverse={isInverse}
               placeholder={placeholder}
               theme={theme}
             />
+            {showSelectedItemContent && (
+              <SelectedItemContent aria-hidden="true" theme={theme}>
+                {selectedItemLeadingIcon && (
+                  <SelectedItemIcon
+                    disabled={disabled}
+                    isInverse={isInverse}
+                    theme={theme}
+                  >
+                    {selectedItemLeadingIcon}
+                  </SelectedItemIcon>
+                )}
+                <SelectedItemText>
+                  <SelectedItemPrimaryText
+                    disabled={disabled}
+                    isInverse={isInverse}
+                    theme={theme}
+                  >
+                    {selectedItemPrimaryText}
+                  </SelectedItemPrimaryText>
+                  {selectedItemSecondaryText && (
+                    <SelectedItemSecondaryText
+                      disabled={disabled}
+                      isInverse={isInverse}
+                      theme={theme}
+                    >
+                      {selectedItemSecondaryText}
+                    </SelectedItemSecondaryText>
+                  )}
+                </SelectedItemText>
+              </SelectedItemContent>
+            )}
           </SelectedItemsWrapper>
           {children}
           {isLoading && !isTypeahead && (

--- a/packages/react-magma-dom/src/components/Combobox/index.tsx
+++ b/packages/react-magma-dom/src/components/Combobox/index.tsx
@@ -44,6 +44,11 @@ export interface ComboboxProps<T extends SelectOptions>
    */
   hasError?: boolean;
   /**
+   * If true, the selected item's `leadingIcon` and `secondaryText` are shown inside the input, in addition to its label
+   * @default false
+   */
+  hasSelectedItemContent?: boolean;
+  /**
    * Position of text label relative to form field
    * @default LabelPosition.top
    */

--- a/packages/react-magma-dom/src/components/Select/shared.ts
+++ b/packages/react-magma-dom/src/components/Select/shared.ts
@@ -129,11 +129,17 @@ export const StyledItem = styled('li')<{
   }
 `;
 
-export const SelectedItemsWrapper = styled.span`
+export const SelectedItemsWrapper = styled.span<{ isRelative?: boolean }>`
   display: flex;
   flex-grow: 1;
   flex-wrap: wrap;
   padding: 0 0 0 4px;
+
+  ${props =>
+    props.isRelative &&
+    css`
+      position: relative;
+    `}
 `;
 
 function buildSelectedItemButtonBackground(props) {

--- a/website/react-magma-docs/src/pages/api/combobox.mdx
+++ b/website/react-magma-docs/src/pages/api/combobox.mdx
@@ -1334,6 +1334,103 @@ export function Example() {
 }
 ```
 
+## Selected Item Content
+
+By default, when an item is selected only its label (the `itemToString` value) is shown in the input. Set the `hasSelectedItemContent` prop to
+also display the selected item's `leadingIcon` and `secondaryText` inside the input, showing an icon and a secondary line of text in addition to
+the label. This mirrors the richer content you can render for each option in the dropdown with a [custom `Item` component](/api/combobox#custom_item_component).
+
+The `leadingIcon` and `secondaryText` are read from the selected item object, so include them on your `items` alongside `label` and `value`. The
+preview is only shown while the input is not focused; focusing the input to edit or select its text shows the standard single-line input.
+
+```tsx
+import React from 'react';
+
+import styled from '@emotion/styled';
+import { Combobox } from 'react-magma-dom';
+import { FolderIcon } from 'react-magma-icons';
+
+export function Example() {
+  const items = [
+    {
+      label: 'Top level',
+      value: 'top-level',
+      secondaryText: 'Not inside any folder',
+      leadingIcon: <FolderIcon aria-hidden />,
+    },
+    {
+      label: 'Teacher Toolkit: Course Essentials',
+      value: 'toolkit',
+      secondaryText: 'Teacher Toolkit: Course Essentials',
+      leadingIcon: <FolderIcon aria-hidden />,
+    },
+    {
+      label: 'Surface Area and Volume',
+      value: 'surface-area',
+      secondaryText: 'Intervention Library > Surface Area and Volume',
+      leadingIcon: <FolderIcon aria-hidden />,
+    },
+  ];
+
+  const StyledItem = styled.li(props => ({
+    alignItems: 'center',
+    background: props.isFocused ? props.theme.colors.neutral200 : 'transparent',
+    cursor: 'pointer',
+    display: 'flex',
+    gap: '8px',
+    padding: '8px 16px',
+  }));
+
+  const IconWrapper = styled.span(props => ({
+    alignItems: 'center',
+    color: props.theme.colors.neutral500,
+    display: 'flex',
+    flexShrink: 0,
+  }));
+
+  const TextWrapper = styled.span(() => ({
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: 0,
+  }));
+
+  const SecondaryText = styled.span(props => ({
+    color: props.theme.colors.neutral500,
+    fontSize: '12px',
+    lineHeight: '16px',
+  }));
+
+  const Item = props => {
+    const { itemRef, itemString, item, ...other } = props;
+
+    return (
+      <StyledItem {...other} ref={itemRef}>
+        <IconWrapper theme={props.theme}>{item.leadingIcon}</IconWrapper>
+        <TextWrapper>
+          {itemString}
+          <SecondaryText theme={props.theme}>
+            {item.secondaryText}
+          </SecondaryText>
+        </TextWrapper>
+      </StyledItem>
+    );
+  };
+
+  return (
+    <Combobox
+      labelText="Location"
+      placeholder="Select a location..."
+      defaultItems={items}
+      components={{ Item }}
+      hasSelectedItemContent
+      isClearable
+      disableCreateItem
+      initialSelectedItem={items[2]}
+    />
+  );
+}
+```
+
 ## Internationalization
 
 Some of the internationalization overrides use placeholders to insert selected values in to the message.


### PR DESCRIPTION
Closes: #2685

## What I did
<!--
Include description of the change and type of change:
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (docs or storybook only)
- Other: style, refactor, performance, build, chore
-->
Created a new `hasSelectedItemContent` prop for displaying additional content inside the Combobox (input)

## Screenshots
<!-- Include screenshot of your change, when applicable -->

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [x] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
<!-- Include testing steps, list of edge cases, components affected by this change, etc. -->
Open Storybook -> Combobox -> Selected Item Content
Open Docs -> Combobox -> Selected Item Content