### PR TITLE
fix(charts): stabilize point Tab navigation

### DIFF
--- a/.changeset/fix-chart-dot-focus-stability.md
+++ b/.changeset/fix-chart-dot-focus-stability.md
@@ -1,0 +1,6 @@
+---
+'@react-magma/charts': patch
+---
+
+fix(charts): improve point Tab navigation accessibility after chart rerenders
+

--- a/packages/charts/src/components/CarbonChart/CarbonChart.test.js
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.test.js
@@ -1329,15 +1329,6 @@ describe('CarbonChart', () => {
     });
 
     describe('focus on dot content', () => {
-      it('should set opacity to 1 when a dot receives focus', () => {
-        const wrapper = renderChart();
-        const dot = addDot(wrapper);
-
-        fireEvent.focusIn(dot);
-
-        expect(dot.style.opacity).toBe('1');
-      });
-
       it('should dispatch mouseover on dot focusin to reveal tooltip data', () => {
         const wrapper = renderChart();
         const dot = addDot(wrapper);
@@ -1377,17 +1368,6 @@ describe('CarbonChart', () => {
     });
 
     describe('data visibility', () => {
-      it('should reset dot opacity when dot loses focus', () => {
-        const wrapper = renderChart();
-        const dot = addDot(wrapper);
-
-        fireEvent.focusIn(dot);
-        expect(dot.style.opacity).toBe('1');
-
-        fireEvent.focusOut(dot);
-        expect(dot.style.opacity).toBe('');
-      });
-
       it('should dispatch mouseout on dot focusout to hide tooltip', () => {
         const wrapper = renderChart();
         const dot = addDot(wrapper);
@@ -1399,6 +1379,34 @@ describe('CarbonChart', () => {
         fireEvent.focusOut(dot);
 
         expect(mouseoutSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not dispatch mouseout when focus moves from one dot to another', () => {
+        const wrapper = renderChart();
+        const firstDot = addDot(wrapper);
+        const secondDot = addDot(wrapper);
+
+        const mouseoutSpy = jest.fn();
+        firstDot.addEventListener('mouseout', mouseoutSpy);
+
+        fireEvent.focusOut(firstDot, { relatedTarget: secondDot });
+
+        expect(mouseoutSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('dynamic dot rendering', () => {
+      it('should stamp tabindex="0" on dots added after initial raf pass', () => {
+        const wrapper = renderChart();
+
+        // Run initial pass before adding a dot so the observer must handle it.
+        act(() => rafCallbacks[rafCallbacks.length - 1](0));
+
+        const lateDot = addDot(wrapper);
+
+        act(() => mutationObserverCallback([]));
+
+        expect(lateDot).toHaveAttribute('tabindex', '0');
       });
     });
   });

--- a/packages/charts/src/components/CarbonChart/CarbonChart.tsx
+++ b/packages/charts/src/components/CarbonChart/CarbonChart.tsx
@@ -1618,6 +1618,16 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
       if (!wrapper) return;
 
+      const stampDotTabIndex = () => {
+        wrapper
+          .querySelectorAll<SVGCircleElement>('circle.dot')
+          .forEach(dot => {
+            if (!dot.hasAttribute('tabindex')) {
+              dot.setAttribute('tabindex', '0');
+            }
+          });
+      };
+
       const isDot = (el: EventTarget | null): el is SVGCircleElement =>
         el instanceof Element &&
         el.nodeName.toLowerCase() === 'circle' &&
@@ -1627,7 +1637,6 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
         if (!isDot(e.target)) return;
         const dot = e.target as SVGCircleElement;
 
-        dot.style.opacity = '1';
         const { left, top, width, height } = dot.getBoundingClientRect();
         const cx = left + width / 2;
         const cy = top + height / 2;
@@ -1656,7 +1665,11 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
         if (!isDot(e.target)) return;
         const dot = e.target;
 
-        dot.style.opacity = '';
+        // Keep tooltip context while Tab focus moves between chart points.
+        if (isDot(e.relatedTarget)) {
+          return;
+        }
+
         dot.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
       };
 
@@ -1679,13 +1692,18 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
       };
 
       const rafId = requestAnimationFrame(() => {
-        wrapper
-          .querySelectorAll<SVGCircleElement>('circle.dot')
-          .forEach(dot => {
-            if (!dot.hasAttribute('tabindex')) {
-              dot.setAttribute('tabindex', '0');
-            }
-          });
+        stampDotTabIndex();
+      });
+
+      const dotObserver = new MutationObserver(() => {
+        stampDotTabIndex();
+      });
+
+      dotObserver.observe(wrapper, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class', 'style', 'tabindex'],
       });
 
       wrapper.addEventListener('focusin', onFocusIn);
@@ -1694,11 +1712,12 @@ export const CarbonChart = React.forwardRef<HTMLDivElement, CarbonChartProps>(
 
       return () => {
         cancelAnimationFrame(rafId);
+        dotObserver.disconnect();
         wrapper.removeEventListener('focusin', onFocusIn);
         wrapper.removeEventListener('focusout', onFocusOut);
         wrapper.removeEventListener('keydown', onKeyDown);
       };
-    }, [type]);
+    }, [type, dataSet]);
 
     const groupsLength = Object.keys(colorScale).length;
 


### PR DESCRIPTION
Closes: #2338
## What I did
- Fixed chart point keyboard Tab navigation regressions in `CarbonChart`.
- Ensured point dots remain keyboard-tabbable after dataset/legend updates by re-applying `tabindex` when chart DOM updates.
- Prevented point visibility flicker during Tab navigation.
- Updated unit tests in `CarbonChart.test.js` to cover:
  - dynamic dot rendering/tabindex behavior after updates
  - dot-to-dot focus transitions without tooltip/visibility flicker

## Screenrecords
before:
https://github.com/user-attachments/assets/a514f687-6807-4d88-a708-1dad1d820487

after:
https://github.com/user-attachments/assets/30e8124c-cfe8-4463-98b0-7522ae06bfaa

## Checklist 
- [x] changeset has been added
- [x] Pull request is assigned, labels have been added and ticket is linked
- [x] Pull request description is descriptive and testing steps are listed
- [ ] Corresponding changes to the documentation have been made
- [x] New and existing unit tests pass locally with the proposed changes
- [x] Tests that prove the fix is effective or that the feature works have been added

## How to test
1. Open any chart with point dots.
2. Tab through points: no `one/all points` flicker.
3. Toggle legend dataset/group.
4. Tab through points again: points stay tabbable after toggle.